### PR TITLE
Release MediaMop 1.0.20 upgrade landing fix

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.19"
+version = "1.0.20"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/api/factory.py
+++ b/apps/backend/src/mediamop/api/factory.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler
+from fastapi.responses import RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette import status
 
 from mediamop import __version__
 from mediamop.api.router import build_v1_router
@@ -30,6 +34,22 @@ def _mount_web_spa_if_configured(application: FastAPI) -> None:
     application.mount("/", StaticFiles(directory=str(root), html=True), name="web")
 
 
+def _is_upgrade_browser_landing_404(request: Request, exc: StarletteHTTPException) -> bool:
+    """Redirect stale/legacy in-app-upgrade browser landings back to the SPA.
+
+    Older installed builds can leave the browser on an API-ish upgrade URL while the
+    app restarts. Without this guard FastAPI returns ``{"detail":"Not Found"}``,
+    which is technically correct but useless for a user during an upgrade.
+    """
+
+    if exc.status_code != status.HTTP_404_NOT_FOUND or request.method != "GET":
+        return False
+    path = request.url.path.lower()
+    if not path.startswith("/api"):
+        return False
+    return any(token in path for token in ("update-now", "upgrade-now", "upgrade"))
+
+
 def create_app() -> FastAPI:
     settings = MediaMopSettings.load()
     application = FastAPI(
@@ -40,6 +60,13 @@ def create_app() -> FastAPI:
 
     application.add_middleware(SecurityHeadersMiddleware)
     application.add_middleware(RequestContextMiddleware)
+
+    @application.exception_handler(StarletteHTTPException)
+    async def _friendly_upgrade_landing_handler(request: Request, exc: StarletteHTTPException):
+        if _is_upgrade_browser_landing_404(request, exc):
+            return RedirectResponse(url="/app/settings", status_code=status.HTTP_303_SEE_OTHER)
+        return await http_exception_handler(request, exc)
+
     if settings.cors_origins:
         application.add_middleware(
             CORSMiddleware,

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -155,13 +155,11 @@ function Write-UpgradeLog([string]$message) {{
   Add-Content -LiteralPath $logPath -Value "[$stamp] $message"
 }}
 Write-UpgradeLog "Starting MediaMop in-app upgrade."
-Start-Sleep -Seconds 2
-Get-Process -Name MediaMop,MediaMopServer -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
-Write-UpgradeLog "Stopped running MediaMop processes."
 $installer = {str(installer_path)!r}
 $args = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS")
-$proc = Start-Process -FilePath $installer -ArgumentList $args -Wait -PassThru -ErrorAction Stop
-Write-UpgradeLog "Installer exited with code $($proc.ExitCode)."
+Write-UpgradeLog "Starting elevated installer. Windows may ask for permission."
+$proc = Start-Process -FilePath $installer -ArgumentList $args -Verb RunAs -Wait -PassThru -ErrorAction Stop
+Write-UpgradeLog "Elevated installer exited with code $($proc.ExitCode)."
 $exe = {str(exe_path)!r}
 if (Test-Path -LiteralPath $exe) {{
   Start-Process -FilePath $exe -WorkingDirectory {str(executable_dir)!r}
@@ -174,9 +172,19 @@ if (Test-Path -LiteralPath $exe) {{
 
 
 def _launch_windows_upgrade_script(script_path: Path) -> None:
+    log_path = script_path.parent / "upgrade-launch.log"
+    log_path.write_text("Launching MediaMop in-app upgrade script.\n", encoding="utf-8")
+    powershell = (
+        Path(os.environ.get("SystemRoot") or r"C:\Windows")
+        / "System32"
+        / "WindowsPowerShell"
+        / "v1.0"
+        / "powershell.exe"
+    )
+    command = str(powershell) if powershell.is_file() else "powershell.exe"
     subprocess.Popen(
         [
-            "powershell.exe",
+            command,
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -12,3 +12,21 @@ def test_health_ok() -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_unknown_upgrade_api_browser_landing_redirects_to_settings() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/api/v1/suite/upgrade-now", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/app/settings"
+
+
+def test_regular_unknown_api_path_still_returns_json_404() -> None:
+    client = TestClient(create_app())
+
+    response = client.get("/api/v1/does-not-exist", follow_redirects=False)
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Not Found"}

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -385,7 +385,9 @@ def test_suite_update_now_stages_windows_installer_and_launches_script(
     assert installer.read_bytes() == b"installer-bytes"
     assert script.is_file()
     assert launched == [str(script)]
-    assert "Stop-Process" in script.read_text(encoding="utf-8")
+    script_text = script.read_text(encoding="utf-8")
+    assert "-Verb RunAs" in script_text
+    assert "Starting elevated installer" in script_text
 
 
 def test_suite_configuration_backup_tick_creates_snapshot(client_with_admin: TestClient) -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.19",
+  "version": "1.0.20",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- redirect stale/legacy upgrade API browser landings back to Settings instead of showing raw FastAPI JSON 404
- keep regular API 404s unchanged
- bump backend and web versions to 1.0.20

## Local validation
- apps/backend: 629 passed, 2 skipped
- apps/web: 134 passed
- apps/web: production build passed
- focused upgrade landing/version tests passed