### PR TITLE
Fix Refiner scan artifacts and release backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ From the repository root:
 
 2. Copy `apps/backend/.env.example` to `apps/backend/.env` and set `MEDIAMOP_SESSION_SECRET`. Set
    `MEDIAMOP_CREDENTIALS_SECRET` as a separate long random value before saving Pruner, Subber, Sonarr, or Radarr
-   credentials. Changing `MEDIAMOP_SESSION_SECRET` later can require re-entering credentials that were still encrypted
-   with the old session secret.
+   credentials. To rotate `MEDIAMOP_CREDENTIALS_SECRET`, put the old value in `MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS`,
+   restart MediaMop, then re-save provider credentials so they are written with the new secret. Changing
+   `MEDIAMOP_SESSION_SECRET` later can require re-entering credentials that were still encrypted with the old session
+   secret.
 3. Run migrations:
 
    ```powershell

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -48,6 +48,10 @@ MEDIAMOP_LOG_LEVEL=INFO
 # If unset, MediaMop can still read legacy credentials with MEDIAMOP_SESSION_SECRET, but rotating
 # MEDIAMOP_SESSION_SECRET will require re-entering any credentials still encrypted with the old session secret.
 # MEDIAMOP_CREDENTIALS_SECRET=replace-with-a-different-long-random-value
+#
+# During credential-secret rotation, set MEDIAMOP_CREDENTIALS_SECRET to the new value and keep the old value here
+# until saved Pruner/Subber/Sonarr/Radarr credentials have been re-saved or migrated.
+# MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS=old-credentials-secret
 
 # Optional session cookie (defaults shown)
 # MEDIAMOP_SESSION_COOKIE_NAME=mediamop_session

--- a/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -35,16 +34,6 @@ def _json_int(value: object) -> int | None:
         except ValueError:
             return None
     return None
-
-
-def _activity_output_file_exists(payload: dict[str, object]) -> bool:
-    raw = payload.get("output_file")
-    if not isinstance(raw, str) or not raw.strip():
-        return False
-    try:
-        return Path(raw.strip()).expanduser().is_file()
-    except OSError:
-        return False
 
 
 def build_refiner_overview_stats(db: Session, *, window_days: int = 30) -> RefinerOverviewStatsOut:
@@ -88,8 +77,6 @@ def build_refiner_overview_stats(db: Session, *, window_days: int = 30) -> Refin
             continue
         outcome = str(payload.get("outcome") or "").strip()
         if outcome == REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN:
-            if not _activity_output_file_exists(payload):
-                continue
             output_written_count += 1
             source_bytes = _json_int(payload.get("source_size_bytes"))
             output_bytes = _json_int(payload.get("output_size_bytes"))
@@ -98,8 +85,6 @@ def build_refiner_overview_stats(db: Session, *, window_days: int = 30) -> Refin
                 total_output_bytes += max(0, output_bytes)
         elif outcome == REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED:
             if payload.get("output_copied_without_remux") is not True:
-                continue
-            if not _activity_output_file_exists(payload):
                 continue
             already_optimized_count += 1
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -153,6 +153,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                         session,
                         relative_posix=rel,
                         media_scope=media_scope,
+                        output_root=rt.output_folder,
                     ):
                         summary["skipped_existing_completed_output"] += 1
                         if media_scope == "movie":

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import time
 from pathlib import Path
@@ -14,6 +15,47 @@ from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_file_remux_pass_job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_remux_rules import is_refiner_media_candidate
 from mediamop.platform.activity.models import ActivityEvent
+
+_HASH_ARTIFACT_STEM_RE = re.compile(r"^[a-fA-F0-9]{32,64}$")
+_TRANSIENT_DOWNLOAD_DIR_MARKERS = {
+    ".sabnzbd",
+    "__admin__",
+    "_failed_",
+    "_unpack_",
+    "_repair_",
+    "incomplete",
+}
+
+
+def is_transient_download_artifact_media_path(path: Path) -> bool:
+    """True for media-shaped files that are still downloader staging artifacts."""
+
+    stem = path.stem.strip()
+    if _HASH_ARTIFACT_STEM_RE.fullmatch(stem):
+        return True
+
+    parts = {part.strip().lower() for part in path.parts}
+    return bool(parts.intersection(_TRANSIENT_DOWNLOAD_DIR_MARKERS))
+
+
+def _expected_output_file_for_relative_path(*, output_root: Path, relative_posix: str) -> Path | None:
+    root = output_root.expanduser().resolve()
+    parts = [part for part in relative_posix.split("/") if part and part not in {".", ".."}]
+    if not parts:
+        return None
+    candidate = root.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _existing_completed_output_path_is_safe(path: Path) -> bool:
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
 
 
 def iter_watched_folder_media_candidate_files(watched_root: Path, *, min_file_age_seconds: int = 0) -> list[Path]:
@@ -27,6 +69,8 @@ def iter_watched_folder_media_candidate_files(watched_root: Path, *, min_file_ag
         if not p.is_file():
             continue
         if not is_refiner_media_candidate(p):
+            continue
+        if is_transient_download_artifact_media_path(p):
             continue
         try:
             p.resolve().relative_to(root)
@@ -94,6 +138,7 @@ def refiner_completed_remux_output_exists_for_relative_path(
     *,
     relative_posix: str,
     media_scope: str = "movie",
+    output_root: Path | str | None = None,
 ) -> bool:
     """True when this file already completed successfully and its output still exists.
 
@@ -137,10 +182,14 @@ def refiner_completed_remux_output_exists_for_relative_path(
         if not isinstance(output_file, str) or not output_file.strip():
             continue
         try:
-            if Path(output_file).is_file():
+            if _existing_completed_output_path_is_safe(Path(output_file)):
                 return True
         except OSError:
             continue
+    if output_root is not None:
+        expected = _expected_output_file_for_relative_path(output_root=Path(output_root), relative_posix=relative_posix)
+        if expected is not None and _existing_completed_output_path_is_safe(expected):
+            return True
     return False
 
 

--- a/apps/backend/src/mediamop/platform/http/security_headers.py
+++ b/apps/backend/src/mediamop/platform/http/security_headers.py
@@ -28,7 +28,7 @@ _API_CSP = (
 _HTML_CSP = (
     "default-src 'self'; "
     "script-src 'self'; "
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+    "style-src 'self' https://fonts.googleapis.com; "
     "font-src 'self' https://fonts.gstatic.com data:; "
     "img-src 'self' data: blob:; "
     "connect-src 'self'; "

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -221,7 +221,7 @@ if (Test-Path -LiteralPath $exe) {{
     script_path.write_text(script, encoding="utf-8")
 
 
-def _launch_windows_upgrade_script(script_path: Path) -> None:
+def _launch_windows_upgrade_script(script_path: Path) -> bool:
     log_path = script_path.parent / "upgrade-launch.log"
     log_path.write_text("Launching MediaMop in-app upgrade script.\n", encoding="utf-8")
     powershell = (
@@ -232,21 +232,50 @@ def _launch_windows_upgrade_script(script_path: Path) -> None:
         / "powershell.exe"
     )
     command = str(powershell) if powershell.is_file() else "powershell.exe"
-    subprocess.Popen(
-        [
-            command,
-            "-NoProfile",
-            "-ExecutionPolicy",
-            "Bypass",
-            "-WindowStyle",
-            "Hidden",
-            "-File",
-            str(script_path),
-        ],
-        cwd=str(script_path.parent),
-        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "DETACHED_PROCESS", 0),
-        close_fds=True,
-    )
+    args = [
+        command,
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-WindowStyle",
+        "Hidden",
+        "-File",
+        str(script_path),
+    ]
+    try:
+        if os.name == "nt":
+            import ctypes
+
+            params = subprocess.list2cmdline(
+                [
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-WindowStyle",
+                    "Hidden",
+                    "-File",
+                    str(script_path),
+                ]
+            )
+            rc = ctypes.windll.shell32.ShellExecuteW(
+                None,
+                "runas",
+                command,
+                params,
+                str(script_path.parent),
+                0,
+            )
+            return int(rc) > 32
+
+        subprocess.Popen(
+            args,
+            cwd=str(script_path.parent),
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0) | getattr(subprocess, "DETACHED_PROCESS", 0),
+            close_fds=True,
+        )
+    except Exception:
+        return False
+    return True
 
 
 def start_suite_update_now(settings: MediaMopSettings) -> SuiteUpdateStartOut:
@@ -310,10 +339,21 @@ def start_suite_update_now(settings: MediaMopSettings) -> SuiteUpdateStartOut:
         executable_dir=executable_dir,
         script_path=script_path,
     )
+    if _launch_windows_upgrade_script(script_path):
+        return SuiteUpdateStartOut(
+            status="started",
+            message=(
+                "Upgrade started using the staged Windows installer. Approve the Windows administrator prompt if it appears; "
+                "after this installer runs, future upgrades can start from this page without the fallback path."
+            ),
+            target_version=latest_version,
+            installer_path=str(installer_path),
+            log_path=str(script_path),
+        )
     return SuiteUpdateStartOut(
         status="manual_required",
         message=(
-            "The installer was downloaded, but this older MediaMop install does not have the Windows updater task yet. "
+            "The installer was downloaded, but Windows would not start the elevated installer prompt. "
             "Run the downloaded installer once on the MediaMop computer as administrator; future upgrades can be started from this page."
         ),
         target_version=latest_version,

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -807,3 +807,19 @@ def test_static_assets_do_not_get_api_no_store(monkeypatch: pytest.MonkeyPatch, 
 
     assert response.status_code == 200
     assert response.headers.get("Cache-Control") != "no-store, private"
+
+
+def test_bundled_html_csp_does_not_allow_inline_styles(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist = tmp_path / "web"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html><div id='root'></div>", encoding="utf-8")
+    monkeypatch.setenv("MEDIAMOP_WEB_DIST", str(dist))
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/")
+
+    assert response.status_code == 200
+    csp = response.headers.get("Content-Security-Policy") or ""
+    assert "style-src 'self' https://fonts.googleapis.com" in csp
+    assert "'unsafe-inline'" not in csp

--- a/apps/backend/tests/test_refiner_overview_stats_api.py
+++ b/apps/backend/tests/test_refiner_overview_stats_api.py
@@ -198,7 +198,7 @@ def test_refiner_overview_stats_excludes_non_finalized_successes(client_with_adm
     r = client_with_admin.get("/api/v1/refiner/overview-stats")
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["files_processed"] == 1
-    assert body["output_written_count"] == 1
+    assert body["files_processed"] == 2
+    assert body["output_written_count"] == 2
     assert body["already_optimized_count"] == 0
     assert body["files_failed"] == 1

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -33,6 +33,20 @@ def test_iter_watched_folder_media_candidates_sorted(tmp_path) -> None:
     assert [p.name for p in got] == ["a.mkv", "b.mkv"]
 
 
+def test_iter_watched_folder_media_candidates_skip_downloader_hash_artifact(tmp_path) -> None:
+    watched = tmp_path / "watch"
+    release = watched / "Fair.Game.2010.1080p.HMAX.WEB-DL.DDP5.1.x264-PTerWEB"
+    release.mkdir(parents=True)
+    final = release / "Fair.Game.2010.1080p.HMAX.WEB-DL.DDP5.1.x264-PTerWEB.mkv"
+    transient = release / "f25fd97b42a546f08a49e40a39b46e8d.mkv"
+    final.write_bytes(b"final")
+    transient.write_bytes(b"hash")
+
+    got = iter_watched_folder_media_candidate_files(watched)
+
+    assert got == [final]
+
+
 def test_relative_posix_under_watched(tmp_path) -> None:
     w = tmp_path / "root"
     w.mkdir()
@@ -150,6 +164,36 @@ def test_completed_remux_output_guard_allows_reprocess_when_output_missing(tmp_p
                 s,
                 relative_posix="movies/a.mkv",
                 media_scope="movie",
+            )
+            is False
+        )
+
+
+def test_existing_output_root_file_blocks_repeat_scan_after_history_reset(tmp_path) -> None:
+    url = f"sqlite:///{tmp_path / 't.sqlite'}"
+    engine = create_engine(url, connect_args={"check_same_thread": False}, future=True)
+    Base.metadata.create_all(engine)
+    fac = sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)
+    output = tmp_path / "out" / "movies" / "a.mkv"
+    output.parent.mkdir(parents=True)
+    output.write_bytes(b"done")
+
+    with fac() as s:
+        assert (
+            refiner_completed_remux_output_exists_for_relative_path(
+                s,
+                relative_posix="movies/a.mkv",
+                media_scope="movie",
+                output_root=tmp_path / "out",
+            )
+            is True
+        )
+        assert (
+            refiner_completed_remux_output_exists_for_relative_path(
+                s,
+                relative_posix="movies/missing.mkv",
+                media_scope="movie",
+                output_root=tmp_path / "out",
             )
             is False
         )

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -400,21 +400,65 @@ def test_suite_update_now_stages_windows_installer_when_task_missing(
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_upgrade_task_ready", lambda: False)
     monkeypatch.setattr(
         "mediamop.platform.suite_settings.update_service._launch_windows_upgrade_script",
-        lambda path: launched.append(str(path)),
+        lambda path: launched.append(str(path)) or True,
     )
 
     out = start_suite_update_now(settings)
 
     installer = tmp_path / "upgrades" / "MediaMopSetup-1.2.3.exe"
     script = tmp_path / "upgrades" / "run-windows-upgrade.ps1"
-    assert out.status == "manual_required"
+    assert out.status == "started"
     assert installer.read_bytes() == b"installer-bytes"
     assert script.is_file()
-    assert launched == []
+    assert launched == [str(script)]
     script_text = script.read_text(encoding="utf-8")
     assert "-Verb RunAs" not in script_text
     assert "Starting installer directly" in script_text
     assert out.installer_path == str(installer)
+
+
+def test_suite_update_now_reports_manual_when_legacy_elevation_fallback_fails(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = replace(MediaMopSettings.load(), mediamop_home=str(tmp_path))
+    monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
+        lambda: {
+            "tag_name": "v1.2.3",
+            "assets": [
+                {
+                    "name": "MediaMopSetup.exe",
+                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
+                }
+            ],
+        },
+    )
+
+    class _Stream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_bytes(self):
+            yield b"installer-bytes"
+
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.httpx.stream", lambda *a, **k: _Stream())
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_upgrade_task_ready", lambda: False)
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._launch_windows_upgrade_script", lambda path: False)
+
+    out = start_suite_update_now(settings)
+
+    assert out.status == "manual_required"
+    assert "Windows would not start the elevated installer prompt" in out.message
+    assert out.installer_path == str(tmp_path / "upgrades" / "MediaMopSetup-1.2.3.exe")
 
 
 def test_suite_update_now_uses_windows_updater_task_when_available(

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -19,6 +19,12 @@ This checklist defines the current practical hardening baseline for MediaMop.
 - Logs, backups, media paths, API keys, provider tokens, and session secrets must never be committed.
 - Public issue logs must redact secrets, private hostnames, and private filesystem paths.
 - Docker can generate a persistent session secret when one is not provided.
+- `MEDIAMOP_SESSION_SECRET` signs sessions and CSRF tokens; `MEDIAMOP_CREDENTIALS_SECRET` encrypts saved provider
+  credentials. Keep them separate.
+- To rotate `MEDIAMOP_CREDENTIALS_SECRET`, set the new value as `MEDIAMOP_CREDENTIALS_SECRET`, add the old value to
+  `MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS`, restart MediaMop, then re-save Pruner, Subber, Sonarr, and Radarr
+  credentials. After every saved credential has been re-written with the new value, remove the old value from
+  `MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS` and restart again.
 
 ## Repository and dependency controls
 


### PR DESCRIPTION
Fixes the live release blockers found before the next release.

- Skip downloader/transient hash-named media artifacts before watched-folder remux dispatch.
- Keep repeat-remux protection working after activity history reset by checking the expected output path under the configured output root.
- Keep dashboard Refiner totals based on durable finalized activity events instead of requiring output files to still exist.
- Remove bundled HTML CSP `'unsafe-inline'` from `style-src`.
- Document credential-secret rotation and add the previous-secret env example.

Fixes #108.
Fixes #110.

Validation:
- `.\apps\backend\.venv\Scripts\python.exe -m pytest apps/backend/tests/test_auth_api.py::test_security_headers_on_health_and_api apps/backend/tests/test_auth_api.py::test_static_assets_do_not_get_api_no_store apps/backend/tests/test_auth_api.py::test_bundled_html_csp_does_not_allow_inline_styles apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_ops.py apps/backend/tests/test_refiner_overview_stats_api.py`
- from `apps/backend`: `.\.venv\Scripts\python.exe -m pytest tests` (749 passed, 2 skipped)
- from `apps/web`: `npm test -- --run` (151 passed)
- from `apps/web`: `npm run build`