### PR TITLE
Tighten CodeQL security hardening

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: MediaMop CodeQL security scan
+
+paths:
+  - apps/backend/src
+  - apps/web/src
+
+paths-ignore:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,8 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
+          queries: security-extended
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v4

--- a/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
@@ -29,7 +29,7 @@ def _get(path: str) -> dict[str, Any] | None:
             parsed = json.loads(raw)
             return parsed if isinstance(parsed, dict) else None
     except Exception:
-        logger.exception("SubDL request failed: %s", url)
+        logger.exception("SubDL request failed.")
         return None
 
 

--- a/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import base64
 import binascii
-import hashlib
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from mediamop.core.config import MediaMopSettings
 
@@ -14,14 +15,20 @@ from mediamop.core.config import MediaMopSettings
 _ARR_API_KEY_KDF_PEPPER = binascii.a2b_hex(
     "6d656469616d6f702e666574636865722e6172725f6170695f6b65792e76317c"
 )
+_ARR_API_KEY_KDF_ITERATIONS = 390_000
 
 
 def _fernet(settings: MediaMopSettings) -> Fernet | None:
     secret = (settings.session_secret or "").strip()
     if not secret:
         return None
-    digest = hashlib.sha256(_ARR_API_KEY_KDF_PEPPER + secret.encode()).digest()
-    key = base64.urlsafe_b64encode(digest)
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_ARR_API_KEY_KDF_PEPPER,
+        iterations=_ARR_API_KEY_KDF_ITERATIONS,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(secret.encode("utf-8")))
     return Fernet(key)
 
 

--- a/apps/backend/src/mediamop/platform/arr_library/arr_v3_http.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_v3_http.py
@@ -13,15 +13,26 @@ class ArrLibraryV3HttpError(RuntimeError):
     """Raised when an Arr HTTP call fails."""
 
 
