### PR TITLE
Harden production risk areas

### DIFF
--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -115,6 +115,7 @@ class MediaMopSettings:
     cors_origins: tuple[str, ...]
     session_secret: str | None
     credentials_secret: str | None
+    previous_credentials_secrets: tuple[str, ...]
     session_cookie_name: str
     session_cookie_secure: bool
     session_cookie_samesite: str
@@ -306,6 +307,11 @@ class MediaMopSettings:
         cors = _parse_csv_urls(os.environ.get("MEDIAMOP_CORS_ORIGINS") or "")
         session = (os.environ.get("MEDIAMOP_SESSION_SECRET") or "").strip() or None
         credentials_secret = (os.environ.get("MEDIAMOP_CREDENTIALS_SECRET") or "").strip() or None
+        previous_credentials_secrets = tuple(
+            item
+            for item in _parse_csv_urls(os.environ.get("MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS") or "")
+            if item and item != credentials_secret
+        )
         cookie_name = (
             (os.environ.get("MEDIAMOP_SESSION_COOKIE_NAME") or "").strip()
             or "mediamop_session"
@@ -495,6 +501,7 @@ class MediaMopSettings:
             cors_origins=cors,
             session_secret=session,
             credentials_secret=credentials_secret,
+            previous_credentials_secrets=previous_credentials_secrets,
             session_cookie_name=cookie_name,
             session_cookie_secure=secure,
             session_cookie_samesite=samesite,

--- a/apps/backend/src/mediamop/core/credentials_rotation.py
+++ b/apps/backend/src/mediamop/core/credentials_rotation.py
@@ -1,0 +1,21 @@
+"""Shared helpers for safe credential-secret rotation."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from mediamop.core.config import MediaMopSettings
+
+T = TypeVar("T")
+
+
+def credential_secret_candidates(settings: MediaMopSettings, build: Callable[[str | None], T | None]) -> list[T]:
+    """Return current then previous credential-key handlers, skipping unusable secrets."""
+
+    out: list[T] = []
+    for secret in (settings.credentials_secret, *settings.previous_credentials_secrets):
+        item = build(secret)
+        if item is not None:
+            out.append(item)
+    return out

--- a/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
@@ -10,6 +10,7 @@ from typing import Literal
 from cryptography.fernet import Fernet, InvalidToken
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.credentials_rotation import credential_secret_candidates
 
 _DOMAIN = b"mediamop.pruner.credentials.v1|"
 _ENVELOPE_VERSION = 2
@@ -68,13 +69,17 @@ def decrypt_pruner_credentials_json(settings: MediaMopSettings, ciphertext: str)
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
-        f = _fernet_for_secret(settings.credentials_secret) if key_id == _CREDENTIALS_KEY_ID else _legacy_fernet(settings)
-        if f is None:
-            return None
-        try:
-            return f.decrypt(token.encode("ascii")).decode("utf-8")
-        except (InvalidToken, ValueError, TypeError):
-            return None
+        fernets = (
+            credential_secret_candidates(settings, _fernet_for_secret)
+            if key_id == _CREDENTIALS_KEY_ID
+            else [f for f in [_legacy_fernet(settings)] if f]
+        )
+        for f in fernets:
+            try:
+                return f.decrypt(token.encode("ascii")).decode("utf-8")
+            except (InvalidToken, ValueError, TypeError):
+                continue
+        return None
 
     f = _legacy_fernet(settings)
     if f is None:

--- a/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
@@ -10,6 +10,7 @@ from typing import Literal
 from cryptography.fernet import Fernet, InvalidToken
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.credentials_rotation import credential_secret_candidates
 
 
 _DOMAIN = b"mediamop.subber.credentials.v1|"
@@ -66,13 +67,19 @@ def decrypt_subber_credentials_json(settings: MediaMopSettings, ciphertext: str)
     if env is not None:
         token = str(env.get("token") or "")
         key_id = str(env.get("key_id") or "")
-        f = _fernet_for_secret(settings.credentials_secret) if key_id == _CREDENTIALS_KEY_ID else _legacy_fernet(settings)
-        if f is None or not token:
+        if not token:
             return None
-        try:
-            return f.decrypt(token.encode("ascii")).decode("utf-8")
-        except (InvalidToken, ValueError, TypeError):
-            return None
+        fernets = (
+            credential_secret_candidates(settings, _fernet_for_secret)
+            if key_id == _CREDENTIALS_KEY_ID
+            else [f for f in [_legacy_fernet(settings)] if f]
+        )
+        for f in fernets:
+            try:
+                return f.decrypt(token.encode("ascii")).decode("utf-8")
+            except (InvalidToken, ValueError, TypeError):
+                continue
+        return None
     f = _legacy_fernet(settings)
     if f is None:
         return None

--- a/apps/backend/src/mediamop/modules/subber/subber_http_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_http_client.py
@@ -62,7 +62,10 @@ def request_json(
     code, text = request_text(url, method=method, headers=merged, data=data, timeout=timeout)
     if not text.strip():
         return code, None
-    parsed = json.loads(text)
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return code, None
     return code, parsed if isinstance(parsed, (dict, list)) else None
 
 
@@ -70,5 +73,8 @@ def decode_http_error_json(exc: urllib.error.HTTPError) -> dict[str, Any] | None
     raw = exc.read().decode("utf-8", errors="replace")
     if not raw.strip():
         return None
-    parsed = json.loads(raw)
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"raw": raw}
     return parsed if isinstance(parsed, dict) else {"raw": raw}

--- a/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
@@ -12,6 +12,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.credentials_rotation import credential_secret_candidates
 
 # Frozen KDF domain bytes (legacy install compatibility). Do not change.
 _ARR_API_KEY_KDF_PEPPER = binascii.a2b_hex(
@@ -80,13 +81,19 @@ def decrypt_arr_api_key(settings: MediaMopSettings, ciphertext: str) -> str | No
     if env is not None:
         token = str(env.get("token") or "")
         key_id = str(env.get("key_id") or "")
-        f = _fernet_for_secret(settings.credentials_secret) if key_id == _CREDENTIALS_KEY_ID else _legacy_fernet(settings)
-        if f is None or not token:
+        if not token:
             return None
-        try:
-            return f.decrypt(token.encode("ascii")).decode("utf-8")
-        except (InvalidToken, ValueError, TypeError):
-            return None
+        fernets = (
+            credential_secret_candidates(settings, _fernet_for_secret)
+            if key_id == _CREDENTIALS_KEY_ID
+            else [f for f in [_legacy_fernet(settings)] if f]
+        )
+        for f in fernets:
+            try:
+                return f.decrypt(token.encode("ascii")).decode("utf-8")
+            except (InvalidToken, ValueError, TypeError):
+                continue
+        return None
     f = _legacy_fernet(settings)
     if f is None:
         return None

--- a/apps/backend/src/mediamop/platform/auth/rate_limit.py
+++ b/apps/backend/src/mediamop/platform/auth/rate_limit.py
@@ -19,14 +19,17 @@ _forwarded_without_trust_warned = False
 class SlidingWindowLimiter:
     """Fixed-capacity sliding window: at most ``max_events`` timestamps within ``window_seconds``."""
 
-    __slots__ = ("_buckets", "_lock", "max_events", "window_seconds")
+    __slots__ = ("_buckets", "_lock", "max_events", "max_keys", "window_seconds")
 
-    def __init__(self, *, max_events: int, window_seconds: float) -> None:
+    def __init__(self, *, max_events: int, window_seconds: float, max_keys: int = 10_000) -> None:
         if max_events < 1:
             raise ValueError("max_events must be >= 1")
         if window_seconds <= 0:
             raise ValueError("window_seconds must be > 0")
+        if max_keys < 1:
+            raise ValueError("max_keys must be >= 1")
         self.max_events = max_events
+        self.max_keys = max_keys
         self.window_seconds = float(window_seconds)
         self._lock = threading.Lock()
         self._buckets: dict[str, list[float]] = defaultdict(list)
@@ -45,6 +48,7 @@ class SlidingWindowLimiter:
             if len(bucket) >= self.max_events:
                 return False
             bucket.append(now)
+            self._evict_over_capacity_locked(prefer_keep=k)
             return True
 
     def _evict_expired_locked(self, cutoff: float) -> None:
@@ -54,6 +58,17 @@ class SlidingWindowLimiter:
                 bucket.pop(0)
             if not bucket:
                 del self._buckets[key]
+
+    def _evict_over_capacity_locked(self, *, prefer_keep: str) -> None:
+        while len(self._buckets) > self.max_keys:
+            oldest_key = min(
+                (key for key in self._buckets if key != prefer_keep),
+                key=lambda key: self._buckets[key][-1] if self._buckets[key] else 0.0,
+                default=None,
+            )
+            if oldest_key is None:
+                break
+            del self._buckets[oldest_key]
 
     def reset_for_tests(self) -> None:
         with self._lock:

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -679,6 +679,9 @@ def test_security_headers_on_health_and_api(monkeypatch: pytest.MonkeyPatch) -> 
     with TestClient(app) as client:
         r_h = client.get("/health")
         assert r_h.headers.get("X-Content-Type-Options") == "nosniff"
+        assert r_h.headers.get("X-Frame-Options") == "DENY"
+        assert r_h.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
+        assert r_h.headers.get("Content-Security-Policy")
         assert r_h.headers.get("strict-transport-security")
         r_csrf = client.get("/api/v1/auth/csrf")
         assert r_csrf.headers.get("Content-Security-Policy")

--- a/apps/backend/tests/test_credentials_secret_crypto.py
+++ b/apps/backend/tests/test_credentials_secret_crypto.py
@@ -75,3 +75,34 @@ def test_legacy_session_secret_ciphertexts_can_be_rewrapped(monkeypatch, tmp_pat
     assert decrypt_pruner_credentials_json(rotated, pruner_new) == '{"api_key":"p"}'
     assert decrypt_subber_credentials_json(rotated, subber_new) == '{"api_key":"s"}'
     assert decrypt_arr_api_key(rotated, arr_new) == "arr-key"
+
+
+def test_previous_credentials_secret_allows_safe_secret_rotation(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("MEDIAMOP_HOME", str(tmp_path))
+    old = _settings(monkeypatch, session="session-secret-a-abcdefghijklmnopqrstuvwxyz", credentials="old-credentials-secret")
+
+    pruner = encrypt_pruner_credentials_json(old, '{"api_key":"p"}')
+    subber = encrypt_subber_credentials_json(old, '{"api_key":"s"}')
+    arr = encrypt_arr_api_key(old, "arr-key")
+
+    monkeypatch.setenv("MEDIAMOP_SESSION_SECRET", "session-secret-b-abcdefghijklmnopqrstuvwxyz")
+    monkeypatch.setenv("MEDIAMOP_CREDENTIALS_SECRET", "new-credentials-secret")
+    monkeypatch.setenv("MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS", "old-credentials-secret")
+    rotated = MediaMopSettings.load()
+
+    assert decrypt_pruner_credentials_json(rotated, pruner) == '{"api_key":"p"}'
+    assert decrypt_subber_credentials_json(rotated, subber) == '{"api_key":"s"}'
+    assert decrypt_arr_api_key(rotated, arr) == "arr-key"
+
+    pruner_new = rewrap_pruner_credentials_json(rotated, pruner)
+    subber_new = rewrap_subber_credentials_json(rotated, subber)
+    arr_new = rewrap_arr_api_key(rotated, arr)
+
+    monkeypatch.setenv("MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS", "")
+    new_only = MediaMopSettings.load()
+    assert pruner_new is not None
+    assert subber_new is not None
+    assert arr_new is not None
+    assert decrypt_pruner_credentials_json(new_only, pruner_new) == '{"api_key":"p"}'
+    assert decrypt_subber_credentials_json(new_only, subber_new) == '{"api_key":"s"}'
+    assert decrypt_arr_api_key(new_only, arr_new) == "arr-key"

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -30,6 +30,7 @@ def _csrf_settings(**overrides: object) -> MediaMopSettings:
         cors_origins=(),
         session_secret="x",
         credentials_secret=None,
+        previous_credentials_secrets=(),
         session_cookie_name="mediamop_session",
         session_cookie_secure=False,
         session_cookie_samesite="lax",

--- a/apps/backend/tests/test_rate_limit.py
+++ b/apps/backend/tests/test_rate_limit.py
@@ -16,3 +16,19 @@ def test_sliding_window_limiter_removes_empty_expired_buckets(monkeypatch) -> No
     assert limiter.allow("three") is True
 
     assert set(limiter._buckets) == {"three"}
+
+
+def test_sliding_window_limiter_caps_active_key_count(monkeypatch) -> None:
+    now = 1000.0
+    monkeypatch.setattr("mediamop.platform.auth.rate_limit.time.monotonic", lambda: now)
+    limiter = SlidingWindowLimiter(max_events=5, window_seconds=60, max_keys=2)
+
+    assert limiter.allow("one") is True
+    now += 1
+    assert limiter.allow("two") is True
+    now += 1
+    assert limiter.allow("three") is True
+
+    assert len(limiter._buckets) == 2
+    assert "one" not in limiter._buckets
+    assert "three" in limiter._buckets

--- a/apps/backend/tests/test_subber_provider_http_client.py
+++ b/apps/backend/tests/test_subber_provider_http_client.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import io
+import urllib.error
+
+from mediamop.modules.subber import subber_http_client
+
 
 def test_subber_provider_clients_do_not_open_urls_directly() -> None:
     root = Path(__file__).resolve().parents[1] / "src" / "mediamop" / "modules" / "subber"
@@ -18,3 +23,21 @@ def test_subber_provider_clients_do_not_open_urls_directly() -> None:
         text = path.read_text(encoding="utf-8")
         assert "urllib.request.urlopen" not in text, path.name
         assert "urllib.request.Request" not in text, path.name
+
+
+def test_subber_request_json_treats_malformed_json_as_empty_payload(monkeypatch) -> None:
+    monkeypatch.setattr(subber_http_client, "request_text", lambda *a, **k: (200, "{not-json"))
+
+    assert subber_http_client.request_json("https://example.invalid") == (200, None)
+
+
+def test_subber_http_error_json_preserves_malformed_payload() -> None:
+    exc = urllib.error.HTTPError(
+        "https://example.invalid",
+        500,
+        "bad",
+        {},
+        fp=io.BytesIO(b"{not-json"),
+    )
+
+    assert subber_http_client.decode_http_error_json(exc) == {"raw": "{not-json"}


### PR DESCRIPTION
## Summary
- support safe credential-secret rotation via previous credential secrets without changing stored credential APIs
- cap active rate-limit buckets after expired cleanup to prevent unbounded memory growth
- assert required security headers in backend coverage
- make Subber provider JSON parsing tolerate malformed response bodies safely

## Validation
- backend: .\\.venv\\Scripts\\python.exe -m pytest -q
- backend lint: .\\.venv\\Scripts\\python.exe -m ruff check src tests
- git diff --check

## Follow-up
- Logged #108 for credential rotation documentation; docs were intentionally excluded from this production-risk-only pass.