### PR TITLE
Opt release workflow into Node 24 action runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
   packages: write
 
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
 
 jobs:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.13"
+version = "1.0.14"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.0.14",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
﻿## Summary
- opt the Release workflow into GitHub Actions Node 24 runtime using `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`
- keep MediaMop's own Node build/test version unchanged at Node 20

## Why
The v1.0.13 release succeeded, but GitHub warned that `actions/upload-artifact@v4` was still running on Node 20. This removes that warning before the next production release path.

## Validation
- `git diff --check` clean except Windows CRLF warnings
- PR checks will validate workflow syntax and normal CI on GitHub
