### PR TITLE
MediaMop 1.0.12 release artifact fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1
 
       - name: Upload MediaMop Windows installer
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: mediamop-windows-installer
           path: dist/windows/MediaMopSetup.exe
@@ -120,7 +120,7 @@ jobs:
         run: echo "name=${REGISTRY}/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Download MediaMop Windows installer
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: mediamop-windows-installer
           path: ${{ github.workspace }}/windows-artifact

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.11"
+version = "1.0.12"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.0.12",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
﻿## Summary
- replace release artifact upload/download handoff with the stable v4 artifact actions
- bump MediaMop to 1.0.12 because v1.0.11 was already tagged before the release workflow handoff failed

## Validation
- git diff whitespace check passed
- previous PR #38 checks passed: CodeQL, Docker smoke, backend/web/E2E, Windows package smoke
- failed v1.0.11 release built and smoke-tested the Windows installer successfully before failing only at artifact upload
