### PR TITLE
Prepare MediaMop 1.0.3 release workflow cleanup

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.2"
+version = "1.0.3"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "npm run dev:stop-api && npm run dev:stop-web && node ./scripts/run-dev-stack.mjs",

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "1.0.2"
+  #define AppVersion "1.0.3"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
Bumps MediaMop to v1.0.3 to ship the release workflow Node 24 action cleanup.\n\nIncluded since v1.0.2:\n- docker/setup-buildx-action v4\n- docker/login-action v4\n- docker/build-push-action v7\n- softprops/action-gh-release v3\n\nValidation:\n- PR Test workflow\n- Tag-driven Release workflow after merge to confirm warning-free release path