### PR TITLE
Fix Windows packaged startup smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,6 @@ jobs:
         env:
           MEDIAMOP_BUILD_VERSION: ci-${{ github.run_number }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
+
+      - name: Smoke test packaged Windows server
+        run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,9 @@ jobs:
           MEDIAMOP_BUILD_VERSION: ${{ github.ref_name }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
+      - name: Smoke test packaged Windows server
+        run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1
+
       - name: Upload MediaMop Windows installer
         uses: actions/upload-artifact@v7
         with:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.6"
+version = "1.0.7"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/core/alembic_revision_check.py
+++ b/apps/backend/src/mediamop/core/alembic_revision_check.py
@@ -5,6 +5,7 @@ Shared by API startup and ``scripts/verify_local_db.py``.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from alembic import command
@@ -34,6 +35,9 @@ def _manual_migration_instructions() -> str:
 
 
 def _backend_root() -> Path:
+    packaged_root = (os.environ.get("MEDIAMOP_ALEMBIC_ROOT") or "").strip()
+    if packaged_root:
+        return Path(packaged_root).expanduser().resolve()
     return Path(__file__).resolve().parents[3]
 
 

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -110,6 +110,7 @@ def _prepare_environment(resource_root: Path, runtime_home: Path) -> Path:
     os.environ["MEDIAMOP_ENV"] = "production"
     os.environ["MEDIAMOP_HOME"] = str(runtime_home)
     os.environ["MEDIAMOP_WEB_DIST"] = str(web_dist)
+    os.environ["MEDIAMOP_ALEMBIC_ROOT"] = str(resource_root)
     os.environ["MEDIAMOP_SESSION_COOKIE_SECURE"] = "false"
     os.environ["MEDIAMOP_SESSION_SECRET"] = _ensure_session_secret(runtime_home)
     return web_dist
@@ -269,6 +270,7 @@ def _run_server_mode(port: int) -> None:
     resource_root = _resource_root()
     runtime_home = _runtime_home()
     _prepare_environment(resource_root, runtime_home)
+    _run_migrations(resource_root)
     app = create_app()
     server = uvicorn.Server(
         uvicorn.Config(

--- a/apps/backend/tests/test_alembic_revision_startup.py
+++ b/apps/backend/tests/test_alembic_revision_startup.py
@@ -13,7 +13,7 @@ from alembic.script import ScriptDirectory
 from starlette.testclient import TestClient
 
 from mediamop.api.factory import create_app
-from mediamop.core.alembic_revision_check import DatabaseSchemaMismatch, ensure_database_at_application_head
+from mediamop.core.alembic_revision_check import DatabaseSchemaMismatch, _script_and_head, ensure_database_at_application_head
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine
 
@@ -127,3 +127,13 @@ def test_api_startup_auto_upgrades_known_behind_revision_to_head(
     with engine.connect() as conn:
         ctx = MigrationContext.configure(conn)
         assert ctx.get_current_revision() == head
+
+
+def test_alembic_root_env_supports_packaged_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    backend = Path(__file__).resolve().parents[1]
+    monkeypatch.setenv("MEDIAMOP_ALEMBIC_ROOT", str(backend))
+
+    script, head = _script_and_head()
+
+    assert head
+    assert script.dir == str(backend / "alembic")

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/scripts/smoke-windows-package.ps1
+++ b/scripts/smoke-windows-package.ps1
@@ -1,0 +1,98 @@
+param(
+  [string]$PackageDir = "",
+  [int]$Port = 8799
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $PackageDir) {
+  $PackageDir = Join-Path $repoRoot "dist\windows\MediaMop"
+}
+$packagePath = (Resolve-Path -LiteralPath $PackageDir).Path
+$serverExe = Join-Path $packagePath "MediaMopServer.exe"
+$webIndex = Join-Path $packagePath "_internal\web-dist\index.html"
+
+if (-not (Test-Path -LiteralPath $serverExe)) {
+  throw "Packaged server executable not found: $serverExe"
+}
+if (-not (Test-Path -LiteralPath $webIndex)) {
+  throw "Packaged web index not found: $webIndex"
+}
+$indexText = Get-Content -LiteralPath $webIndex -Raw
+if ($indexText -notmatch "MediaMop") {
+  throw "Packaged web index does not look like MediaMop."
+}
+
+$runtimeHome = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-package-smoke-" + [System.Guid]::NewGuid().ToString("N"))
+$stdout = Join-Path $runtimeHome "server.stdout.log"
+$stderr = Join-Path $runtimeHome "server.stderr.log"
+New-Item -ItemType Directory -Path $runtimeHome | Out-Null
+
+$oldHome = $env:MEDIAMOP_HOME
+$oldSecret = $env:MEDIAMOP_SESSION_SECRET
+$oldEnv = $env:MEDIAMOP_ENV
+$oldWebDist = $env:MEDIAMOP_WEB_DIST
+$oldAlembicRoot = $env:MEDIAMOP_ALEMBIC_ROOT
+$proc = $null
+
+try {
+  $env:MEDIAMOP_HOME = $runtimeHome
+  $env:MEDIAMOP_SESSION_SECRET = "ci-mediamop-session-secret-32chars-min"
+  Remove-Item Env:\MEDIAMOP_ENV -ErrorAction SilentlyContinue
+  Remove-Item Env:\MEDIAMOP_WEB_DIST -ErrorAction SilentlyContinue
+  Remove-Item Env:\MEDIAMOP_ALEMBIC_ROOT -ErrorAction SilentlyContinue
+
+  $proc = Start-Process -FilePath $serverExe `
+    -ArgumentList @("--serve", "--port", [string]$Port) `
+    -WorkingDirectory $packagePath `
+    -RedirectStandardOutput $stdout `
+    -RedirectStandardError $stderr `
+    -WindowStyle Hidden `
+    -PassThru
+
+  $healthUrl = "http://127.0.0.1:$Port/health"
+  $deadline = (Get-Date).AddSeconds(45)
+  do {
+    if ($proc.HasExited) {
+      throw "Packaged MediaMop server exited early with code $($proc.ExitCode)."
+    }
+    try {
+      $response = Invoke-RestMethod -Uri $healthUrl -Method Get -TimeoutSec 2
+      if ($response.status -eq "ok") {
+        Write-Host "Packaged MediaMop server health check passed on $healthUrl"
+        exit 0
+      }
+    } catch {
+      Start-Sleep -Milliseconds 500
+    }
+  } while ((Get-Date) -lt $deadline)
+
+  throw "Packaged MediaMop server did not become healthy at $healthUrl."
+} catch {
+  Write-Host "Packaged server smoke failed."
+  if (Test-Path -LiteralPath $stdout) {
+    Write-Host "--- stdout ---"
+    Get-Content -LiteralPath $stdout -Tail 200
+  }
+  if (Test-Path -LiteralPath $stderr) {
+    Write-Host "--- stderr ---"
+    Get-Content -LiteralPath $stderr -Tail 200
+  }
+  $logPath = Join-Path $runtimeHome "logs\mediamop.log"
+  if (Test-Path -LiteralPath $logPath) {
+    Write-Host "--- mediamop.log ---"
+    Get-Content -LiteralPath $logPath -Tail 200
+  }
+  throw
+} finally {
+  if ($proc -and -not $proc.HasExited) {
+    Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+  }
+  if ($null -ne $oldHome) { $env:MEDIAMOP_HOME = $oldHome } else { Remove-Item Env:\MEDIAMOP_HOME -ErrorAction SilentlyContinue }
+  if ($null -ne $oldSecret) { $env:MEDIAMOP_SESSION_SECRET = $oldSecret } else { Remove-Item Env:\MEDIAMOP_SESSION_SECRET -ErrorAction SilentlyContinue }
+  if ($null -ne $oldEnv) { $env:MEDIAMOP_ENV = $oldEnv } else { Remove-Item Env:\MEDIAMOP_ENV -ErrorAction SilentlyContinue }
+  if ($null -ne $oldWebDist) { $env:MEDIAMOP_WEB_DIST = $oldWebDist } else { Remove-Item Env:\MEDIAMOP_WEB_DIST -ErrorAction SilentlyContinue }
+  if ($null -ne $oldAlembicRoot) { $env:MEDIAMOP_ALEMBIC_ROOT = $oldAlembicRoot } else { Remove-Item Env:\MEDIAMOP_ALEMBIC_ROOT -ErrorAction SilentlyContinue }
+  Remove-Item -LiteralPath $runtimeHome -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- fixes packaged Windows backend schema verification by pointing packaged processes at bundled Alembic files
- makes MediaMopServer run bundled migrations before app startup, so fresh packaged runtimes can start cleanly
- adds a Windows package smoke script that launches MediaMopServer.exe and verifies /health
- wires that packaged runtime smoke into CI and release workflows
- bumps release version to 1.0.7 because v1.0.6 Windows installer is bad

## Local validation
- apps/backend: pytest tests (610 passed, 2 skipped)
- apps/web: npm run build && npm run test (132 passed)
- E2E: pytest tests/e2e/mediamop (5 passed)
- Windows package rebuild: packaging/windows/build.ps1 -SkipWebBuild
- Packaged server smoke: scripts/smoke-windows-package.ps1
- workflow YAML parse
- git diff --check