### PR TITLE
Document release hardening checklists

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,3 +18,7 @@
 
 - Initial acknowledgment target: within 7 days.
 - Confirmed vulnerabilities are triaged, fixed, and disclosed once a patch is available.
+
+## Hardening baseline
+
+The practical release hardening checklist lives in [`docs/security-hardening.md`](docs/security-hardening.md).

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -8,3 +8,4 @@ Short summary:
 - same-origin API under `/api/v1`
 - stable tags are published by `.github/workflows/release.yml`
 - root `compose.yaml` pulls `ghcr.io/jampat000/mediamop:latest`
+- release smoke validation is defined in [`smoke-checklists.md`](smoke-checklists.md)

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -1,0 +1,34 @@
+# Release Governance
+
+This is the canonical governance checklist for keeping MediaMop releases controlled and repeatable.
+
+## GitHub repository controls
+
+- `main` is protected by the active `Owner-Only Main Protection` ruleset.
+- Direct deletion and force-pushes to `main` are blocked.
+- Pull requests into `main` require conversation resolution.
+- Code-owner review is required by the ruleset. `.github/CODEOWNERS` owns the full tree.
+- Required status checks for `main` are:
+  - `mediamop`
+  - `docker-smoke`
+  - `windows-package-smoke`
+- The repo Wiki is disabled. Public docs live in the repository.
+- Issues are enabled and use structured templates.
+- Releases are tag-driven from `v*` tags.
+
+## Before every release
+
+1. Confirm the working tree is clean.
+2. Confirm `main` is up to date with `origin/main`.
+3. Confirm `.github/workflows/ci.yml` and `.github/workflows/release.yml` still expose the required check names listed above.
+4. Confirm Dependabot has no stale action-runtime holds that conflict with the workflow pins.
+5. Confirm open issues tagged `priority: critical` or `priority: high` are either fixed, intentionally deferred, or not release-blocking.
+6. Run the release path from `docs/release.md`.
+
+## After every release
+
+1. Confirm the GitHub Release exists for the pushed tag.
+2. Confirm `MediaMopSetup.exe` is attached to the release.
+3. Confirm the GHCR image exists for both `vX.Y.Z` and `latest`.
+4. Confirm the release workflow completed `mediamop`, Docker publish, Docker smoke, and Windows package jobs.
+5. Open a follow-up issue for any manual smoke-test failure.

--- a/docs/release.md
+++ b/docs/release.md
@@ -122,5 +122,7 @@ only if you want to override defaults such as the image tag or runtime home.
 
 - `.github/workflows/ci.yml`
 - `.github/workflows/release.yml`
+- `docs/release-governance.md`
+- `docs/smoke-checklists.md`
 - `docker/README.md`
 - `docs/local-development.md`

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -1,0 +1,46 @@
+# Security Hardening
+
+This checklist defines the current practical hardening baseline for MediaMop.
+
+## Authentication and setup
+
+- First-run bootstrap is only available when no admin user exists.
+- Passwords shorter than 8 characters must be blocked by both frontend and backend validation.
+- Login and bootstrap routes are rate-limited.
+- Authenticated state-changing browser requests require CSRF protection.
+- Session cookies are HTTP-only.
+- Secure cookies should be enabled when deployed behind HTTPS.
+- Existing users must persist across restarts and upgrades.
+
+## Secrets and private data
+
+- Real `.env` files must never be committed.
+- Runtime SQLite databases must never be committed.
+- Logs, backups, media paths, API keys, provider tokens, and session secrets must never be committed.
+- Public issue logs must redact secrets, private hostnames, and private filesystem paths.
+- Docker can generate a persistent session secret when one is not provided.
+
+## Repository and dependency controls
+
+- `main` is protected by GitHub rules.
+- Required checks are `mediamop`, `docker-smoke`, and `windows-package-smoke`.
+- Dependabot is enabled for Python and GitHub Actions dependencies.
+- Security vulnerabilities are reported privately through `SECURITY.md`.
+- Public issues are not used for unpatched vulnerabilities.
+
+## Release controls
+
+- Releases are built from tagged source.
+- Windows and Docker artifacts are produced by GitHub Actions.
+- Local Docker Desktop is not required to validate Docker packaging.
+- Release artifacts remain under AGPL-3.0-or-later.
+
+## Ongoing checks
+
+Run this list before any major release:
+
+1. Confirm no secrets or runtime files are staged.
+2. Confirm dependency audit jobs pass.
+3. Confirm auth setup, login, logout, and password validation smoke tests pass.
+4. Confirm backup files do not expose secrets in public docs, logs, or screenshots.
+5. Confirm activity/log views do not expose tokens or internal implementation details to normal users.

