### PR TITLE
Harden high-load production readiness

### DIFF
--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -64,6 +64,8 @@ from mediamop.modules.pruner.worker_loop import (
     stop_pruner_worker_background_tasks,
 )
 from mediamop.platform.auth.rate_limit import SlidingWindowLimiter
+from mediamop.platform.auth.session_cleanup import start_session_cleanup_task, stop_session_cleanup_task
+from mediamop.platform.auth.service import cleanup_inactive_sessions
 from mediamop.platform.jobs.startup_recovery import recover_incomplete_jobs_after_startup
 from mediamop.platform.suite_settings.logs_service import prune_logs_for_retention
 from mediamop.platform.suite_settings.suite_configuration_backup_periodic import (
@@ -103,6 +105,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             recovered = recover_incomplete_jobs_after_startup(session)
             partial_outputs_removed = cleanup_refiner_partial_output_files(session, settings)
             prune_logs_for_retention(session, settings)
+            cleanup_inactive_sessions(session, settings=settings)
         if recovered.total_recovered or partial_outputs_removed:
             _lifespan_log.warning(
                 "MediaMop startup recovered interrupted work recovered_jobs=%s partial_outputs_removed=%s",
@@ -110,6 +113,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 partial_outputs_removed,
             )
     stop = asyncio.Event()
+    session_cleanup_task = start_session_cleanup_task(
+        session_factory,
+        stop_event=stop,
+        settings=settings,
+    )
     log_retention_tasks = start_log_retention_tasks(
         session_factory,
         stop_event=stop,
@@ -211,6 +219,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         except Exception:
             _lifespan_log.exception("Subber upgrade schedule enqueue stop failed")
         await stop_suite_configuration_backup_tasks(suite_configuration_backup_tasks)
+        await stop_session_cleanup_task(session_cleanup_task)
         await stop_log_retention_tasks(log_retention_tasks)
         await stop_subber_worker_background_tasks(subber_stop, subber_worker_tasks)
         await stop_pruner_preview_schedule_enqueue_tasks(pruner_preview_schedule_tasks)

--- a/apps/backend/src/mediamop/modules/dashboard/service.py
+++ b/apps/backend/src/mediamop/modules/dashboard/service.py
@@ -12,7 +12,6 @@ from mediamop.core.config import MediaMopSettings
 from mediamop.modules.dashboard.schemas import ActivitySummaryOut, DashboardStatusOut, SystemStatusOut, WorkerLaneHealthOut
 from mediamop.platform.activity.schemas import ActivityEventItemOut
 from mediamop.platform.activity import service as activity_service
-from mediamop.platform.health.service import get_health
 from mediamop.platform.jobs.worker_health import build_worker_health_snapshot
 
 
@@ -25,7 +24,6 @@ def _build_activity_summary(db: Session) -> ActivitySummaryOut:
 
 
 def build_dashboard_status(db: Session, settings: MediaMopSettings) -> DashboardStatusOut:
-    health = get_health()
     worker_health = build_worker_health_snapshot(
         expected_workers={
             "refiner": int(settings.refiner_worker_count),
@@ -38,7 +36,7 @@ def build_dashboard_status(db: Session, settings: MediaMopSettings) -> Dashboard
         system=SystemStatusOut(
             api_version=__version__,
             environment=settings.env,
-            healthy=health.status == "ok" and workers_healthy,
+            healthy=workers_healthy,
             worker_health=[WorkerLaneHealthOut(**asdict(row)) for row in worker_health],
         ),
         activity_summary=_build_activity_summary(db),

--- a/apps/backend/src/mediamop/platform/auth/bootstrap.py
+++ b/apps/backend/src/mediamop/platform/auth/bootstrap.py
@@ -11,7 +11,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from mediamop.platform.auth.models import User, UserRole
-from mediamop.platform.auth.password import hash_password
+from mediamop.platform.auth.password import hash_password, validate_password_strength
 
 
 def acquire_bootstrap_transaction_lock(db: Session) -> None:
@@ -41,6 +41,7 @@ def create_initial_admin(db: Session, *, username: str, password: str) -> User:
 
     if any_admin_user_exists(db):
         raise RuntimeError("bootstrap not allowed: an admin user already exists")
+    validate_password_strength(password, username=username)
     row = User(
         username=username.strip(),
         password_hash=hash_password(password),

--- a/apps/backend/src/mediamop/platform/auth/password.py
+++ b/apps/backend/src/mediamop/platform/auth/password.py
@@ -9,6 +9,18 @@ from argon2.exceptions import InvalidHashError, VerifyMismatchError
 
 logger = logging.getLogger(__name__)
 
+MIN_PASSWORD_LENGTH = 12
+_WEAK_PASSWORDS = {
+    "admin",
+    "changeme",
+    "letmein",
+    "mediamop",
+    "password",
+    "password1",
+    "qwerty",
+    "welcome",
+}
+
 _hasher = PasswordHasher(
     time_cost=3,
     memory_cost=65_536,
@@ -21,6 +33,21 @@ _hasher = PasswordHasher(
 def hash_password(plain: str) -> str:
     """Return a PHC-style Argon2id string suitable for ``users.password_hash``."""
     return _hasher.hash(plain)
+
+
+def validate_password_strength(plain: str, *, username: str | None = None) -> None:
+    password = plain or ""
+    normalized = password.strip().lower()
+    user = (username or "").strip().lower()
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise ValueError(f"Password must be at least {MIN_PASSWORD_LENGTH} characters.")
+    normalized_without_trailing_digits = normalized.rstrip("0123456789")
+    if normalized in _WEAK_PASSWORDS or normalized_without_trailing_digits in _WEAK_PASSWORDS:
+        raise ValueError("Password is too common. Choose a stronger password.")
+    if user and user in normalized:
+        raise ValueError("Password must not contain the username.")
+    if len(set(password)) < 4:
+        raise ValueError("Password must use a wider mix of characters.")
 
 
 def verify_password(plain: str, password_hash: str) -> bool:

--- a/apps/backend/src/mediamop/platform/auth/rate_limit.py
+++ b/apps/backend/src/mediamop/platform/auth/rate_limit.py
@@ -10,7 +10,8 @@ import ipaddress
 import logging
 import threading
 import time
-from collections import defaultdict
+from collections import OrderedDict, deque
+from typing import Deque
 
 logger = logging.getLogger(__name__)
 _forwarded_without_trust_warned = False
@@ -32,7 +33,7 @@ class SlidingWindowLimiter:
         self.max_keys = max_keys
         self.window_seconds = float(window_seconds)
         self._lock = threading.Lock()
-        self._buckets: dict[str, list[float]] = defaultdict(list)
+        self._buckets: OrderedDict[str, Deque[float]] = OrderedDict()
 
     def allow(self, key: str) -> bool:
         """Record one event for ``key``. Return True if allowed, False if limited."""
@@ -42,33 +43,30 @@ class SlidingWindowLimiter:
         k = key or "unknown"
         with self._lock:
             self._evict_expired_locked(cutoff)
-            bucket = self._buckets[k]
+            bucket = self._buckets.get(k)
+            if bucket is None:
+                bucket = deque()
+                self._buckets[k] = bucket
             while bucket and bucket[0] < cutoff:
-                bucket.pop(0)
+                bucket.popleft()
             if len(bucket) >= self.max_events:
                 return False
             bucket.append(now)
-            self._evict_over_capacity_locked(prefer_keep=k)
+            self._buckets.move_to_end(k)
+            self._evict_over_capacity_locked()
             return True
 
     def _evict_expired_locked(self, cutoff: float) -> None:
         for key in list(self._buckets):
             bucket = self._buckets[key]
             while bucket and bucket[0] < cutoff:
-                bucket.pop(0)
+                bucket.popleft()
             if not bucket:
                 del self._buckets[key]
 
-    def _evict_over_capacity_locked(self, *, prefer_keep: str) -> None:
+    def _evict_over_capacity_locked(self) -> None:
         while len(self._buckets) > self.max_keys:
-            oldest_key = min(
-                (key for key in self._buckets if key != prefer_keep),
-                key=lambda key: self._buckets[key][-1] if self._buckets[key] else 0.0,
-                default=None,
-            )
-            if oldest_key is None:
-                break
-            del self._buckets[oldest_key]
+            self._buckets.popitem(last=False)
 
     def reset_for_tests(self) -> None:
         with self._lock:

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -217,6 +217,9 @@ def post_bootstrap(
             username=body.username.strip(),
             password=body.password,
         )
+    except ValueError as exc:
+        logger.warning("auth event: bootstrap failed (weak password)")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     except IntegrityError as exc:
         logger.warning("auth event: bootstrap failed (username conflict)")
         raise HTTPException(

--- a/apps/backend/src/mediamop/platform/auth/schemas.py
+++ b/apps/backend/src/mediamop/platform/auth/schemas.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, Field
 
+from mediamop.platform.auth.password import MIN_PASSWORD_LENGTH
+
 
 class CsrfOut(BaseModel):
     csrf_token: str = Field(..., description="Send on unsafe requests (header X-CSRF-Token or body).")
@@ -44,7 +46,7 @@ class BootstrapStatusOut(BaseModel):
 
 class BootstrapIn(BaseModel):
     username: str = Field(..., min_length=1, max_length=64)
-    password: str = Field(..., min_length=8, max_length=512)
+    password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=512)
     csrf_token: str = Field(..., min_length=1)
 
 
@@ -55,7 +57,7 @@ class BootstrapOut(BaseModel):
 
 class ChangePasswordIn(BaseModel):
     current_password: str = Field(..., min_length=1)
-    new_password: str = Field(..., min_length=8, max_length=512)
+    new_password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=512)
     csrf_token: str = Field(..., min_length=1)
 
 

--- a/apps/backend/src/mediamop/platform/auth/service.py
+++ b/apps/backend/src/mediamop/platform/auth/service.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.datetime_util import as_utc
 from mediamop.platform.auth.models import User, UserSession
-from mediamop.platform.auth.password import hash_password, verify_password
+from mediamop.platform.auth.password import hash_password, validate_password_strength, verify_password
 from mediamop.platform.auth.sessions import (
     compute_absolute_expiry,
     generate_raw_session_token,
@@ -26,6 +26,7 @@ from mediamop.platform.auth.sessions import (
 )
 
 logger = logging.getLogger(__name__)
+MAX_ACTIVE_SESSIONS_PER_USER = 5
 
 
 def authenticate_user(db: Session, username: str, password: str) -> User | None:
@@ -49,6 +50,59 @@ def revoke_active_sessions_for_user(db: Session, user_id: int) -> None:
     db.execute(stmt)
 
 
+def cleanup_inactive_sessions(db: Session, *, settings: MediaMopSettings, now=None) -> int:
+    """Delete sessions that can no longer authenticate a request."""
+
+    n = now or utcnow()
+    idle_cutoff = n - timedelta(minutes=settings.session_idle_minutes)
+    result = db.execute(
+        delete(UserSession).where(
+            (UserSession.revoked_at.is_not(None))
+            | (UserSession.absolute_expires_at <= n)
+            | (UserSession.last_seen_at < idle_cutoff),
+        )
+    )
+    return int(result.rowcount or 0)
+
+
+def enforce_session_limit_for_user(
+    db: Session,
+    user_id: int,
+    *,
+    max_active_sessions: int = MAX_ACTIVE_SESSIONS_PER_USER,
+) -> int:
+    """Keep newest active sessions and revoke older overflow rows."""
+
+    if max_active_sessions < 1:
+        max_active_sessions = 1
+    now = utcnow()
+    active_count = db.scalar(
+        select(func.count())
+        .select_from(UserSession)
+        .where(
+            UserSession.user_id == user_id,
+            UserSession.revoked_at.is_(None),
+            UserSession.absolute_expires_at > now,
+        )
+    ) or 0
+    overflow = int(active_count) - max_active_sessions
+    if overflow <= 0:
+        return 0
+    rows = db.scalars(
+        select(UserSession)
+        .where(
+            UserSession.user_id == user_id,
+            UserSession.revoked_at.is_(None),
+            UserSession.absolute_expires_at > now,
+        )
+        .order_by(UserSession.created_at.asc(), UserSession.id.asc())
+        .limit(overflow)
+    ).all()
+    for row in rows:
+        revoke_session(row, at=now)
+    return len(rows)
+
+
 def create_user_session(
     db: Session,
     user: User,
@@ -64,11 +118,15 @@ def create_user_session(
     row = UserSession(
         user_id=user.id,
         token_hash=th,
+        created_at=now,
         absolute_expires_at=compute_absolute_expiry(now=now, ttl=abs_ttl),
         last_seen_at=now,
     )
     db.add(row)
     db.flush()
+    revoked = enforce_session_limit_for_user(db, user.id)
+    if revoked:
+        logger.info("auth event: oldest sessions revoked after session cap (user_id=%s, count=%s)", user.id, revoked)
     logger.info("auth event: session created (user_id=%s, absolute_expires_at=%s)", user.id, row.absolute_expires_at)
     return row, raw
 
@@ -166,6 +224,7 @@ def change_password_for_user(
         raise ValueError("Current password is incorrect.")
     if current_password == new_password:
         raise ValueError("New password must be different from the current password.")
+    validate_password_strength(new_password, username=user.username)
     user.password_hash = hash_password(new_password)
     revoke_active_sessions_for_user(db, user.id)
     db.flush()

--- a/apps/backend/src/mediamop/platform/auth/session_cleanup.py
+++ b/apps/backend/src/mediamop/platform/auth/session_cleanup.py
@@ -1,0 +1,58 @@
+"""Periodic cleanup for server-side auth sessions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.platform.auth.service import cleanup_inactive_sessions
+
+logger = logging.getLogger(__name__)
+_INTERVAL_SECONDS = 3600
+
+
+async def _session_cleanup_loop(
+    session_factory: sessionmaker[Session],
+    *,
+    stop_event: asyncio.Event,
+    settings: MediaMopSettings,
+    interval_seconds: float = _INTERVAL_SECONDS,
+) -> None:
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+        except TimeoutError:
+            pass
+        if stop_event.is_set():
+            break
+        try:
+            with session_factory() as session:
+                removed = cleanup_inactive_sessions(session, settings=settings)
+                session.commit()
+            if removed:
+                logger.info("auth event: cleaned up inactive sessions (count=%s)", removed)
+        except Exception:
+            logger.exception("auth event: inactive session cleanup failed")
+
+
+def start_session_cleanup_task(
+    session_factory: sessionmaker[Session],
+    *,
+    stop_event: asyncio.Event,
+    settings: MediaMopSettings,
+) -> asyncio.Task:
+    return asyncio.create_task(
+        _session_cleanup_loop(session_factory, stop_event=stop_event, settings=settings),
+        name="auth-session-cleanup",
+    )
+
+
+async def stop_session_cleanup_task(task: asyncio.Task) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass

--- a/apps/backend/src/mediamop/platform/health/router.py
+++ b/apps/backend/src/mediamop/platform/health/router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request, Response, status
 
 from mediamop.platform.health.schemas import HealthResponse
 from mediamop.platform.health.service import get_health
@@ -11,5 +11,8 @@ router = APIRouter(tags=["health"])
 
 
 @router.get("/health", response_model=HealthResponse)
-def health() -> HealthResponse:
-    return get_health()
+def health(request: Request, response: Response) -> HealthResponse:
+    payload = get_health(request.app.state)
+    if payload.status != "ok":
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    return payload

--- a/apps/backend/src/mediamop/platform/health/schemas.py
+++ b/apps/backend/src/mediamop/platform/health/schemas.py
@@ -9,3 +9,4 @@ class HealthResponse(BaseModel):
     """Minimal liveness payload for load balancers and ops."""
 
     status: str = Field(..., description="Application liveness indicator.")
+    dependencies: dict[str, str] = Field(default_factory=dict, description="Basic dependency check states.")

--- a/apps/backend/src/mediamop/platform/health/service.py
+++ b/apps/backend/src/mediamop/platform/health/service.py
@@ -2,9 +2,42 @@
 
 from __future__ import annotations
 
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
 from mediamop.platform.health.schemas import HealthResponse
 
+logger = logging.getLogger(__name__)
+_HEALTH_DB_BUSY_TIMEOUT_MS = 1000
 
-def get_health() -> HealthResponse:
-    """Return current process liveness. No dependency checks in Phase 3."""
-    return HealthResponse(status="ok")
+
+def database_is_connected(app_state: Any) -> bool:
+    factory = getattr(app_state, "session_factory", None)
+    if factory is None:
+        return False
+    try:
+        with factory() as session:
+            conn = session.connection()
+            previous_timeout = conn.exec_driver_sql("PRAGMA busy_timeout").scalar_one_or_none()
+            conn.exec_driver_sql(f"PRAGMA busy_timeout={_HEALTH_DB_BUSY_TIMEOUT_MS}")
+            try:
+                session.execute(text("SELECT 1"))
+            finally:
+                if previous_timeout is not None:
+                    conn.exec_driver_sql(f"PRAGMA busy_timeout={int(previous_timeout)}")
+        return True
+    except Exception:
+        logger.exception("health check failed: database connectivity probe failed")
+        return False
+
+
+def get_health(app_state: Any) -> HealthResponse:
+    """Return process health plus basic local dependency checks."""
+
+    db_ok = database_is_connected(app_state)
+    return HealthResponse(
+        status="ok" if db_ok else "unhealthy",
+        dependencies={"database": "ok" if db_ok else "failed"},
+    )

--- a/apps/backend/src/mediamop/platform/http/request_context.py
+++ b/apps/backend/src/mediamop/platform/http/request_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from uuid import uuid4
@@ -13,6 +14,7 @@ from starlette.responses import Response
 
 from mediamop.platform.metrics.service import record_http_request
 
+logger = logging.getLogger(__name__)
 _request_id_var: ContextVar[str | None] = ContextVar("mediamop_request_id", default=None)
 _job_id_var: ContextVar[str | None] = ContextVar("mediamop_job_id", default=None)
 
@@ -46,6 +48,12 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
             response = await call_next(request)
         except Exception:
             duration_ms = (time.perf_counter() - started) * 1000
+            logger.exception(
+                "Unhandled request failure request_id=%s method=%s route=%s",
+                request_id,
+                request.method,
+                _route_label(request),
+            )
             record_http_request(
                 method=request.method,
                 route=_route_label(request),

--- a/apps/backend/src/mediamop/platform/http/security_headers.py
+++ b/apps/backend/src/mediamop/platform/http/security_headers.py
@@ -55,7 +55,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers.setdefault("X-Frame-Options", "DENY")
         # API responses can include filesystem paths, credentials metadata, and operator settings.
         path = request.url.path
-        if path.startswith("/api/v1"):
+        if path.startswith("/api/v1") or path in {"/health", "/ready", "/readiness", "/metrics"}:
             response.headers.setdefault("Cache-Control", "no-store, private")
 
         if settings is not None and settings.security_enable_hsts:

--- a/apps/backend/src/mediamop/platform/readiness/service.py
+++ b/apps/backend/src/mediamop/platform/readiness/service.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import asdict
 from typing import Any
 
+from mediamop.platform.health.service import database_is_connected
 from mediamop.platform.jobs.worker_health import build_worker_health_snapshot
 from mediamop.platform.readiness.schemas import ReadinessResponse, ReadinessStep, ReadinessWorkerOut
 
@@ -15,6 +16,7 @@ def build_readiness(app_state: Any) -> ReadinessResponse:
     startup_seconds = max(0.0, time.monotonic() - started_at)
     session_factory = getattr(app_state, "session_factory", None)
     engine = getattr(app_state, "engine", None)
+    database_ready = session_factory is not None and engine is not None and database_is_connected(app_state)
     startup_complete = bool(getattr(app_state, "startup_ready", False))
     settings = getattr(app_state, "settings", None)
     worker_health: list[ReadinessWorkerOut] = []
@@ -33,10 +35,12 @@ def build_readiness(app_state: Any) -> ReadinessResponse:
     steps = [
         ReadinessStep(
             name="database",
-            status="ready" if session_factory is not None and engine is not None else "starting",
+            status="ready" if database_ready else ("starting" if not startup_complete else "failed"),
             detail=(
                 "Local database is connected and migrations are complete."
-                if session_factory is not None and engine is not None
+                if database_ready
+                else "MediaMop could not verify the local database connection."
+                if startup_complete
                 else "MediaMop is preparing the local database."
             ),
         ),

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -19,6 +19,7 @@ from mediamop.platform.activity.models import ActivityEvent
 from mediamop.platform.auth import service as auth_service
 from mediamop.platform.auth.models import User, UserRole, UserSession
 from mediamop.platform.auth.password import hash_password
+from mediamop.platform.auth.sessions import revoke_session
 from mediamop.core.datetime_util import as_utc
 from tests.integration_helpers import auth_post, csrf as fetch_csrf, reset_user_tables, seed_admin_user
 
@@ -298,6 +299,58 @@ def test_second_browser_login_does_not_revoke_first_browser_session() -> None:
         assert remote_client.get("/api/v1/auth/me").status_code == 200
 
 
+def test_login_keeps_only_newest_five_active_sessions() -> None:
+    seed_admin_user()
+    settings = MediaMopSettings.load()
+    app = create_app()
+    clients = [TestClient(app) for _ in range(6)]
+    with clients[0], clients[1], clients[2], clients[3], clients[4], clients[5]:
+        for client in clients:
+            csrf = fetch_csrf(client)
+            login = auth_post(
+                client,
+                "/api/v1/auth/login",
+                json={"username": "alice", "password": "test-password-strong", "csrf_token": csrf},
+            )
+            assert login.status_code == 200, login.text
+
+        assert clients[0].get("/api/v1/auth/me").status_code == 401
+        for client in clients[1:]:
+            assert client.get("/api/v1/auth/me").status_code == 200
+
+    eng = create_db_engine(settings)
+    fac = create_session_factory(eng)
+    with fac() as db:
+        active = db.scalars(select(UserSession).where(UserSession.revoked_at.is_(None))).all()
+        revoked = db.scalars(select(UserSession).where(UserSession.revoked_at.is_not(None))).all()
+    assert len(active) == 5
+    assert len(revoked) == 1
+
+
+def test_session_limit_ignores_absolute_expired_sessions() -> None:
+    seed_admin_user()
+    settings = MediaMopSettings.load()
+    eng = create_db_engine(settings)
+    fac = create_session_factory(eng)
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
+        with fac() as db:
+            user = db.scalars(select(User).where(User.username == "alice")).one()
+            for _ in range(5):
+                row, _raw = auth_service.create_user_session(db, user, settings=settings)
+                row.absolute_expires_at = base - timedelta(seconds=1)
+            live, _raw = auth_service.create_user_session(db, user, settings=settings)
+            db.commit()
+
+    with fac() as db:
+        live_row = db.get(UserSession, live.id)
+        expired_rows = db.scalars(select(UserSession).where(UserSession.id != live.id)).all()
+
+    assert live_row is not None
+    assert live_row.revoked_at is None
+    assert all(row.revoked_at is None for row in expired_rows)
+
+
 def test_admin_ping_requires_admin(client_with_admin: TestClient) -> None:
     csrf = fetch_csrf(client_with_admin)
     auth_post(
@@ -419,10 +472,28 @@ def test_bootstrap_rejects_short_password() -> None:
         assert r.status_code == 422, r.text
         detail = r.json().get("detail") or []
         assert any(
-            item.get("loc") == ["body", "password"] and "at least 8 characters" in item.get("msg", "")
+            item.get("loc") == ["body", "password"] and "at least 12 characters" in item.get("msg", "")
             for item in detail
             if isinstance(item, dict)
         )
+
+
+def test_bootstrap_rejects_common_password() -> None:
+    reset_user_tables()
+    app = create_app()
+    with TestClient(app) as client:
+        csrf = fetch_csrf(client)
+        r = auth_post(
+            client,
+            "/api/v1/auth/bootstrap",
+            json={
+                "username": "owner1",
+                "password": "password1234",
+                "csrf_token": csrf,
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "common" in r.json()["detail"].lower()
 
 
 def test_bootstrap_blocked_after_admin_exists(client_with_admin: TestClient) -> None:
@@ -672,6 +743,34 @@ def test_expired_session_is_rejected_and_revoked(monkeypatch: pytest.MonkeyPatch
         assert row.revoked_at is not None
 
 
+def test_session_cleanup_deletes_revoked_and_expired_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEDIAMOP_SESSION_IDLE_MINUTES", "720")
+    seed_admin_user()
+    settings = MediaMopSettings.load()
+    eng = create_db_engine(settings)
+    fac = create_session_factory(eng)
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
+        with fac() as db:
+            user = db.scalars(select(User).where(User.username == "alice")).one()
+            revoked, _ = auth_service.create_user_session(db, user, settings=settings)
+            expired, _ = auth_service.create_user_session(db, user, settings=settings)
+            active, _ = auth_service.create_user_session(db, user, settings=settings)
+            revoke_session(revoked, at=base)
+            expired.absolute_expires_at = base - timedelta(seconds=1)
+            db.commit()
+
+    with fac() as db:
+        removed = auth_service.cleanup_inactive_sessions(db, settings=settings, now=base)
+        db.commit()
+
+    assert removed == 2
+    with fac() as db:
+        rows = db.scalars(select(UserSession)).all()
+    assert [row.id for row in rows] == [active.id]
+
+
 def test_security_headers_on_health_and_api(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MEDIAMOP_SECURITY_ENABLE_HSTS", "1")
     reset_user_tables()
@@ -682,6 +781,7 @@ def test_security_headers_on_health_and_api(monkeypatch: pytest.MonkeyPatch) -> 
         assert r_h.headers.get("X-Frame-Options") == "DENY"
         assert r_h.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
         assert r_h.headers.get("Content-Security-Policy")
+        assert r_h.headers.get("Cache-Control", "").startswith("no-store")
         assert r_h.headers.get("strict-transport-security")
         r_csrf = client.get("/api/v1/auth/csrf")
         assert r_csrf.headers.get("Content-Security-Policy")
@@ -689,6 +789,8 @@ def test_security_headers_on_health_and_api(monkeypatch: pytest.MonkeyPatch) -> 
         assert r_csrf.headers.get("Cache-Control", "").startswith("no-store")
         r_system = client.get("/api/v1/system/directories")
         assert r_system.headers.get("Cache-Control", "").startswith("no-store")
+        r_metrics = client.get("/metrics")
+        assert r_metrics.headers.get("Cache-Control", "").startswith("no-store")
 
 
 def test_static_assets_do_not_get_api_no_store(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -14,10 +14,19 @@ from mediamop.platform.readiness.service import build_readiness
 
 
 def test_health_ok() -> None:
-    client = TestClient(create_app())
-    response = client.get("/health")
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.json() == {"status": "ok", "dependencies": {"database": "ok"}}
+    assert response.headers.get("Cache-Control", "").startswith("no-store")
+    assert response.headers.get("X-Request-ID")
+
+
+def test_request_id_header_is_echoed() -> None:
+    with TestClient(create_app()) as client:
+        response = client.get("/health", headers={"X-Request-ID": "audit-request-1"})
+
+    assert response.headers.get("X-Request-ID") == "audit-request-1"
 
 
 def test_ready_ok_after_lifespan_startup() -> None:
@@ -28,6 +37,7 @@ def test_ready_ok_after_lifespan_startup() -> None:
     assert body["ready"] is True
     assert body["status"] == "ready"
     assert {step["name"] for step in body["steps"]} == {"database", "workers"}
+    assert response.headers.get("Cache-Control", "").startswith("no-store")
 
 
 def test_readiness_reports_starting_before_startup_complete() -> None:
@@ -50,15 +60,15 @@ def test_readiness_reports_failed_when_worker_heartbeat_missing() -> None:
     class State:
         startup_started_at = 0.0
         startup_ready = True
-        engine = object()
-        session_factory = object()
+        engine = None
+        session_factory = None
         settings = replace(MediaMopSettings.load(), refiner_worker_count=1, pruner_worker_count=0, subber_worker_count=0)
 
     payload = build_readiness(State())
 
     assert payload.ready is False
     assert payload.status == "failed"
-    assert any(step.name == "workers" and step.status == "failed" for step in payload.steps)
+    assert any(step.name in {"database", "workers"} and step.status == "failed" for step in payload.steps)
 
 
 def test_unknown_upgrade_api_browser_landing_redirects_to_settings() -> None:


### PR DESCRIPTION
## Summary
- allow concurrent sessions while capping active sessions per user and revoking oldest overflow rows
- add startup and periodic cleanup for revoked, absolute-expired, and idle-expired session rows
- replace rate limiter list buckets with deque + ordered key eviction to avoid O(n) per-event pops and unbounded key growth
- make health/readiness perform real DB connectivity probes
- apply no-store cache control to /health, /ready, /metrics, and existing sensitive API paths
- enforce stronger passwords for bootstrap and password changes
- log unhandled request failures with request ID while preserving request metrics

## Validation
- backend full suite: .\\.venv\\Scripts\\python.exe -m pytest -q
- backend lint: .\\.venv\\Scripts\\python.exe -m ruff check src tests
- whitespace: git diff --check

## Follow-up
- Logged #110 to evaluate removing unsafe-inline from the bundled HTML CSP separately.