### PR TITLE
Prepare MediaMop 1.0.5

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.4"
+version = "1.0.5"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump backend and web package metadata to 1.0.5
- includes the light/dark theme toggle, AGPL/license governance, hardening docs, branch cleanup process, and latest release workflow action bump already merged to main

## Validation
- npm run build
- npm run test
- py -3 pyproject version parse
- git diff --check