### PR TITLE
Update artifact actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
       - name: Upload MediaMop Windows installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mediamop-windows-installer
           path: dist/windows/MediaMopSetup.exe
@@ -117,7 +117,7 @@ jobs:
         run: echo "name=${REGISTRY}/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Download MediaMop Windows installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mediamop-windows-installer
           path: ${{ github.workspace }}/windows-artifact


### PR DESCRIPTION
Updates the release workflow artifact upload/download actions to Node 24-compatible versions so the release workflow no longer emits the GitHub Actions Node 20 deprecation warning.\n\nChanges:\n- actions/upload-artifact: v4 -> v7\n- actions/download-artifact: v4 -> v7\n\nValidation planned:\n- PR Test workflow\n- Main Test workflow after merge\n- Next tag-driven Release workflow validates artifact upload/download in the real release path