### PR TITLE
Harden Windows install paths and CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# Static security analysis for MediaMop source.
+name: CodeQL
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "37 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+          - language: javascript-typescript
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -4,7 +4,7 @@
 # See ADR-0002 (database) and ADR-0003 (auth).
 #
 # Product-owned data root (not an implicit “use the Git checkout” path; not cwd). Unset defaults:
-#   Windows: %LOCALAPPDATA%\MediaMop
+#   Windows: %PROGRAMDATA%\MediaMop (normally C:\ProgramData\MediaMop)
 #   Linux/macOS: $XDG_DATA_HOME/mediamop or ~/.local/share/mediamop
 # Future logs/cache/files should live under this tree.
 # MEDIAMOP_HOME=C:\ProgramData\MediaMop

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -31,7 +31,7 @@ See `mediamop/api/router.py` for composition.
 
 Copy **`.env.example`** to **`.env`** in this directory (gitignored). The API loads **`.env`** on startup; Alembic loads it too. Variables use the **`MEDIAMOP_*`** prefix only.
 
-**`MEDIAMOP_HOME`:** canonical on-disk root for future MediaMop file artifacts (not “this Git clone” as an implicit data directory; see ADR intent in **`../../docs/local-development.md`**). Defaults: Windows `%LOCALAPPDATA%\MediaMop`, Unix `XDG_DATA_HOME|mediamop` or `~/.local/share/mediamop`. Exposed as `MediaMopSettings.mediamop_home`.
+**`MEDIAMOP_HOME`:** canonical on-disk root for future MediaMop file artifacts (not “this Git clone” as an implicit data directory; see ADR intent in **`../../docs/local-development.md`**). Defaults: Windows `%PROGRAMDATA%\MediaMop`, Unix `XDG_DATA_HOME|mediamop` or `~/.local/share/mediamop`. Exposed as `MediaMopSettings.mediamop_home`.
 
 | Variable | Purpose |
 |----------|---------|

--- a/apps/backend/src/mediamop/core/paths.py
+++ b/apps/backend/src/mediamop/core/paths.py
@@ -5,7 +5,7 @@ derived from the process current working directory unless ``MEDIAMOP_HOME`` expl
 uses a relative segment (discouraged).
 
 Defaults:
-- **Windows:** ``%LOCALAPPDATA%\\MediaMop``
+- **Windows:** ``%PROGRAMDATA%\\MediaMop`` (normally ``C:\\ProgramData\\MediaMop``)
 - **Unix:** ``$XDG_DATA_HOME/mediamop`` if set, else ``~/.local/share/mediamop``
 
 Future runtime artifacts (logs, cache, local exports) should live under this root; nothing
@@ -23,10 +23,8 @@ def default_mediamop_home() -> Path:
     """OS-appropriate default when ``MEDIAMOP_HOME`` is unset."""
 
     if sys.platform == "win32":
-        base = (os.environ.get("LOCALAPPDATA") or "").strip()
-        if base:
-            return Path(base) / "MediaMop"
-        return Path.home() / "AppData" / "Local" / "MediaMop"
+        base = (os.environ.get("PROGRAMDATA") or r"C:\ProgramData").strip()
+        return Path(base) / "MediaMop"
     xdg = (os.environ.get("XDG_DATA_HOME") or "").strip()
     if xdg:
         return Path(xdg) / "mediamop"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -14,33 +13,36 @@ from mediamop.modules.refiner.refiner_path_settings_model import RefinerPathSett
 
 RefinerMediaScope = Literal["movie", "tv"]
 
-# Windows product defaults (fixed paths; not under MEDIAMOP_HOME).
-_REFINER_DEFAULT_WINDOWS_MOVIE_WORK = Path(r"C:\ProgramData\Media\refiner-movie-work")
-_REFINER_DEFAULT_WINDOWS_TV_WORK = Path(r"C:\ProgramData\MediaMop\refiner-tv-work")
+_REFINER_LEGACY_WINDOWS_MOVIE_WORK = Path(r"C:\ProgramData\Media\refiner-movie-work")
+_REFINER_LEGACY_WINDOWS_TV_WORK = Path(r"C:\ProgramData\MediaMop\refiner-tv-work")
 
 
 def resolved_default_refiner_work_folder(*, mediamop_home: str) -> str:
     """Default Movies work/temp directory.
 
-    On Windows: ``C:\\ProgramData\\Media\\refiner-movie-work``.
-    Elsewhere: ``<MEDIAMOP_HOME>/refiner/refiner-movie-work`` (portable dev/CI).
+    Defaults are under ``MEDIAMOP_HOME`` so packaged Windows installs use
+    ``C:\\ProgramData\\MediaMop`` while Docker/dev installs follow their configured
+    runtime root.
     """
 
