### PR TITLE
Add remote Docker validation path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,14 @@ pytest tests/e2e/mediamop -q --tb=short
 
 See **[`docs/local-development.md`](docs/local-development.md)** for env layout and CI parity.
 
+**Remote Docker validation** (no local Docker Desktop required):
+
+```powershell
+.\scripts\verify-docker-remote.ps1
+```
+
+This triggers the GitHub `Test` workflow for the current ref and watches it. The Docker build and smoke test run on GitHub-hosted runners.
+
 ## Security
 
 Do **not** commit `.env`, real secrets, or production database paths. Use `.env.example` patterns only.

--- a/docker/README.md
+++ b/docker/README.md
@@ -55,6 +55,8 @@ The image exposes `GET /health` and includes a Docker `HEALTHCHECK`.
 
 - `compose.yaml` defaults to `ghcr.io/jampat000/mediamop:latest`
 - `.github/workflows/release.yml` publishes stable images on tagged releases
+- maintainers do not need local Docker to ship releases; use `scripts/verify-docker-remote.ps1`
+  or the tag-driven release workflow to run Docker build and smoke checks on GitHub-hosted runners
 
 ## What Docker does not do
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -10,6 +10,7 @@ This **MediaMop** repository contains **`apps/backend`** (FastAPI, **SQLite**, c
 - **Node.js LTS** (npm on `PATH`)
 
 The backend persists state in **file-backed SQLite** under **`MEDIAMOP_HOME`** (see **`apps/backend/.env.example`**). You do **not** install or run PostgreSQL for normal MediaMop development.
+Docker Desktop is not required for normal local development or for shipping a release.
 
 ## Backend `.env` (local)
 
@@ -143,7 +144,15 @@ MediaMop local development is SQLite-first. There is no separate Postgres compos
 
 ## All-in-one Docker
 
-For a **single-container** build (API + production web UI, SQLite volume), see **`docker/README.md`** (requirements + steps), root **`compose.yaml`** (GHCR, default `docker compose`), or **`docker-compose.mediamop.yml`** (local build). Overview: **`docs/docker.md`**.
+For a **single-container** runtime (API + production web UI, SQLite volume), see **`docker/README.md`** and root **`compose.yaml`**. These files are for users or maintainers who want to run the published container.
+
+For maintainers without working local Docker, use GitHub-hosted validation:
+
+```powershell
+.\scripts\verify-docker-remote.ps1
+```
+
+The release workflow also builds, publishes, verifies, and smoke-tests Docker on GitHub-hosted runners.
 
 ## Visual shell
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -26,6 +26,10 @@ The Windows artifact is an installer-based desktop app with a tray host. It is n
 
 4. Pushing `v*` triggers `.github/workflows/release.yml`.
 
+Local Docker is not required for this release path. Docker build, publish,
+manifest verification, and container smoke testing all run on GitHub-hosted
+Actions runners.
+
 ## What the release workflow does
 
 The `Release` workflow:
@@ -73,6 +77,16 @@ This design is intentional. Running in the user session avoids common NAS or ext
 ## Docker
 
 Stable Docker releases are published from the same tag workflow.
+
+If Docker Desktop is broken or not installed locally, do not block the release
+on this workstation. Run the remote validation workflow instead:
+
+```powershell
+.\scripts\verify-docker-remote.ps1
+```
+
+That command triggers the `Test` workflow for the current ref and watches it.
+The Docker image build and Docker smoke test run on GitHub infrastructure.
 
 Pull and run:
 

--- a/scripts/verify-docker-remote.ps1
+++ b/scripts/verify-docker-remote.ps1
@@ -1,0 +1,83 @@
+# Runs MediaMop Docker validation on GitHub-hosted runners instead of requiring
+# Docker Desktop on this workstation.
+param(
+    [string] $Ref,
+    [string] $Workflow = "ci.yml",
+    [switch] $NoWatch
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+try {
+    if (-not $Ref -or -not $Ref.Trim()) {
+        $Ref = (& git rev-parse --abbrev-ref HEAD).Trim()
+        if (-not $Ref -or $Ref -eq "HEAD") {
+            $Ref = (& git rev-parse HEAD).Trim()
+        }
+    }
+
+    $gh = Get-Command gh -ErrorAction SilentlyContinue
+    if (-not $gh) {
+        Write-Error "GitHub CLI is required. Install gh or use GitHub Actions in the browser."
+    }
+
+    & gh auth status | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "GitHub CLI is not authenticated. Run: gh auth login"
+    }
+
+    $repo = (& gh repo view --json nameWithOwner --jq ".nameWithOwner").Trim()
+    $startedAfter = (Get-Date).ToUniversalTime().AddSeconds(-10)
+
+    Write-Host "Triggering remote Docker validation via GitHub Actions." -ForegroundColor Cyan
+    Write-Host "Repository: $repo"
+    Write-Host "Workflow:   $Workflow"
+    Write-Host "Ref:        $Ref"
+
+    & gh workflow run $Workflow --ref $Ref
+    if ($LASTEXITCODE -ne 0) {
+        exit $LASTEXITCODE
+    }
+
+    $run = $null
+    for ($i = 0; $i -lt 60; $i++) {
+        $runsJson = & gh run list `
+            --repo $repo `
+            --workflow $Workflow `
+            --event workflow_dispatch `
+            --limit 20 `
+            --json databaseId,createdAt,status,conclusion,url,headBranch,headSha,displayTitle
+
+        $runs = $runsJson | ConvertFrom-Json
+        $run = $runs |
+            Where-Object {
+                ([datetime]$_.createdAt).ToUniversalTime() -ge $startedAfter -and
+                ($_.headBranch -eq $Ref -or $_.headSha -eq $Ref)
+            } |
+            Sort-Object createdAt -Descending |
+            Select-Object -First 1
+
+        if ($run) {
+            break
+        }
+
+        Start-Sleep -Seconds 5
+    }
+
+    if (-not $run) {
+        Write-Error "Workflow was triggered, but the new run could not be located. Check Actions for workflow '$Workflow' on ref '$Ref'."
+    }
+
+    Write-Host "Remote validation run: $($run.url)" -ForegroundColor Green
+
+    if ($NoWatch) {
+        exit 0
+    }
+
+    & gh run watch $run.databaseId --repo $repo --interval 30 --exit-status
+    exit $LASTEXITCODE
+} finally {
+    Pop-Location
+}


### PR DESCRIPTION
Adds a GitHub Actions-backed Docker validation script so maintainers do not need local Docker Desktop to build or smoke-test containers. Updates release, local development, Docker, and contributing docs to make local Docker optional for maintainers.\n\nValidation:\n- PowerShell script syntax check passed\n- Remote Test workflow passed via scripts/verify-docker-remote.ps1: https://github.com/jampat000/MediaMop/actions/runs/24882002930