### PR TITLE
Use native Node 24 artifact actions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ permissions:
   packages: write
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   REGISTRY: ghcr.io
 
 jobs:
@@ -57,7 +56,7 @@ jobs:
         run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1
 
       - name: Upload MediaMop Windows installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mediamop-windows-installer
           path: dist/windows/MediaMopSetup.exe
@@ -121,7 +120,7 @@ jobs:
         run: echo "name=${REGISTRY}/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Download MediaMop Windows installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: mediamop-windows-installer
           path: ${{ github.workspace }}/windows-artifact

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.14"
+version = "1.0.15"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
﻿## Summary
- replace release artifact upload/download actions with native Node 24 majors
- remove the forced Node 24 compatibility env workaround
- bump MediaMop to 1.0.15 so the verification release has consistent installed/web/backend versions

## Why
The previous v1.0.14 workflow fix forced `actions/upload-artifact@v4` onto Node 24, but GitHub still emitted a deprecation annotation because the action itself targets Node 20. This uses artifact actions that natively target Node 24.

## Validation
- `git diff --check` clean except Windows CRLF warnings
- PR checks will validate normal CI and Windows package smoke
- after merge, tag `v1.0.15` will validate the tag-only release artifact path
