### PR TITLE
Polish Refiner progress completion state

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.23"
+version = "1.0.24"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.23",
+  "version": "1.0.24",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
@@ -54,4 +54,37 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
     expect(screen.getByText(/About 1m 11s left/i)).toBeInTheDocument();
     expect(screen.getByText(/Speed 16x/i)).toBeInTheDocument();
   });
+
+  it("uses finished styling and copy when Refiner progress completes", () => {
+    const detail = JSON.stringify({
+      status: "finished",
+      relative_media_path: "movies/Mickey 17.mkv",
+      percent: 100,
+      eta_seconds: 0,
+      elapsed_seconds: 183,
+      message: "Refiner is writing the cleaned-up file.",
+    });
+    render(<RefinerFileProcessingProgressDetail detail={detail} />);
+    const card = screen.getByTestId("refiner-processing-progress-detail");
+
+    expect(card).toHaveClass("mm-activity-processing--finished");
+    expect(screen.getAllByText("Finished")).toHaveLength(2);
+    expect(screen.getByText("Refiner finished processing this file.")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(screen.queryByText(/About 0s left/i)).not.toBeInTheDocument();
+  });
+
+  it("uses failed styling when Refiner progress stops", () => {
+    const detail = JSON.stringify({
+      status: "failed",
+      relative_media_path: "movies/Broken.mkv",
+      percent: 63,
+      reason: "ffmpeg stopped unexpectedly.",
+    });
+    render(<RefinerFileProcessingProgressDetail detail={detail} />);
+
+    expect(screen.getByTestId("refiner-processing-progress-detail")).toHaveClass("mm-activity-processing--failed");
+    expect(screen.getAllByText("Stopped")).toHaveLength(2);
+    expect(screen.getByText("ffmpeg stopped unexpectedly.")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
@@ -351,13 +351,37 @@ export function RefinerFileProcessingProgressDetail({ detail }: { detail: string
         : status === "finishing"
           ? "Final checks"
           : "Processing";
+  const statusClass =
+    status === "finished"
+      ? "mm-activity-processing--finished"
+      : status === "failed"
+        ? "mm-activity-processing--failed"
+        : status === "finishing"
+          ? "mm-activity-processing--finishing"
+          : "mm-activity-processing--processing";
+  const message =
+    status === "finished"
+      ? "Refiner finished processing this file."
+      : status === "failed"
+        ? parsed.message || "Refiner could not finish this file."
+        : parsed.message || `Refiner is processing ${fileName}.`;
+  const primaryMetric =
+    status === "finished"
+      ? "Finished"
+      : status === "failed"
+        ? "Stopped"
+        : eta
+          ? `About ${eta} left`
+          : status === "processing"
+            ? "Estimating time left"
+            : statusText;
 
   return (
-    <div className="mm-activity-processing" data-testid="refiner-processing-progress-detail">
+    <div className={`mm-activity-processing ${statusClass}`} data-testid="refiner-processing-progress-detail">
       <div className="mm-activity-processing__header">
         <div>
           <p className="mm-activity-processing__eyebrow">{statusText}</p>
-          <p className="mm-activity-processing__title">{parsed.message || `Refiner is processing ${fileName}.`}</p>
+          <p className="mm-activity-processing__title">{message}</p>
         </div>
         <strong className="mm-activity-processing__percent">{percent == null ? "Working" : `${Math.round(percent)}%`}</strong>
       </div>
@@ -365,7 +389,7 @@ export function RefinerFileProcessingProgressDetail({ detail }: { detail: string
         <span style={{ width: `${percent ?? 8}%` }} />
       </div>
       <div className="mm-activity-processing__metrics">
-        <span>{eta ? `About ${eta} left` : status === "processing" ? "Estimating time left" : statusText}</span>
+        <span>{primaryMetric}</span>
         {elapsed ? <span>Running {elapsed}</span> : null}
         {processed && duration ? <span>Processed {processed} of {duration}</span> : null}
         {parsed.speed ? <span>Speed {parsed.speed}</span> : null}

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -952,6 +952,28 @@ html[data-mm-theme="light"] .mm-theme-toggle {
     color-mix(in srgb, var(--mm-card-bg) 92%, transparent);
 }
 
+.mm-activity-processing--processing,
+.mm-activity-processing--finishing {
+  border-color: rgba(230, 193, 92, 0.26);
+  background:
+    linear-gradient(135deg, rgba(230, 193, 92, 0.12), transparent 46%),
+    color-mix(in srgb, var(--mm-card-bg) 92%, transparent);
+}
+
+.mm-activity-processing--finished {
+  border-color: rgba(52, 211, 153, 0.32);
+  background:
+    linear-gradient(135deg, rgba(16, 185, 129, 0.16), transparent 46%),
+    color-mix(in srgb, var(--mm-card-bg) 92%, transparent);
+}
+
+.mm-activity-processing--failed {
+  border-color: rgba(248, 113, 113, 0.36);
+  background:
+    linear-gradient(135deg, rgba(239, 68, 68, 0.15), transparent 46%),
+    color-mix(in srgb, var(--mm-card-bg) 92%, transparent);
+}
+
 .mm-activity-processing__header {
   display: flex;
   align-items: flex-start;
@@ -966,6 +988,14 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+}
+
+.mm-activity-processing--finished .mm-activity-processing__eyebrow {
+  color: #6ee7b7;
+}
+
+.mm-activity-processing--failed .mm-activity-processing__eyebrow {
+  color: #fca5a5;
 }
 
 .mm-activity-processing__title {
@@ -989,6 +1019,14 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   background: color-mix(in srgb, var(--mm-slate) 88%, transparent);
 }
 
+.mm-activity-processing--finished .mm-activity-processing__bar {
+  border-color: rgba(52, 211, 153, 0.3);
+}
+
+.mm-activity-processing--failed .mm-activity-processing__bar {
+  border-color: rgba(248, 113, 113, 0.34);
+}
+
 .mm-activity-processing__bar > span {
   display: block;
   min-width: 0.45rem;
@@ -997,6 +1035,16 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   background: linear-gradient(90deg, #d7b13f, #f2d36f);
   box-shadow: 0 0 22px rgba(230, 193, 92, 0.32);
   transition: width 240ms ease;
+}
+
+.mm-activity-processing--finished .mm-activity-processing__bar > span {
+  background: linear-gradient(90deg, #10b981, #6ee7b7);
+  box-shadow: 0 0 22px rgba(16, 185, 129, 0.34);
+}
+
+.mm-activity-processing--failed .mm-activity-processing__bar > span {
+  background: linear-gradient(90deg, #dc2626, #fca5a5);
+  box-shadow: 0 0 22px rgba(248, 113, 113, 0.28);
 }
 
 .mm-activity-processing__metrics {


### PR DESCRIPTION
## Summary
- give Refiner processing progress distinct visual states for processing, finished, and failed
- stop completed progress rows from saying they are still writing or have 0s left
- bump app version to 1.0.24

## Tests
- apps/backend: pytest -q
- apps/web: npm test -- --run
- apps/web: npm run build