### PR TITLE
Release MediaMop 1.0.18 installer cleanup

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.17"
+version = "1.0.18"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/version.py
+++ b/apps/backend/src/mediamop/version.py
@@ -1,13 +1,54 @@
 from __future__ import annotations
 
 import os
+import re
+import sys
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+_DIST_INFO_RE = re.compile(r"^mediamop_backend-(?P<version>\d+(?:\.\d+)*)(?:[^\d].*)?\.dist-info$")
+
+
+def _version_key(raw: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in raw.split(".") if part.isdigit())
+
+
+def _packaged_resource_root() -> Path | None:
+    if not getattr(sys, "frozen", False):
+        return None
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass:
+        return Path(meipass)
+    executable_dir = Path(sys.executable).resolve().parent
+    internal_dir = executable_dir / "_internal"
+    if internal_dir.is_dir():
+        return internal_dir
+    return executable_dir
+
+
+def _packaged_dist_info_version() -> str | None:
+    root = _packaged_resource_root()
+    if root is None or not root.is_dir():
+        return None
+
+    versions: list[str] = []
+    for child in root.iterdir():
+        match = _DIST_INFO_RE.match(child.name)
+        if match:
+            versions.append(match.group("version"))
+    if not versions:
+        return None
+    return sorted(versions, key=_version_key)[-1]
 
 
 def get_version() -> str:
     env_version = (os.environ.get("MEDIAMOP_VERSION") or "").strip()
     if env_version:
         return env_version
+    packaged_version = _packaged_dist_info_version()
+    if packaged_version:
+        return packaged_version
     try:
         pkg_version = (version("mediamop-backend") or "").strip()
         if pkg_version:

--- a/apps/backend/tests/test_version.py
+++ b/apps/backend/tests/test_version.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+
+from mediamop.version import get_version
+
+
+def test_get_version_prefers_highest_packaged_dist_info(tmp_path, monkeypatch):
+    for version in ("1.0.7", "1.0.17", "1.0.13"):
+        (tmp_path / f"mediamop_backend-{version}.dist-info").mkdir()
+
+    monkeypatch.delenv("MEDIAMOP_VERSION", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert get_version() == "1.0.17"
+
+
+def test_get_version_environment_override_wins(tmp_path, monkeypatch):
+    (tmp_path / "mediamop_backend-1.0.17.dist-info").mkdir()
+
+    monkeypatch.setenv("MEDIAMOP_VERSION", "9.9.9")
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert get_version() == "9.9.9"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.17",
+  "version": "1.0.18",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -41,6 +41,11 @@ Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription:
 [Dirs]
 Name: "{commonappdata}\MediaMop"; Permissions: users-modify
 
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\_internal"
+Type: files; Name: "{app}\MediaMop.exe"
+Type: files; Name: "{app}\MediaMopServer.exe"
+
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 


### PR DESCRIPTION
Fixes the dirty Windows upgrade discovered on app-server where old packaged _internal files remained after over-the-top installs.\n\nChanges:\n- Windows installer deletes stale packaged _internal files and old launchers before copying the new build.\n- Packaged version detection prefers the highest bundled mediamop_backend dist-info when stale metadata exists.\n- Bumps backend and web versions to 1.0.18.\n- Adds regression tests for packaged version detection.\n\nLocal validation:\n- Backend focused tests: tests/test_version.py tests/test_suite_settings_api.py passed.\n- Web focused tests for density/settings/setup/shell passed.\n- Web production build passed.