### PR TITLE
Fix live activity SSE updates

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.22"
+version = "1.0.23"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/activity/live_stream.py
+++ b/apps/backend/src/mediamop/platform/activity/live_stream.py
@@ -11,8 +11,7 @@ class ActivityLatestNotifier:
         self._lock = threading.Lock()
         self._latest_id: int | None = None
         self._version = 0
-        self._loop: asyncio.AbstractEventLoop | None = None
-        self._event: asyncio.Event | None = None
+        self._waiters: dict[asyncio.AbstractEventLoop, set[asyncio.Future[tuple[int | None, int]]]] = {}
 
     def snapshot(self) -> tuple[int | None, int]:
         with self._lock:
@@ -22,42 +21,64 @@ class ActivityLatestNotifier:
         with self._lock:
             self._latest_id = latest_id
             self._version += 1
-            loop = self._loop
-            event = self._event
-        if loop is not None and event is not None:
+            latest = (self._latest_id, self._version)
+            waiters = [(loop, future) for loop, futures in self._waiters.items() for future in list(futures)]
+        for loop, future in waiters:
+            if future.done():
+                continue
             try:
-                loop.call_soon_threadsafe(event.set)
+                loop.call_soon_threadsafe(self._resolve_waiter, future, latest)
             except RuntimeError:
-                with self._lock:
-                    if self._loop is loop:
-                        self._loop = None
-                    if self._event is event:
-                        self._event = None
+                self._discard_waiter(loop, future)
+
+    def _resolve_waiter(
+        self,
+        future: asyncio.Future[tuple[int | None, int]],
+        latest: tuple[int | None, int],
+    ) -> None:
+        if not future.done():
+            future.set_result(latest)
+
+    def _discard_waiter(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        future: asyncio.Future[tuple[int | None, int]],
+    ) -> None:
+        with self._lock:
+            futures = self._waiters.get(loop)
+            if futures is None:
+                return
+            futures.discard(future)
+            if not futures:
+                self._waiters.pop(loop, None)
 
     async def wait_for_change(self, previous_version: int, *, timeout: float) -> tuple[int | None, int] | None:
         loop = asyncio.get_running_loop()
+        future: asyncio.Future[tuple[int | None, int]] = loop.create_future()
         with self._lock:
             if self._version != previous_version:
                 return self._latest_id, self._version
-            if self._loop is not loop or self._event is None:
-                self._loop = loop
-                self._event = asyncio.Event()
-            event = self._event
+            self._waiters.setdefault(loop, set()).add(future)
         try:
-            await asyncio.wait_for(event.wait(), timeout=timeout)
+            return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError:
             return None
         finally:
-            event.clear()
+            self._discard_waiter(loop, future)
+
+    def waiter_count_for_tests(self) -> int:
         with self._lock:
-            return self._latest_id, self._version
+            return sum(len(futures) for futures in self._waiters.values())
 
     def reset_for_tests(self) -> None:
         with self._lock:
+            for futures in self._waiters.values():
+                for future in futures:
+                    if not future.done():
+                        future.cancel()
             self._latest_id = None
             self._version = 0
-            self._loop = None
-            self._event = None
+            self._waiters = {}
 
 
 activity_latest_notifier = ActivityLatestNotifier()

