### PR TITLE
MediaMop 1.0.11 refiner workflow

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.10"
+version = "1.0.11"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -290,7 +290,7 @@ class MediaMopSettings:
         )
         refiner_wf_scan_periodic_remux_enq = _env_bool(
             "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS",
-            False,
+            True,
         )
         refiner_probe_size_mb = max(1, min(1024, _env_int("MEDIAMOP_REFINER_PROBE_SIZE_MB", 10)))
         refiner_analyze_duration_seconds = max(

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
@@ -13,7 +13,6 @@ from mediamop.platform.arr_library import resolve_radarr_http_credentials, resol
 from mediamop.modules.refiner.domain import (
     FileAnchorCandidate,
     RefinerQueueRowView,
-    file_is_owned_by_queue,
     should_block_for_upstream,
 )
 from mediamop.modules.refiner.radarr_queue_adapter import map_radarr_queue_row_to_refiner_view
@@ -43,13 +42,13 @@ def merge_queue_views_for_watched_file(
 
 
 def verdict_for_watched_scan_file(views: Sequence[RefinerQueueRowView], *, candidate: FileAnchorCandidate) -> Verdict:
-    """Same applicability as :func:`file_is_owned_by_queue` / :func:`should_block_for_upstream` on merged queues."""
+    """Decide whether a watched-folder file can be processed.
 
-    if not views:
-        return "not_held"
-    owned = file_is_owned_by_queue(views, file_candidate=candidate)
-    if not owned:
-        return "not_held"
+    Radarr/Sonarr are safety signals only. Refiner must still process files when
+    those apps are not configured, or when the file is not currently in their
+    active queue.
+    """
+
     if should_block_for_upstream(views, file_candidate=candidate):
         return "wait_upstream"
     return "proceed"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -81,6 +81,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             "job_id": ctx.id,
             "scan_trigger": scan_trigger,
             "media_scope": media_scope,
+            "scan_result_label": "Watched folder checked",
             "watched_folder_resolved": watched_root,
             "enqueue_remux_jobs": enqueue_remux_jobs,
             "min_file_age_seconds": op_settings.min_file_age_seconds,
@@ -95,6 +96,8 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             "remux_jobs_enqueued": 0,
             "skipped_duplicate_same_scan": 0,
             "skipped_duplicate_active_queue": 0,
+            "user_message": "",
+            "waiting_message": None,
             "enqueued_relative_paths_sample": sample_paths,
         }
 
@@ -150,6 +153,39 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                     summary["remux_jobs_enqueued"] += 1
                     if len(sample_paths) < sample_cap:
                         sample_paths.append(rel)
+
+                queued = int(summary["remux_jobs_enqueued"])
+                waiting = int(summary["verdict_wait_upstream"])
+                seen = int(summary["media_candidates_seen"])
+                duplicates = int(summary["skipped_duplicate_same_scan"]) + int(summary["skipped_duplicate_active_queue"])
+                if queued:
+                    summary["scan_result_label"] = "Files added to Refiner"
+                    summary["user_message"] = (
+                        f"{queued} file{' was' if queued == 1 else 's were'} added to Refiner for processing."
+                    )
+                elif waiting:
+                    summary["scan_result_label"] = "Waiting for files to finish"
+                    summary["user_message"] = (
+                        f"{waiting} file{' looks' if waiting == 1 else 's look'} like it is still being copied or imported, "
+                        "so MediaMop left it alone for now."
+                    )
+                    summary["waiting_message"] = "MediaMop will check again on the next scheduled scan."
+                elif seen and not enqueue_remux_jobs:
+                    summary["scan_result_label"] = "Folder checked only"
+                    summary["user_message"] = (
+                        f"{seen} media file{' was' if seen == 1 else 's were'} found, but this scan was set to check only."
+                    )
+                elif seen and duplicates:
+                    summary["scan_result_label"] = "Already queued"
+                    summary["user_message"] = (
+                        "MediaMop found matching media files, but they were already waiting for Refiner."
+                    )
+                elif seen:
+                    summary["scan_result_label"] = "No new Refiner work"
+                    summary["user_message"] = "MediaMop found media files, but there was nothing new to queue."
+                else:
+                    summary["scan_result_label"] = "No media found"
+                    summary["user_message"] = "MediaMop did not find any media files in this watched folder."
 
                 detail = format_scan_summary_for_activity(summary)
                 record_refiner_watched_folder_remux_scan_dispatch_completed(session, detail=detail)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_watched_folder_remux_scan_dispatch_manual.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_watched_folder_remux_scan_dispatch_manual.py
@@ -8,16 +8,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class RefinerWatchedFolderRemuxScanDispatchManualEnqueueIn(BaseModel):
-    """Queue one watched-folder scan; optional enqueue of per-file ``refiner.file.remux_pass.v1`` rows."""
+    """Queue one watched-folder scan."""
 
     model_config = ConfigDict(extra="forbid")
 
     csrf_token: str = Field(..., min_length=1)
     enqueue_remux_jobs: bool = Field(
-        default=False,
+        default=True,
         description=(
-            "When false (default), the scan only classifies files and writes one activity summary — "
-            "no remux jobs are queued. When true, eligible files (verdict proceed) also enqueue remux jobs."
+            "When true, files found in the watched folder are added to Refiner's processing queue. "
+            "When false, MediaMop only checks the folder and writes an activity summary."
         ),
     )
     media_scope: Literal["movie", "tv"] = Field(

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_evaluate.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_evaluate.py
@@ -11,13 +11,25 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_evaluat
 )
 
 
-def test_verdict_not_held_when_no_queue_rows(tmp_path) -> None:
+def test_verdict_proceeds_when_no_queue_rows(tmp_path) -> None:
     d = tmp_path / "root"
     d.mkdir()
     f = d / "Gate Test 2001.mkv"
     f.write_bytes(b"1")
     v = merge_queue_views_for_watched_file(radarr_rows=[], sonarr_rows=[], file_path=f)
-    assert verdict_for_watched_scan_file(v, candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "not_held"
+    assert verdict_for_watched_scan_file(v, candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "proceed"
+
+
+def test_verdict_proceeds_when_unrelated_queue_row_exists() -> None:
+    f = Path("/movies/Gate Test 2001.mkv")
+    row = RefinerQueueRowView(
+        applies_to_file=False,
+        is_upstream_active=True,
+        is_import_pending=False,
+        queue_title="Different Movie",
+        queue_year=2001,
+    )
+    assert verdict_for_watched_scan_file([row], candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "proceed"
 
 
 def test_verdict_proceed_when_owned_and_not_blocked() -> None:

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
@@ -91,7 +91,7 @@ def test_scan_handler_enqueues_remux_when_requested(
                 id=1,
                 refiner_watched_folder=str(watch.resolve()),
                 refiner_work_folder=None,
-                    refiner_output_folder=str(out.resolve()),
+                refiner_output_folder=str(out.resolve()),
             ),
         )
         s.merge(RefinerOperatorSettingsRow(id=1, min_file_age_seconds=0))
@@ -144,4 +144,81 @@ def test_scan_handler_enqueues_remux_when_requested(
         detail = json.loads(ev.detail or "{}")
         assert detail.get("verdict_proceed") == 1
         assert detail.get("remux_jobs_enqueued") == 1
+        assert detail.get("scan_result_label") == "Files added to Refiner"
         assert detail.get("scan_trigger") == "manual"
+
+
+def test_scan_handler_enqueues_remux_without_arr_connections(
+    session_factory,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MEDIAMOP_REFINER_WATCHED_FOLDER_MIN_FILE_AGE_SECONDS", "0")
+    settings = MediaMopSettings.load()
+
+    watch = tmp_path / "watch_no_arr"
+    watch.mkdir()
+    out = tmp_path / "out_no_arr"
+    out.mkdir()
+    mkv = watch / "Standalone Movie 2026.mkv"
+    mkv.write_bytes(b"x")
+
+    def _fake_fetch(_session: Session, _settings: MediaMopSettings):
+        return [], [], "Radarr not configured", "Sonarr not configured"
+
+    with session_factory() as s:
+        s.merge(
+            RefinerPathSettingsRow(
+                id=1,
+                refiner_watched_folder=str(watch.resolve()),
+                refiner_work_folder=None,
+                refiner_output_folder=str(out.resolve()),
+            ),
+        )
+        s.merge(RefinerOperatorSettingsRow(id=1, min_file_age_seconds=0))
+        s.commit()
+
+    with session_factory() as s:
+        refiner_enqueue_or_get_job(
+            s,
+            dedupe_key="refiner.watched_folder.remux_scan_dispatch.v1:no-arr",
+            job_kind=REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
+            payload_json=json.dumps({"enqueue_remux_jobs": True}),
+        )
+        s.commit()
+
+    handlers = build_refiner_job_handlers(settings, session_factory)
+    with patch(
+        "mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_handlers.fetch_radarr_and_sonarr_queue_rows_for_scan",
+        side_effect=_fake_fetch,
+    ):
+        assert (
+            process_one_refiner_job(
+                session_factory,
+                lease_owner="scan-test",
+                job_handlers=handlers,
+                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc),
+                lease_seconds=3600,
+            )
+            == "processed"
+        )
+
+    with session_factory() as s:
+        remux = [
+            j
+            for j in s.scalars(select(RefinerJob)).all()
+            if j.job_kind == "refiner.file.remux_pass.v1"
+        ]
+        assert len(remux) == 1
+        body = json.loads(remux[0].payload_json or "{}")
+        assert body.get("relative_media_path") == "Standalone Movie 2026.mkv"
+        ev = s.scalars(
+            select(ActivityEvent).where(
+                ActivityEvent.event_type == C.REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_COMPLETED,
+            ),
+        ).first()
+        assert ev is not None
+        detail = json.loads(ev.detail or "{}")
+        assert detail.get("verdict_proceed") == 1
+        assert detail.get("remux_jobs_enqueued") == 1
+        assert detail.get("user_message") == "1 file was added to Refiner for processing."

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
@@ -6,6 +6,9 @@ from pathlib import Path
 
 from starlette.testclient import TestClient
 
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.modules.refiner.jobs_model import RefinerJob
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
     REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
 )
@@ -69,3 +72,25 @@ def test_watched_folder_scan_enqueue_ok(client_with_admin: TestClient, tmp_path:
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["job_kind"] == REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND
+
+
+def test_watched_folder_scan_enqueue_defaults_to_processing_files(client_with_admin: TestClient, tmp_path: Path) -> None:
+    _login_admin(client_with_admin)
+    w = tmp_path / "w_scan_api_default"
+    w.mkdir()
+    out = tmp_path / "out_scan_api_default"
+    out.mkdir()
+    _put_paths(client_with_admin, watched=str(w.resolve()), output=str(out.resolve()))
+    tok = fetch_csrf(client_with_admin)
+    r = auth_post(
+        client_with_admin,
+        "/api/v1/refiner/jobs/watched-folder-remux-scan-dispatch/enqueue",
+        json={"csrf_token": tok},
+    )
+    assert r.status_code == 200, r.text
+    job_id = r.json()["job_id"]
+    engine = create_db_engine(MediaMopSettings.load())
+    with create_session_factory(engine)() as db:
+        job = db.get(RefinerJob, job_id)
+        assert job is not None
+        assert '"enqueue_remux_jobs":true' in (job.payload_json or "")

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -37,7 +37,7 @@ def _settings_on() -> MediaMopSettings:
         base,
         refiner_watched_folder_remux_scan_dispatch_schedule_enabled=True,
         refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds=3600,
-        refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=False,
+        refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=True,
     )
 
 
@@ -246,6 +246,7 @@ def test_try_enqueue_periodic_inserts_movie_and_tv_when_both_scopes_ready(tmp_pa
         for r in rows:
             body = json.loads(r.payload_json or "{}")
             assert body.get("scan_trigger") == "periodic"
+            assert body.get("enqueue_remux_jobs") is True
     finally:
         with fac() as db:
             db.execute(delete(RefinerJob))

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.10",
+  "version": "1.0.11",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/pages/activity/activity-page.tsx
+++ b/apps/web/src/pages/activity/activity-page.tsx
@@ -331,7 +331,7 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
   if (ev.event_type === "refiner.supplied_payload_evaluation_completed") {
     return {
       title: "Manual queue check finished",
-      summary: "Queue ownership check",
+      summary: "Download queue safety check",
       detail: ev.detail,
       chip: "Queue check finished",
       tone: "success",
@@ -341,7 +341,7 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
   if (ev.event_type === "refiner.candidate_gate_completed") {
     return {
       title: "Queue check finished",
-      summary: "Queue ownership check",
+      summary: "Download queue safety check",
       detail: ev.detail,
       chip: "Queue check finished",
       tone: "success",
@@ -349,13 +349,30 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
     };
   }
   if (ev.event_type === "refiner.watched_folder_remux_scan_dispatch_completed") {
+    const parsed = parseDetail(ev.detail);
+    const queued = asNumber(parsed?.remux_jobs_enqueued) ?? 0;
+    const seen = asNumber(parsed?.media_candidates_seen) ?? 0;
+    const waiting = asNumber(parsed?.verdict_wait_upstream) ?? 0;
+    const userMessage = asString(parsed?.user_message);
+    const waitingMessage = asString(parsed?.waiting_message);
+    const label = asString(parsed?.scan_result_label);
+    const paths = asStringArray(parsed?.enqueued_relative_paths_sample);
+    const details = [userMessage, waitingMessage, paths.length ? `Added: ${paths.join(", ")}` : null]
+      .filter(Boolean)
+      .join(" ");
     return {
-      title: "Watched-folder scan finished",
-      summary: "Watched-folder scan result",
-      detail: ev.detail,
-      chip: "Scan finished",
-      tone: "success",
-      compact: true,
+      title: label ?? "Watched folder checked",
+      summary: seen
+        ? `${seen} media file${seen === 1 ? "" : "s"} checked`
+        : "No media files found",
+      detail: details || ev.detail,
+      chip: queued
+        ? `${queued} added to Refiner`
+        : waiting
+          ? "Waiting for files"
+          : "Folder checked",
+      tone: waiting ? "warning" : queued ? "success" : "info",
+      compact: false,
     };
   }
   if (ev.event_type === "refiner.work_temp_stale_sweep_completed") {

--- a/apps/web/src/pages/refiner/refiner-page.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.test.tsx
@@ -208,8 +208,8 @@ describe("RefinerPage", () => {
   it("Schedules includes independent TV and Movies scan-now actions", () => {
     renderRefinerPage();
     openTab("Schedules");
-    expect(screen.getByRole("button", { name: "Run TV scan now" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Run Movies scan now" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Scan TV now" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Scan Movies now" })).toBeInTheDocument();
   });
 
   it("Schedules tab has no master scheduled-processing toggle (folder poll is under Libraries)", () => {

--- a/apps/web/src/pages/refiner/refiner-schedules-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-schedules-section.tsx
@@ -248,7 +248,7 @@ export function RefinerSchedulesSection() {
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-4">
             <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">TV</p>
             <p className="mt-1 text-xs text-[var(--mm-text3)]">
-              Queues only the TV watched-folder scan job. Does not queue Movies.
+              Checks the TV watched folder now and adds any ready files to Refiner.
             </p>
             {!tvWatchedSet ? (
               <p className="mt-2 text-xs text-amber-200/90">Save a TV watched folder in Libraries before running this scan.</p>
@@ -269,16 +269,16 @@ export function RefinerSchedulesSection() {
                   disabled: !canQueueManual || !tvWatchedSet || queueTvScan.isPending,
                 })}
                 disabled={!canQueueManual || !tvWatchedSet || queueTvScan.isPending}
-                onClick={() => queueTvScan.mutate({ enqueue_remux_jobs: false, media_scope: "tv" })}
+                onClick={() => queueTvScan.mutate({ enqueue_remux_jobs: true, media_scope: "tv" })}
               >
-                {queueTvScan.isPending ? "Queuing TV scan…" : "Run TV scan now"}
+                {queueTvScan.isPending ? "Starting TV scan..." : "Scan TV now"}
               </button>
             </div>
           </div>
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-4">
             <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Movies</p>
             <p className="mt-1 text-xs text-[var(--mm-text3)]">
-              Queues only the Movies watched-folder scan job. Does not queue TV.
+              Checks the Movies watched folder now and adds any ready files to Refiner.
             </p>
             {!movieWatchedSet ? (
               <p className="mt-2 text-xs text-amber-200/90">Save a Movies watched folder in Libraries before running this scan.</p>
@@ -299,9 +299,9 @@ export function RefinerSchedulesSection() {
                   disabled: !canQueueManual || !movieWatchedSet || queueMovieScan.isPending,
                 })}
                 disabled={!canQueueManual || !movieWatchedSet || queueMovieScan.isPending}
-                onClick={() => queueMovieScan.mutate({ enqueue_remux_jobs: false, media_scope: "movie" })}
+                onClick={() => queueMovieScan.mutate({ enqueue_remux_jobs: true, media_scope: "movie" })}
               >
-                {queueMovieScan.isPending ? "Queuing Movies scan…" : "Run Movies scan now"}
+                {queueMovieScan.isPending ? "Starting Movies scan..." : "Scan Movies now"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
﻿## Summary
- make Refiner watched-folder scans queue ready files without requiring Sonarr/Radarr configuration
- keep Sonarr/Radarr queue data as a safety signal only when it shows a file is still importing/copying
- update Refiner activity and schedule wording so users see plain-language outcomes

## Validation
- backend focused tests: watched-folder dispatch, manual enqueue API, periodic enqueue, failure cleanup, Windows packaging paths
- web focused tests: activity page and Refiner page
- web production build
- Windows installer build
- packaged Windows server smoke

## Workflow audit
- GitHub workflows remain intentionally limited to Test, Release, and CodeQL
- Release still builds and smokes Windows installer plus publishes/smokes Docker via GitHub Actions, without local Docker dependency
