### PR TITLE
Fix Windows in-app updater reliability

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.26"
+version = "1.0.27"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -173,9 +173,11 @@ class SuiteUpdateStartOut(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    status: str = Field(min_length=1, description="started or unavailable")
+    status: str = Field(min_length=1, description="started, manual_required, or unavailable")
     message: str = Field(min_length=1)
     target_version: str | None = None
+    installer_path: str | None = None
+    log_path: str | None = None
 
 
 class SuiteUpdateStartIn(BaseModel):

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -17,6 +17,7 @@ from mediamop.version import __version__
 GH_REPO = "jampat000/MediaMop"
 GH_RELEASES_LATEST_URL = f"https://api.github.com/repos/{GH_REPO}/releases/latest"
 DOCKER_IMAGE = "ghcr.io/jampat000/mediamop"
+WINDOWS_UPGRADE_TASK_NAME = "MediaMop Upgrade"
 
 
 def _detect_install_type() -> str:
@@ -71,6 +72,54 @@ def _find_windows_installer_asset(payload: dict[str, Any]) -> str | None:
         if name == "mediamopsetup.exe":
             return str(asset.get("browser_download_url") or "").strip() or None
     return None
+
+
+def _windows_system_exe(name: str) -> str:
+    root = Path(os.environ.get("SystemRoot") or r"C:\Windows") / "System32"
+    candidate = root / name
+    return str(candidate) if candidate.is_file() else name
+
+
+def _windows_upgrade_task_ready() -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        proc = subprocess.run(
+            [
+                _windows_system_exe("schtasks.exe"),
+                "/Query",
+                "/TN",
+                WINDOWS_UPGRADE_TASK_NAME,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return False
+    return proc.returncode == 0
+
+
+def _run_windows_upgrade_task() -> bool:
+    if os.name != "nt":
+        return False
+    try:
+        proc = subprocess.run(
+            [
+                _windows_system_exe("schtasks.exe"),
+                "/Run",
+                "/TN",
+                WINDOWS_UPGRADE_TASK_NAME,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return False
+    return proc.returncode == 0
 
 
 def build_suite_update_status() -> SuiteUpdateStatusOut:
@@ -156,10 +205,11 @@ function Write-UpgradeLog([string]$message) {{
 }}
 Write-UpgradeLog "Starting MediaMop in-app upgrade."
 $installer = {str(installer_path)!r}
-$args = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS")
-Write-UpgradeLog "Starting elevated installer. Windows may ask for permission."
-$proc = Start-Process -FilePath $installer -ArgumentList $args -Verb RunAs -Wait -PassThru -ErrorAction Stop
-Write-UpgradeLog "Elevated installer exited with code $($proc.ExitCode)."
+$setupLog = {str(installer_path.parent / "installer-direct.log")!r}
+$args = @("/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART", "/CLOSEAPPLICATIONS", "/RESTARTAPPLICATIONS", "/LOG=`"$setupLog`"")
+Write-UpgradeLog "Starting installer directly."
+$proc = Start-Process -FilePath $installer -ArgumentList $args -Wait -PassThru -ErrorAction Stop
+Write-UpgradeLog "Installer exited with code $($proc.ExitCode)."
 $exe = {str(exe_path)!r}
 if (Test-Path -LiteralPath $exe) {{
   Start-Process -FilePath $exe -WorkingDirectory {str(executable_dir)!r}
@@ -222,6 +272,28 @@ def start_suite_update_now(settings: MediaMopSettings) -> SuiteUpdateStartOut:
         )
 
     upgrade_dir = Path(settings.mediamop_home) / "upgrades"
+    task_log_path = upgrade_dir / "upgrade-task.log"
+    if _windows_upgrade_task_ready():
+        if _run_windows_upgrade_task():
+            return SuiteUpdateStartOut(
+                status="started",
+                message=(
+                    "Upgrade started using the MediaMop Windows updater. MediaMop will close, install the update, "
+                    "reopen, and this page should reconnect after the app is back."
+                ),
+                target_version=latest_version,
+                log_path=str(task_log_path),
+            )
+        return SuiteUpdateStartOut(
+            status="unavailable",
+            message=(
+                "MediaMop found the Windows updater task, but Windows would not start it. "
+                f"Check {task_log_path} or download and run the installer manually."
+            ),
+            target_version=latest_version,
+            log_path=str(task_log_path),
+        )
+
     upgrade_dir.mkdir(parents=True, exist_ok=True)
     installer_path = upgrade_dir / f"MediaMopSetup-{latest_version}.exe"
     with httpx.stream("GET", installer_url, timeout=60.0, follow_redirects=True) as response:
@@ -238,9 +310,13 @@ def start_suite_update_now(settings: MediaMopSettings) -> SuiteUpdateStartOut:
         executable_dir=executable_dir,
         script_path=script_path,
     )
-    _launch_windows_upgrade_script(script_path)
     return SuiteUpdateStartOut(
-        status="started",
-        message="Upgrade started. MediaMop will close, install the update, reopen, and this page should reconnect after the app is back.",
+        status="manual_required",
+        message=(
+            "The installer was downloaded, but this older MediaMop install does not have the Windows updater task yet. "
+            "Run the downloaded installer once on the MediaMop computer as administrator; future upgrades can be started from this page."
+        ),
         target_version=latest_version,
+        installer_path=str(installer_path),
+        log_path=str(script_path),
     )

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -362,7 +362,7 @@ def test_suite_update_status_not_published_when_release_missing(
     assert "no public mediamop release is published yet" in body["summary"].lower()
 
 
-def test_suite_update_now_stages_windows_installer_and_launches_script(
+def test_suite_update_now_stages_windows_installer_when_task_missing(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -397,6 +397,7 @@ def test_suite_update_now_stages_windows_installer_and_launches_script(
 
     launched: list[str] = []
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.httpx.stream", lambda *a, **k: _Stream())
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_upgrade_task_ready", lambda: False)
     monkeypatch.setattr(
         "mediamop.platform.suite_settings.update_service._launch_windows_upgrade_script",
         lambda path: launched.append(str(path)),
@@ -406,13 +407,43 @@ def test_suite_update_now_stages_windows_installer_and_launches_script(
 
     installer = tmp_path / "upgrades" / "MediaMopSetup-1.2.3.exe"
     script = tmp_path / "upgrades" / "run-windows-upgrade.ps1"
-    assert out.status == "started"
+    assert out.status == "manual_required"
     assert installer.read_bytes() == b"installer-bytes"
     assert script.is_file()
-    assert launched == [str(script)]
+    assert launched == []
     script_text = script.read_text(encoding="utf-8")
-    assert "-Verb RunAs" in script_text
-    assert "Starting elevated installer" in script_text
+    assert "-Verb RunAs" not in script_text
+    assert "Starting installer directly" in script_text
+    assert out.installer_path == str(installer)
+
+
+def test_suite_update_now_uses_windows_updater_task_when_available(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = replace(MediaMopSettings.load(), mediamop_home=str(tmp_path))
+    monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
+        lambda: {
+            "tag_name": "v1.2.3",
+            "assets": [
+                {
+                    "name": "MediaMopSetup.exe",
+                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_upgrade_task_ready", lambda: True)
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._run_windows_upgrade_task", lambda: True)
+
+    out = start_suite_update_now(settings)
+
+    assert out.status == "started"
+    assert out.target_version == "1.2.3"
+    assert out.log_path == str(tmp_path / "upgrades" / "upgrade-task.log")
 
 
 def test_suite_configuration_backup_tick_creates_snapshot(client_with_admin: TestClient) -> None:

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -76,6 +76,25 @@ def test_windows_installer_surfaces_firewall_rule_failures() -> None:
     assert 'Filename: "{sys}\\netsh.exe"; Parameters: "advfirewall firewall add rule' not in text
 
 
+def test_windows_installer_installs_dedicated_upgrade_task() -> None:
+    repo = Path(__file__).resolve().parents[3]
+    installer = repo / "packaging" / "windows" / "MediaMop.iss"
+    upgrade_script = repo / "packaging" / "windows" / "MediaMopUpgrade.ps1"
+    text = installer.read_text(encoding="utf-8")
+    script_text = upgrade_script.read_text(encoding="utf-8")
+
+    assert upgrade_script.is_file()
+    assert 'Source: "{#RepoRoot}\\packaging\\windows\\MediaMopUpgrade.ps1"; DestDir: "{app}"' in text
+    assert "procedure InstallUpgradeTask()" in text
+    assert '/TN "MediaMop Upgrade"' in text
+    assert "/RL HIGHEST" in text
+    assert "MediaMopUpgrade.ps1" in text
+    assert 'Filename: "{sys}\\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"' in text
+    assert "https://api.github.com/repos/jampat000/MediaMop/releases/latest" in script_text
+    assert "MediaMopSetup.exe" in script_text
+    assert "/CLOSEAPPLICATIONS" in script_text
+
+
 def test_windows_package_uses_dedicated_tray_icon_assets() -> None:
     repo = Path(__file__).resolve().parents[3]
     spec = repo / "packaging" / "windows" / "mediamop-tray.spec"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.26",
+  "version": "1.0.27",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/apps/web/src/lib/suite/types.ts
+++ b/apps/web/src/lib/suite/types.ts
@@ -69,9 +69,11 @@ export type SuiteUpdateStatusOut = {
 };
 
 export type SuiteUpdateStartOut = {
-  status: "started" | "unavailable" | string;
+  status: "started" | "manual_required" | "unavailable" | string;
   message: string;
   target_version?: string | null;
+  installer_path?: string | null;
+  log_path?: string | null;
 };
 
 export type SuiteLogEntry = {

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -473,6 +473,8 @@ export function SettingsPage() {
         window.setTimeout(() => {
           window.location.assign("/app/settings");
         }, 30_000);
+      } else {
+        void queryClient.invalidateQueries({ queryKey: ["suite", "update-status"] });
       }
     } catch {
       /* surfaced below */

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -49,6 +49,7 @@ Type: files; Name: "{app}\MediaMopServer.exe"
 
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "{#RepoRoot}\packaging\windows\MediaMopUpgrade.ps1"; DestDir: "{app}"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\MediaMop"; Filename: "{app}\{#ExeName}"
@@ -62,6 +63,7 @@ Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait post
 
 [UninstallRun]
 Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""MediaMop Server"""; Flags: runhidden waituntilterminated
+Filename: "{sys}\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"; Flags: runhidden waituntilterminated
 
 [Code]
 procedure StopMediaMopProcess(ProcessName: String);
@@ -121,10 +123,33 @@ begin
   end;
 end;
 
+procedure InstallUpgradeTask();
+var
+  ResultCode: Integer;
+  TaskCommand: String;
+  UserName: String;
+begin
+  UserName := ExpandConstant('{username}');
+  TaskCommand :=
+    '/Create /TN "MediaMop Upgrade" /SC ONDEMAND /RL HIGHEST /IT /F /RU "' + UserName +
+    '" /TR "\"' + ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe') +
+    '\" -NoProfile -ExecutionPolicy Bypass -File \"' + ExpandConstant('{app}\MediaMopUpgrade.ps1') + '\""';
+
+  Exec(
+    ExpandConstant('{sys}\schtasks.exe'),
+    TaskCommand,
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  );
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
     InstallFirewallRule();
+    InstallUpgradeTask();
   end;
 end;

--- a/packaging/windows/MediaMopUpgrade.ps1
+++ b/packaging/windows/MediaMopUpgrade.ps1
@@ -1,0 +1,61 @@
+$ErrorActionPreference = "Stop"
+
+$upgradeRoot = Join-Path $env:ProgramData "MediaMop\upgrades"
+$logPath = Join-Path $upgradeRoot "upgrade-task.log"
+$setupLogPath = Join-Path $upgradeRoot "installer-latest.log"
+$releaseApi = "https://api.github.com/repos/jampat000/MediaMop/releases/latest"
+
+function Write-MediaMopUpgradeLog([string]$message) {
+  New-Item -ItemType Directory -Path $upgradeRoot -Force | Out-Null
+  $stamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+  Add-Content -LiteralPath $logPath -Value "[$stamp] $message"
+}
+
+try {
+  Write-MediaMopUpgradeLog "Updater task started."
+
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  $release = Invoke-RestMethod -Uri $releaseApi -Headers @{ "User-Agent" = "MediaMop Windows Updater" } -TimeoutSec 30
+  $tag = [string]$release.tag_name
+  if ([string]::IsNullOrWhiteSpace($tag)) {
+    throw "GitHub release response did not include a tag name."
+  }
+
+  $asset = $release.assets | Where-Object { $_.name -eq "MediaMopSetup.exe" } | Select-Object -First 1
+  if (-not $asset -or [string]::IsNullOrWhiteSpace([string]$asset.browser_download_url)) {
+    throw "Latest MediaMop release does not include MediaMopSetup.exe."
+  }
+
+  $version = $tag.TrimStart("v")
+  $installerPath = Join-Path $upgradeRoot ("MediaMopSetup-" + $version + ".exe")
+  Write-MediaMopUpgradeLog ("Downloading MediaMop " + $version + " installer.")
+  Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $installerPath -UseBasicParsing -TimeoutSec 120
+
+  $installerArgs = @(
+    "/VERYSILENT",
+    "/SUPPRESSMSGBOXES",
+    "/NORESTART",
+    "/CLOSEAPPLICATIONS",
+    "/RESTARTAPPLICATIONS",
+    "/LOG=`"$setupLogPath`""
+  )
+  Write-MediaMopUpgradeLog ("Starting installer: " + $installerPath)
+  $proc = Start-Process -FilePath $installerPath -ArgumentList $installerArgs -Wait -PassThru
+  Write-MediaMopUpgradeLog ("Installer exited with code " + $proc.ExitCode + ".")
+  if ($proc.ExitCode -ne 0) {
+    throw ("Installer failed with exit code " + $proc.ExitCode + ".")
+  }
+
+  $exe = Join-Path $env:ProgramFiles "MediaMop\MediaMop.exe"
+  if (Test-Path -LiteralPath $exe) {
+    Start-Process -FilePath $exe -WorkingDirectory (Split-Path -Parent $exe)
+    Write-MediaMopUpgradeLog "MediaMop restart requested."
+  } else {
+    Write-MediaMopUpgradeLog ("MediaMop executable was not found after upgrade: " + $exe)
+  }
+
+  Write-MediaMopUpgradeLog "Updater task completed."
+} catch {
+  Write-MediaMopUpgradeLog ("Updater task failed: " + $_.Exception.Message)
+  throw
+}


### PR DESCRIPTION
Fixes the Windows in-app updater so future per-machine installs use a dedicated elevated updater task instead of a fragile hidden UAC launch. Adds updater task packaging, backend task trigger path, manual-required fallback for older installs, and tests.