### PR TITLE
Release v1.0.28

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.27"
+version = "1.0.28"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.27",
+  "version": "1.0.28",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump backend and web package versions to 1.0.28 for the next tagged release

## Validation
- backend targeted: .\\.venv\\Scripts\\python.exe -m pytest tests\\test_version.py tests\\test_health.py -q --tb=short
- web build: npm run build
- git diff --check