### PR TITLE
Release MediaMop 1.0.22 tray double-click open

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.21"
+version = "1.0.22"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -232,7 +232,7 @@ class _MediaMopTrayApp:
             _load_icon(self._resource_root),
             "MediaMop",
             menu=pystray.Menu(
-                Item("Open MediaMop", self._handle_open),
+                Item("Open MediaMop", self._handle_open, default=True),
                 Item("Open Data Folder", self._handle_open_data_folder),
                 Item("Quit", self._handle_quit),
             ),

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -86,3 +86,9 @@ def test_packaged_server_binds_to_lan_interfaces() -> None:
     assert 'host="0.0.0.0"' in source
     assert 'host="127.0.0.1"' not in source
     assert "MediaMop LAN URLs" in source
+
+
+def test_tray_double_click_opens_mediamop() -> None:
+    source = Path(tray_app.__file__).read_text(encoding="utf-8")
+
+    assert 'Item("Open MediaMop", self._handle_open, default=True)' in source

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.21",
+      "version": "1.0.22",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.21",
+  "version": "1.0.22",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- make Open MediaMop the default tray menu item so double-clicking the Windows tray icon opens MediaMop
- add a Windows packaging regression test for the default tray action
- bump backend and web package versions to 1.0.22

## Verification
- apps/backend: pytest -q (633 passed, 2 skipped)
- apps/web: npm test -- --run (134 passed)
- apps/web: npm run build