### PR TITLE
Release MediaMop 1.0.17

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.16"
+version = "1.0.17"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_visibility.py
@@ -50,7 +50,7 @@ def remux_pass_activity_title(payload: dict[str, Any]) -> str:
     if outcome == REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN:
         return f"{name} was processed successfully"
     if outcome == REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED:
-        return f"{name} already matched your Refiner rules"
+        return f"No changes needed for {name}"
     if outcome == REMUX_PASS_OUTCOME_FAILED_DURING_EXECUTION:
         return f"{name} could not be processed"
     if outcome == REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION or payload.get("ok") is False:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -15,13 +15,9 @@ from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_file_remux_pass_job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
-from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_activity import (
-    record_refiner_watched_folder_remux_scan_dispatch_completed,
-)
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_evaluate import (
     evaluate_watched_media_file_for_dispatch,
     fetch_radarr_and_sonarr_queue_rows_for_scan,
-    format_scan_summary_for_activity,
 )
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops import (
     iter_watched_folder_media_candidate_files,
@@ -81,7 +77,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             "job_id": ctx.id,
             "scan_trigger": scan_trigger,
             "media_scope": media_scope,
-            "scan_result_label": "Watched folder checked",
+            "scan_result_label": "watched_folder_checked",
             "watched_folder_resolved": watched_root,
             "enqueue_remux_jobs": enqueue_remux_jobs,
             "min_file_age_seconds": op_settings.min_file_age_seconds,
@@ -159,36 +155,35 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                 seen = int(summary["media_candidates_seen"])
                 duplicates = int(summary["skipped_duplicate_same_scan"]) + int(summary["skipped_duplicate_active_queue"])
                 if queued:
-                    summary["scan_result_label"] = "Files added to Refiner"
+                    summary["scan_result_label"] = "files_queued"
                     summary["user_message"] = (
                         f"{queued} file{' was' if queued == 1 else 's were'} added to Refiner for processing."
                     )
                 elif waiting:
-                    summary["scan_result_label"] = "Waiting for files to finish"
+                    summary["scan_result_label"] = "waiting_for_files"
                     summary["user_message"] = (
                         f"{waiting} file{' looks' if waiting == 1 else 's look'} like it is still being copied or imported, "
                         "so MediaMop left it alone for now."
                     )
                     summary["waiting_message"] = "MediaMop will check again on the next scheduled scan."
                 elif seen and not enqueue_remux_jobs:
-                    summary["scan_result_label"] = "Folder checked only"
+                    summary["scan_result_label"] = "check_only"
                     summary["user_message"] = (
                         f"{seen} media file{' was' if seen == 1 else 's were'} found, but this scan was set to check only."
                     )
                 elif seen and duplicates:
-                    summary["scan_result_label"] = "Already queued"
+                    summary["scan_result_label"] = "already_queued"
                     summary["user_message"] = (
                         "MediaMop found matching media files, but they were already waiting for Refiner."
                     )
                 elif seen:
-                    summary["scan_result_label"] = "No new Refiner work"
+                    summary["scan_result_label"] = "nothing_new"
                     summary["user_message"] = "MediaMop found media files, but there was nothing new to queue."
                 else:
-                    summary["scan_result_label"] = "No media found"
+                    summary["scan_result_label"] = "no_media_found"
                     summary["user_message"] = "MediaMop did not find any media files in this watched folder."
 
-                if int(summary["remux_jobs_enqueued"]) > 0:
-                    detail = format_scan_summary_for_activity(summary)
-                    record_refiner_watched_folder_remux_scan_dispatch_completed(session, detail=detail)
+                # File-level processing events now tell the user what happened. Recording a scan
+                # event here makes Activity look backwards when completed file events arrive first.
 
     return _run

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_overview_stats.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_overview_stats.py
@@ -17,7 +17,7 @@ class RefinerOverviewStatsOut(BaseModel):
     )
     already_optimized_count: int = Field(
         ge=0,
-        description="Refiner remux activity rows skipped because the file already matched the plan.",
+        description="Refiner activity rows where no file changes were needed.",
     )
     net_space_saved_bytes: int = Field(
         description="Net source-bytes minus output-bytes across output-written remuxes in the window.",

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from starlette import status
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
@@ -172,6 +172,14 @@ def get_suite_update_status(_user: UserPublicDep) -> SuiteUpdateStatusOut:
     """Read-only update check for the signed-in Settings page."""
 
     return build_suite_update_status()
+
+
+@router.get("/suite/update-now")
+@router.get("/suite/settings/update-now")
+def get_suite_update_now_redirect() -> RedirectResponse:
+    """If a browser lands on the upgrade API after restart, send it back to the app."""
+
+    return RedirectResponse(url="/app/settings", status_code=status.HTTP_303_SEE_OTHER)
 
 
 @router.post("/suite/update-now", response_model=SuiteUpdateStartOut)

--- a/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
@@ -39,7 +39,7 @@ def test_activity_title_per_outcome() -> None:
     assert "processed successfully" in remux_pass_activity_title(
         {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN},
     ).lower()
-    assert "matched your refiner rules" in remux_pass_activity_title(
+    assert "no changes needed" in remux_pass_activity_title(
         {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED},
     ).lower()
 

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
@@ -1,4 +1,4 @@
-"""Refiner watched-folder remux scan dispatch: refiner_jobs + handler + activity (isolated SQLite)."""
+"""Refiner watched-folder remux scan dispatch: refiner_jobs + handler (isolated SQLite)."""
 
 from __future__ import annotations
 
@@ -22,7 +22,6 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kin
     REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
 )
 from mediamop.modules.refiner.worker_loop import process_one_refiner_job
-from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
 
 import mediamop.modules.refiner.jobs_model  # noqa: F401
@@ -135,17 +134,7 @@ def test_scan_handler_enqueues_remux_when_requested(
         assert body.get("relative_media_path") == "Gate Test 2001.mkv"
         assert "dry_run" not in body
 
-        ev = s.scalars(
-            select(ActivityEvent).where(
-                ActivityEvent.event_type == C.REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_COMPLETED,
-            ),
-        ).first()
-        assert ev is not None
-        detail = json.loads(ev.detail or "{}")
-        assert detail.get("verdict_proceed") == 1
-        assert detail.get("remux_jobs_enqueued") == 1
-        assert detail.get("scan_result_label") == "Files added to Refiner"
-        assert detail.get("scan_trigger") == "manual"
+        assert s.scalar(select(ActivityEvent)) is None
 
 
 def test_scan_handler_enqueues_remux_without_arr_connections(
@@ -212,16 +201,7 @@ def test_scan_handler_enqueues_remux_without_arr_connections(
         assert len(remux) == 1
         body = json.loads(remux[0].payload_json or "{}")
         assert body.get("relative_media_path") == "Standalone Movie 2026.mkv"
-        ev = s.scalars(
-            select(ActivityEvent).where(
-                ActivityEvent.event_type == C.REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_COMPLETED,
-            ),
-        ).first()
-        assert ev is not None
-        detail = json.loads(ev.detail or "{}")
-        assert detail.get("verdict_proceed") == 1
-        assert detail.get("remux_jobs_enqueued") == 1
-        assert detail.get("user_message") == "1 file was added to Refiner for processing."
+        assert s.scalar(select(ActivityEvent)) is None
 
 
 def test_scan_handler_does_not_record_activity_when_no_files_are_queued(
@@ -276,11 +256,4 @@ def test_scan_handler_does_not_record_activity_when_no_files_are_queued(
         )
 
     with session_factory() as s:
-        assert (
-            s.scalar(
-                select(ActivityEvent).where(
-                    ActivityEvent.event_type == C.REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_COMPLETED,
-                ),
-            )
-            is None
-        )
+        assert s.scalar(select(ActivityEvent)) is None

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -303,6 +303,15 @@ def test_suite_update_status_alias_ok(client_with_admin: TestClient, monkeypatch
     assert r.json()["status"] == "update_available"
 
 
+def test_suite_update_now_get_redirects_back_to_settings(client_with_admin: TestClient) -> None:
+    _login_admin(client_with_admin)
+
+    r = client_with_admin.get("/api/v1/suite/update-now", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/app/settings"
+
+
 def test_suite_update_status_not_published_when_release_missing(
     client_with_admin: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.16",
+  "version": "1.0.17",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -95,21 +95,23 @@ export function AppShell() {
         </div>
       </aside>
       <main className="mm-main" id="mm-main-content" tabIndex={-1}>
-        <button
-          type="button"
-          className="mm-theme-toggle"
-          data-testid="theme-toggle"
-          aria-label={`Switch to ${nextTheme} mode`}
-          title={`Switch to ${nextTheme} mode`}
-          onClick={() => {
-            setTheme(nextTheme);
-            persistAppTheme(nextTheme);
-          }}
-        >
-          <span className="mm-theme-toggle__dot" aria-hidden="true" />
-          <span className="mm-theme-toggle__label">{theme === "dark" ? "Dark" : "Light"}</span>
-        </button>
         <div className="mm-main-inner">
+          <div className="mm-shell-toolbar" aria-label="Display controls">
+            <button
+              type="button"
+              className="mm-theme-toggle"
+              data-testid="theme-toggle"
+              aria-label={`Switch to ${nextTheme} mode`}
+              title={`Switch to ${nextTheme} mode`}
+              onClick={() => {
+                setTheme(nextTheme);
+                persistAppTheme(nextTheme);
+              }}
+            >
+              <span className="mm-theme-toggle__dot" aria-hidden="true" />
+              <span className="mm-theme-toggle__label">{theme === "dark" ? "Dark" : "Light"}</span>
+            </button>
+          </div>
           <Outlet />
         </div>
       </main>

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
@@ -59,7 +59,7 @@ function outcomeLabel(outcome: string | undefined): string {
     case "live_output_written":
       return "File processed";
     case "live_skipped_not_required":
-      return "Already matched rules";
+      return "No changes needed";
     case "failed_before_execution":
       return "Could not check file";
     case "failed_during_execution":

--- a/apps/web/src/lib/ui/display-density.test.ts
+++ b/apps/web/src/lib/ui/display-density.test.ts
@@ -7,6 +7,7 @@ describe("display-density", () => {
     expect(parseDisplayDensity("")).toBe("default");
     expect(parseDisplayDensity("comfortable")).toBe("comfortable");
     expect(parseDisplayDensity("compact")).toBe("compact");
+    expect(parseDisplayDensity("expanded")).toBe("expanded");
     expect(parseDisplayDensity("nope")).toBe("default");
   });
 

--- a/apps/web/src/lib/ui/display-density.ts
+++ b/apps/web/src/lib/ui/display-density.ts
@@ -2,10 +2,10 @@
 
 export const DISPLAY_DENSITY_STORAGE_KEY = "mediamop-display-density";
 
-export type DisplayDensity = "default" | "comfortable" | "compact";
+export type DisplayDensity = "default" | "compact" | "comfortable" | "expanded";
 
 export function parseDisplayDensity(raw: string | null): DisplayDensity {
-  if (raw === "comfortable" || raw === "compact") {
+  if (raw === "compact" || raw === "comfortable" || raw === "expanded") {
     return raw;
   }
   return "default";

--- a/apps/web/src/pages/activity/activity-page.tsx
+++ b/apps/web/src/pages/activity/activity-page.tsx
@@ -354,7 +354,7 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
     return {
       title:
         outcome === "live_skipped_not_required"
-          ? `${fileName} already matched your rules`
+          ? `No changes needed for ${fileName}`
           : outcome?.startsWith("failed")
             ? `${fileName} could not be processed`
             : `${fileName} was processed successfully`,
@@ -364,12 +364,12 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
           : outcome?.startsWith("failed")
             ? "Refiner could not finish this file"
             : remuxNeeded === false
-              ? "The file already matched your rules"
+              ? "The file already fits your Refiner rules"
               : "Refiner finished writing the cleaned-up file",
       detail: ev.detail,
       chip:
         outcome === "live_skipped_not_required"
-          ? "Already clean"
+          ? "No changes needed"
           : outcome?.startsWith("failed")
             ? "Processing failed"
             : "File processed",

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -215,7 +215,7 @@ describe("DashboardPage", () => {
     );
 
     expect(screen.getByText("Files handled")).toBeInTheDocument();
-    expect(screen.getByText("2 changed - 0 already clean")).toBeInTheDocument();
+    expect(screen.getByText("2 changed - 0 needed no changes")).toBeInTheDocument();
     expect(screen.queryByText("Scan watched folders")).not.toBeInTheDocument();
     expect(screen.getByText("Process file")).toBeInTheDocument();
   });

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -232,7 +232,7 @@ function buildRefinerCard(args: {
           : "Ready. No recent remux work recorded.",
     metrics: [
       { label: "Completed jobs", value: formatCount(args.processed), detail: `Success rate ${formatPercent(args.successRatePercent)}` },
-      { label: "Output written", value: formatCount(args.outputWritten), detail: `Already optimized ${formatCount(args.alreadyOptimized)}` },
+      { label: "Output written", value: formatCount(args.outputWritten), detail: `No-change files ${formatCount(args.alreadyOptimized)}` },
       { label: "Net space saved", value: formatBytesCompact(args.netSpaceSavedBytes), detail: describeNetSizeChange(args.netSpaceSavedBytes, args.netSpaceSavedPercent) },
       { label: "Failures", value: formatCount(args.failed) },
     ],
@@ -418,7 +418,7 @@ export function DashboardPage() {
             value: formatCount(refinerFileOutcomes),
             detail:
               refinerFileOutcomes > 0
-                ? `${formatCount(refinerStats.data?.output_written_count ?? 0)} changed - ${formatCount(refinerStats.data?.already_optimized_count ?? 0)} already clean`
+                ? `${formatCount(refinerStats.data?.output_written_count ?? 0)} changed - ${formatCount(refinerStats.data?.already_optimized_count ?? 0)} needed no changes`
                 : "No completed file outcomes yet",
           }
         : metric,

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -208,7 +208,9 @@ describe("SettingsPage (suite settings)", () => {
     expect(screen.getByTestId("suite-settings-display-density")).toBeTruthy();
     fireEvent.click(screen.getByText("Comfortable"));
     expect(document.documentElement.getAttribute("data-mm-density")).toBe("comfortable");
-    fireEvent.click(screen.getByText("Default"));
+    fireEvent.click(screen.getByText("Expanded"));
+    expect(document.documentElement.getAttribute("data-mm-density")).toBe("expanded");
+    fireEvent.click(screen.getByText("Balanced"));
     expect(document.documentElement.getAttribute("data-mm-density")).toBeNull();
   });
 });

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -471,7 +471,7 @@ export function SettingsPage() {
       setUpgradeMsg(result.message);
       if (result.status === "started") {
         window.setTimeout(() => {
-          window.location.reload();
+          window.location.assign("/app/settings");
         }, 30_000);
       }
     } catch {
@@ -685,8 +685,7 @@ export function SettingsPage() {
                   Display density (this browser)
                 </legend>
                 <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                  Adjust type size and how wide the main column can grow on large monitors. Your choice saves in this
-                  browser only and applies as soon as you select it. Choose Default to clear the stored preference.
+                  Adjust text, spacing, sidebar width, and card density for this browser. The change applies immediately.
                 </p>
                 <div
                   className="mt-3 flex flex-col gap-2"
@@ -696,9 +695,10 @@ export function SettingsPage() {
                 >
                   {(
                     [
-                      { id: "default" as const, label: "Default", hint: "Balanced" },
-                      { id: "compact" as const, label: "Compact", hint: "Smaller text, narrower cap" },
-                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger text (+10%), wider cap" },
+                      { id: "compact" as const, label: "Compact", hint: "Smaller, tighter app layout" },
+                      { id: "default" as const, label: "Balanced", hint: "Readable default" },
+                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger text and controls" },
+                      { id: "expanded" as const, label: "Expanded", hint: "Big-screen reading mode" },
                     ] as const
                   ).map(({ id, label, hint }) => (
                     <label

--- a/apps/web/src/pages/setup/setup-wizard-page.tsx
+++ b/apps/web/src/pages/setup/setup-wizard-page.tsx
@@ -372,12 +372,13 @@ export function SetupWizardPage() {
               </div>
               <div>
                 <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Display density</p>
-                <div className="grid gap-2 sm:grid-cols-3" role="radiogroup" aria-label="Display density">
+                <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4" role="radiogroup" aria-label="Display density">
                   {(
                     [
-                      { id: "default" as const, label: "Default", hint: "Balanced" },
-                      { id: "compact" as const, label: "Compact", hint: "Denser layout" },
-                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger text" },
+                      { id: "compact" as const, label: "Compact", hint: "Smaller layout" },
+                      { id: "default" as const, label: "Balanced", hint: "Readable default" },
+                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger controls" },
+                      { id: "expanded" as const, label: "Expanded", hint: "Big-screen mode" },
                     ] as const
                   ).map(({ id, label, hint }) => (
                     <label

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -40,7 +40,7 @@ body.mm-body {
   height: 100%;
   margin: 0;
   font-family: var(--mm-font);
-  font-size: 0.953125rem; /* 15.25px when html root is 16px */
+  font-size: 1rem;
   line-height: 1.52;
   font-weight: 400;
   font-feature-settings: var(--mm-font-feature);
@@ -78,17 +78,21 @@ body.mm-body {
   background: var(--mm-bg);
 }
 
+.mm-shell-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  min-height: var(--mm-control-height);
+  margin: 0 0 calc(12px * var(--mm-density-ui-scale));
+}
+
 .mm-theme-toggle {
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  float: right;
+  position: static;
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  min-height: 34px;
-  margin: 0 2px 10px 14px;
-  padding: 7px 11px;
+  min-height: var(--mm-control-height);
+  margin: 0;
+  padding: var(--mm-control-pad-y) var(--mm-control-pad-x);
   border: 1px solid var(--mm-border);
   border-radius: var(--mm-radius-pill);
   background:
@@ -98,7 +102,7 @@ body.mm-body {
   box-shadow: var(--mm-shadow-card-inner), 0 8px 24px rgba(0, 0, 0, 0.16);
   cursor: pointer;
   font: inherit;
-  font-size: 0.78rem;
+  font-size: 0.8125rem;
   font-weight: 700;
   letter-spacing: 0.04em;
   text-transform: uppercase;
@@ -149,7 +153,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
-  padding: 8px 0 14px;
+  padding: calc(8px * var(--mm-density-ui-scale)) 0 calc(14px * var(--mm-density-ui-scale));
   overflow-y: auto;
   position: relative;
   z-index: 2;
@@ -160,9 +164,9 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   flex-direction: column;
   align-items: flex-start;
   text-align: left;
-  padding: 0 16px 4px;
+  padding: 0 calc(16px * var(--mm-density-ui-scale)) calc(4px * var(--mm-density-ui-scale));
   border-bottom: 1px solid var(--mm-border);
-  margin: 0 10px 3px;
+  margin: 0 calc(10px * var(--mm-density-ui-scale)) calc(3px * var(--mm-density-ui-scale));
   text-decoration: none;
   color: inherit;
   transition: opacity 0.15s ease;
@@ -207,7 +211,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 .mm-sidebar-product-title {
   margin: 6px 0 0;
   padding: 0;
-  font-size: 13px;
+  font-size: 0.875rem;
   line-height: 1.25;
   font-weight: 600;
   letter-spacing: 0.01em;
@@ -219,7 +223,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 .mm-sidebar-tagline {
   margin: 2px 0 0;
   padding: 0;
-  font-size: 10px;
+  font-size: 0.75rem;
   line-height: 1.35;
   font-weight: 500;
   font-style: normal;
@@ -234,14 +238,18 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 2px 10px 0;
-  gap: 3px;
+  padding: calc(2px * var(--mm-density-ui-scale)) calc(10px * var(--mm-density-ui-scale)) 0;
+  gap: calc(3px * var(--mm-density-ui-scale));
 }
 
 .mm-sidebar-section-label {
   margin: 0;
-  padding: 6px 14px 1px 16px;
-  font-size: 9px;
+  padding:
+    calc(6px * var(--mm-density-ui-scale))
+    calc(14px * var(--mm-density-ui-scale))
+    calc(1px * var(--mm-density-ui-scale))
+    calc(16px * var(--mm-density-ui-scale));
+  font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -270,13 +278,13 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 .mm-sidebar-link {
   display: flex;
   align-items: center;
-  gap: 11px;
-  padding: 10px 14px;
-  margin: 0 4px 0 2px;
+  gap: calc(11px * var(--mm-density-ui-scale));
+  padding: calc(10px * var(--mm-density-ui-scale)) calc(14px * var(--mm-density-ui-scale));
+  margin: 0 calc(4px * var(--mm-density-ui-scale)) 0 calc(2px * var(--mm-density-ui-scale));
   border-radius: var(--mm-radius-pill);
   color: var(--mm-text2);
   text-decoration: none;
-  font-size: 13px;
+  font-size: 0.9375rem;
   font-weight: 500;
   letter-spacing: 0.015em;
   border: 1px solid transparent;
@@ -316,12 +324,15 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-sidebar-footer {
-  padding: 0 10px 6px;
+  padding: 0 calc(10px * var(--mm-density-ui-scale)) calc(6px * var(--mm-density-ui-scale));
   margin-top: auto;
 }
 
 .mm-sidebar-footer-panel {
-  padding: 14px 14px 12px;
+  padding:
+    calc(14px * var(--mm-density-ui-scale))
+    calc(14px * var(--mm-density-ui-scale))
+    calc(12px * var(--mm-density-ui-scale));
   border-radius: 11px;
   background: rgba(0, 0, 0, 0.22);
   border: 1px solid rgba(231, 231, 234, 0.07);
@@ -329,7 +340,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-sidebar-meta {
-  font-size: 9px;
+  font-size: 0.6875rem;
   color: var(--mm-gold);
   font-weight: 600;
   letter-spacing: 0.18em;
@@ -339,7 +350,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 
 .mm-sidebar-version {
   margin-top: 8px;
-  font-size: 10.5px;
+  font-size: 0.75rem;
   color: var(--mm-text2);
   font-variant-numeric: tabular-nums;
   font-weight: 500;
@@ -357,7 +368,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   justify-content: flex-start;
   background: none;
   font: inherit;
-  font-size: 11.5px;
+  font-size: 0.8125rem;
   font-weight: 600;
   color: var(--mm-text2);
   cursor: pointer;
@@ -386,7 +397,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 .mm-main {
   flex: 1;
   height: 100vh;
-  padding: 32px clamp(16px, 3vw, 40px) 40px;
+  padding: var(--mm-main-pad-y) var(--mm-main-pad-x) calc(40px * var(--mm-density-ui-scale));
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;
@@ -444,8 +455,8 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-main {
-    padding-top: 34px;
-    padding-bottom: 44px;
+    padding-top: calc(34px * var(--mm-density-ui-scale));
+    padding-bottom: calc(44px * var(--mm-density-ui-scale));
   }
 
   .mm-page__title {
@@ -458,7 +469,9 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-card {
-    padding: 1.45rem 1.55rem;
+    padding:
+      calc(1.45rem * var(--mm-density-ui-scale))
+      calc(1.55rem * var(--mm-density-ui-scale));
   }
 
   .mm-card__title {
@@ -510,8 +523,8 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-main {
-    padding-top: 36px;
-    padding-bottom: 48px;
+    padding-top: calc(36px * var(--mm-density-ui-scale));
+    padding-bottom: calc(48px * var(--mm-density-ui-scale));
   }
 
   .mm-page__title {
@@ -519,7 +532,9 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-card {
-    padding: 1.5rem 1.6rem;
+    padding:
+      calc(1.5rem * var(--mm-density-ui-scale))
+      calc(1.6rem * var(--mm-density-ui-scale));
   }
 
   .mm-card__body {
@@ -699,7 +714,9 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-card {
-  padding: 1.35rem 1.45rem;
+  padding:
+    calc(1.35rem * var(--mm-density-ui-scale))
+    calc(1.45rem * var(--mm-density-ui-scale));
   min-height: 5rem;
   background: var(--mm-card-bg);
   border: 1px solid rgba(255, 255, 255, 0.06);
@@ -708,7 +725,10 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-card--shell {
-  padding: 1.45rem 1.55rem 1.5rem;
+  padding:
+    calc(1.45rem * var(--mm-density-ui-scale))
+    calc(1.55rem * var(--mm-density-ui-scale))
+    calc(1.5rem * var(--mm-density-ui-scale));
   border-color: rgba(212, 175, 55, 0.2);
   background: linear-gradient(150deg, rgba(212, 175, 55, 0.06) 0%, var(--mm-card-bg) 50%);
   box-shadow: var(--mm-shadow-card), var(--mm-shadow-card-inner);

--- a/apps/web/src/styles/mediamop-tokens.css
+++ b/apps/web/src/styles/mediamop-tokens.css
@@ -3,7 +3,8 @@
 :root {
   color-scheme: dark;
   /* Display density: overridden on `html[data-mm-density="…"]` (see below). */
-  --mm-density-font-scale: 1;
+  --mm-density-font-scale: 1.08;
+  --mm-density-ui-scale: 1;
   --mm-main-max-cap: 2400px;
   --mm-charcoal: #0b0b10;
   --mm-slate: #1f232a;
@@ -31,18 +32,23 @@
   --mm-accent-soft: rgba(212, 175, 55, 0.16);
   --mm-accent-ring: rgba(212, 175, 55, 0.45);
   --mm-on-accent: #0b0b10;
-  --mm-sidebar-w: 256px;
+  --mm-sidebar-w: calc(256px * var(--mm-density-ui-scale));
   --mm-radius: 12px;
   --mm-radius-sm: 8px;
   --mm-radius-pill: 999px;
   /* Main column: never wider than the pane; cap scales slightly with display density. */
   --mm-main-max: min(100%, var(--mm-main-max-cap));
-  --mm-space: clamp(1.125rem, 3vw, 1.75rem);
-  --mm-space-lg: clamp(1.65rem, 4vw, 2.35rem);
-  --mm-bubble-stack-gap-mobile: 1.25rem;
-  --mm-bubble-stack-gap-desktop: 1.75rem;
-  --mm-bubble-grid-gap-mobile: 1.25rem;
-  --mm-bubble-grid-gap-desktop: 1.75rem;
+  --mm-space: calc(clamp(1.125rem, 3vw, 1.75rem) * var(--mm-density-ui-scale));
+  --mm-space-lg: calc(clamp(1.65rem, 4vw, 2.35rem) * var(--mm-density-ui-scale));
+  --mm-bubble-stack-gap-mobile: calc(1.25rem * var(--mm-density-ui-scale));
+  --mm-bubble-stack-gap-desktop: calc(1.75rem * var(--mm-density-ui-scale));
+  --mm-bubble-grid-gap-mobile: calc(1.25rem * var(--mm-density-ui-scale));
+  --mm-bubble-grid-gap-desktop: calc(1.75rem * var(--mm-density-ui-scale));
+  --mm-main-pad-y: calc(clamp(32px, 2.2vw, 40px) * var(--mm-density-ui-scale));
+  --mm-main-pad-x: calc(clamp(16px, 3vw, 40px) * var(--mm-density-ui-scale));
+  --mm-control-height: calc(34px * var(--mm-density-ui-scale));
+  --mm-control-pad-x: calc(11px * var(--mm-density-ui-scale));
+  --mm-control-pad-y: calc(7px * var(--mm-density-ui-scale));
   --mm-font: "Outfit", system-ui, -apple-system, sans-serif;
   --mm-shadow-card: 0 16px 48px rgba(0, 0, 0, 0.45);
   --mm-shadow-card-inner: 0 1px 0 rgba(255, 255, 255, 0.04) inset;
@@ -98,12 +104,19 @@ html[data-mm-theme="light"] {
 }
 
 html[data-mm-density="comfortable"] {
-  /* Stronger lift for QHD / 4K where UI can still feel small next to physical screen size. */
-  --mm-density-font-scale: 1.1;
+  --mm-density-font-scale: 1.2;
+  --mm-density-ui-scale: 1.12;
   --mm-main-max-cap: 2600px;
+}
+
+html[data-mm-density="expanded"] {
+  --mm-density-font-scale: 1.32;
+  --mm-density-ui-scale: 1.22;
+  --mm-main-max-cap: 2800px;
 }
 
 html[data-mm-density="compact"] {
   --mm-density-font-scale: 0.94;
+  --mm-density-ui-scale: 0.84;
   --mm-main-max-cap: 2100px;
 }


### PR DESCRIPTION
## Summary
- fixes upgrade fallback so a browser that lands on the upgrade API is redirected back to Settings
- changes upgrade completion refresh to return to /app/settings instead of reloading the current URL
- pins the dark/light toggle to app chrome instead of scrolling over content
- removes redundant Refiner watched-folder scan activity rows so Activity shows file outcomes only
- replaces technical/skipped Refiner wording with no-change user language
- bumps MediaMop to 1.0.17

## Validation
- Backend full suite: 623 passed, 2 skipped
- Web build: passed
- Web unit suite: 134 passed
- E2E smoke: 5 passed