### PR TITLE
Update release actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,16 +122,16 @@ jobs:
           name: mediamop-windows-installer
           path: ${{ github.workspace }}/windows-artifact
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish release Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -171,7 +171,7 @@ jobs:
         run: docker rm -f mediamop-release-smoke >/dev/null 2>&1 || true
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2.6.2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             mediamop-web-dist.zip


### PR DESCRIPTION
Updates the remaining third-party release workflow actions to Node 24-compatible major versions.\n\nChanges:\n- docker/setup-buildx-action: v3 -> v4\n- docker/login-action: v3 -> v4\n- docker/build-push-action: v6 -> v7\n- softprops/action-gh-release: v2.6.2 -> v3\n\nValidation:\n- PR Test workflow\n- Tag-driven release after merge to prove the release workflow is warning-free