### PR TITLE
Share activity SSE connection per tab

### DIFF
--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ReactNode } from "react";
 
@@ -80,5 +80,49 @@ describe("useActivityStreamInvalidation", () => {
     src.emit("activity.latest", JSON.stringify({ latest_event_id: 77 }));
 
     expect(spy).toHaveBeenCalledWith({ queryKey: dashboardStatusKey });
+  });
+
+  it("shares one EventSource across multiple query subscribers", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    const qc = new QueryClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    const first = renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
+      wrapper: withQueryClient(qc),
+    });
+    const second = renderHook(() => useActivityStreamInvalidation(dashboardStatusKey), {
+      wrapper: withQueryClient(qc),
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(1);
+    const src = FakeEventSource.instances[0];
+    src.emit("activity.latest", JSON.stringify({ latest_event_id: 88 }));
+
+    expect(spy).toHaveBeenCalledWith({ queryKey: activityRecentKey });
+    expect(spy).toHaveBeenCalledWith({ queryKey: dashboardStatusKey });
+
+    first.unmount();
+    expect(src.closed).toBe(false);
+
+    second.unmount();
+    expect(src.closed).toBe(true);
+  });
+
+  it("opens a fresh EventSource after all subscribers unmount", async () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    const qc = new QueryClient();
+
+    const first = renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
+      wrapper: withQueryClient(qc),
+    });
+    first.unmount();
+    await waitFor(() => expect(FakeEventSource.instances[0].closed).toBe(true));
+
+    renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
+      wrapper: withQueryClient(qc),
+    });
+
+    expect(FakeEventSource.instances).toHaveLength(2);
+    expect(FakeEventSource.instances[1].closed).toBe(false);
   });
 });

--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
@@ -2,6 +2,14 @@ import { useEffect } from "react";
 import { useQueryClient, type QueryKey } from "@tanstack/react-query";
 
 type LatestPayload = { latest_event_id: number };
+type ActivityLatestSubscriber = () => void;
+
+let source: EventSource | null = null;
+const subscribers = new Set<ActivityLatestSubscriber>();
+
+function emitActivityLatest(): void {
+  subscribers.forEach((subscriber) => subscriber());
+}
 
 function parseLatestPayload(data: string): LatestPayload | null {
   try {
@@ -15,24 +23,43 @@ function parseLatestPayload(data: string): LatestPayload | null {
   }
 }
 
+function ensureActivityStream(): EventSource | null {
+  if (source) {
+    return source;
+  }
+  if (typeof EventSource === "undefined") {
+    return null;
+  }
+  source = new EventSource("/api/v1/activity/stream");
+  source.addEventListener("activity.latest", (ev) => {
+    const payload = parseLatestPayload((ev as MessageEvent<string>).data);
+    if (!payload) {
+      return;
+    }
+    emitActivityLatest();
+  });
+  return source;
+}
+
+function subscribeActivityLatest(subscriber: ActivityLatestSubscriber): () => void {
+  subscribers.add(subscriber);
+  ensureActivityStream();
+
+  return () => {
+    subscribers.delete(subscriber);
+    if (subscribers.size === 0) {
+      source?.close();
+      source = null;
+    }
+  };
+}
+
 export function useActivityStreamInvalidation(queryKey: QueryKey): void {
   const qc = useQueryClient();
 
   useEffect(() => {
-    const es = new EventSource("/api/v1/activity/stream");
-
-    const onLatest = (ev: MessageEvent<string>) => {
-      const payload = parseLatestPayload(ev.data);
-      if (!payload) {
-        return;
-      }
+    return subscribeActivityLatest(() => {
       void qc.invalidateQueries({ queryKey });
-    };
-
-    es.addEventListener("activity.latest", onLatest as EventListener);
-    return () => {
-      es.removeEventListener("activity.latest", onLatest as EventListener);
-      es.close();
-    };
+    });
   }, [qc, queryKey]);
 }


### PR DESCRIPTION
Refactors the activity stream invalidation hook so multiple subscribers in the same browser tab share one EventSource connection. This keeps live Activity/Dashboard behavior while avoiding duplicate SSE connections.\n\nValidation:\n- npm run test -- use-activity-stream-invalidation\n- npm run test\n- npm run build