### PR TITLE
MediaMop 1.0.13 packaged runtime fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ artifacts/
 tmp/
 scripts/node_modules/
 apps/web/tmp-*.cjs
+
+# Build-time downloaded Windows FFmpeg runtime
+packaging/windows/vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    ffmpeg \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/mediamop

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,13 @@
+# Third-party notices
+
+MediaMop bundles or installs the following third-party runtime tools for packaged user installs.
+
+## FFmpeg
+
+Windows builds bundle FFmpeg and ffprobe from the BtbN FFmpeg Builds project. Docker builds install FFmpeg from the Debian package repositories.
+
+FFmpeg is a third-party project and is not owned by MediaMop. FFmpeg licensing depends on the specific build configuration used by the distributor. MediaMop's Windows package uses the LGPL-labelled BtbN Windows build archive.
+
+- Project: https://ffmpeg.org/
+- Windows build source: https://github.com/BtbN/FFmpeg-Builds
+- License information: https://ffmpeg.org/legal.html

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.12"
+version = "1.0.13"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -33,25 +34,33 @@ def resolve_ffprobe_ffmpeg(*, mediamop_home: str) -> tuple[str, str]:
     """Prefer bundled tools under ``mediamop_home``, then host ``PATH``."""
 
     home = Path(mediamop_home).expanduser().resolve()