--- a/apps/backend/src/mediamop/platform/activity/router.py
+++ b/apps/backend/src/mediamop/platform/activity/router.py
@@ -147,15 +147,23 @@ async def iter_activity_latest_sse(
         latest_id = read_latest_id()
         if latest_id is not None and latest_id != last_sent_id:
             last_sent_id = latest_id
-            yield _sse_event(event="activity.latest", data={"latest_event_id": latest_id})
+            _notifier_latest_id, notifier_version = activity_latest_notifier.snapshot()
+            last_seen_version = max(last_seen_version, notifier_version)
+            yield _sse_event(
+                event="activity.latest",
+                data={"latest_event_id": latest_id, "activity_revision": last_seen_version},
+            )
             polls_since_keepalive = 0
             continue
         changed = await activity_latest_notifier.wait_for_change(last_seen_version, timeout=poll_seconds)
         if changed is not None:
             latest_id, last_seen_version = changed
-            if latest_id is not None and latest_id != last_sent_id:
+            if latest_id is not None:
                 last_sent_id = latest_id
-                yield _sse_event(event="activity.latest", data={"latest_event_id": latest_id})
+                yield _sse_event(
+                    event="activity.latest",
+                    data={"latest_event_id": latest_id, "activity_revision": last_seen_version},
+                )
                 polls_since_keepalive = 0
                 continue
         polls_since_keepalive += 1

--- a/apps/backend/tests/test_activity_stream.py
+++ b/apps/backend/tests/test_activity_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -78,6 +79,64 @@ def test_record_activity_event_notifies_only_after_commit() -> None:
         assert committed_version == 1
 
 
+def test_update_activity_event_notifies_same_row_progress_after_commit() -> None:
+    activity_latest_notifier.reset_for_tests()
+    settings = MediaMopSettings.load()
+    eng = create_db_engine(settings)
+    fac = create_session_factory(eng)
+    with fac() as db:
+        row = activity_service.record_activity_event(
+            db,
+            event_type=activity_constants.REFINER_FILE_PROCESSING_PROGRESS,
+            module="refiner",
+            title="Refiner is processing movie.mkv",
+            detail='{"percent":10}',
+        )
+        db.commit()
+        first_id, first_version = activity_latest_notifier.snapshot()
+        assert first_id == int(row.id)
+        assert first_version == 1
+
+        activity_service.update_activity_event(
+            db,
+            activity_id=int(row.id),
+            title="Refiner is processing movie.mkv",
+            detail='{"percent":42}',
+        )
+        latest_id, version_before_commit = activity_latest_notifier.snapshot()
+        assert latest_id == int(row.id)
+        assert version_before_commit == 1
+        db.commit()
+
+        updated_id, updated_version = activity_latest_notifier.snapshot()
+        assert updated_id == int(row.id)
+        assert updated_version == 2
+
+
+@pytest.mark.anyio
+async def test_activity_latest_notifier_wakes_all_active_stream_subscribers() -> None:
+    activity_latest_notifier.reset_for_tests()
+
+    first = asyncio.create_task(activity_latest_notifier.wait_for_change(0, timeout=1.0))
+    second = asyncio.create_task(activity_latest_notifier.wait_for_change(0, timeout=1.0))
+    await asyncio.sleep(0)
+    assert activity_latest_notifier.waiter_count_for_tests() == 2
+
+    activity_latest_notifier.notify(99)
+
+    assert await first == (99, 1)
+    assert await second == (99, 1)
+    assert activity_latest_notifier.waiter_count_for_tests() == 0
+
+
+@pytest.mark.anyio
+async def test_activity_latest_notifier_removes_timed_out_stream_subscribers() -> None:
+    activity_latest_notifier.reset_for_tests()
+
+    assert await activity_latest_notifier.wait_for_change(0, timeout=0.001) is None
+    assert activity_latest_notifier.waiter_count_for_tests() == 0
+
+
 @pytest.mark.anyio
 async def test_activity_stream_authenticated_emits_latest_format(client_with_admin: TestClient) -> None:
     _login(client_with_admin)
@@ -129,8 +188,38 @@ async def test_activity_stream_generator_emits_expected_payload_for_newer_id() -
 
     merged = "".join(chunks)
     assert "event: activity.latest" in merged
-    assert 'data: {"latest_event_id":10}' in merged
-    assert 'data: {"latest_event_id":11}' in merged
+    assert 'data: {"latest_event_id":10,"activity_revision":0}' in merged
+    assert 'data: {"latest_event_id":11,"activity_revision":0}' in merged
+
+
+@pytest.mark.anyio
+async def test_activity_stream_generator_emits_same_id_when_activity_revision_changes() -> None:
+    activity_latest_notifier.reset_for_tests()
+    checks = {"n": 0}
+
+    async def _is_disconnected() -> bool:
+        checks["n"] += 1
+        if checks["n"] == 2:
+            activity_latest_notifier.notify(42)
+        if checks["n"] == 3:
+            activity_latest_notifier.notify(42)
+        return checks["n"] > 3
+
+    gen = iter_activity_latest_sse(
+        read_latest_id=lambda: 42,
+        is_disconnected=_is_disconnected,
+        poll_seconds=0.0,
+        keepalive_every_polls=100,
+    )
+    chunks: list[str] = []
+    async for chunk in gen:
+        chunks.append(chunk)
+
+    merged = "".join(chunks)
+    assert merged.count('"latest_event_id":42') == 3
+    assert '"activity_revision":0' in merged
+    assert '"activity_revision":1' in merged
+    assert '"activity_revision":2' in merged
 
 
 def test_activity_stream_does_not_depend_on_request_db_dependency(client_with_admin: TestClient) -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.22",
+      "version": "1.0.23",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.22",
+  "version": "1.0.23",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
@@ -67,6 +67,41 @@ describe("useActivityStreamInvalidation", () => {
     expect(spy).toHaveBeenCalledWith({ queryKey: activityRecentKey });
   });
 
+  it("invalidates when an existing activity row receives a newer revision", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    const qc = new QueryClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
+      wrapper: withQueryClient(qc),
+    });
+
+    const src = FakeEventSource.instances[0];
+    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 1 }));
+    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 2 }));
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenLastCalledWith({ queryKey: activityRecentKey });
+  });
+
+  it("ignores malformed stream messages instead of breaking live updates", () => {
+    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    const qc = new QueryClient();
+    const spy = vi.spyOn(qc, "invalidateQueries");
+
+    renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
+      wrapper: withQueryClient(qc),
+    });
+
+    const src = FakeEventSource.instances[0];
+    src.emit("activity.latest", "{");
+    src.emit("activity.latest", JSON.stringify({ activity_revision: 1 }));
+    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 2 }));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ queryKey: activityRecentKey });
+  });
+
   it("invalidates dashboard status query on activity.latest", () => {
     vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
     const qc = new QueryClient();

--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useQueryClient, type QueryKey } from "@tanstack/react-query";
 
-type LatestPayload = { latest_event_id: number };
+type LatestPayload = { latest_event_id: number; activity_revision?: number };
 type ActivityLatestSubscriber = () => void;
 
 let source: EventSource | null = null;


### PR DESCRIPTION
## Summary
- make activity SSE revisions emit for updates to existing rows, not just new activity ids
- allow all active SSE subscribers to wake on the same activity update
- add backend and frontend regression coverage for Refiner live progress updates
- bump app version to 1.0.23

## Tests
- apps/backend: pytest -q
- apps/web: npm test -- --run
- apps/web: npm run build