### PR TITLE
Release 1.0.30

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.29"
+version = "1.0.30"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.29",
+      "version": "1.0.30",
       "dependencies": {
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.29",
+  "version": "1.0.30",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bumps MediaMop to 1.0.30 so we can publish a Windows installer that includes the PR #122 fixes for:

- Refiner downloader hash artifact skipping
- repeat-remux protection after history reset
- dashboard Refiner totals after upgrade/output cleanup
- legacy in-app updater fallback bootstrap
- CSP and credential rotation backlog items

Validation:
- from apps/backend: `.\.venv\Scripts\python.exe -m pytest tests/test_version.py tests/test_windows_packaging_paths.py tests/test_suite_settings_api.py::test_suite_update_now_stages_windows_installer_when_task_missing tests/test_suite_settings_api.py::test_suite_update_now_uses_windows_updater_task_when_available`
- from apps/web: `npm test -- --run src/lib/refiner/overview-stats-api.test.ts src/lib/refiner/runtime-settings-api.test.ts`