-    bundled_win = [
-        home / "bin" / "ffmpeg" / "ffprobe.exe",
-        home / "bin" / "ffmpeg" / "ffmpeg.exe",
-    ]
-    if bundled_win[0].is_file() and bundled_win[1].is_file():
-        return str(bundled_win[0]), str(bundled_win[1])
-    bundled_unix = [
-        home / "bin" / "ffmpeg" / "ffprobe",
-        home / "bin" / "ffmpeg" / "ffmpeg",
-    ]
-    if bundled_unix[0].is_file() and bundled_unix[1].is_file():
-        return str(bundled_unix[0]), str(bundled_unix[1])
+    candidate_dirs: list[Path] = []
+    raw_env_dir = (os.environ.get("MEDIAMOP_FFMPEG_DIR") or "").strip()
+    if raw_env_dir:
+        candidate_dirs.append(Path(raw_env_dir).expanduser())
+    candidate_dirs.append(home / "bin" / "ffmpeg")
+    if getattr(sys, "frozen", False):
+        exe_dir = Path(sys.executable).resolve().parent
+        candidate_dirs.extend(
+            [
+                exe_dir / "bin" / "ffmpeg",
+                exe_dir / "_internal" / "bin" / "ffmpeg",
+            ]
+        )
+
+    names = ("ffprobe.exe", "ffmpeg.exe") if os.name == "nt" else ("ffprobe", "ffmpeg")
+    for candidate_dir in candidate_dirs:
+        ffprobe_path = candidate_dir / names[0]
+        ffmpeg_path = candidate_dir / names[1]
+        if ffprobe_path.is_file() and ffmpeg_path.is_file():
+            return str(ffprobe_path), str(ffmpeg_path)
 
     ffprobe = shutil.which("ffprobe")
     ffmpeg = shutil.which("ffmpeg")
     if not ffprobe or not ffmpeg:
         raise RuntimeError(
-            "Refiner needs ffprobe and ffmpeg. Place binaries under MEDIAMOP_HOME/bin/ffmpeg/, "
-            "or install both on the host PATH (Linux/macOS/Windows).",
+            "Refiner could not find the video tools it needs. Windows and Docker installs should include them; "
+            "source installs must provide ffprobe and ffmpeg on PATH or set MEDIAMOP_FFMPEG_DIR.",
         )
     return ffprobe, ffmpeg
 

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -167,6 +167,7 @@ def get_suite_security_overview(
 
 
 @router.get("/suite/update-status", response_model=SuiteUpdateStatusOut)
+@router.get("/suite/settings/update-status", response_model=SuiteUpdateStatusOut)
 def get_suite_update_status(_user: UserPublicDep) -> SuiteUpdateStatusOut:
     """Read-only update check for the signed-in Settings page."""
 
@@ -174,6 +175,7 @@ def get_suite_update_status(_user: UserPublicDep) -> SuiteUpdateStatusOut:
 
 
 @router.post("/suite/update-now", response_model=SuiteUpdateStartOut)
+@router.post("/suite/settings/update-now", response_model=SuiteUpdateStartOut)
 def post_suite_update_now(
     body: SuiteUpdateStartIn,
     request: Request,

--- a/apps/backend/tests/test_refiner_probe_controls.py
+++ b/apps/backend/tests/test_refiner_probe_controls.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.refiner.refiner_remux_mux import build_ffprobe_argv
+from mediamop.modules.refiner.refiner_remux_mux import build_ffprobe_argv, resolve_ffprobe_ffmpeg
 
 
 def test_build_ffprobe_argv_includes_probe_controls() -> None:
@@ -38,4 +39,16 @@ def test_refiner_probe_controls_load_from_env(monkeypatch: pytest.MonkeyPatch) -
     s = MediaMopSettings.load()
     assert s.refiner_probe_size_mb == 32
     assert s.refiner_analyze_duration_seconds == 28
+
+
+def test_resolve_ffprobe_ffmpeg_uses_explicit_tool_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tool_dir = tmp_path / "ffmpeg-tools"
+    tool_dir.mkdir()
+    ffprobe = tool_dir / ("ffprobe.exe" if os.name == "nt" else "ffprobe")
+    ffmpeg = tool_dir / ("ffmpeg.exe" if os.name == "nt" else "ffmpeg")
+    ffprobe.write_text("", encoding="utf-8")
+    ffmpeg.write_text("", encoding="utf-8")
+    monkeypatch.setenv("MEDIAMOP_FFMPEG_DIR", str(tool_dir))
+
+    assert resolve_ffprobe_ffmpeg(mediamop_home=str(tmp_path / "home")) == (str(ffprobe), str(ffmpeg))
 

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -283,6 +283,26 @@ def test_suite_update_status_ok(client_with_admin: TestClient, monkeypatch: pyte
     assert body["status"] == "update_available"
 
 
+def test_suite_update_status_alias_ok(client_with_admin: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _login_admin(client_with_admin)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
+        lambda: {
+            "tag_name": "v1.2.3",
+            "name": "MediaMop 1.2.3",
+            "html_url": "https://example.com/release",
+            "published_at": "2026-04-23T00:00:00Z",
+            "assets": [],
+        },
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
+
+    r = client_with_admin.get("/api/v1/suite/settings/update-status")
+
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "update_available"
+
+
 def test_suite_update_status_not_published_when_release_missing(
     client_with_admin: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -61,4 +61,18 @@ def test_windows_package_uses_dedicated_tray_icon_assets() -> None:
     assert 'TRAY_ICON_ICO = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.ico"' in text
     assert "(str(TRAY_ICON_PNG), \"assets\")" in text
     assert "(str(TRAY_ICON_ICO), \"assets\")" in text
+    assert "(str(THIRD_PARTY_NOTICES), \".\")" in text
     assert "icon=str(TRAY_ICON_ICO)" in text
+
+
+def test_windows_package_includes_ffmpeg_runtime_assets() -> None:
+    repo = Path(__file__).resolve().parents[3]
+    spec = repo / "packaging" / "windows" / "mediamop-tray.spec"
+    build = repo / "packaging" / "windows" / "build.ps1"
+    spec_text = spec.read_text(encoding="utf-8")
+    build_text = build.read_text(encoding="utf-8")
+
+    assert 'FFMPEG_VENDOR = ROOT / "packaging" / "windows" / "vendor" / "ffmpeg"' in spec_text
+    assert '(str(FFMPEG_VENDOR), "bin/ffmpeg")' in spec_text
+    assert "Ensure-WindowsFfmpegRuntime" in build_text
+    assert "ffmpeg-master-latest-win64-lgpl.zip" in build_text

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/suite/suite-settings-api.ts
+++ b/apps/web/src/lib/suite/suite-settings-api.ts
@@ -13,8 +13,10 @@ import type {
 
 export const suiteSettingsPath = () => "/api/v1/suite/settings";
 export const suiteSecurityOverviewPath = () => "/api/v1/suite/security-overview";
-export const suiteUpdateStatusPath = () => "/api/v1/suite/update-status";
-export const suiteUpdateNowPath = () => "/api/v1/suite/update-now";
+export const suiteUpdateStatusPaths = ["/api/v1/suite/update-status", "/api/v1/suite/settings/update-status"] as const;
+export const suiteUpdateNowPaths = ["/api/v1/suite/update-now", "/api/v1/suite/settings/update-now"] as const;
+export const suiteUpdateStatusPath = () => suiteUpdateStatusPaths[0];
+export const suiteUpdateNowPath = () => suiteUpdateNowPaths[0];
 export const suiteLogsPath = () => "/api/v1/suite/logs";
 export const suiteMetricsPath = () => "/api/v1/suite/metrics";
 
@@ -86,24 +88,40 @@ export async function fetchSuiteSecurityOverview(): Promise<SuiteSecurityOvervie
 }
 
 export async function fetchSuiteUpdateStatus(): Promise<SuiteUpdateStatusOut> {
-  const r = await apiFetch(suiteUpdateStatusPath());
-  if (!r.ok) {
-    throw new Error(await readFailedRequestMessage(r, "Could not check for updates"));
+  let last: Response | undefined;
+  for (const path of suiteUpdateStatusPaths) {
+    const r = await apiFetch(path);
+    last = r;
+    if (r.status === 404) {
+      continue;
+    }
+    if (!r.ok) {
+      throw new Error(await readFailedRequestMessage(r, "Could not check for updates"));
+    }
+    return readJson<SuiteUpdateStatusOut>(r);
   }
-  return readJson<SuiteUpdateStatusOut>(r);
+  throw new Error(await readFailedRequestMessage(last!, "Could not check for updates"));
 }
 
 export async function startSuiteUpdateNow(): Promise<SuiteUpdateStartOut> {
   const csrf_token = await fetchCsrfToken();
-  const r = await apiFetch(suiteUpdateNowPath(), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ csrf_token }),
-  });
-  if (!r.ok) {
-    throw new Error(await readFailedRequestMessage(r, "Could not start upgrade"));
+  let last: Response | undefined;
+  for (const path of suiteUpdateNowPaths) {
+    const r = await apiFetch(path, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ csrf_token }),
+    });
+    last = r;
+    if (r.status === 404) {
+      continue;
+    }
+    if (!r.ok) {
+      throw new Error(await readFailedRequestMessage(r, "Could not start upgrade"));
+    }
+    return readJson<SuiteUpdateStartOut>(r);
   }
-  return readJson<SuiteUpdateStartOut>(r);
+  throw new Error(await readFailedRequestMessage(last!, "Could not start upgrade"));
 }
 
 export async function fetchSuiteLogs(filters?: {

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -10,6 +10,7 @@ $backendDir = Join-Path $repoRoot "apps\\backend"
 $webDir = Join-Path $repoRoot "apps\\web"
 $specPath = Join-Path $PSScriptRoot "mediamop-tray.spec"
 $distRoot = Join-Path $repoRoot "dist\\windows"
+$ffmpegVendorDir = Join-Path $PSScriptRoot "vendor\\ffmpeg"
 $venvScriptsDir = Join-Path $backendDir ".venv\\Scripts"
 $py = Join-Path $venvScriptsDir "python.exe"
 
@@ -104,6 +105,44 @@ function Resolve-IsccPath {
   return $null
 }
 
+function Ensure-WindowsFfmpegRuntime {
+  $ffmpegExe = Join-Path $ffmpegVendorDir "ffmpeg.exe"
+  $ffprobeExe = Join-Path $ffmpegVendorDir "ffprobe.exe"
+  if ((Test-Path -LiteralPath $ffmpegExe) -and (Test-Path -LiteralPath $ffprobeExe)) {
+    return
+  }
+
+  $downloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-ffmpeg-" + [System.Guid]::NewGuid().ToString("N"))
+  $archivePath = Join-Path $downloadRoot "ffmpeg.zip"
+  $extractRoot = Join-Path $downloadRoot "extract"
+  $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
+  try {
+    New-Item -ItemType Directory -Path $downloadRoot | Out-Null
+    New-Item -ItemType Directory -Path $extractRoot | Out-Null
+    Write-Host "Downloading Windows FFmpeg runtime..."
+    Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing
+    Expand-Archive -LiteralPath $archivePath -DestinationPath $extractRoot -Force
+    $binDir = Get-ChildItem -Path $extractRoot -Recurse -Directory |
+      Where-Object {
+        (Test-Path (Join-Path $_.FullName "ffmpeg.exe")) -and
+        (Test-Path (Join-Path $_.FullName "ffprobe.exe"))
+      } |
+      Select-Object -First 1
+    if (-not $binDir) {
+      throw "Downloaded FFmpeg archive did not contain ffmpeg.exe and ffprobe.exe."
+    }
+    if (Test-Path $ffmpegVendorDir) {
+      Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $ffmpegVendorDir | Out-Null
+    Copy-Item -Path (Join-Path $binDir.FullName "*") -Destination $ffmpegVendorDir -Recurse -Force
+  } finally {
+    if (Test-Path $downloadRoot) {
+      Remove-Item -LiteralPath $downloadRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
 $iscc = Resolve-IsccPath
 $buildVersion = if ($env:MEDIAMOP_BUILD_VERSION) {
   $env:MEDIAMOP_BUILD_VERSION
@@ -182,6 +221,8 @@ if (Test-Path $distRoot) {
   Remove-Item -LiteralPath $distRoot -Recurse -Force
 }
 New-Item -ItemType Directory -Path $distRoot | Out-Null
+
+Ensure-WindowsFfmpegRuntime
 
 Push-Location $repoRoot
 try {

--- a/packaging/windows/mediamop-tray.spec
+++ b/packaging/windows/mediamop-tray.spec
@@ -9,6 +9,8 @@ WEB_DIST = ROOT / "apps" / "web" / "dist"
 LOGO = ROOT / "apps" / "web" / "src" / "components" / "brand" / "mediamop-logo-premium.png"
 TRAY_ICON_PNG = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.png"
 TRAY_ICON_ICO = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.ico"
+FFMPEG_VENDOR = ROOT / "packaging" / "windows" / "vendor" / "ffmpeg"
+THIRD_PARTY_NOTICES = ROOT / "THIRD_PARTY_NOTICES.md"
 
 hiddenimports = collect_submodules("mediamop")
 datas = [
@@ -18,7 +20,10 @@ datas = [
     (str(LOGO), "assets"),
     (str(TRAY_ICON_PNG), "assets"),
     (str(TRAY_ICON_ICO), "assets"),
+    (str(THIRD_PARTY_NOTICES), "."),
 ]
+if FFMPEG_VENDOR.is_dir():
+    datas.append((str(FFMPEG_VENDOR), "bin/ffmpeg"))
 
 a = Analysis(
     [str(BACKEND / "src" / "mediamop" / "windows" / "tray_app.py")],

--- a/scripts/smoke-windows-package.ps1
+++ b/scripts/smoke-windows-package.ps1
@@ -13,6 +13,9 @@ $packagePath = (Resolve-Path -LiteralPath $PackageDir).Path
 $serverExe = Join-Path $packagePath "MediaMopServer.exe"
 $webIndex = Join-Path $packagePath "_internal\web-dist\index.html"
 $trayIcon = Join-Path $packagePath "_internal\assets\mediamop-tray-icon.png"
+$alembicIni = Join-Path $packagePath "_internal\alembic.ini"
+$ffmpegExe = Join-Path $packagePath "_internal\bin\ffmpeg\ffmpeg.exe"
+$ffprobeExe = Join-Path $packagePath "_internal\bin\ffmpeg\ffprobe.exe"
 
 if (-not (Test-Path -LiteralPath $serverExe)) {
   throw "Packaged server executable not found: $serverExe"
@@ -22,6 +25,15 @@ if (-not (Test-Path -LiteralPath $webIndex)) {
 }
 if (-not (Test-Path -LiteralPath $trayIcon)) {
   throw "Packaged tray icon not found: $trayIcon"
+}
+if (-not (Test-Path -LiteralPath $alembicIni)) {
+  throw "Packaged database migration config not found: $alembicIni"
+}
+if (-not (Test-Path -LiteralPath $ffmpegExe)) {
+  throw "Packaged ffmpeg executable not found: $ffmpegExe"
+}
+if (-not (Test-Path -LiteralPath $ffprobeExe)) {
+  throw "Packaged ffprobe executable not found: $ffprobeExe"
 }
 $indexText = Get-Content -LiteralPath $webIndex -Raw
 if ($indexText -notmatch "MediaMop") {


### PR DESCRIPTION
﻿## Summary
- bundle FFmpeg/ffprobe into the Windows installer so Refiner can probe/remux media without host installs
- install ffmpeg in the Docker image for the same out-of-box Refiner behavior
- add suite update route aliases plus frontend 404 fallback so in-app upgrade survives minor path mismatches
- harden packaged smoke checks for Alembic, web assets, tray icon, ffmpeg, and ffprobe runtime files
- add third-party notice for bundled FFmpeg runtime

## Validation
- Backend focused tests: 13 passed
- Frontend suite/settings tests: passed
- Web build: passed
- Windows installer build: passed
- Packaged Windows smoke: server health passed and required runtime files verified
- git diff --check: clean except CRLF warnings
