### PR TITLE
MediaMop 1.0.10 installer close apps

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.9"
+version = "1.0.10"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -43,6 +43,11 @@ def test_inno_installer_uses_program_files_and_programdata() -> None:
     assert "DisableDirPage=no" in text
     assert "DisableProgramGroupPage=no" in text
     assert "DisableReadyPage=no" in text
+    assert "CloseApplications=no" in text
+    assert "RestartApplications=no" in text
+    assert "taskkill.exe" in text
+    assert "MediaMop.exe" in text
+    assert "MediaMopServer.exe" in text
 
 
 def test_windows_package_uses_dedicated_tray_icon_assets() -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.9",
+  "version": "1.0.10",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -27,6 +27,8 @@ DisableWelcomePage=no
 DisableDirPage=no
 DisableProgramGroupPage=no
 DisableReadyPage=no
+CloseApplications=no
+RestartApplications=no
 PrivilegesRequired=admin
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
@@ -48,3 +50,26 @@ Name: "{commondesktop}\MediaMop"; Filename: "{app}\{#ExeName}"; Tasks: desktopic
 
 [Run]
 Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall skipifsilent
+
+[Code]
+procedure StopMediaMopProcess(ProcessName: String);
+var
+  ResultCode: Integer;
+begin
+  Exec(
+    ExpandConstant('{sys}\taskkill.exe'),
+    '/F /T /IM "' + ProcessName + '"',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  );
+end;
+
+function PrepareToInstall(var NeedsRestart: Boolean): String;
+begin
+  StopMediaMopProcess('MediaMop.exe');
+  StopMediaMopProcess('MediaMopServer.exe');
+  Sleep(1000);
+  Result := '';
+end;


### PR DESCRIPTION
## Summary
- release MediaMop 1.0.10
- replace Inno's unreliable close-app prompt with explicit shutdown of MediaMop tray and server processes before install
- keep the installer from trying to restart stale processes itself; MediaMop relaunch remains controlled by the existing post-install launch step
- add packaging assertions so the installer shutdown behavior is covered

## Validation
- .\.venv\Scripts\python.exe -m pytest tests\test_windows_packaging_paths.py
- npm run build
- powershell -ExecutionPolicy Bypass -File packaging\windows\build.ps1
- powershell -ExecutionPolicy Bypass -File scripts\smoke-windows-package.ps1