-    if sys.platform == "win32":
-        return str(_REFINER_DEFAULT_WINDOWS_MOVIE_WORK)
     return str(Path(mediamop_home).expanduser().resolve() / "refiner" / "refiner-movie-work")
 
 
 def resolved_default_refiner_tv_work_folder(*, mediamop_home: str) -> str:
     """Default TV work/temp directory (separate from Movies).
 
-    On Windows: ``C:\\ProgramData\\MediaMop\\refiner-tv-work``.
-    Elsewhere: ``<MEDIAMOP_HOME>/refiner/refiner-tv-work``.
+    Defaults are under ``MEDIAMOP_HOME`` so packaged Windows installs use
+    ``C:\\ProgramData\\MediaMop`` while Docker/dev installs follow their configured
+    runtime root.
     """
 
-    if sys.platform == "win32":
-        return str(_REFINER_DEFAULT_WINDOWS_TV_WORK)
     return str(Path(mediamop_home).expanduser().resolve() / "refiner" / "refiner-tv-work")
+
+
+def _is_legacy_refiner_default_work_folder(raw: str, *, media_scope: RefinerMediaScope) -> bool:
+    candidate = Path(raw).expanduser()
+    legacy = _REFINER_LEGACY_WINDOWS_TV_WORK if media_scope == "tv" else _REFINER_LEGACY_WINDOWS_MOVIE_WORK
+    return str(candidate).rstrip("\\/").lower() == str(legacy).rstrip("\\/").lower()
 
 
 def _norm_dir_path(raw: str) -> Path:
@@ -101,6 +103,8 @@ def effective_work_folder(*, row: RefinerPathSettingsRow, mediamop_home: str) ->
 
     stored = (row.refiner_work_folder or "").strip()
     if stored:
+        if _is_legacy_refiner_default_work_folder(stored, media_scope="movie"):
+            return resolved_default_refiner_work_folder(mediamop_home=mediamop_home), True
         return stored, False
     return resolved_default_refiner_work_folder(mediamop_home=mediamop_home), True
 
@@ -110,6 +114,8 @@ def effective_tv_work_folder(*, row: RefinerPathSettingsRow, mediamop_home: str)
 
     stored = (row.refiner_tv_work_folder or "").strip()
     if stored:
+        if _is_legacy_refiner_default_work_folder(stored, media_scope="tv"):
+            return resolved_default_refiner_tv_work_folder(mediamop_home=mediamop_home), True
         return stored, False
     return resolved_default_refiner_tv_work_folder(mediamop_home=mediamop_home), True
 

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -59,10 +59,8 @@ def _runtime_home() -> Path:
     raw = (os.environ.get("MEDIAMOP_HOME") or "").strip()
     if raw:
         return Path(raw).expanduser().resolve()
-    local_app_data = os.environ.get("LOCALAPPDATA")
-    if local_app_data:
-        return Path(local_app_data).resolve() / "MediaMop"
-    return Path.home() / "AppData" / "Local" / "MediaMop"
+    program_data = (os.environ.get("PROGRAMDATA") or r"C:\ProgramData").strip()
+    return Path(program_data) / "MediaMop"
 
 
 def _find_free_port(preferred: int = 8788) -> int:

