### PR TITLE
Keep Refiner completion on the live activity row

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.24"
+version = "1.0.25"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_activity.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_activity.py
@@ -30,6 +30,23 @@ def record_refiner_file_remux_pass_completed(db: Session, *, title: str, detail:
     )
 
 
+def complete_refiner_file_processing_activity(
+    db: Session,
+    *,
+    activity_id: int,
+    title: str,
+    detail: str | None,
+) -> bool:
+    row = update_activity_event(
+        db,
+        activity_id=activity_id,
+        event_type=C.REFINER_FILE_REMUX_PASS_COMPLETED,
+        title=title,
+        detail=detail,
+    )
+    return row is not None
+
+
 def record_refiner_file_processing_started(db: Session, *, payload: dict[str, Any]) -> int:
     name = _filename(payload.get("relative_media_path"))
     row = record_activity_event(

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_handlers.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.refiner.refiner_file_remux_pass_activity import (
+    complete_refiner_file_processing_activity,
     record_refiner_file_processing_started,
     record_refiner_file_remux_pass_completed,
     update_refiner_file_processing_progress,
@@ -26,28 +27,41 @@ from mediamop.modules.refiner.refiner_file_remux_pass_visibility import (
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
 
 
-def _record(session_factory: sessionmaker[Session], *, payload: dict[str, Any]) -> None:
+def _record(session_factory: sessionmaker[Session], *, payload: dict[str, Any], activity_id: int | None = None) -> None:
     detail = remux_pass_result_to_activity_detail(payload)
     title = remux_pass_activity_title(payload)
     with session_factory() as session:
         with session.begin():
+            if activity_id is not None:
+                updated = complete_refiner_file_processing_activity(
+                    session,
+                    activity_id=activity_id,
+                    title=title,
+                    detail=detail,
+                )
+                if updated:
+                    return
             record_refiner_file_remux_pass_completed(session, title=title, detail=detail)
 
 
-def _make_progress_reporter(session_factory: sessionmaker[Session], *, job_id: int) -> Callable[[dict[str, Any]], None]:
-    activity_id: int | None = None
+class RefinerActivityProgressReporter:
+    def __init__(self, session_factory: sessionmaker[Session], *, job_id: int) -> None:
+        self._session_factory = session_factory
+        self._job_id = job_id
+        self.activity_id: int | None = None
 
-    def _report(payload: dict[str, Any]) -> None:
-        nonlocal activity_id
-        body = {"job_id": job_id, **payload}
-        with session_factory() as session:
+    def __call__(self, payload: dict[str, Any]) -> None:
+        body = {"job_id": self._job_id, **payload}
+        with self._session_factory() as session:
             with session.begin():
-                if activity_id is None:
-                    activity_id = record_refiner_file_processing_started(session, payload=body)
+                if self.activity_id is None:
+                    self.activity_id = record_refiner_file_processing_started(session, payload=body)
                 else:
-                    update_refiner_file_processing_progress(session, activity_id=activity_id, payload=body)
+                    update_refiner_file_processing_progress(session, activity_id=self.activity_id, payload=body)
 
-    return _report
+
+def _make_progress_reporter(session_factory: sessionmaker[Session], *, job_id: int) -> RefinerActivityProgressReporter:
+    return RefinerActivityProgressReporter(session_factory, job_id=job_id)
 
 
 def make_refiner_file_remux_pass_handler(
@@ -151,6 +165,7 @@ def make_refiner_file_remux_pass_handler(
                 )
                 return
 
+            progress_reporter = _make_progress_reporter(session_factory, job_id=ctx.id)
             result = run_refiner_file_remux_pass(
                 settings=settings,
                 path_runtime=path_runtime,
@@ -160,9 +175,9 @@ def make_refiner_file_remux_pass_handler(
                 media_scope=media_scope,
                 cleanup_session=session,
                 current_job_id=ctx.id,
-                progress_reporter=_make_progress_reporter(session_factory, job_id=ctx.id),
+                progress_reporter=progress_reporter,
             )
             result["job_id"] = ctx.id
-        _record(session_factory, payload=result)
+        _record(session_factory, payload=result, activity_id=progress_reporter.activity_id)
 
     return _run

--- a/apps/backend/src/mediamop/platform/activity/service.py
+++ b/apps/backend/src/mediamop/platform/activity/service.py
@@ -51,6 +51,7 @@ def update_activity_event(
     db: Session,
     *,
     activity_id: int,
+    event_type: str | None = None,
     title: str | None = None,
     detail: str | None = None,
 ) -> ActivityEvent | None:
@@ -59,6 +60,8 @@ def update_activity_event(
     row = db.get(ActivityEvent, int(activity_id))
     if row is None:
         return None
+    if event_type is not None:
+        row.event_type = event_type
     if title is not None:
         row.title = title
     if detail is not None:

--- a/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
@@ -1,0 +1,102 @@
+"""Refiner file activity handler keeps one live row per processed file."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.modules.refiner import refiner_file_remux_pass_handlers as handler_mod
+from mediamop.modules.refiner.refiner_file_remux_pass_visibility import REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN
+from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
+from mediamop.platform.activity import constants as activity_constants
+from mediamop.platform.activity.live_stream import activity_latest_notifier
+from mediamop.platform.activity.models import ActivityEvent
+
+
+def test_refiner_remux_handler_updates_progress_row_to_completed_activity(
+    monkeypatch,
+) -> None:
+    settings = MediaMopSettings.load()
+    eng = create_db_engine(settings)
+    fac = create_session_factory(eng)
+    activity_latest_notifier.reset_for_tests()
+    with fac() as db:
+        assert isinstance(db, Session)
+        db.execute(delete(ActivityEvent))
+        db.commit()
+
+    monkeypatch.setattr(
+        handler_mod,
+        "ensure_refiner_operator_settings_row",
+        lambda _session: SimpleNamespace(min_file_age_seconds=0),
+    )
+    monkeypatch.setattr(handler_mod, "load_refiner_remux_rules_config", lambda _session, *, media_scope: object())
+    monkeypatch.setattr(handler_mod, "resolve_refiner_path_runtime_for_remux", lambda *_args, **_kwargs: (object(), None))
+
+    def _fake_run_refiner_file_remux_pass(**kwargs: Any) -> dict[str, Any]:
+        progress_reporter = kwargs["progress_reporter"]
+        progress_reporter(
+            {
+                "status": "processing",
+                "relative_media_path": "Movie/file.mkv",
+                "percent": 10.0,
+                "message": "Refiner is writing the cleaned-up file.",
+            }
+        )
+        progress_reporter(
+            {
+                "status": "processing",
+                "relative_media_path": "Movie/file.mkv",
+                "percent": 55.0,
+                "message": "Refiner is writing the cleaned-up file.",
+            }
+        )
+        return {
+            "ok": True,
+            "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN,
+            "relative_media_path": "Movie/file.mkv",
+            "source_size_bytes": 2000,
+            "output_size_bytes": 1000,
+        }
+
+    monkeypatch.setattr(handler_mod, "run_refiner_file_remux_pass", _fake_run_refiner_file_remux_pass)
+
+    handler = handler_mod.make_refiner_file_remux_pass_handler(settings, fac)
+    handler(
+        RefinerJobWorkContext(
+            id=123,
+            job_kind="refiner.file.remux_pass.v1",
+            payload_json=json.dumps({"relative_media_path": "Movie/file.mkv", "media_scope": "movie"}),
+            lease_owner="test",
+        )
+    )
+
+    with fac() as db:
+        rows = list(db.scalars(select(ActivityEvent).order_by(ActivityEvent.id)).all())
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.event_type == activity_constants.REFINER_FILE_REMUX_PASS_COMPLETED
+    assert row.module == "refiner"
+    assert row.title == "file.mkv was processed successfully"
+    assert row.detail is not None
+    detail = json.loads(row.detail)
+    assert detail["outcome"] == REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN
+    assert detail["job_id"] == 123
+    assert detail["source_size_bytes"] == 2000
+    assert detail["output_size_bytes"] == 1000
+
+    latest_id, revision = activity_latest_notifier.snapshot()
+    assert latest_id == row.id
+    assert revision == 3
+
+    with fac() as db:
+        assert isinstance(db, Session)
+        db.execute(delete(ActivityEvent))
+        db.commit()

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.24",
+      "version": "1.0.25",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- keep Refiner file processing as one live Activity row instead of adding a second finished row
- update that row from progress to completed result details when the file finishes
- keep SSE revision updates live for progress and completion state changes
- bump app version to 1.0.25

## Tests
- apps/backend: pytest -q
- apps/web: npm test -- --run
- apps/web: npm run build