### PR TITLE
Release MediaMop 1.0.19 refiner LAN density fixes

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.18"
+version = "1.0.19"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_run.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_run.py
@@ -144,6 +144,24 @@ def _check_output_file_completeness(*, output_file: Path, source_file: Path) -> 
     }
 
 
+def _copy_unchanged_source_to_output(*, src: Path, final: Path) -> tuple[bool, bool]:
+    """For already-correct files, still place a copy in the output tree before cleanup."""
+
+    src_resolved = src.resolve()
+    final.parent.mkdir(parents=True, exist_ok=True)
+    if final.exists():
+        final_resolved = final.resolve()
+        if final_resolved == src_resolved:
+            raise RuntimeError(
+                "Refiner output path resolves to the watched source file; output and watched folders must differ."
+            )
+        final.unlink()
+        shutil.copy2(src_resolved, final)
+        return True, True
+    shutil.copy2(src_resolved, final)
+    return True, False
+
+
 def _cascade_delete_empty_parents(
     *,
     first_parent: Path,
@@ -493,18 +511,55 @@ def run_refiner_file_remux_pass(
 
     if not remux_needed:
         out["outcome"] = REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED
-        out["live_mutations_skipped"] = True
         out["refiner_output_folder_resolved"] = str(out_dir)
         out["after_track_lines_meaning"] = (
-            "No ffmpeg run; before/after lines compare the file as-is to the planned layout "
-            "(they may match when remux was not required)."
+            "No ffmpeg run was needed because the file already matched the saved Refiner rules."
         )
         out["reason"] = (
-            "Streams already match the remux plan; no ffmpeg run in this pass. "
-            "On success, the source file under the watched folder may still be removed per Refiner path settings."
+            "The file already matched the saved Refiner rules, so Refiner copied it to the output folder without rewriting it."
         )
         rel_skip = src.resolve().relative_to(watched_root)
         final_skip = out_dir / rel_skip
+        try:
+            _copied, output_replaced_existing = _copy_unchanged_source_to_output(src=src, final=final_skip)
+        except Exception as exc:
+            if progress_reporter is not None:
+                progress_reporter(
+                    {
+                        "status": "failed",
+                        "percent": None,
+                        "eta_seconds": None,
+                        "relative_media_path": relative_media_path,
+                        "inspected_source_path": inspected,
+                        "media_scope": scope,
+                        "message": "Refiner could not copy this unchanged file to the output folder.",
+                        "reason": str(exc),
+                    }
+                )
+            return {
+                "ok": False,
+                "outcome": REMUX_PASS_OUTCOME_FAILED_DURING_EXECUTION,
+                "preflight_status": "ok",
+                "preflight_reason": "ffprobe completed and remux plan was evaluated",
+                "reason": str(exc),
+                "relative_media_path": relative_media_path,
+                "inspected_source_path": inspected,
+                "refiner_watched_folder_resolved": str(watched_root),
+                "refiner_output_folder_resolved": str(out_dir),
+                "stream_counts": out.get("stream_counts"),
+                "plan_summary": out.get("plan_summary"),
+                "audio_before": before_a,
+                "audio_after": after_a,
+                "subs_before": before_s,
+                "subs_after": after_s,
+                "remux_required": remux_needed,
+                "ffmpeg_argv": [str(x) for x in argv],
+                "audio_selection_notes": list(plan.audio_selection_notes),
+            }
+        out["output_file"] = str(final_skip.resolve())
+        out["output_replaced_existing"] = output_replaced_existing
+        out["output_copied_without_remux"] = True
+        out["live_mutations_skipped"] = False
         _handle_refiner_cleanup_after_success(
             src=src,
             watched_root=watched_root,

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -130,6 +130,24 @@ def _open_browser(port: int) -> None:
     webbrowser.open(f"http://127.0.0.1:{port}/", new=2)
 
 
+def _lan_urls(port: int) -> list[str]:
+    urls: list[str] = []
+    seen: set[str] = set()
+    try:
+        hostname = socket.gethostname()
+        for info in socket.getaddrinfo(hostname, port, family=socket.AF_INET, type=socket.SOCK_STREAM):
+            addr = str(info[4][0])
+            if addr.startswith("127."):
+                continue
+            url = f"http://{addr}:{port}/"
+            if url not in seen:
+                seen.add(url)
+                urls.append(url)
+    except OSError:
+        return []
+    return urls
+
+
 def _wait_for_health(port: int, timeout_seconds: float = 30.0) -> None:
     import http.client
 
@@ -255,6 +273,9 @@ class _MediaMopTrayApp:
             self._log("Waiting for local health endpoint")
             _wait_for_health(self._port)
             self._log(f"MediaMop is healthy on http://127.0.0.1:{self._port}/")
+            lan = _lan_urls(self._port)
+            if lan:
+                self._log("MediaMop LAN URLs: " + ", ".join(lan))
             _open_browser(self._port)
             self._icon = self._create_icon()
             self._log("Starting tray icon event loop")
@@ -276,7 +297,7 @@ def _run_server_mode(port: int) -> None:
     server = uvicorn.Server(
         uvicorn.Config(
             app,
-            host="127.0.0.1",
+            host="0.0.0.0",
             port=port,
             log_level="info",
             log_config=None,

--- a/apps/backend/tests/test_refiner_file_remux_pass_run.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_run.py
@@ -72,7 +72,10 @@ def test_run_fails_when_watched_root_missing(tmp_path: Path) -> None:
     assert r["preflight_status"] == "failed"
     assert "watched folder" in r["reason"].lower()
 
-def test_live_skips_when_no_remux_required_deletes_release_folder(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_skips_when_no_remux_required_copies_to_output_and_deletes_release_folder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     home = tmp_path / "home"
     home.mkdir()
     media = tmp_path / "media"
@@ -83,9 +86,6 @@ def test_live_skips_when_no_remux_required_deletes_release_folder(tmp_path: Path
     mkv.write_bytes(b"x" * 2000)
     out = tmp_path / "out"
     out.mkdir()
-    out_rel = out / "ReleaseTitle"
-    out_rel.mkdir()
-    (out_rel / "one.mkv").write_bytes(b"y" * 500)
 
     settings = replace(MediaMopSettings.load(), mediamop_home=str(home), refiner_watched_folder_min_file_age_seconds=0)
     rt = _runtime(media=media, home=home, out=out)
@@ -102,11 +102,51 @@ def test_live_skips_when_no_remux_required_deletes_release_folder(tmp_path: Path
     assert r["ok"] is True
     assert r["outcome"] == REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED
     assert r["preflight_status"] == "ok"
-    assert r.get("live_mutations_skipped") is True
+    assert r.get("live_mutations_skipped") is False
+    assert r.get("output_copied_without_remux") is True
+    assert Path(r["output_file"]).resolve() == (out / "ReleaseTitle" / "one.mkv").resolve()
+    assert (out / "ReleaseTitle" / "one.mkv").read_bytes() == b"x" * 2000
     assert r.get("source_deleted_after_success") is True
     assert r.get("source_folder_deleted") is True
     assert not mkv.exists()
     assert not release.exists()
+
+
+def test_live_skips_when_no_remux_required_replaces_existing_output_before_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    media = tmp_path / "media"
+    media.mkdir()
+    release = media / "ReleaseTitle"
+    release.mkdir()
+    mkv = release / "one.mkv"
+    mkv.write_bytes(b"x" * 2000)
+    out = tmp_path / "out"
+    out.mkdir()
+    out_rel = out / "ReleaseTitle"
+    out_rel.mkdir()
+    existing = out_rel / "one.mkv"
+    existing.write_bytes(b"tiny")
+
+    settings = replace(MediaMopSettings.load(), mediamop_home=str(home), refiner_watched_folder_min_file_age_seconds=0)
+    rt = _runtime(media=media, home=home, out=out)
+
+    monkeypatch.setattr(runmod, "ffprobe_json", lambda path, mediamop_home, **kwargs: _fake_probe())
+    monkeypatch.setattr(runmod, "resolve_ffprobe_ffmpeg", lambda *, mediamop_home: ("ffprobe-x", "ffmpeg-x"))
+    monkeypatch.setattr(runmod, "is_remux_required", lambda *_a, **_k: False)
+
+    r = runmod.run_refiner_file_remux_pass(
+        settings=settings,
+        path_runtime=rt,
+        relative_media_path="ReleaseTitle/one.mkv",
+    )
+    assert r["ok"] is True
+    assert r.get("output_replaced_existing") is True
+    assert existing.read_bytes() == b"x" * 2000
+    assert r.get("source_folder_deleted") is True
 
 def test_live_fails_during_ffmpeg_surfaces_outcome(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
@@ -288,6 +328,7 @@ def test_tv_live_skips_movie_folder_cleanup_deletes_season_folder_when_gates_pas
         lambda **kwargs: [],
     )
     old = time.time() - 200_000
+    os.utime(mkv, (old, old))
     os.utime(out_season / "ep.mkv", (old, old))
 
     r = runmod.run_refiner_file_remux_pass(
@@ -311,7 +352,10 @@ def test_tv_live_skips_movie_folder_cleanup_deletes_season_folder_when_gates_pas
     assert not out_season.is_dir()
 
 
-def test_movie_live_skips_when_output_smaller_than_one_percent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_movie_live_no_remux_replaces_tiny_existing_output_before_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     home = tmp_path / "home"
     home.mkdir()
     media = tmp_path / "media"
@@ -338,9 +382,10 @@ def test_movie_live_skips_when_output_smaller_than_one_percent(tmp_path: Path, m
         relative_media_path="M/a.mkv",
     )
     assert r["ok"] is True
-    assert r.get("source_folder_deleted") is False
-    assert mkv.exists()
-    assert r.get("output_completeness_check") == "failed"
+    assert r.get("source_folder_deleted") is True
+    assert not mkv.exists()
+    assert (out_m / "a.mkv").read_bytes() == b"x" * 10_000
+    assert r.get("output_completeness_check") == "passed"
     assert "tv_season_folder_deleted" not in r
     assert "tv_output_season_folder_deleted" not in r
     assert "tv_output_truth_check" not in r

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -46,6 +46,8 @@ def test_inno_installer_uses_program_files_and_programdata() -> None:
     assert "CloseApplications=no" in text
     assert "RestartApplications=no" in text
     assert "taskkill.exe" in text
+    assert "advfirewall firewall add rule" in text
+    assert 'program=""{app}\\MediaMopServer.exe""' in text
     assert "MediaMop.exe" in text
     assert "MediaMopServer.exe" in text
 
@@ -76,3 +78,11 @@ def test_windows_package_includes_ffmpeg_runtime_assets() -> None:
     assert '(str(FFMPEG_VENDOR), "bin/ffmpeg")' in spec_text
     assert "Ensure-WindowsFfmpegRuntime" in build_text
     assert "ffmpeg-master-latest-win64-lgpl.zip" in build_text
+
+
+def test_packaged_server_binds_to_lan_interfaces() -> None:
+    source = Path(tray_app.__file__).read_text(encoding="utf-8")
+
+    assert 'host="0.0.0.0"' in source
+    assert 'host="127.0.0.1"' not in source
+    assert "MediaMop LAN URLs" in source

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.18",
+      "version": "1.0.19",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.18",
+  "version": "1.0.19",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/styles/mediamop-tokens.css
+++ b/apps/web/src/styles/mediamop-tokens.css
@@ -118,5 +118,5 @@ html[data-mm-density="expanded"] {
 html[data-mm-density="compact"] {
   --mm-density-font-scale: 0.94;
   --mm-density-ui-scale: 0.84;
-  --mm-main-max-cap: 2100px;
+  --mm-main-max-cap: 2800px;
 }

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -54,7 +54,12 @@ Name: "{group}\MediaMop"; Filename: "{app}\{#ExeName}"
 Name: "{commondesktop}\MediaMop"; Filename: "{app}\{#ExeName}"; Tasks: desktopicon
 
 [Run]
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""MediaMop Server"""; Flags: runhidden waituntilterminated
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall add rule name=""MediaMop Server"" dir=in action=allow program=""{app}\MediaMopServer.exe"" enable=yes profile=private"; Flags: runhidden waituntilterminated
 Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall skipifsilent
+
+[UninstallRun]
+Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""MediaMop Server"""; Flags: runhidden waituntilterminated
 
 [Code]
 procedure StopMediaMopProcess(ProcessName: String);


### PR DESCRIPTION
## Summary
- copy no-change Refiner files into the output tree before watched-folder cleanup
- let compact density use the same wide main canvas as the larger modes
- bind packaged Windows server to LAN interfaces and add/remove a Private-profile firewall rule in the installer
- bump backend and web versions to 1.0.19

## Local validation
- apps/backend: 627 passed, 2 skipped
- apps/web: 134 passed
- apps/web: production build passed
- focused version/refiner/packaging tests passed after version bump