+def _validated_base_url(raw: str) -> str:
+    parsed = urllib.parse.urlsplit(raw.strip().rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ArrLibraryV3HttpError("Sonarr/Radarr base URL must be a valid http(s) URL.")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ArrLibraryV3HttpError("Sonarr/Radarr base URL must not include credentials, query strings, or fragments.")
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+
 class ArrLibraryV3Client:
     """Narrow surface: health, wanted pages, catalog walks, tags, commands."""
 
     def __init__(self, base_url: str, api_key: str, *, timeout_seconds: float = 30.0) -> None:
-        self._base = base_url.rstrip("/")
+        self._base = _validated_base_url(base_url)
         self._api_key = api_key
         self._timeout = timeout_seconds
 
     def _url(self, path: str, params: dict[str, str] | None = None) -> str:
+        if urllib.parse.urlsplit(path).scheme:
+            raise ArrLibraryV3HttpError("Sonarr/Radarr API path must be relative.")
         p = path if path.startswith("/") else f"/{path}"
         u = f"{self._base}{p}"
         if params:

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -79,7 +79,7 @@ def post_login(
         settings=settings,
     )
     if result is None:
-        logger.warning("auth event: login failed (username=%s)", uname)
+        logger.warning("auth event: login failed")
         activity_service.maybe_record_login_failed(db, username=uname)
         db.commit()
         raise HTTPException(
@@ -87,7 +87,7 @@ def post_login(
             detail="Invalid username or password.",
         )
     user, raw = result
-    logger.info("auth event: login succeeded (user_id=%s username=%s)", user.id, user.username)
+    logger.info("auth event: login succeeded (user_id=%s)", user.id)
     activity_service.record_activity_event(
         db,
         event_type=activity_constants.AUTH_LOGIN_SUCCEEDED,
@@ -224,9 +224,8 @@ def post_bootstrap(
             detail="Username already exists.",
         ) from exc
     logger.info(
-        "auth event: bootstrap succeeded (user_id=%s username=%s)",
+        "auth event: bootstrap succeeded (user_id=%s)",
         user.id,
-        user.username,
     )
     activity_service.record_activity_event(
         db,
@@ -328,7 +327,7 @@ def post_change_password(
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-    logger.info("auth event: password changed (user_id=%s username=%s)", user.id, user.username)
+    logger.info("auth event: password changed (user_id=%s)", user.id)
     activity_service.record_activity_event(
         db,
         event_type=activity_constants.AUTH_PASSWORD_CHANGED,

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
@@ -41,7 +41,14 @@ def get_suite_configuration_backup_file_path(
     row = session.get(SuiteConfigurationBackupRow, int(backup_id))
     if row is None:
         raise ValueError("Configuration snapshot not found.")
-    p = _backup_dir(settings) / row.file_name
+    if Path(row.file_name).name != row.file_name or not row.file_name.startswith("suite-configuration-"):
+        raise ValueError("Configuration snapshot file name is invalid.")
+    backup_root = _backup_dir(settings)
+    p = (backup_root / row.file_name).resolve()
+    try:
+        p.relative_to(backup_root)
+    except ValueError as exc:
+        raise ValueError("Configuration snapshot path is outside the backup directory.") from exc
     if not p.is_file():
         raise ValueError("Configuration snapshot file is missing on disk.")
     return p, row

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -79,9 +79,27 @@ def _ensure_session_secret(runtime_home: Path) -> str:
         if len(existing) >= 32:
             return existing
     runtime_home.mkdir(parents=True, exist_ok=True)
-    secret = secrets.token_urlsafe(48)
-    secret_path.write_text(secret, encoding="utf-8")
-    return secret
+    token = secrets.token_urlsafe(48)
+    _write_private_runtime_token(secret_path, token)
+    return token
+
+
+def _write_private_runtime_token(path: Path, value: str) -> None:
+    """Persist the local session token with owner-only permissions where supported."""
+
+    if os.name == "nt":
+        path.write_text(value, encoding="utf-8")
+        return
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(value)
+    finally:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
 
 
 def _prepare_environment(resource_root: Path, runtime_home: Path) -> Path:

--- a/apps/backend/tests/test_arr_v3_http_security.py
+++ b/apps/backend/tests/test_arr_v3_http_security.py
@@ -1,0 +1,28 @@
+"""Security guardrails for the Sonarr/Radarr v3 HTTP client."""
+
+from __future__ import annotations
+
+import pytest
+
+from mediamop.platform.arr_library.arr_v3_http import ArrLibraryV3Client, ArrLibraryV3HttpError
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "ftp://127.0.0.1:8989",
+        "http://user:pass@127.0.0.1:8989",
+        "http://127.0.0.1:8989/?x=1",
+        "http://127.0.0.1:8989/#fragment",
+    ],
+)
+def test_arr_v3_client_rejects_unsafe_base_urls(base_url: str) -> None:
+    with pytest.raises(ArrLibraryV3HttpError):
+        ArrLibraryV3Client(base_url, "api-key")
+
+
+def test_arr_v3_client_rejects_absolute_api_paths() -> None:
+    client = ArrLibraryV3Client("http://127.0.0.1:8989", "api-key")
+
+    with pytest.raises(ArrLibraryV3HttpError):
+        client.get_json("http://169.254.169.254/latest/meta-data/")

--- a/apps/backend/tests/test_suite_configuration_backup_security.py
+++ b/apps/backend/tests/test_suite_configuration_backup_security.py
@@ -1,0 +1,25 @@
+"""Security guardrails for saved configuration snapshot downloads."""
+
+from __future__ import annotations
+
+import pytest
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.platform.suite_settings.suite_configuration_backup_model import SuiteConfigurationBackupRow
+from mediamop.platform.suite_settings.suite_configuration_backup_service import get_suite_configuration_backup_file_path
+
+
+def test_configuration_backup_download_rejects_path_traversal_file_name() -> None:
+    settings = MediaMopSettings.load()
+    factory = create_session_factory(create_db_engine(settings))
+
+    with factory() as db:
+        row = SuiteConfigurationBackupRow(file_name="../outside.json", size_bytes=2)
+        db.add(row)
+        db.commit()
+        backup_id = row.id
+
+    with factory() as db:
+        with pytest.raises(ValueError, match="file name is invalid"):
+            get_suite_configuration_backup_file_path(db, settings=settings, backup_id=backup_id)


### PR DESCRIPTION
## Summary
- limits CodeQL to source security scanning instead of quality/test noise
- hardens ARR URL validation, auth logging, SubDL error logging, backup download path resolution, local runtime token file permissions, and ARR API key derivation
- adds focused security regression tests

## Validation
- .\\apps\\backend\\.venv\\Scripts\\python.exe -m pytest apps\\backend\\tests\\test_arr_v3_http_security.py apps\\backend\\tests\\test_suite_configuration_backup_security.py apps\\backend\\tests\\test_configuration_bundle_api.py apps\\backend\\tests\\test_local_browse_api.py apps\\backend\\tests\\test_windows_packaging_paths.py
- cd apps\\backend; .\\.venv\\Scripts\\python.exe -m pytest tests
- workflow YAML parse check
- git diff --check