--- a/apps/backend/tests/test_paths.py
+++ b/apps/backend/tests/test_paths.py
@@ -19,3 +19,12 @@ def test_default_home_leaf_name(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MEDIAMOP_HOME", raising=False)
     home = default_mediamop_home()
     assert home.name in ("MediaMop", "mediamop")
+
+
+def test_windows_default_home_is_machine_wide_programdata(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MEDIAMOP_HOME", raising=False)
+    monkeypatch.setattr("sys.platform", "win32")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Example\AppData\Local")
+
+    assert str(default_mediamop_home()).replace("/", "\\") == r"C:\ProgramData\MediaMop"

--- a/apps/backend/tests/test_refiner_path_settings_service.py
+++ b/apps/backend/tests/test_refiner_path_settings_service.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
 
 import pytest
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_path_settings_model import RefinerPathSettingsRow
 from mediamop.modules.refiner.refiner_path_settings_service import (
     _validate_path_separation,
+    effective_work_folder,
     resolved_default_refiner_tv_work_folder,
     resolved_default_refiner_work_folder,
 )
@@ -22,10 +23,7 @@ def test_resolved_default_work_under_home(tmp_path: Path, monkeypatch: pytest.Mo
     monkeypatch.setenv("MEDIAMOP_HOME", str(h))
     s = MediaMopSettings.load()
     got = resolved_default_refiner_work_folder(mediamop_home=s.mediamop_home)
-    if sys.platform == "win32":
-        assert got == str(Path(r"C:\ProgramData\Media\refiner-movie-work"))
-    else:
-        assert got.endswith(str(Path("refiner") / "refiner-movie-work"))
+    assert got == str(h.resolve() / "refiner" / "refiner-movie-work")
     assert Path(got).is_absolute()
 
 
@@ -36,11 +34,17 @@ def test_resolved_default_tv_work_under_home(tmp_path: Path, monkeypatch: pytest
     monkeypatch.setenv("MEDIAMOP_HOME", str(h))
     s = MediaMopSettings.load()
     got = resolved_default_refiner_tv_work_folder(mediamop_home=s.mediamop_home)
-    if sys.platform == "win32":
-        assert got == str(Path(r"C:\ProgramData\MediaMop\refiner-tv-work"))
-    else:
-        assert got.endswith(str(Path("refiner") / "refiner-tv-work"))
+    assert got == str(h.resolve() / "refiner" / "refiner-tv-work")
     assert Path(got).is_absolute()
+
+
+def test_legacy_movie_default_is_treated_as_default(tmp_path: Path) -> None:
+    row = RefinerPathSettingsRow(id=1, refiner_work_folder=r"C:\ProgramData\Media\refiner-movie-work")
+
+    got, is_default = effective_work_folder(row=row, mediamop_home=str(tmp_path))
+
+    assert is_default is True
+    assert got == str(tmp_path.resolve() / "refiner" / "refiner-movie-work")
 
 
 def test_validate_rejects_nested_watched_and_output(tmp_path: Path) -> None:

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mediamop.windows import tray_app
+
+
+def test_packaged_tray_defaults_to_programdata(monkeypatch) -> None:
+    monkeypatch.delenv("MEDIAMOP_HOME", raising=False)
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Example\AppData\Local")
+
+    assert str(tray_app._runtime_home()).replace("/", "\\") == r"C:\ProgramData\MediaMop"
+
+
+def test_packaged_tray_falls_back_to_machine_programdata_path(monkeypatch) -> None:
+    monkeypatch.delenv("MEDIAMOP_HOME", raising=False)
+    monkeypatch.delenv("PROGRAMDATA", raising=False)
+    monkeypatch.setenv("LOCALAPPDATA", r"C:\Users\Example\AppData\Local")
+
+    assert str(tray_app._runtime_home()).replace("/", "\\") == r"C:\ProgramData\MediaMop"
+
+
+def test_packaged_tray_honors_explicit_mediamop_home(monkeypatch, tmp_path: Path) -> None:
+    explicit = tmp_path / "custom-home"
+    monkeypatch.setenv("MEDIAMOP_HOME", str(explicit))
+    monkeypatch.setenv("PROGRAMDATA", r"C:\ProgramData")
+
+    assert tray_app._runtime_home() == explicit.resolve()
+
+
+def test_inno_installer_uses_program_files_and_programdata() -> None:
+    installer = Path(__file__).resolve().parents[3] / "packaging" / "windows" / "MediaMop.iss"
+    text = installer.read_text(encoding="utf-8")
+
+    assert "DefaultDirName={autopf}\\MediaMop" in text
+    assert "PrivilegesRequired=admin" in text
+    assert 'Name: "{commonappdata}\\MediaMop"; Permissions: users-modify' in text
+    assert "{localappdata}\\MediaMop" not in text
+    assert "{userdesktop}\\MediaMop" not in text

--- a/apps/web/src/pages/refiner/refiner-page.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.test.tsx
@@ -17,20 +17,20 @@ import { RefinerPage } from "./refiner-page";
 
 const operatorMe: UserPublic = { id: 1, username: "alice", role: "operator" };
 
-/** Seeded path API shape — matches Windows product defaults from the backend. */
+/** Seeded path API shape: default work folders live under MediaMop runtime data. */
 const minimalRefinerPathSettings: RefinerPathSettingsOut = {
   refiner_watched_folder: null,
   refiner_watched_folder_exists: false,
   refiner_work_folder: null,
   refiner_output_folder: "",
-  resolved_default_work_folder: "C:\\ProgramData\\Media\\refiner-movie-work",
-  effective_work_folder: "C:\\ProgramData\\Media\\refiner-movie-work",
+  resolved_default_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
+  effective_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
   refiner_tv_watched_folder: null,
   refiner_tv_watched_folder_exists: false,
   refiner_tv_work_folder: null,
   refiner_tv_output_folder: null,
-  resolved_default_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner-tv-work",
-  effective_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner-tv-work",
+  resolved_default_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
+  effective_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
   movie_watched_folder_check_interval_seconds: 300,
   tv_watched_folder_check_interval_seconds: 300,
   updated_at: "2026-04-11T00:00:00Z",

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -72,7 +72,7 @@ On-disk runtime defaults must **not** be tied to “the Git clone directory” o
 
 - **`MEDIAMOP_HOME`** (optional): explicit absolute root for product-owned data. Loaded into `MediaMopSettings.mediamop_home`.
 - **Default when unset:**
-  - **Windows:** `%LOCALAPPDATA%\MediaMop`
+  - **Windows:** `%PROGRAMDATA%\MediaMop` (normally `C:\ProgramData\MediaMop`)
   - **Linux/macOS:** `$XDG_DATA_HOME/mediamop`, or `~/.local/share/mediamop`
 
 The default SQLite file is **`{MEDIAMOP_HOME}/data/mediamop.sqlite3`** unless **`MEDIAMOP_DB_PATH`** overrides.

--- a/docs/release.md
+++ b/docs/release.md
@@ -72,9 +72,10 @@ After installing it:
 1. Launch `MediaMop` from the Start Menu or desktop shortcut.
 2. MediaMop starts in the user session, not as a Windows service.
 3. The tray icon opens the local app in the browser and exposes `Open MediaMop`, `Open Data Folder`, and `Quit`.
-4. The local runtime root is created under `%LOCALAPPDATA%\MediaMop`.
+4. Application binaries install under `C:\Program Files\MediaMop`.
+5. The local runtime root is created under `C:\ProgramData\MediaMop`.
 
-This design is intentional. Running in the user session avoids common NAS or external-drive access issues that affect Windows services.
+This design is intentional. Running in the user session avoids common NAS or external-drive access issues that affect Windows services, while keeping writable configuration, logs, backups, and the SQLite database out of the protected application install directory.
 
 ## Docker
 

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -25,6 +25,7 @@ This checklist defines the current practical hardening baseline for MediaMop.
 - `main` is protected by GitHub rules.
 - Required checks are `mediamop`, `docker-smoke`, and `windows-package-smoke`.
 - Dependabot is enabled for Python and GitHub Actions dependencies.
+- CodeQL code scanning runs on `main`, pull requests to `main`, weekly schedule, and manual dispatch.
 - Security vulnerabilities are reported privately through `SECURITY.md`.
 - Public issues are not used for unpatched vulnerabilities.
 
@@ -41,6 +42,7 @@ Run this list before any major release:
 
 1. Confirm no secrets or runtime files are staged.
 2. Confirm dependency audit jobs pass.
-3. Confirm auth setup, login, logout, and password validation smoke tests pass.
-4. Confirm backup files do not expose secrets in public docs, logs, or screenshots.
-5. Confirm activity/log views do not expose tokens or internal implementation details to normal users.
+3. Confirm CodeQL has no open high-confidence security findings.
+4. Confirm auth setup, login, logout, and password validation smoke tests pass.
+5. Confirm backup files do not expose secrets in public docs, logs, or screenshots.
+6. Confirm activity/log views do not expose tokens or internal implementation details to normal users.

--- a/docs/smoke-checklists.md
+++ b/docs/smoke-checklists.md
@@ -7,26 +7,28 @@ These checklists define the minimum user-level validation before calling a relea
 Use `MediaMopSetup.exe` from the release being validated.
 
 1. Install MediaMop on a clean Windows user profile or a reset test profile.
-2. Launch MediaMop from the Start Menu shortcut.
-3. Confirm the tray icon appears and the browser opens the app.
-4. Confirm first-run user creation appears when no user exists.
-5. Attempt a password shorter than 8 characters and confirm it is blocked.
-6. Create the first user with a valid password.
-7. Confirm the setup wizard opens after first-user creation.
-8. Confirm `Skip for now` exits the wizard and can be reopened from Settings.
-9. Confirm `Finish setup` saves timezone, display density, backup schedule, and starter module settings.
-10. In Settings, confirm setup wizard, timezone, log retention, and display density cards render correctly.
-11. Confirm Backup and Restore controls sit consistently at the bottom of their cards.
-12. Create a configuration backup.
-13. Restore that backup and confirm the app remains usable.
-14. Confirm Upgrade shows a meaningful status, even when no update is available.
-15. Open Refiner path inputs and use Browse for a local folder.
-16. Enter a UNC-style path manually and confirm validation warns without blocking legitimate save paths by design.
-17. Confirm Pruner and Subber settings can save required connection/path fields without exposing internal webhook controls.
-18. Quit MediaMop from the tray icon.
-19. Relaunch MediaMop and confirm the existing user, settings, and wizard completion state persist.
-20. Install the next version over the current version and confirm this is treated as an upgrade, not a first-run install.
-21. Uninstall and reinstall only when intentionally testing clean-install behavior.
+2. Confirm application files install under `C:\Program Files\MediaMop`, not a user profile.
+3. Confirm runtime data is created under `C:\ProgramData\MediaMop`, not `AppData\Local`.
+4. Launch MediaMop from the Start Menu shortcut.
+5. Confirm the tray icon appears and the browser opens the app.
+6. Confirm first-run user creation appears when no user exists.
+7. Attempt a password shorter than 8 characters and confirm it is blocked.
+8. Create the first user with a valid password.
+9. Confirm the setup wizard opens after first-user creation.
+10. Confirm `Skip for now` exits the wizard and can be reopened from Settings.
+11. Confirm `Finish setup` saves timezone, display density, backup schedule, and starter module settings.
+12. In Settings, confirm setup wizard, timezone, log retention, and display density cards render correctly.
+13. Confirm Backup and Restore controls sit consistently at the bottom of their cards.
+14. Create a configuration backup.
+15. Restore that backup and confirm the app remains usable.
+16. Confirm Upgrade shows a meaningful status, even when no update is available.
+17. Open Refiner path inputs and use Browse for a local folder.
+18. Enter a UNC-style path manually and confirm validation warns without blocking legitimate save paths by design.
+19. Confirm Pruner and Subber settings can save required connection/path fields without exposing internal webhook controls.
+20. Quit MediaMop from the tray icon.
+21. Relaunch MediaMop and confirm the existing user, settings, and wizard completion state persist.
+22. Install the next version over the current version and confirm this is treated as an upgrade, not a first-run install.
+23. Uninstall and reinstall only when intentionally testing clean-install behavior.
 
 ## Docker smoke
 

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -16,14 +16,14 @@ AppId={{F8AB6B61-0A66-4B7A-BC41-7EF0D2FA5126}
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher={#Publisher}
-DefaultDirName={localappdata}\MediaMop
+DefaultDirName={autopf}\MediaMop
 DefaultGroupName=MediaMop
 OutputDir={#OutputRoot}
 OutputBaseFilename=MediaMopSetup
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-PrivilegesRequired=lowest
+PrivilegesRequired=admin
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 UninstallDisplayIcon={app}\{#ExeName}
@@ -31,12 +31,15 @@ UninstallDisplayIcon={app}\{#ExeName}
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"
 
+[Dirs]
+Name: "{commonappdata}\MediaMop"; Permissions: users-modify
+
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{group}\MediaMop"; Filename: "{app}\{#ExeName}"
-Name: "{userdesktop}\MediaMop"; Filename: "{app}\{#ExeName}"; Tasks: desktopicon
+Name: "{commondesktop}\MediaMop"; Filename: "{app}\{#ExeName}"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall skipifsilent

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "mediamop-scripts",
       "dependencies": {
-        "playwright": "1.49.1"
+        "playwright": "^1.59.1"
       }
     },
     "node_modules/fsevents": {
@@ -24,12 +24,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
-      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.49.1"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.49.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
-      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "description": "Optional tooling deps for maintainer scripts (e.g. Playwright screenshots).",
   "dependencies": {
-    "playwright": "1.49.1"
+    "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
﻿## What changed

- Adds GitHub CodeQL code scanning for Python and JavaScript/TypeScript.
- Runs CodeQL on pushes to `main`, pull requests to `main`, weekly schedule, and manual dispatch.
- Documents CodeQL in the security hardening baseline.
- Keeps the Windows installer/runtime changes aligned to per-machine installation and `ProgramData` runtime data.

## Validation

- Parsed all GitHub workflow YAML files successfully.
- Backend path/refiner/package tests: `36 passed`.
- Web Refiner tests: `14 passed`.
- `git diff --check` passed.
- Full Windows package rebuild completed and produced `dist/windows/MediaMopSetup.exe`.
