### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -1,9 +1,11 @@
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useState } from "react";
 import { BrandHeaderLink } from "../components/brand/brand-header-link";
 import { NavIconActivity, NavIconDashboard, NavIconRefiner, NavIconSettings, NavIconSubber, NavIconPruner } from "../components/shell/nav-icons";
 import { WEB_APP_VERSION } from "../lib/app-meta";
 import { useLogoutMutation } from "../lib/auth/queries";
 import { useSuiteSettingsQuery } from "../lib/suite/queries";
+import { persistAppTheme, readStoredAppTheme, type AppTheme } from "../lib/ui/app-theme";
 
 function sidebarNavClass({ isActive }: { isActive: boolean }) {
   return isActive ? "mm-sidebar-link active" : "mm-sidebar-link";
@@ -13,7 +15,9 @@ export function AppShell() {
   const navigate = useNavigate();
   const logout = useLogoutMutation();
   const suite = useSuiteSettingsQuery();
+  const [theme, setTheme] = useState<AppTheme>(() => readStoredAppTheme());
   const productTitle = (suite.data?.product_display_name ?? "MediaMop").trim() || "MediaMop";
+  const nextTheme: AppTheme = theme === "dark" ? "light" : "dark";
   const handleSignOut = () => {
     logout.mutate(undefined, {
       onSettled: () => {
@@ -89,6 +93,20 @@ export function AppShell() {
         </div>
       </aside>
       <main className="mm-main" id="mm-main-content" tabIndex={-1}>
+        <button
+          type="button"
+          className="mm-theme-toggle"
+          data-testid="theme-toggle"
+          aria-label={`Switch to ${nextTheme} mode`}
+          title={`Switch to ${nextTheme} mode`}
+          onClick={() => {
+            setTheme(nextTheme);
+            persistAppTheme(nextTheme);
+          }}
+        >
+          <span className="mm-theme-toggle__dot" aria-hidden="true" />
+          <span className="mm-theme-toggle__label">{theme === "dark" ? "Dark" : "Light"}</span>
+        </button>
         <div className="mm-main-inner">
           <Outlet />
         </div>

--- a/apps/web/src/lib/ui/app-theme.test.ts
+++ b/apps/web/src/lib/ui/app-theme.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  APP_THEME_STORAGE_KEY,
+  applyAppThemeToDocument,
+  parseAppTheme,
+  persistAppTheme,
+  readStoredAppTheme,
+} from "./app-theme";
+
+describe("app-theme", () => {
+  afterEach(() => {
+    localStorage.removeItem(APP_THEME_STORAGE_KEY);
+    document.documentElement.removeAttribute("data-mm-theme");
+  });
+
+  it("parses stored values", () => {
+    expect(parseAppTheme(null)).toBe("dark");
+    expect(parseAppTheme("")).toBe("dark");
+    expect(parseAppTheme("dark")).toBe("dark");
+    expect(parseAppTheme("light")).toBe("light");
+    expect(parseAppTheme("nope")).toBe("dark");
+  });
+
+  it("reads from localStorage", () => {
+    localStorage.setItem(APP_THEME_STORAGE_KEY, "light");
+    expect(readStoredAppTheme()).toBe("light");
+    localStorage.removeItem(APP_THEME_STORAGE_KEY);
+    expect(readStoredAppTheme()).toBe("dark");
+  });
+
+  it("applies and persists the document theme", () => {
+    applyAppThemeToDocument("light");
+    expect(document.documentElement.getAttribute("data-mm-theme")).toBe("light");
+    persistAppTheme("dark");
+    expect(localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
+    expect(document.documentElement.getAttribute("data-mm-theme")).toBe("dark");
+  });
+});

--- a/apps/web/src/lib/ui/app-theme.ts
+++ b/apps/web/src/lib/ui/app-theme.ts
@@ -1,0 +1,31 @@
+/** Browser-local color theme; not synced to the server and safe to change instantly. */
+
+export const APP_THEME_STORAGE_KEY = "mediamop-app-theme";
+
+export type AppTheme = "dark" | "light";
+
+export function parseAppTheme(raw: string | null): AppTheme {
+  return raw === "light" ? "light" : "dark";
+}
+
+export function readStoredAppTheme(): AppTheme {
+  try {
+    return parseAppTheme(localStorage.getItem(APP_THEME_STORAGE_KEY));
+  } catch {
+    return "dark";
+  }
+}
+
+export function applyAppThemeToDocument(theme: AppTheme): void {
+  document.documentElement.setAttribute("data-mm-theme", theme);
+}
+
+export function persistAppTheme(theme: AppTheme): void {
+  try {
+    localStorage.setItem(APP_THEME_STORAGE_KEY, theme);
+  } catch {
+    /* private mode / blocked storage */
+  }
+  applyAppThemeToDocument(theme);
+}
+

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,9 +2,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { AppRouter } from "./app/router";
 import { AppProviders } from "./app/providers";
+import { applyAppThemeToDocument, readStoredAppTheme } from "./lib/ui/app-theme";
 import { applyDisplayDensityToDocument, readStoredDisplayDensity } from "./lib/ui/display-density";
 import "./index.css";
 
+applyAppThemeToDocument(readStoredAppTheme());
 applyDisplayDensityToDocument(readStoredDisplayDensity());
 
 const el = document.getElementById("root");

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -78,6 +78,67 @@ body.mm-body {
   background: var(--mm-bg);
 }
 
+.mm-theme-toggle {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  float: right;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  margin: 0 2px 10px 14px;
+  padding: 7px 11px;
+  border: 1px solid var(--mm-border);
+  border-radius: var(--mm-radius-pill);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.01)),
+    color-mix(in srgb, var(--mm-card-bg) 88%, transparent);
+  color: var(--mm-text2);
+  box-shadow: var(--mm-shadow-card-inner), 0 8px 24px rgba(0, 0, 0, 0.16);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition:
+    border-color 0.16s ease,
+    color 0.16s ease,
+    background 0.16s ease,
+    transform 0.16s ease;
+}
+
+.mm-theme-toggle:hover {
+  border-color: var(--mm-accent-ring);
+  color: var(--mm-text);
+  transform: translateY(-1px);
+}
+
+.mm-theme-toggle:focus-visible {
+  outline: 2px solid var(--mm-accent-ring);
+  outline-offset: 2px;
+}
+
+.mm-theme-toggle__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--mm-accent);
+  box-shadow: 0 0 0 3px var(--mm-accent-soft);
+}
+
+.mm-theme-toggle__label {
+  line-height: 1;
+}
+
+html[data-mm-theme="light"] .mm-theme-toggle {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 250, 240, 0.78)),
+    var(--mm-card-bg);
+  box-shadow: var(--mm-shadow-card-inner), 0 10px 30px rgba(88, 65, 20, 0.1);
+}
+
 .mm-sidebar {
   width: var(--mm-sidebar-w);
   flex-shrink: 0;

--- a/apps/web/src/styles/mediamop-tokens.css
+++ b/apps/web/src/styles/mediamop-tokens.css
@@ -58,6 +58,45 @@
   --mm-eyebrow-color: var(--mm-stone-muted);
 }
 
+html[data-mm-theme="light"] {
+  color-scheme: light;
+  --mm-charcoal: #f4f0e7;
+  --mm-slate: #fffaf0;
+  --mm-slate-elevated: #f0e7d6;
+  --mm-stone: #211f1a;
+  --mm-stone-muted: rgba(33, 31, 26, 0.68);
+  --mm-stone-dim: rgba(33, 31, 26, 0.48);
+  --mm-gold: #9f7417;
+  --mm-gold-bright: #7d5a11;
+  --mm-gold-dim: #c79a32;
+  --mm-indigo: #4050c8;
+  --mm-indigo-soft: rgba(64, 80, 200, 0.11);
+  --mm-bg: #f4f0e7;
+  --mm-bg-main: #f7f1e6;
+  --mm-surface: #fffaf0;
+  --mm-surface-2: #f0e7d6;
+  --mm-card-bg: #fffaf0;
+  --mm-border: rgba(33, 31, 26, 0.13);
+  --mm-border-sidebar: rgba(33, 31, 26, 0.1);
+  --mm-text: var(--mm-stone);
+  --mm-text2: var(--mm-stone-muted);
+  --mm-text3: var(--mm-stone-dim);
+  --mm-accent: #b88719;
+  --mm-accent-bright: #8c6413;
+  --mm-accent-soft: rgba(184, 135, 25, 0.14);
+  --mm-accent-ring: rgba(184, 135, 25, 0.34);
+  --mm-on-accent: #fffaf0;
+  --mm-shadow-card: 0 18px 46px rgba(65, 47, 15, 0.12);
+  --mm-shadow-card-inner: 0 1px 0 rgba(255, 255, 255, 0.8) inset;
+  --mm-input-bg: rgba(255, 252, 245, 0.96);
+  --mm-input-bg-hover: rgba(255, 255, 255, 0.98);
+  --mm-input-border: rgba(33, 31, 26, 0.16);
+  --mm-input-border-hover: rgba(33, 31, 26, 0.24);
+  --mm-input-border-focus: rgba(184, 135, 25, 0.55);
+  --mm-input-focus-ring: rgba(184, 135, 25, 0.18);
+  --mm-eyebrow-color: rgba(33, 31, 26, 0.6);
+}
+
 html[data-mm-density="comfortable"] {
   /* Stronger lift for QHD / 4K where UI can still feel small next to physical screen size. */
   --mm-density-font-scale: 1.1;


### PR DESCRIPTION
## Summary
- add a browser-local light/dark theme preference
- apply the saved theme before React renders to avoid a visible flash
- add a subtle top-right shell toggle and light-mode design tokens
- cover theme parsing, persistence, and document application with tests

## Validation
- npm run test -- app-theme display-density
- npm run build
- npm run test