--- a/docs/smoke-checklists.md
+++ b/docs/smoke-checklists.md
@@ -1,0 +1,68 @@
+# Smoke Checklists
+
+These checklists define the minimum user-level validation before calling a release ready. Automated CI checks are necessary but not enough; these are the click-through paths that catch packaging and first-run regressions.
+
+## Windows installer smoke
+
+Use `MediaMopSetup.exe` from the release being validated.
+
+1. Install MediaMop on a clean Windows user profile or a reset test profile.
+2. Launch MediaMop from the Start Menu shortcut.
+3. Confirm the tray icon appears and the browser opens the app.
+4. Confirm first-run user creation appears when no user exists.
+5. Attempt a password shorter than 8 characters and confirm it is blocked.
+6. Create the first user with a valid password.
+7. Confirm the setup wizard opens after first-user creation.
+8. Confirm `Skip for now` exits the wizard and can be reopened from Settings.
+9. Confirm `Finish setup` saves timezone, display density, backup schedule, and starter module settings.
+10. In Settings, confirm setup wizard, timezone, log retention, and display density cards render correctly.
+11. Confirm Backup and Restore controls sit consistently at the bottom of their cards.
+12. Create a configuration backup.
+13. Restore that backup and confirm the app remains usable.
+14. Confirm Upgrade shows a meaningful status, even when no update is available.
+15. Open Refiner path inputs and use Browse for a local folder.
+16. Enter a UNC-style path manually and confirm validation warns without blocking legitimate save paths by design.
+17. Confirm Pruner and Subber settings can save required connection/path fields without exposing internal webhook controls.
+18. Quit MediaMop from the tray icon.
+19. Relaunch MediaMop and confirm the existing user, settings, and wizard completion state persist.
+20. Install the next version over the current version and confirm this is treated as an upgrade, not a first-run install.
+21. Uninstall and reinstall only when intentionally testing clean-install behavior.
+
+## Docker smoke
+
+Use the published release image, not a locally built image.
+
+1. Pull the versioned image:
+
+   ```bash
+   docker pull ghcr.io/jampat000/mediamop:vX.Y.Z
+   ```
+
+2. Start with a fresh named volume:
+
+   ```bash
+   docker run --rm -p 8788:8788 -v mediamop-smoke:/data/mediamop ghcr.io/jampat000/mediamop:vX.Y.Z
+   ```
+
+3. Open `http://localhost:8788/`.
+4. Confirm first-run user creation appears.
+5. Attempt a password shorter than 8 characters and confirm it is blocked.
+6. Create the first user with a valid password.
+7. Confirm the setup wizard opens.
+8. Complete or skip the setup wizard and confirm Settings can reopen it.
+9. Confirm `/health` returns healthy while the container is running.
+10. Confirm Activity updates without manual page reload when a module action is triggered.
+11. Confirm Logs show application/runtime events, not developer build noise.
+12. Confirm Backup and Restore work against the mounted volume.
+13. Stop and restart the container with the same volume.
+14. Confirm the user, settings, and runtime state persist.
+15. Pull and run `latest` and confirm it resolves to the expected release digest.
+16. Upgrade from the previous release tag to the new release tag using the same volume.
+17. Confirm Docker path wording is clear: paths inside the container may differ from host/NAS paths.
+18. Remove the smoke volume only after validation is complete.
+
+## Failure handling
+
+- Any failed smoke step gets a GitHub issue with the install type, version, exact step, expected result, actual result, and screenshots/logs with secrets removed.
+- Release-blocking failures get `priority: critical`.
+- Core workflow failures without data loss get `priority: high`.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -30,3 +30,10 @@ MediaMop issues should stay practical and reproducible. Every issue needs a clea
 4. Add one `priority:*` label after impact is understood.
 5. Close issues only when the fix is merged, intentionally declined, or superseded by a better issue.
 
+## Backlog references
+
+- Release governance: [`release-governance.md`](release-governance.md)
+- Windows and Docker smoke checks: [`smoke-checklists.md`](smoke-checklists.md)
+- Security hardening: [`security-hardening.md`](security-hardening.md)
+- UX polish baseline: [`ux-polish.md`](ux-polish.md)
+

--- a/docs/ux-polish.md
+++ b/docs/ux-polish.md
@@ -1,0 +1,41 @@
+# UX Polish Standard
+
+This is the app-wide UX baseline for MediaMop. Use it when reviewing screens before release.
+
+## Language
+
+- User-facing text explains what happened and why in plain language.
+- Avoid raw internal event keys, auth implementation names, library names, traceback wording, or JSON blobs unless the user explicitly opens a technical details view.
+- Activity events describe the user outcome first, then technical detail second.
+- Logs are system/application event logs for troubleshooting runtime issues, not a development changelog.
+
+## Layout
+
+- Cards in the same section should use consistent spacing, action placement, and visual weight.
+- Primary card actions should sit at the bottom of the card unless the control needs to remain inline for usability.
+- Settings cards should be grouped by user task, not backend implementation.
+- Empty states should be compact, aligned with the surrounding layout, and explain what to do next.
+- Long detail views should be compressed by default and expandable when more information is useful.
+
+## Visuals
+
+- Status colors must be consistent:
+  - healthy or complete: green
+  - warning or review needed: amber
+  - failed or blocked: red
+  - informational or queued: blue/neutral
+- Bubbles, badges, and pills should use the same shape language across Dashboard, Activity, Settings, and module pages.
+- Font sizing should stay consistent across headings, labels, body text, and compact metadata.
+
+## Screen-specific baseline
+
+- Dashboard shows useful operational status, not just navigation.
+- Activity is live, user-friendly, filterable, searchable, color-coded, and readable at scale.
+- Refiner activity can show before/after file details, size savings, languages, subtitles, and removals in an expandable layout.
+- Settings General groups setup wizard, timezone, log retention, and display density cleanly.
+- Backup/Restore and Upgrade belong together as operational safety controls.
+- Folder path inputs that need user-selected paths should support browsing where technically possible and allow manual local, Docker, and UNC-style paths.
+
+## Review rule
+
+If a screen looks technically correct but a normal user would not understand what happened or what to do next, it is not done.


### PR DESCRIPTION
## Summary
- add release governance checklist for branch protection, required checks, and release controls
- add Windows installer and Docker smoke checklists
- add security hardening and UX polish baselines
- link the new docs from release, Docker, security, and triage docs

## Validation
- git diff --cached --check before commit

Closes #16
Closes #19
Closes #20
Closes #21
Closes #22