### PR TITLE
Fix backlog foundation hardening and web resilience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
           MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
         run: |
+          alembic check
           alembic upgrade head
           pytest -q --cov=mediamop --cov-fail-under=60
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,12 @@ jobs:
       - name: MediaMop agent documentation map
         run: node scripts/check-agent-docs.mjs
 
-      - name: MediaMop web - install, build, unit tests
+      - name: MediaMop web - install, lint, format, build, unit tests
         working-directory: apps/web
         run: |
           npm ci
+          npm run lint
+          npm run format
           npm run build
           npm run test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         env:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
         run: |
-          alembic check
           alembic upgrade head
+          alembic check
           pytest -q --cov=mediamop --cov-fail-under=70
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
 
       - name: Backend dependency vulnerability scan (pip-audit)
         working-directory: apps/backend
-        run: pip-audit --strict
+        run: |
+          python -m pip freeze --exclude-editable > pip-audit-requirements.txt
+          pip-audit --strict -r pip-audit-requirements.txt
+          rm pip-audit-requirements.txt
 
       - name: MediaMop backend type check
         working-directory: apps/backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
   mediamop:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      MEDIAMOP_SESSION_SECRET: ${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-ci-session-secret-32chars-min
     steps:
       - uses: actions/checkout@v6
 
@@ -38,6 +40,14 @@ jobs:
         working-directory: apps/backend
         run: ruff check src tests
 
+      - name: Backend security scan (bandit)
+        working-directory: apps/backend
+        run: bandit -r src -lll -q
+
+      - name: Backend dependency vulnerability scan (pip-audit)
+        working-directory: apps/backend
+        run: pip-audit --strict
+
       - name: MediaMop backend type check
         working-directory: apps/backend
         run: mypy src/mediamop
@@ -46,11 +56,10 @@ jobs:
         working-directory: apps/backend
         env:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
-          MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
         run: |
           alembic check
           alembic upgrade head
-          pytest -q --cov=mediamop --cov-fail-under=60
+          pytest -q --cov=mediamop --cov-fail-under=70
 
       - uses: actions/setup-node@v6
         with:
@@ -68,17 +77,22 @@ jobs:
           npm run build
           npm run test
 
+      - name: Frontend dependency vulnerability scan
+        working-directory: apps/web
+        run: npm audit --audit-level=high
+
       - name: MediaMop E2E smoke (Playwright + real API)
         env:
           MEDIAMOP_E2E: "1"
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-e2e
-          MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
           PYTHONPATH: ${{ github.workspace }}/apps/backend/src
         run: python -m pytest tests/e2e/mediamop -q --tb=short
 
   docker-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      MEDIAMOP_SESSION_SECRET: ${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-ci-session-secret-32chars-min
     steps:
       - uses: actions/checkout@v6
 
@@ -89,7 +103,7 @@ jobs:
         run: |
           docker rm -f mediamop-ci-smoke >/dev/null 2>&1 || true
           docker run -d --name mediamop-ci-smoke -p 8788:8788 \
-            -e MEDIAMOP_SESSION_SECRET=ci-mediamop-session-secret-32chars-min \
+            -e MEDIAMOP_SESSION_SECRET="$MEDIAMOP_SESSION_SECRET" \
             mediamop-ci-smoke
           for i in {1..30}; do
             if curl -fsS http://127.0.0.1:8788/health >/tmp/mediamop-health.json; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: windows-latest
     if: ${{ !contains(github.ref_name, '-') }}
     timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -69,6 +71,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      MEDIAMOP_SESSION_SECRET: ${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-release-session-secret-32chars-min
     steps:
       - uses: actions/checkout@v6
 
@@ -86,11 +90,10 @@ jobs:
         working-directory: apps/backend
         env:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
-          MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
         run: |
           alembic check
           alembic upgrade head
-          pytest -q
+          pytest -q --cov=mediamop --cov-fail-under=70
 
       - uses: actions/setup-node@v6
         with:
@@ -112,7 +115,6 @@ jobs:
         env:
           MEDIAMOP_E2E: "1"
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-e2e
-          MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
           PYTHONPATH: ${{ github.workspace }}/apps/backend/src
         run: python -m pytest tests/e2e/mediamop -q --tb=short
 
@@ -158,7 +160,7 @@ jobs:
         run: |
           docker rm -f mediamop-release-smoke >/dev/null 2>&1 || true
           docker run -d --name mediamop-release-smoke -p 8788:8788 \
-            -e MEDIAMOP_SESSION_SECRET=ci-mediamop-session-secret-32chars-min \
+            -e MEDIAMOP_SESSION_SECRET="$MEDIAMOP_SESSION_SECRET" \
             "${{ steps.image.outputs.name }}:latest"
           for i in {1..30}; do
             if curl -fsS http://127.0.0.1:8788/health >/tmp/mediamop-health.json; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
           MEDIAMOP_SESSION_SECRET: ci-mediamop-session-secret-32chars-min
         run: |
+          alembic check
           alembic upgrade head
           pytest -q
 
@@ -140,8 +141,8 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          provenance: false
-          sbom: false
+          provenance: true
+          sbom: true
           tags: |
             ${{ steps.image.outputs.name }}:${{ github.ref_name }}
             ${{ steps.image.outputs.name }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,8 @@ jobs:
         env:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-ci
         run: |
-          alembic check
           alembic upgrade head
+          alembic check
           pytest -q --cov=mediamop --cov-fail-under=70
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,13 @@ jobs:
           python -m pip install -e "./apps/backend[dev]"
           python -m playwright install --with-deps chromium
 
+      - name: Backend dependency vulnerability scan (pip-audit)
+        working-directory: apps/backend
+        run: |
+          python -m pip freeze --exclude-editable > pip-audit-requirements.txt
+          pip-audit --strict -r pip-audit-requirements.txt
+          rm pip-audit-requirements.txt
+
       - name: Run MediaMop backend tests
         working-directory: apps/backend
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,14 +31,16 @@ RUN groupadd --system --gid 1000 mediamop \
   && mkdir -p /data/mediamop /opt/mediamop/apps/backend /opt/mediamop/web-dist \
   && chown -R mediamop:mediamop /data/mediamop /opt/mediamop /home/mediamop
 COPY --chown=mediamop:mediamop apps/backend /opt/mediamop/apps/backend
-RUN pip install --no-cache-dir --upgrade pip \
-  && pip install --no-cache-dir --prefer-binary -e "/opt/mediamop/apps/backend"
+RUN python -m venv /opt/mediamop/.venv \
+  && /opt/mediamop/.venv/bin/pip install --no-cache-dir --upgrade pip \
+  && /opt/mediamop/.venv/bin/pip install --no-cache-dir --prefer-binary -e "/opt/mediamop/apps/backend"
 
 COPY --from=web --chown=mediamop:mediamop /src/apps/web/dist /opt/mediamop/web-dist
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 ENV PYTHONPATH=/opt/mediamop/apps/backend/src
+ENV PATH=/opt/mediamop/.venv/bin:$PATH
 ENV MEDIAMOP_WEB_DIST=/opt/mediamop/web-dist
 ENV MEDIAMOP_ENV=production
 # All-in-one is usually reached over plain HTTP first (localhost / LAN). Secure cookies would

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/mediamop
-COPY apps/backend /opt/mediamop/apps/backend
+RUN groupadd --system --gid 1000 mediamop \
+  && useradd --system --uid 1000 --gid 1000 --create-home --home-dir /home/mediamop --shell /usr/sbin/nologin mediamop \
+  && mkdir -p /data/mediamop /opt/mediamop/apps/backend /opt/mediamop/web-dist \
+  && chown -R mediamop:mediamop /data/mediamop /opt/mediamop /home/mediamop
+COPY --chown=mediamop:mediamop apps/backend /opt/mediamop/apps/backend
 RUN pip install --no-cache-dir --upgrade pip \
   && pip install --no-cache-dir --prefer-binary -e "/opt/mediamop/apps/backend"
 
-COPY --from=web /src/apps/web/dist /opt/mediamop/web-dist
+COPY --from=web --chown=mediamop:mediamop /src/apps/web/dist /opt/mediamop/web-dist
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -41,6 +45,8 @@ ENV MEDIAMOP_ENV=production
 # never be sent on http://, which breaks sign-in. Set MEDIAMOP_SESSION_COOKIE_SECURE=true when
 # browsers always use HTTPS (e.g. TLS terminated at a reverse proxy in front of this container).
 ENV MEDIAMOP_SESSION_COOKIE_SECURE=false
+
+USER mediamop
 
 EXPOSE 8788
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -11,3 +11,11 @@ FFmpeg is a third-party project and is not owned by MediaMop. FFmpeg licensing d
 - Project: https://ffmpeg.org/
 - Windows build source: https://github.com/BtbN/FFmpeg-Builds
 - License information: https://ffmpeg.org/legal.html
+
+## Outfit font
+
+The web app bundles the Outfit typeface locally via the `@fontsource/outfit` package. Outfit is distributed under the SIL Open Font License 1.1.
+
+- Project: https://github.com/Outfitio/Outfit-Fonts
+- Package source: https://www.npmjs.com/package/@fontsource/outfit
+- License: https://openfontlicense.org/

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -40,6 +40,9 @@ MEDIAMOP_LOG_LEVEL=INFO
 
 # HSTS: only when this app is always reached over HTTPS (defaults off)
 # MEDIAMOP_SECURITY_ENABLE_HSTS=0
+# Optional bearer token for machine scrapes of GET /metrics (for example Prometheus).
+# Browser operators can still use their normal admin/operator session cookie.
+# MEDIAMOP_METRICS_BEARER_TOKEN=replace-with-long-random-value
 
 # Required for GET /api/v1/auth/csrf and signed CSRF tokens (login/logout)
 # MEDIAMOP_SESSION_SECRET=replace-with-long-random-value

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -19,7 +19,6 @@ Requires **`MEDIAMOP_SESSION_SECRET`**, a writable SQLite file under **`MEDIAMOP
 | GET | `/api/v1/auth/me` | Current user from cookie + ``UserSession`` row. |
 | GET | `/api/v1/auth/bootstrap/status` | Whether first-run bootstrap is allowed (no ``admin`` user yet). |
 | POST | `/api/v1/auth/bootstrap` | Create initial ``admin`` only while bootstrap is allowed; CSRF + optional Origin checks (Phase 6). |
-| GET | `/api/v1/auth/admin/ping` | Authenticated **admin** probe (uses ``RequireAdminDep``). |
 
 When trusted browser origins are configured — **`MEDIAMOP_TRUSTED_BROWSER_ORIGINS`** if set, otherwise **`MEDIAMOP_CORS_ORIGINS`** — browser **POST** auth routes require a matching **Origin** or **Referer**.
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -41,6 +41,7 @@ Copy **`.env.example`** to **`.env`** in this directory (gitignored). The API lo
 | `MEDIAMOP_BOOTSTRAP_RATE_MAX_ATTEMPTS` | Max ``POST /auth/bootstrap`` per IP per window (default `10`). |
 | `MEDIAMOP_BOOTSTRAP_RATE_WINDOW_SECONDS` | Bootstrap window (default `3600`). |
 | `MEDIAMOP_SECURITY_ENABLE_HSTS` | If `1`/`true`, send ``Strict-Transport-Security`` on responses. Only when **all** clients use HTTPS. |
+| `MEDIAMOP_METRICS_BEARER_TOKEN` | Optional bearer token for machine access to ``GET /metrics``; operator/admin browser sessions still work. |
 
 ## Run API (development)
 

--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -64,6 +64,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        compare_type=True,
     )
 
     with context.begin_transaction():
@@ -81,7 +82,7 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -31,6 +31,8 @@ dev = [
   "pytest-cov>=5.0",
   "pytest-asyncio>=0.23",
   "httpx>=0.27",
+  "bandit>=1.7",
+  "pip-audit>=2.7",
 ]
 
 [tool.setuptools.packages.find]

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -128,6 +128,7 @@ class MediaMopSettings:
     bootstrap_rate_max_attempts: int
     bootstrap_rate_window_seconds: int
     security_enable_hsts: bool
+    metrics_bearer_token: str | None
     mediamop_home: str
     db_path: str
     backup_dir: str
@@ -345,6 +346,7 @@ class MediaMopSettings:
         boot_max = max(1, _env_int("MEDIAMOP_BOOTSTRAP_RATE_MAX_ATTEMPTS", 10))
         boot_win = max(1, _env_int("MEDIAMOP_BOOTSTRAP_RATE_WINDOW_SECONDS", 3600))
         enable_hsts = _env_bool("MEDIAMOP_SECURITY_ENABLE_HSTS", default=False)
+        metrics_bearer_token = (os.environ.get("MEDIAMOP_METRICS_BEARER_TOKEN") or "").strip() or None
 
         home_path, db_p, backup_p, log_p, temp_p = resolve_all_runtime_paths()
         ensure_runtime_directories(
@@ -514,6 +516,7 @@ class MediaMopSettings:
             bootstrap_rate_max_attempts=boot_max,
             bootstrap_rate_window_seconds=boot_win,
             security_enable_hsts=enable_hsts,
+            metrics_bearer_token=metrics_bearer_token,
             mediamop_home=str(home_path),
             db_path=str(db_p),
             backup_dir=str(backup_p),

--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -80,6 +80,20 @@ from mediamop.platform.suite_settings.logs_retention_periodic import (
 _lifespan_log = logging.getLogger(__name__)
 
 
+def _run_non_essential_startup_step(name: str, step) -> None:
+    try:
+        step()
+    except Exception:
+        _lifespan_log.exception("MediaMop startup step failed but startup will continue step=%s", name)
+
+
+async def _stop_task_group(name: str, step) -> None:
+    try:
+        await step()
+    except Exception:
+        _lifespan_log.exception("MediaMop shutdown step failed step=%s", name)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.startup_started_at = time.monotonic()
@@ -104,8 +118,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         with session.begin():
             recovered = recover_incomplete_jobs_after_startup(session)
             partial_outputs_removed = cleanup_refiner_partial_output_files(session, settings)
-            prune_logs_for_retention(session, settings)
-            cleanup_inactive_sessions(session, settings=settings)
+            _run_non_essential_startup_step("log_retention_prune", lambda: prune_logs_for_retention(session, settings))
+            _run_non_essential_startup_step(
+                "inactive_session_cleanup",
+                lambda: cleanup_inactive_sessions(session, settings=settings),
+            )
         if recovered.total_recovered or partial_outputs_removed:
             _lifespan_log.warning(
                 "MediaMop startup recovered interrupted work recovered_jobs=%s partial_outputs_removed=%s",
@@ -113,36 +130,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
                 partial_outputs_removed,
             )
     stop = asyncio.Event()
-    session_cleanup_task = start_session_cleanup_task(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    log_retention_tasks = start_log_retention_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    refiner_supplied_payload_eval_tasks = start_refiner_supplied_payload_evaluation_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    refiner_watched_folder_scan_dispatch_tasks = start_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    refiner_work_temp_stale_sweep_tasks = start_refiner_work_temp_stale_sweep_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    refiner_failure_cleanup_tasks = start_refiner_failure_cleanup_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
+    session_cleanup_task = None
+    log_retention_tasks: list[asyncio.Task[None]] = []
+    refiner_supplied_payload_eval_tasks: list[asyncio.Task[None]] = []
+    refiner_watched_folder_scan_dispatch_tasks: list[asyncio.Task[None]] = []
+    refiner_work_temp_stale_sweep_tasks: list[asyncio.Task[None]] = []
+    refiner_failure_cleanup_tasks: list[asyncio.Task[None]] = []
     refiner_handlers = build_refiner_job_handlers(settings, session_factory)
 
     def _refiner_max_concurrent_files() -> int:
@@ -150,81 +143,202 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             row = ensure_refiner_operator_settings_row(session)
             return max(1, min(8, int(row.max_concurrent_files)))
 
-    refiner_stop, refiner_worker_tasks = start_refiner_worker_background_tasks(
-        session_factory,
-        settings,
-        stop_event=stop,
-        job_handlers=refiner_handlers,
-        max_concurrent_files_getter=_refiner_max_concurrent_files,
-    )
+    refiner_stop = None
+    refiner_worker_tasks: list[asyncio.Task[None]] = []
     pruner_handlers = build_pruner_job_handlers(settings, session_factory)
-    pruner_preview_schedule_tasks = start_pruner_preview_schedule_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    pruner_stop, pruner_worker_tasks = start_pruner_worker_background_tasks(
-        session_factory,
-        settings,
-        stop_event=stop,
-        job_handlers=pruner_handlers,
-    )
+    pruner_preview_schedule_tasks: list[asyncio.Task[None]] = []
+    pruner_stop = None
+    pruner_worker_tasks: list[asyncio.Task[None]] = []
     subber_handlers = build_subber_job_handlers(settings, session_factory)
-    subber_tv_scan_tasks = start_subber_tv_scan_schedule_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
+    subber_tv_scan_tasks: list[asyncio.Task[None]] = []
+    subber_movies_scan_tasks: list[asyncio.Task[None]] = []
+    subber_upgrade_tasks: list[asyncio.Task[None]] = []
+    subber_stop = None
+    subber_worker_tasks: list[asyncio.Task[None]] = []
+    suite_configuration_backup_tasks: list[asyncio.Task[None]] = []
+
+    def _start_session_cleanup_task() -> None:
+        nonlocal session_cleanup_task
+        session_cleanup_task = start_session_cleanup_task(session_factory, stop_event=stop, settings=settings)
+
+    def _start_log_retention_tasks() -> None:
+        nonlocal log_retention_tasks
+        log_retention_tasks = start_log_retention_tasks(session_factory, stop_event=stop, settings=settings)
+
+    def _start_refiner_supplied_payload_eval_tasks() -> None:
+        nonlocal refiner_supplied_payload_eval_tasks
+        refiner_supplied_payload_eval_tasks = start_refiner_supplied_payload_evaluation_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_watched_folder_scan_dispatch_tasks() -> None:
+        nonlocal refiner_watched_folder_scan_dispatch_tasks
+        refiner_watched_folder_scan_dispatch_tasks = start_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_work_temp_stale_sweep_tasks() -> None:
+        nonlocal refiner_work_temp_stale_sweep_tasks
+        refiner_work_temp_stale_sweep_tasks = start_refiner_work_temp_stale_sweep_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_failure_cleanup_tasks() -> None:
+        nonlocal refiner_failure_cleanup_tasks
+        refiner_failure_cleanup_tasks = start_refiner_failure_cleanup_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_workers() -> None:
+        nonlocal refiner_stop, refiner_worker_tasks
+        refiner_stop, refiner_worker_tasks = start_refiner_worker_background_tasks(
+            session_factory,
+            settings,
+            stop_event=stop,
+            job_handlers=refiner_handlers,
+            max_concurrent_files_getter=_refiner_max_concurrent_files,
+        )
+
+    def _start_pruner_preview_schedule_tasks() -> None:
+        nonlocal pruner_preview_schedule_tasks
+        pruner_preview_schedule_tasks = start_pruner_preview_schedule_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_pruner_workers() -> None:
+        nonlocal pruner_stop, pruner_worker_tasks
+        pruner_stop, pruner_worker_tasks = start_pruner_worker_background_tasks(
+            session_factory,
+            settings,
+            stop_event=stop,
+            job_handlers=pruner_handlers,
+        )
+
+    def _start_subber_tv_scan_tasks() -> None:
+        nonlocal subber_tv_scan_tasks
+        subber_tv_scan_tasks = start_subber_tv_scan_schedule_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_subber_movies_scan_tasks() -> None:
+        nonlocal subber_movies_scan_tasks
+        subber_movies_scan_tasks = start_subber_movies_scan_schedule_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_subber_upgrade_tasks() -> None:
+        nonlocal subber_upgrade_tasks
+        subber_upgrade_tasks = start_subber_upgrade_schedule_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_subber_workers() -> None:
+        nonlocal subber_stop, subber_worker_tasks
+        subber_stop, subber_worker_tasks = start_subber_worker_background_tasks(
+            session_factory,
+            settings,
+            stop_event=stop,
+            job_handlers=subber_handlers,
+        )
+
+    def _start_suite_configuration_backup_tasks() -> None:
+        nonlocal suite_configuration_backup_tasks
+        suite_configuration_backup_tasks = start_suite_configuration_backup_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    _run_non_essential_startup_step("session_cleanup_task_start", _start_session_cleanup_task)
+    _run_non_essential_startup_step("log_retention_tasks_start", _start_log_retention_tasks)
+    _run_non_essential_startup_step("refiner_supplied_payload_eval_start", _start_refiner_supplied_payload_eval_tasks)
+    _run_non_essential_startup_step(
+        "refiner_watched_folder_scan_dispatch_start",
+        _start_refiner_watched_folder_scan_dispatch_tasks,
     )
-    subber_movies_scan_tasks = start_subber_movies_scan_schedule_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    subber_upgrade_tasks = start_subber_upgrade_schedule_enqueue_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
-    subber_stop, subber_worker_tasks = start_subber_worker_background_tasks(
-        session_factory,
-        settings,
-        stop_event=stop,
-        job_handlers=subber_handlers,
-    )
-    suite_configuration_backup_tasks = start_suite_configuration_backup_tasks(
-        session_factory,
-        stop_event=stop,
-        settings=settings,
-    )
+    _run_non_essential_startup_step("refiner_work_temp_stale_sweep_start", _start_refiner_work_temp_stale_sweep_tasks)
+    _run_non_essential_startup_step("refiner_failure_cleanup_start", _start_refiner_failure_cleanup_tasks)
+    _run_non_essential_startup_step("refiner_worker_start", _start_refiner_workers)
+    _run_non_essential_startup_step("pruner_preview_schedule_start", _start_pruner_preview_schedule_tasks)
+    _run_non_essential_startup_step("pruner_worker_start", _start_pruner_workers)
+    _run_non_essential_startup_step("subber_tv_scan_schedule_start", _start_subber_tv_scan_tasks)
+    _run_non_essential_startup_step("subber_movies_scan_schedule_start", _start_subber_movies_scan_tasks)
+    _run_non_essential_startup_step("subber_upgrade_schedule_start", _start_subber_upgrade_tasks)
+    _run_non_essential_startup_step("subber_worker_start", _start_subber_workers)
+    _run_non_essential_startup_step("suite_configuration_backup_start", _start_suite_configuration_backup_tasks)
     app.state.startup_ready = True
     try:
         yield
     finally:
         app.state.startup_ready = False
         stop.set()
-        await stop_refiner_supplied_payload_evaluation_enqueue_tasks(refiner_supplied_payload_eval_tasks)
-        await stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(refiner_watched_folder_scan_dispatch_tasks)
-        await stop_refiner_work_temp_stale_sweep_enqueue_tasks(refiner_work_temp_stale_sweep_tasks)
-        await stop_refiner_failure_cleanup_enqueue_tasks(refiner_failure_cleanup_tasks)
-        try:
-            await stop_subber_tv_scan_schedule_enqueue_tasks(subber_tv_scan_tasks)
-        except Exception:
-            _lifespan_log.exception("Subber TV scan schedule enqueue stop failed")
-        try:
-            await stop_subber_movies_scan_schedule_enqueue_tasks(subber_movies_scan_tasks)
-        except Exception:
-            _lifespan_log.exception("Subber Movies scan schedule enqueue stop failed")
-        try:
-            await stop_subber_upgrade_schedule_enqueue_tasks(subber_upgrade_tasks)
-        except Exception:
-            _lifespan_log.exception("Subber upgrade schedule enqueue stop failed")
-        await stop_suite_configuration_backup_tasks(suite_configuration_backup_tasks)
-        await stop_session_cleanup_task(session_cleanup_task)
-        await stop_log_retention_tasks(log_retention_tasks)
-        await stop_subber_worker_background_tasks(subber_stop, subber_worker_tasks)
-        await stop_pruner_preview_schedule_enqueue_tasks(pruner_preview_schedule_tasks)
-        await stop_pruner_worker_background_tasks(pruner_stop, pruner_worker_tasks)
-        await stop_refiner_worker_background_tasks(refiner_stop, refiner_worker_tasks)
+        await _stop_task_group(
+            "refiner_supplied_payload_eval_stop",
+            lambda: stop_refiner_supplied_payload_evaluation_enqueue_tasks(refiner_supplied_payload_eval_tasks),
+        )
+        await _stop_task_group(
+            "refiner_watched_folder_scan_dispatch_stop",
+            lambda: stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(refiner_watched_folder_scan_dispatch_tasks),
+        )
+        await _stop_task_group(
+            "refiner_work_temp_stale_sweep_stop",
+            lambda: stop_refiner_work_temp_stale_sweep_enqueue_tasks(refiner_work_temp_stale_sweep_tasks),
+        )
+        await _stop_task_group(
+            "refiner_failure_cleanup_stop",
+            lambda: stop_refiner_failure_cleanup_enqueue_tasks(refiner_failure_cleanup_tasks),
+        )
+        await _stop_task_group("subber_tv_scan_schedule_stop", lambda: stop_subber_tv_scan_schedule_enqueue_tasks(subber_tv_scan_tasks))
+        await _stop_task_group(
+            "subber_movies_scan_schedule_stop",
+            lambda: stop_subber_movies_scan_schedule_enqueue_tasks(subber_movies_scan_tasks),
+        )
+        await _stop_task_group(
+            "subber_upgrade_schedule_stop",
+            lambda: stop_subber_upgrade_schedule_enqueue_tasks(subber_upgrade_tasks),
+        )
+        await _stop_task_group(
+            "suite_configuration_backup_stop",
+            lambda: stop_suite_configuration_backup_tasks(suite_configuration_backup_tasks),
+        )
+        if session_cleanup_task is not None:
+            await _stop_task_group("session_cleanup_task_stop", lambda: stop_session_cleanup_task(session_cleanup_task))
+        await _stop_task_group("log_retention_tasks_stop", lambda: stop_log_retention_tasks(log_retention_tasks))
+        if subber_stop is not None:
+            await _stop_task_group(
+                "subber_worker_stop",
+                lambda: stop_subber_worker_background_tasks(subber_stop, subber_worker_tasks),
+            )
+        await _stop_task_group(
+            "pruner_preview_schedule_stop",
+            lambda: stop_pruner_preview_schedule_enqueue_tasks(pruner_preview_schedule_tasks),
+        )
+        if pruner_stop is not None:
+            await _stop_task_group(
+                "pruner_worker_stop",
+                lambda: stop_pruner_worker_background_tasks(pruner_stop, pruner_worker_tasks),
+            )
+        if refiner_stop is not None:
+            await _stop_task_group(
+                "refiner_worker_stop",
+                lambda: stop_refiner_worker_background_tasks(refiner_stop, refiner_worker_tasks),
+            )
         dispose_engine(app.state.engine)
         app.state.engine = None
         app.state.session_factory = None

--- a/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -36,6 +37,8 @@ from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, media_scope_label, provider_label
+
+logger = logging.getLogger(__name__)
 
 _APPLY_SUPPORTED = frozenset(
     {
@@ -188,6 +191,7 @@ def make_pruner_candidate_removal_apply_handler(
         for c in candidates:
             item_id = str(c.get("item_id", "")).strip()
             if not item_id:
+                logger.warning("Pruner apply skipped a candidate with no item_id preview_run_id=%s", preview_run_uuid)
                 failed += 1
                 continue
             if provider_for_delete == "emby":
@@ -198,6 +202,11 @@ def make_pruner_candidate_removal_apply_handler(
                 )
             elif provider_for_delete == "plex":
                 if not plex_token.strip():
+                    logger.warning(
+                        "Pruner apply could not delete Plex item %s because the auth token is missing preview_run_id=%s",
+                        item_id,
+                        preview_run_uuid,
+                    )
                     failed += 1
                     continue
                 status, _err_body = plex_delete_library_metadata(
@@ -214,8 +223,19 @@ def make_pruner_candidate_removal_apply_handler(
             if status in (200, 204):
                 removed += 1
             elif status == 404:
+                logger.debug(
+                    "Pruner apply skipped item_id=%s because it was already absent on provider=%s.",
+                    item_id,
+                    provider_for_delete,
+                )
                 skipped += 1
             else:
+                logger.warning(
+                    "Pruner apply failed to delete item_id=%s on provider=%s (HTTP %s).",
+                    item_id,
+                    provider_for_delete,
+                    status,
+                )
                 failed += 1
 
         label = _scope_label(scope)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
@@ -3,39 +3,57 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import json
 from typing import Literal
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.credentials_rotation import credential_secret_candidates
 
-_DOMAIN = b"mediamop.pruner.credentials.v1|"
-_ENVELOPE_VERSION = 2
-_CREDENTIALS_KEY_ID = "credentials:v1"
+_HKDF_INFO = b"mediamop.pruner.credentials.v1.fernet"
+_ENVELOPE_VERSION = 3
+_CREDENTIALS_KEY_ID = "credentials:hkdf:v1"
+_CREDENTIALS_KEY_ID_LEGACY = "credentials:v1"
 _SESSION_LEGACY_KEY_ID = "session-legacy:v1"
 
 
-def _fernet_for_secret(secret: str | None) -> Fernet | None:
+def _fernet_for_secret_hkdf(secret: str | None) -> Fernet | None:
     raw = (secret or "").strip()
     if not raw:
         return None
-    digest = hashlib.sha256(_DOMAIN + raw.encode()).digest()
-    key = base64.urlsafe_b64encode(digest)
+    derived = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=_HKDF_INFO,
+    ).derive(raw.encode("utf-8"))
+    key = base64.urlsafe_b64encode(derived)
     return Fernet(key)
 
 
-def _active_fernet(settings: MediaMopSettings) -> tuple[Fernet | None, Literal["credentials:v1", "session-legacy:v1"]]:
-    f = _fernet_for_secret(settings.credentials_secret)
+def _fernet_for_secret_legacy(secret: str | None) -> Fernet | None:
+    raw = (secret or "").strip()
+    if not raw:
+        return None
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(b"mediamop.pruner.credentials.v1|")
+    digest.update(raw.encode("utf-8"))
+    key = base64.urlsafe_b64encode(digest.finalize())
+    return Fernet(key)
+
+
+def _active_fernet(settings: MediaMopSettings) -> tuple[Fernet | None, Literal["credentials:hkdf:v1", "session-legacy:v1"]]:
+    f = _fernet_for_secret_hkdf(settings.credentials_secret)
     if f is not None:
         return f, _CREDENTIALS_KEY_ID
-    return _fernet_for_secret(settings.session_secret), _SESSION_LEGACY_KEY_ID
+    return _fernet_for_secret_legacy(settings.session_secret), _SESSION_LEGACY_KEY_ID
 
 
 def _legacy_fernet(settings: MediaMopSettings) -> Fernet | None:
-    return _fernet_for_secret(settings.session_secret)
+    return _fernet_for_secret_legacy(settings.session_secret)
 
 
 def _decode_envelope(ciphertext: str) -> dict[str, object] | None:
@@ -61,7 +79,7 @@ def encrypt_pruner_credentials_json(settings: MediaMopSettings, plaintext_json: 
 
 
 def decrypt_pruner_credentials_json(settings: MediaMopSettings, ciphertext: str) -> str | None:
-    """Decrypt stored JSON, supporting v2 credential envelopes and legacy raw session-secret tokens."""
+    """Decrypt stored JSON, supporting HKDF credential envelopes and legacy raw session-secret tokens."""
 
     env = _decode_envelope(ciphertext)
     if env is not None:
@@ -69,11 +87,12 @@ def decrypt_pruner_credentials_json(settings: MediaMopSettings, ciphertext: str)
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
-        fernets = (
-            credential_secret_candidates(settings, _fernet_for_secret)
-            if key_id == _CREDENTIALS_KEY_ID
-            else [f for f in [_legacy_fernet(settings)] if f]
-        )
+        if key_id == _CREDENTIALS_KEY_ID:
+            fernets = credential_secret_candidates(settings, _fernet_for_secret_hkdf)
+        elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
+            fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)
+        else:
+            fernets = [f for f in [_legacy_fernet(settings)] if f]
         for f in fernets:
             try:
                 return f.decrypt(token.encode("ascii")).decode("utf-8")

--- a/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import urllib.error
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -35,6 +36,8 @@ from mediamop.modules.pruner.pruner_plex_missing_thumb_candidates import (
     _section_matches_scope,
 )
 from mediamop.modules.pruner.pruner_studio_collection_filters import jellyfin_emby_item_studio_names
+
+logger = logging.getLogger(__name__)
 
 def _jf_emby_truncated(
     *,
@@ -97,6 +100,7 @@ def list_jf_emby_genre_match_candidates(
         assert data is not None
         items = data.get("Items")
         if not isinstance(items, list):
+            logger.debug("Pruner genre-match preview stopped because Jellyfin/Emby Items payload had no list.")
             break
         fetched = len(items)
         if "TotalRecordCount" in data and isinstance(data["TotalRecordCount"], int):
@@ -192,6 +196,7 @@ def list_jf_emby_studio_match_candidates(
         assert data is not None
         items = data.get("Items")
         if not isinstance(items, list):
+            logger.debug("Pruner studio-match preview stopped because Jellyfin/Emby Items payload had no list.")
             break
         fetched = len(items)
         if "TotalRecordCount" in data and isinstance(data["TotalRecordCount"], int):
@@ -289,6 +294,7 @@ def list_jf_emby_people_match_candidates(
         assert data is not None
         items = data.get("Items")
         if not isinstance(items, list):
+            logger.debug("Pruner people-match preview stopped because Jellyfin/Emby Items payload had no list.")
             break
         fetched = len(items)
         if "TotalRecordCount" in data and isinstance(data["TotalRecordCount"], int):
@@ -388,6 +394,7 @@ def list_jf_emby_year_range_match_candidates(
         assert data is not None
         items = data.get("Items")
         if not isinstance(items, list):
+            logger.debug("Pruner year-range preview stopped because Jellyfin/Emby Items payload had no list.")
             break
         fetched = len(items)
         if "TotalRecordCount" in data and isinstance(data["TotalRecordCount"], int):

--- a/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
@@ -81,6 +81,7 @@ from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSetti
 from mediamop.modules.pruner.pruner_server_instance_model import PrunerServerInstance
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -177,7 +178,7 @@ def post_pruner_instance(
 ) -> PrunerServerInstanceOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
 
     prov = cast(PrunerProvider, body.provider)
@@ -264,7 +265,7 @@ def patch_pruner_instance(
 ) -> PrunerServerInstanceOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
 
     row = db.scalars(
@@ -346,7 +347,7 @@ def patch_pruner_scope(
 ) -> PrunerScopeSummaryOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
@@ -533,7 +534,7 @@ def post_pruner_apply_from_preview(
 ) -> PrunerEnqueueOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
@@ -607,7 +608,7 @@ def post_pruner_plex_live_removal(
 ) -> PrunerEnqueueOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
@@ -658,7 +659,7 @@ def post_pruner_connection_test(
 ) -> PrunerEnqueueOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if get_server_instance(db, instance_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")
@@ -683,7 +684,7 @@ def post_pruner_preview(
 ) -> PrunerEnqueueOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if get_server_instance(db, instance_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from typing import Any
@@ -49,6 +50,8 @@ from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, provider_label, scan_title
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_payload(payload_json: str | None) -> dict[str, Any]:
@@ -195,6 +198,12 @@ def make_pruner_candidate_removal_preview_handler(
             trunc = False
             cand_json = "[]"
             err = str(exc)[:10_000]
+            logger.exception(
+                "Pruner preview failed server_instance_id=%s media_scope=%s rule_family_id=%s",
+                sid,
+                scope,
+                rule_family_id,
+            )
 
         run_uuid = str(uuid.uuid4())
         label_scope = "TV (episodes)" if scope == "tv" else "Movies (one row per movie item)"

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/api.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/api.py
@@ -18,6 +18,7 @@ from mediamop.modules.refiner.schemas_file_remux_pass_manual import (
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -41,7 +42,7 @@ def post_refiner_file_remux_pass_enqueue(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_candidate_gate_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_candidate_gate_api.py
@@ -17,6 +17,7 @@ from mediamop.modules.refiner.schemas_candidate_gate_manual import (
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -40,7 +41,7 @@ def post_refiner_candidate_gate_enqueue(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
@@ -163,6 +163,7 @@ def _failed_jobs_for_scope(
         try:
             rel, scope, legacy_dry_run = _parse_payload(row.payload_json)
         except (ValueError, json.JSONDecodeError):
+            logger.debug("Refiner failure cleanup ignored malformed failed-job payload job_id=%s", row.id, exc_info=True)
             continue
         if scope != media_scope:
             continue
@@ -270,6 +271,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
         out["processed_failed_jobs"] += 1
         out["jobs"].append(detail)
         if legacy_dry_run:
+            logger.debug(
+                "Refiner failure cleanup skipped legacy dry-run payload job_id=%s relative_media_path=%s",
+                job.id,
+                rel_norm,
+            )
             detail[f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_skip_reason"] = (
                 "Skipped for compatibility: this failed remux row uses legacy dry_run payload format, "
                 "which is not a current Refiner mode."
@@ -306,6 +312,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                             out=detail["movie_failure_cleanup_cascade_folders_deleted"],
                         )
             except ValueError:
+                logger.warning(
+                    "Refiner movie failure cleanup skipped source folder outside watched root job_id=%s path=%s",
+                    job.id,
+                    src_folder,
+                )
                 pass
             try:
                 out_folder.relative_to(output_root)
@@ -319,6 +330,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                             out=detail["movie_failure_cleanup_cascade_folders_deleted"],
                         )
             except ValueError:
+                logger.warning(
+                    "Refiner movie failure cleanup skipped output folder outside output root job_id=%s path=%s",
+                    job.id,
+                    out_folder,
+                )
                 pass
             for temp in _job_temp_candidates(work_root=work_root, rel_norm=rel_norm):
                 ok, _ = _safe_unlink(temp)
@@ -349,6 +365,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                 try:
                     rel = relative_posix_path_under_watched(watched_root=watched_root, file_path=ep)
                 except ValueError:
+                    logger.warning(
+                        "Refiner TV failure cleanup skipped episode outside watched root job_id=%s path=%s",
+                        job.id,
+                        ep,
+                    )
                     continue
                 if refiner_active_remux_pass_exists_for_relative_path(
                     session,
@@ -381,6 +402,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                             out=detail["tv_failure_cleanup_cascade_folders_deleted"],
                         )
             except ValueError:
+                logger.warning(
+                    "Refiner TV failure cleanup skipped season folder outside watched root job_id=%s path=%s",
+                    job.id,
+                    src_season,
+                )
                 pass
             try:
                 out_season.relative_to(output_root)
@@ -394,6 +420,11 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                             out=detail["tv_failure_cleanup_cascade_folders_deleted"],
                         )
             except ValueError:
+                logger.warning(
+                    "Refiner TV failure cleanup skipped output season outside output root job_id=%s path=%s",
+                    job.id,
+                    out_season,
+                )
                 pass
             for temp in _job_temp_candidates(work_root=work_root, rel_norm=rel_norm):
                 ok, _ = _safe_unlink(temp)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_jobs_inspection_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_jobs_inspection_api.py
@@ -21,6 +21,7 @@ from mediamop.modules.refiner.schemas_refiner_jobs_inspection import (
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -76,7 +77,7 @@ def post_refiner_job_cancel_pending(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
@@ -25,6 +25,7 @@ from mediamop.modules.refiner.refiner_file_remux_pass_job_kinds import REFINER_F
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 
 logger = logging.getLogger(__name__)
+_RADARR_PAGE_SIZE = 200_000
 
 
 def _normalize_media_scope(raw: str | None) -> str:
@@ -60,7 +61,8 @@ def fetch_radarr_library_movies(
     """GET ``/api/v3/movie`` (Refiner-owned stdlib HTTP; same style as queue fetch)."""
 
     base = base_url.rstrip("/")
-    url = f"{base}/api/v3/movie?pageSize=200000"
+    # Radarr's movie endpoint effectively behaves as an unpaginated library listing; use a very high cap.
+    url = f"{base}/api/v3/movie?pageSize={_RADARR_PAGE_SIZE}"
     req = urllib.request.Request(
         url,
         method="GET",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_api.py
@@ -18,6 +18,7 @@ from mediamop.modules.refiner.schemas_refiner_operator_settings import (
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -45,7 +46,7 @@ def put_refiner_operator_settings(
 ) -> RefinerOperatorSettingsOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired CSRF token.")
     try:
         row = apply_refiner_operator_settings_put(db, body)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_api.py
@@ -16,6 +16,7 @@ from mediamop.modules.refiner.refiner_path_settings_service import (
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -59,7 +60,7 @@ def put_refiner_path_settings(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 REFINER_FFMPEG_TIMEOUT_S: int = 3600
 _REFINER_FFPROBE_LOG_MAX_CHARS = 2000
+_REFINER_FFMPEG_STDERR_TAIL_BYTES = 32 * 1024
 
 
 def _clip_probe_text(raw: object, *, max_chars: int = _REFINER_FFPROBE_LOG_MAX_CHARS) -> str:
@@ -30,6 +31,17 @@ def _clip_probe_text(raw: object, *, max_chars: int = _REFINER_FFPROBE_LOG_MAX_C
     if len(t) > max_chars:
         return t[:max_chars] + "…(truncated)"
     return t
+
+
+def _read_tail_text(path: Path, *, max_bytes: int = _REFINER_FFMPEG_STDERR_TAIL_BYTES) -> str:
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - max_bytes), os.SEEK_SET)
+            return handle.read().decode("utf-8", errors="replace").strip()
+    except OSError:
+        return ""
 
 
 def resolve_ffprobe_ffmpeg(*, mediamop_home: str) -> tuple[str, str]:
@@ -236,10 +248,30 @@ def run_ffmpeg(
     duration_seconds: float | None = None,
 ) -> None:
     if progress_callback is None:
-        r = subprocess.run(argv, capture_output=True, text=True, timeout=timeout_s)
-        if r.returncode != 0:
-            msg = (r.stderr or r.stdout or "").strip()
-            raise RuntimeError(msg or "ffmpeg failed")
+        with tempfile.NamedTemporaryFile(delete=False) as stderr_file:
+            stderr_path = Path(stderr_file.name)
+        try:
+            with stderr_path.open("wb") as stderr_handle:
+                r = subprocess.run(
+                    argv,
+                    stdout=subprocess.DEVNULL,
+                    stderr=stderr_handle,
+                    stdin=subprocess.DEVNULL,
+                    timeout=timeout_s,
+                    check=False,
+                )
+            if r.returncode != 0:
+                msg = _read_tail_text(stderr_path)
+                raise RuntimeError(msg or "ffmpeg failed")
+        finally:
+            try:
+                stderr_path.unlink(missing_ok=True)
+            except OSError:
+                logger.debug(
+                    "Refiner: could not remove temporary ffmpeg stderr log %s",
+                    stderr_path,
+                    exc_info=True,
+                )
         return
 
     progress_argv = _argv_with_progress(argv)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_api.py
@@ -18,6 +18,7 @@ from mediamop.modules.refiner.schemas_refiner_remux_rules_settings import (
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -51,7 +52,7 @@ def put_refiner_remux_rules_settings(
 ) -> RefinerRemuxRulesSettingsOut:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_supplied_payload_evaluation_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_supplied_payload_evaluation_api.py
@@ -15,6 +15,7 @@ from mediamop.modules.refiner.schemas_supplied_payload_evaluation_manual import 
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -38,7 +39,7 @@ def post_refiner_supplied_payload_evaluation_enqueue(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
@@ -27,6 +27,7 @@ from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRu
 from mediamop.modules.refiner.refiner_remux_rules import is_refiner_media_candidate
 
 logger = logging.getLogger(__name__)
+_SONARR_PAGE_SIZE = 200_000
 
 
 def _normalize_media_scope(raw: str | None) -> str:
@@ -92,7 +93,8 @@ def fetch_sonarr_library_episodefiles(
     """GET ``/api/v3/episodefile`` — full library episode file list (Refiner-owned stdlib HTTP)."""
 
     base = base_url.rstrip("/")
-    url = f"{base}/api/v3/episodefile?pageSize=200000"
+    # Sonarr's episodefile endpoint is treated as a full library listing here; use a very high cap.
+    url = f"{base}/api/v3/episodefile?pageSize={_SONARR_PAGE_SIZE}"
     req = urllib.request.Request(
         url,
         method="GET",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_api.py
@@ -16,6 +16,7 @@ from mediamop.modules.refiner.schemas_watched_folder_remux_scan_dispatch_manual 
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -39,7 +40,7 @@ def post_refiner_watched_folder_remux_scan_dispatch_enqueue(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -27,6 +28,8 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops imp
     retry_completed_movie_source_cleanup,
 )
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_job_payload(payload_json: str | None) -> dict[str, Any]:
@@ -116,9 +119,15 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                         try:
                             size_bytes = int(file_path.stat().st_size)
                         except OSError:
+                            logger.debug("Refiner scan skipped size check because file metadata could not be read: %s", file_path)
                             continue
                         if size_bytes < min_size_mb * 1024 * 1024:
                             summary["skipped_below_minimum_file_size"] += 1
+                            logger.debug(
+                                "Refiner scan skipped %s because it is below the minimum input size (%s MB).",
+                                file_path,
+                                min_size_mb,
+                            )
                             continue
 
                     verdict = evaluate_watched_media_file_for_dispatch(
@@ -166,6 +175,10 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                                 summary["completed_source_cleanup_retry_deleted"] += 1
                             else:
                                 summary["completed_source_cleanup_retry_failed"] += 1
+                                logger.warning(
+                                    "Refiner completed-output source cleanup retry failed for %s",
+                                    file_path,
+                                )
                         continue
 
                     payload = json.dumps(

--- a/apps/backend/src/mediamop/modules/refiner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_loop.py
@@ -261,7 +261,10 @@ async def refiner_worker_run_forever(
             worker_heartbeat("refiner", worker_index)
             if max_concurrent_files_getter is not None:
                 try:
-                    max_concurrent = max(1, min(8, int(max_concurrent_files_getter())))
+                    max_concurrent_raw = await asyncio.to_thread(
+                        max_concurrent_files_getter
+                    )
+                    max_concurrent = max(1, min(8, int(max_concurrent_raw)))
                 except Exception:
                     max_concurrent = 1
                 if worker_index >= max_concurrent:

--- a/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
@@ -3,40 +3,57 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import json
 from typing import Literal
 
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.credentials_rotation import credential_secret_candidates
 
-
-_DOMAIN = b"mediamop.subber.credentials.v1|"
-_ENVELOPE_VERSION = 2
-_CREDENTIALS_KEY_ID = "credentials:v1"
+_HKDF_INFO = b"mediamop.subber.credentials.v1.fernet"
+_ENVELOPE_VERSION = 3
+_CREDENTIALS_KEY_ID = "credentials:hkdf:v1"
+_CREDENTIALS_KEY_ID_LEGACY = "credentials:v1"
 _SESSION_LEGACY_KEY_ID = "session-legacy:v1"
 
 
-def _fernet_for_secret(secret: str | None) -> Fernet | None:
+def _fernet_for_secret_hkdf(secret: str | None) -> Fernet | None:
     raw = (secret or "").strip()
     if not raw:
         return None
-    digest = hashlib.sha256(_DOMAIN + raw.encode()).digest()
-    key = base64.urlsafe_b64encode(digest)
+    derived = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=_HKDF_INFO,
+    ).derive(raw.encode("utf-8"))
+    key = base64.urlsafe_b64encode(derived)
     return Fernet(key)
 
 
-def _active_fernet(settings: MediaMopSettings) -> tuple[Fernet | None, Literal["credentials:v1", "session-legacy:v1"]]:
-    f = _fernet_for_secret(settings.credentials_secret)
+def _fernet_for_secret_legacy(secret: str | None) -> Fernet | None:
+    raw = (secret or "").strip()
+    if not raw:
+        return None
+    digest = hashes.Hash(hashes.SHA256())
+    digest.update(b"mediamop.subber.credentials.v1|")
+    digest.update(raw.encode("utf-8"))
+    key = base64.urlsafe_b64encode(digest.finalize())
+    return Fernet(key)
+
+
+def _active_fernet(settings: MediaMopSettings) -> tuple[Fernet | None, Literal["credentials:hkdf:v1", "session-legacy:v1"]]:
+    f = _fernet_for_secret_hkdf(settings.credentials_secret)
     if f is not None:
         return f, _CREDENTIALS_KEY_ID
-    return _fernet_for_secret(settings.session_secret), _SESSION_LEGACY_KEY_ID
+    return _fernet_for_secret_legacy(settings.session_secret), _SESSION_LEGACY_KEY_ID
 
 
 def _legacy_fernet(settings: MediaMopSettings) -> Fernet | None:
-    return _fernet_for_secret(settings.session_secret)
+    return _fernet_for_secret_legacy(settings.session_secret)
 
 
 def _decode_envelope(ciphertext: str) -> dict[str, object] | None:
@@ -69,11 +86,12 @@ def decrypt_subber_credentials_json(settings: MediaMopSettings, ciphertext: str)
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
-        fernets = (
-            credential_secret_candidates(settings, _fernet_for_secret)
-            if key_id == _CREDENTIALS_KEY_ID
-            else [f for f in [_legacy_fernet(settings)] if f]
-        )
+        if key_id == _CREDENTIALS_KEY_ID:
+            fernets = credential_secret_candidates(settings, _fernet_for_secret_hkdf)
+        elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
+            fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)
+        else:
+            fernets = [f for f in [_legacy_fernet(settings)] if f]
         for f in fernets:
             try:
                 return f.decrypt(token.encode("ascii")).decode("utf-8")

--- a/apps/backend/src/mediamop/modules/subber/subber_gestdown_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_gestdown_client.py
@@ -68,5 +68,5 @@ def search(
 def download(*, download_url: str) -> bytes:
     """Download SRT directly from Gestdown download URL."""
     url = download_url if download_url.startswith("http") else f"{BASE}{download_url}"
-    _code, data = request_bytes(url, headers={"User-Agent": USER_AGENT}, timeout=60)
+    _code, data = request_bytes(url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_http_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_http_client.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import base64
+import ipaddress
 import json
-import urllib.error
-import urllib.request
 from typing import Any
+from urllib.parse import urlparse
+
+import httpx
 
 DEFAULT_USER_AGENT = "MediaMop/1.0"
 HTML_USER_AGENT = "Mozilla/5.0 (compatible; MediaMop/1.0)"
+_SHARED_CLIENT = httpx.Client(follow_redirects=True, max_redirects=5)
 
 
 def basic_auth_header(username: str | None, password: str | None) -> str | None:
@@ -28,10 +31,18 @@ def request_bytes(
     headers: dict[str, str] | None = None,
     data: bytes | None = None,
     timeout: float = 60,
+    validate_provider_url: bool = False,
 ) -> tuple[int, bytes]:
-    req = urllib.request.Request(url, data=data, headers=headers or {}, method=method)  # noqa: S310
-    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
-        return int(getattr(resp, "status", 200)), resp.read()
+    request_url = safe_provider_url(url) if validate_provider_url else url
+    response = _SHARED_CLIENT.request(
+        method=method,
+        url=request_url,
+        headers=headers,
+        content=data,
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.status_code, response.content
 
 
 def request_text(
@@ -69,8 +80,8 @@ def request_json(
     return code, parsed if isinstance(parsed, (dict, list)) else None
 
 
-def decode_http_error_json(exc: urllib.error.HTTPError) -> dict[str, Any] | None:
-    raw = exc.read().decode("utf-8", errors="replace")
+def decode_http_error_json(exc: httpx.HTTPStatusError) -> dict[str, Any] | None:
+    raw = exc.response.text
     if not raw.strip():
         return None
     try:
@@ -78,3 +89,21 @@ def decode_http_error_json(exc: urllib.error.HTTPError) -> dict[str, Any] | None
     except json.JSONDecodeError:
         return {"raw": raw}
     return parsed if isinstance(parsed, dict) else {"raw": raw}
+
+
+def safe_provider_url(url: str) -> str:
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Blocked provider URL scheme: {parsed.scheme or '<missing>'}")
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        raise ValueError("Blocked provider URL host: <missing>")
+    if host in {"localhost", "127.0.0.1", "::1", "0.0.0.0"}:
+        raise ValueError(f"Blocked provider URL host: {host}")
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return url
+    if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+        raise ValueError(f"Blocked provider URL host: {host}")
+    return url

--- a/apps/backend/src/mediamop/modules/subber/subber_library_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_api.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
@@ -24,7 +24,7 @@ from mediamop.modules.subber.subber_schemas import SubberMoviesLibraryOut, Subbe
 from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row, language_preferences_list
 from mediamop.modules.subber.subber_subtitle_state_service import get_all_for_scope, get_state_by_id
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.csrf import verify_csrf_token
+from mediamop.platform.auth.csrf import current_raw_session_token, verify_csrf_token
 from mediamop.platform.auth.deps_auth import UserPublicDep
 
 router = APIRouter(tags=["subber-library"])
@@ -87,11 +87,16 @@ def post_subber_search_now(
     _user: RequireOperatorDep,
     db: DbSessionDep,
     settings: SettingsDep,
+    request: Request,
     state_id: int,
     body: SubberCsrfBody,
 ) -> dict[str, str]:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+    ):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     st = get_state_by_id(db, state_id)
     if st is None:
@@ -112,10 +117,15 @@ def post_subber_search_all_missing_tv(
     _user: RequireOperatorDep,
     db: DbSessionDep,
     settings: SettingsDep,
+    request: Request,
     body: SubberCsrfBody,
 ) -> dict[str, str]:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+    ):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     dedupe = f"subber:libscan:manual:tv:{uuid.uuid4()}"
     subber_enqueue_or_get_job(
@@ -132,10 +142,15 @@ def post_subber_search_all_missing_movies(
     _user: RequireOperatorDep,
     db: DbSessionDep,
     settings: SettingsDep,
+    request: Request,
     body: SubberCsrfBody,
 ) -> dict[str, str]:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+    ):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     dedupe = f"subber:libscan:manual:movies:{uuid.uuid4()}"
     subber_enqueue_or_get_job(
@@ -152,10 +167,15 @@ def post_subber_library_sync_tv(
     _user: RequireOperatorDep,
     db: DbSessionDep,
     settings: SettingsDep,
+    request: Request,
     body: SubberCsrfBody,
 ) -> dict[str, str]:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+    ):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     dedupe = f"subber:libsync:manual:tv:{uuid.uuid4()}"
     subber_enqueue_or_get_job(
@@ -172,10 +192,15 @@ def post_subber_library_sync_movies(
     _user: RequireOperatorDep,
     db: DbSessionDep,
     settings: SettingsDep,
+    request: Request,
     body: SubberCsrfBody,
 ) -> dict[str, str]:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+    ):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     dedupe = f"subber:libsync:manual:movies:{uuid.uuid4()}"
     subber_enqueue_or_get_job(

--- a/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import Callable
 
@@ -25,6 +26,8 @@ from mediamop.modules.subber.subber_subtitle_search_service import apply_path_ma
 from mediamop.modules.subber.subber_subtitle_state_service import upsert_subtitle_state
 from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
+
+logger = logging.getLogger(__name__)
 
 
 def _arr_api_key(settings: MediaMopSettings, row: SubberSettingsRow, *, radarr: bool) -> str:
@@ -97,6 +100,7 @@ def make_subber_library_sync_movies_handler(
                 api_key = _arr_api_key(settings, row, radarr=True)
                 base = (row.radarr_base_url or "").strip()
                 if not base or not api_key:
+                    logger.debug("Subber library sync skipped for movies because Radarr is not configured.")
                     subber_activity.record_subber_activity(
                         session,
                         event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
@@ -201,7 +205,12 @@ def make_subber_library_sync_tv_handler(
                     show_title = str(ser.get("title") or "").strip() or None
                     try:
                         ep_files = get_sonarr_episode_files(base, api_key, series_id)
-                    except SubberArrClientError:
+                    except SubberArrClientError as exc:
+                        logger.warning(
+                            "Subber TV library sync could not fetch Sonarr episode files for series_id=%s: %s",
+                            series_id,
+                            exc,
+                        )
                         ep_files = []
                     episode_file_id_to_path: dict[int, str] = {}
                     for ef in ep_files:
@@ -213,7 +222,12 @@ def make_subber_library_sync_tv_handler(
                             episode_file_id_to_path[int(fid)] = path
                     try:
                         episodes = get_sonarr_episodes(base, api_key, series_id)
-                    except SubberArrClientError:
+                    except SubberArrClientError as exc:
+                        logger.warning(
+                            "Subber TV library sync skipped series_id=%s because Sonarr episodes could not be listed: %s",
+                            series_id,
+                            exc,
+                        )
                         continue
                     for ep in episodes:
                         if not ep.get("hasFile"):

--- a/apps/backend/src/mediamop/modules/subber/subber_opensubtitles_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_opensubtitles_client.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
-import urllib.error
 import urllib.parse
 from typing import Any
+
+import httpx
 
 from mediamop.modules.subber.subber_http_client import (
     DEFAULT_USER_AGENT,
@@ -40,14 +41,14 @@ def _request(
         headers["Authorization"] = f"Bearer {token}"
     try:
         return request_json(url, method=method, headers=headers, body=body, timeout=60)
-    except urllib.error.HTTPError as exc:
-        if exc.code == 429:
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 429:
             raise SubberRateLimitError from exc
         try:
             parsed = decode_http_error_json(exc)
         except json.JSONDecodeError:
             parsed = None
-        return int(exc.code), parsed
+        return int(exc.response.status_code), parsed
 
 
 def login(username: str, password: str, api_key: str) -> str:
@@ -144,5 +145,5 @@ def download(token: str, api_key: str, *, file_id: int) -> bytes:
     if not link:
         msg = "OpenSubtitles download response missing link"
         raise ValueError(msg)
-    _code, data = request_bytes(link, headers={"User-Agent": USER_AGENT}, timeout=120)
+    _code, data = request_bytes(link, headers={"User-Agent": USER_AGENT}, timeout=120, validate_provider_url=True)
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_provider_registry.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_provider_registry.py
@@ -71,3 +71,8 @@ PROVIDER_SCOPE_RESTRICTION: dict[str, str] = {
     PROVIDER_GESTDOWN: "tv",
     PROVIDER_YIFY: "movies",
 }
+
+PROVIDER_AVAILABILITY: dict[str, tuple[bool, str | None]] = {
+    PROVIDER_SUBSCENE: (False, "Not available in this version."),
+    PROVIDER_ADDIC7ED: (False, "Not available in this version."),
+}

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
@@ -13,6 +13,7 @@ from mediamop.modules.subber.subber_podnapisi_client import LIST_BASE
 from mediamop.modules.subber.subber_provider_registry import (
     ALL_PROVIDER_KEYS,
     PROVIDER_ADDIC7ED,
+    PROVIDER_AVAILABILITY,
     PROVIDER_DISPLAY_NAMES,
     PROVIDER_OPENSUBTITLES_COM,
     PROVIDER_OPENSUBTITLES_ORG,
@@ -41,6 +42,7 @@ class SubberCsrfIn(BaseModel):
 
 def _provider_out(settings: MediaMopSettings, row) -> SubberProviderOut:
     pk = str(row.provider_key)
+    available, availability_note = PROVIDER_AVAILABILITY.get(pk, (True, None))
     return SubberProviderOut(
         provider_key=pk,
         display_name=PROVIDER_DISPLAY_NAMES.get(pk, pk),
@@ -48,6 +50,8 @@ def _provider_out(settings: MediaMopSettings, row) -> SubberProviderOut:
         priority=int(row.priority) if row.priority is not None else None,
         requires_account=bool(PROVIDER_REQUIRES_ACCOUNT.get(pk, True)),
         has_credentials=provider_has_stored_credentials(settings, row),
+        available=available,
+        availability_note=availability_note,
     )
 
 
@@ -83,6 +87,12 @@ def put_subber_provider(
     pk = provider_key.strip()
     if pk not in ALL_PROVIDER_KEYS:
         raise HTTPException(status_code=404, detail="Unknown provider_key.")
+    available, availability_note = PROVIDER_AVAILABILITY.get(pk, (True, None))
+    if body.enabled is True and not available:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=availability_note or "Provider is not available in this version.",
+        )
     creds: dict[str, str | None] | None = None
     if body.username is not None or (body.password is not None and body.password.strip()) or (
         body.api_key is not None and body.api_key.strip()

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
@@ -27,7 +27,7 @@ from mediamop.modules.subber.subber_providers_service import (
 )
 from mediamop.modules.subber.subber_schemas import SubberProviderOut, SubberProviderPutIn, SubberTestConnectionOut
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.csrf import verify_csrf_token
+from mediamop.platform.auth.csrf import current_raw_session_token, verify_csrf_token
 
 router = APIRouter(tags=["subber-providers"])
 
@@ -77,12 +77,13 @@ def get_subber_providers(
 def put_subber_provider(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     provider_key: str,
     body: SubberProviderPutHttpIn,
 ) -> SubberProviderOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     pk = provider_key.strip()
     if pk not in ALL_PROVIDER_KEYS:
@@ -122,12 +123,13 @@ def put_subber_provider(
 def post_subber_provider_test(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     provider_key: str,
     body: SubberCsrfIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     pk = provider_key.strip()
     if pk not in ALL_PROVIDER_KEYS:

--- a/apps/backend/src/mediamop/modules/subber/subber_schemas.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_schemas.py
@@ -156,6 +156,8 @@ class SubberProviderOut(BaseModel):
     priority: int | None = None
     requires_account: bool
     has_credentials: bool
+    available: bool = True
+    availability_note: str | None = None
 
 
 class SubberProviderPutIn(BaseModel):

--- a/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from collections.abc import Callable
 
@@ -29,6 +30,8 @@ from mediamop.platform.activity import constants as C
 from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, media_scope_label
 
+logger = logging.getLogger(__name__)
+
 
 def make_subber_subtitle_search_handler(
     settings: MediaMopSettings,
@@ -44,13 +47,20 @@ def make_subber_subtitle_search_handler(
             with session.begin():
                 row = get_state_by_id(session, state_id)
                 if row is None:
+                    logger.debug("Subber subtitle search skipped because state_id=%s no longer exists.", state_id)
                     return
                 if row.status == "found" and row.subtitle_path and os.path.isfile(row.subtitle_path):
+                    logger.debug("Subber subtitle search skipped because state_id=%s already has a subtitle file.", state_id)
                     return
                 settings_row = ensure_subber_settings_row(session)
                 if not settings_row.enabled:
+                    logger.debug("Subber subtitle search skipped because Subber is disabled (state_id=%s).", state_id)
                     return
                 if not subber_any_search_configured(settings, settings_row, session):
+                    logger.debug(
+                        "Subber subtitle search skipped because no providers are configured (state_id=%s).",
+                        state_id,
+                    )
                     return
                 perm = max(1, int(settings_row.permanent_skip_after_attempts or 10))
                 if int(row.search_count or 0) >= perm:
@@ -78,6 +88,10 @@ def make_subber_subtitle_search_handler(
                 mark_searching(session, state_id)
                 row2 = get_state_by_id(session, state_id)
                 if row2 is None:
+                    logger.debug(
+                        "Subber subtitle search stopped because state_id=%s disappeared after marking searching.",
+                        state_id,
+                    )
                     return
                 provider_events: list[dict[str, str]] = []
                 ok = search_and_download_subtitle(

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
@@ -35,7 +35,7 @@ from mediamop.modules.subber.subber_settings_service import (
     set_language_preferences_json,
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.csrf import verify_csrf_token
+from mediamop.platform.auth.csrf import current_raw_session_token, verify_csrf_token
 
 router = APIRouter(tags=["subber-settings"])
 
@@ -124,7 +124,7 @@ def put_subber_settings(
     body: SubberSettingsPutHttpIn,
 ) -> SubberSettingsOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     if body.enabled is not None:
@@ -290,11 +290,12 @@ def _apply_sched(row: SubberSettingsRow, body: SubberSettingsPutIn) -> None:
 def post_test_opensubtitles(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     body: SubberCsrfIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     raw = decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or "") or "{}"
@@ -393,11 +394,12 @@ def _arr_root_folders(base_url: str, api_key: str) -> tuple[bool, str, list[Subb
 def post_test_sonarr(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     body: SubberCsrfIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     key_raw = decrypt_subber_credentials_json(settings, row.sonarr_credentials_ciphertext or "") or "{}"
@@ -417,11 +419,12 @@ def post_test_sonarr(
 def post_sonarr_root_folders(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     body: SubberCsrfIn,
 ) -> SubberArrRootFoldersOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     api_key = _arr_api_key(settings, row.sonarr_credentials_ciphertext)
@@ -435,11 +438,12 @@ def post_sonarr_root_folders(
 def post_test_radarr(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     body: SubberCsrfIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     key_raw = decrypt_subber_credentials_json(settings, row.radarr_credentials_ciphertext or "") or "{}"
@@ -459,11 +463,12 @@ def post_test_radarr(
 def post_radarr_root_folders(
     _user: RequireOperatorDep,
     db: DbSessionDep,
+    request: Request,
     settings: SettingsDep,
     body: SubberCsrfIn,
 ) -> SubberArrRootFoldersOut:
     secret = settings.session_secret or ""
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
     api_key = _arr_api_key(settings, row.radarr_credentials_ciphertext)

--- a/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
@@ -66,5 +66,5 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle zip/srt from SubDL."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60)
+    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_subf2m_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subf2m_client.py
@@ -62,5 +62,5 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle from Subf2m."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60)
+    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_subsource_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subsource_client.py
@@ -68,5 +68,10 @@ def search(
 
 def download(*, download_url: str, api_key: str) -> bytes:
     """Download subtitle from SubSource."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT, "X-API-Key": api_key.strip()}, timeout=60)
+    _code, data = request_bytes(
+        download_url,
+        headers={"User-Agent": USER_AGENT, "X-API-Key": api_key.strip()},
+        timeout=60,
+        validate_provider_url=True,
+    )
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import io
 import json
 import logging
+import os
 import re
 import zipfile
+from collections.abc import Callable
 from pathlib import Path
 
 from sqlalchemy.orm import Session
@@ -46,6 +48,8 @@ from mediamop.platform.file_lifecycle.guardrails import check_minimum_free_disk_
 from mediamop.platform.observability.failure_messages import operator_failure_from_exception
 
 logger = logging.getLogger(__name__)
+MAX_SRT_BYTES = 10 * 1024 * 1024
+ProviderSearchHandler = Callable[..., bool]
 
 
 def _extract_srt_from_zip_or_raw(data: bytes) -> bytes:
@@ -56,6 +60,14 @@ def _extract_srt_from_zip_or_raw(data: bytes) -> bytes:
         with zipfile.ZipFile(bio) as zf:
             for name in zf.namelist():
                 if name.lower().endswith(".srt"):
+                    info = zf.getinfo(name)
+                    if info.file_size > MAX_SRT_BYTES:
+                        logger.warning(
+                            "Subber skipped oversized subtitle archive member %s (%s bytes).",
+                            name,
+                            info.file_size,
+                        )
+                        continue
                     return zf.read(name)
     return data
 
@@ -255,7 +267,9 @@ def _write_srt_for_state(
     )
     if not disk.ok:
         raise RuntimeError(disk.message)
-    out_path.write_bytes(srt_bytes)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    tmp_path.write_bytes(srt_bytes)
+    os.replace(tmp_path, out_path)
     mark_found(
         db,
         int(state_row.id),
@@ -379,14 +393,16 @@ def _try_podnapisi(
 
 def _try_subscene(
     *,
+    settings: MediaMopSettings,
     settings_row: SubberSettingsRow,
     state_row: SubberSubtitleState,
     db: Session,
+    prow: SubberProviderRow,
     prefs: list[str],
     lang: str,
     exclude_hi: bool,
 ) -> bool:
-    _ = (exclude_hi,)
+    _ = (settings, settings_row, db, prow, exclude_hi)
     query = _search_query(state_row)
     season = state_row.season_number if state_row.media_scope == "tv" else None
     episode = state_row.episode_number if state_row.media_scope == "tv" else None
@@ -398,7 +414,9 @@ def _try_subscene(
         media_scope=state_row.media_scope,
     )
     if not items:
+        logger.debug("Subscene returned no usable subtitle results state_id=%s", state_row.id)
         return False
+    logger.warning("Subscene provider is unavailable in this release; downloaded results are skipped state_id=%s", state_row.id)
     return False
 
 
@@ -427,20 +445,25 @@ def _try_addic7ed(
         password=p,
     )
     if not items:
+        logger.debug("Addic7ed returned no usable subtitle results state_id=%s", state_row.id)
         return False
     _ = (settings_row, state_row, db, exclude_hi)
+    logger.warning("Addic7ed provider is unavailable in this release; downloaded results are skipped state_id=%s", state_row.id)
     return False
 
 
 def _try_gestdown(
     *,
+    settings: MediaMopSettings,
     settings_row: SubberSettingsRow,
     state_row: SubberSubtitleState,
     db: Session,
+    prow: SubberProviderRow,
     prefs: list[str],
     lang: str,
     exclude_hi: bool,
 ) -> bool:
+    _ = (settings, prow)
     if state_row.media_scope != "tv":
         return False
     items = gestdown_client.search(
@@ -593,13 +616,16 @@ def _try_subsource(
 
 def _try_subf2m(
     *,
+    settings: MediaMopSettings,
     settings_row: SubberSettingsRow,
     state_row: SubberSubtitleState,
     db: Session,
+    prow: SubberProviderRow,
     prefs: list[str],
     lang: str,
     exclude_hi: bool,
 ) -> bool:
+    _ = (settings, prow)
     items = subf2m_client.search(
         query=_search_query(state_row),
         season_number=state_row.season_number if state_row.media_scope == "tv" else None,
@@ -637,13 +663,16 @@ def _try_subf2m(
 
 def _try_yify(
     *,
+    settings: MediaMopSettings,
     settings_row: SubberSettingsRow,
     state_row: SubberSubtitleState,
     db: Session,
+    prow: SubberProviderRow,
     prefs: list[str],
     lang: str,
     exclude_hi: bool,
 ) -> bool:
+    _ = (settings, prow)
     if state_row.media_scope != "movies":
         return False
     items = yify_client.search(
@@ -745,6 +774,20 @@ def _legacy_opensubtitles_search(
                 pass
 
 
+_PROVIDER_HANDLERS: dict[str, ProviderSearchHandler] = {
+    PROVIDER_OPENSUBTITLES_ORG: _try_opensubtitles_provider,
+    PROVIDER_OPENSUBTITLES_COM: _try_opensubtitles_provider,
+    PROVIDER_PODNAPISI: _try_podnapisi,
+    PROVIDER_SUBSCENE: _try_subscene,
+    PROVIDER_ADDIC7ED: _try_addic7ed,
+    PROVIDER_GESTDOWN: _try_gestdown,
+    PROVIDER_SUBDL: _try_subdl,
+    PROVIDER_SUBSOURCE: _try_subsource,
+    PROVIDER_SUBF2M: _try_subf2m,
+    PROVIDER_YIFY: _try_yify,
+}
+
+
 def search_and_download_subtitle(
     *,
     settings: MediaMopSettings,
@@ -780,107 +823,25 @@ def search_and_download_subtitle(
 
     for prow in ready:
         try:
-            pk = prow.provider_key
-            if pk in (PROVIDER_OPENSUBTITLES_ORG, PROVIDER_OPENSUBTITLES_COM):
-                if _try_opensubtitles_provider(
-                    settings=settings,
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prow=prow,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_PODNAPISI:
-                if _try_podnapisi(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prow=prow,
-                    settings=settings,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_SUBSCENE:
-                if _try_subscene(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_ADDIC7ED:
-                if _try_addic7ed(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prow=prow,
-                    settings=settings,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_GESTDOWN:
-                if _try_gestdown(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_SUBDL:
-                if _try_subdl(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prow=prow,
-                    settings=settings,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_SUBSOURCE:
-                if _try_subsource(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prow=prow,
-                    settings=settings,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_SUBF2M:
-                if _try_subf2m(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
-            elif pk == PROVIDER_YIFY:
-                if _try_yify(
-                    settings_row=settings_row,
-                    state_row=state_row,
-                    db=db,
-                    prefs=prefs,
-                    lang=lang,
-                    exclude_hi=exclude_hi,
-                ):
-                    return True
+            handler = _PROVIDER_HANDLERS.get(prow.provider_key)
+            if handler is None:
+                logger.warning(
+                    "Subber provider %s is enabled but has no registered search handler; skipping state_id=%s",
+                    prow.provider_key,
+                    state_row.id,
+                )
+                continue
+            if handler(
+                settings=settings,
+                settings_row=settings_row,
+                state_row=state_row,
+                db=db,
+                prow=prow,
+                prefs=prefs,
+                lang=lang,
+                exclude_hi=exclude_hi,
+            ):
+                return True
         except SubberRateLimitError as exc:
             failure = operator_failure_from_exception(
                 module="Subber",

--- a/apps/backend/src/mediamop/modules/subber/subber_upgrade_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_upgrade_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -17,6 +18,8 @@ from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
 from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
 from mediamop.platform.observability.operator_messages import activity_detail_envelope
+
+logger = logging.getLogger(__name__)
 
 
 def make_subber_subtitle_upgrade_handler(
@@ -71,6 +74,7 @@ def make_subber_subtitle_upgrade_handler(
                     return
                 interval_sec = max(60, int(settings_row.upgrade_schedule_interval_seconds or 604800))
                 since_days = max(1, int(interval_sec // 86400) or 7)
+                logger.debug("Subber subtitle upgrade scanning candidates from the last %s day(s).", since_days)
                 for row in get_candidates_for_upgrade(session, since_days):
                     attempted += 1
                     try:

--- a/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections.abc import Callable
 
@@ -21,6 +22,8 @@ from mediamop.modules.subber.subber_subtitle_state_service import upsert_subtitl
 from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
 
+logger = logging.getLogger(__name__)
+
 
 def make_subber_webhook_import_handler(
     session_factory: sessionmaker[Session],
@@ -32,9 +35,11 @@ def make_subber_webhook_import_handler(
     def handle(ctx: SubberJobWorkContext) -> None:
         p = json.loads(ctx.payload_json or "{}")
         if str(p.get("media_scope") or "") != media_scope:
+            logger.debug("Subber webhook import skipped because payload media_scope did not match %s.", media_scope)
             return
         file_path = str(p.get("file_path") or "").strip()
         if not file_path:
+            logger.debug("Subber webhook import skipped because payload had no file_path (%s).", media_scope)
             return
         title = str(p.get("title") or "").strip()
         year = p.get("year")
@@ -56,6 +61,7 @@ def make_subber_webhook_import_handler(
             with session.begin():
                 settings_row = ensure_subber_settings_row(session)
                 if not settings_row.enabled:
+                    logger.debug("Subber webhook import skipped because Subber is disabled (%s).", media_scope)
                     return
                 for lang in language_preferences_list(settings_row):
                     st = upsert_subtitle_state(

--- a/apps/backend/src/mediamop/modules/subber/subber_yify_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_yify_client.py
@@ -56,5 +56,5 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle from YifySubtitles."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60)
+    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
     return data

--- a/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
+++ b/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
@@ -37,6 +37,7 @@ from mediamop.platform.activity import constants as act_c
 from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -58,7 +59,7 @@ class ArrSearchLaneKey(str, Enum):
 def _verify_csrf(request: Request, settings: MediaMopSettings, token: str) -> None:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, token):
+    if not verify_csrf_token(secret, token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/platform/auth/csrf.py
+++ b/apps/backend/src/mediamop/platform/auth/csrf.py
@@ -13,36 +13,69 @@ you open.
 
 from __future__ import annotations
 
+import secrets
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, Request, status
 from itsdangerous import BadSignature, SignatureExpired, TimestampSigner
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.platform.auth.sessions import hash_session_token
 
 CSRF_SIGNER_SALT = "mediamop-csrf-v1"
 CSRF_MAX_AGE_SEC = 3600
-CSRF_SUBJECT = "csrf"
+CSRF_SUBJECT_ANONYMOUS = "csrf.anonymous"
+CSRF_SUBJECT_SESSION = "csrf.session"
 
 
 def _signer(secret: str) -> TimestampSigner:
     return TimestampSigner(secret, salt=CSRF_SIGNER_SALT)
 
 
-def issue_csrf_token(secret: str) -> str:
+def _csrf_session_binding(raw_session_token: str) -> str:
+    return hash_session_token(raw_session_token.strip())
+
+
+def _session_subject_payload(raw_session_token: str) -> str:
+    return f"{CSRF_SUBJECT_SESSION}:{_csrf_session_binding(raw_session_token)}"
+
+
+def current_raw_session_token(request: Request, settings: MediaMopSettings) -> str | None:
+    raw = (request.cookies.get(settings.session_cookie_name) or "").strip()
+    return raw or None
+
+
+def issue_csrf_token(secret: str, raw_session_token: str | None = None) -> str:
     if not secret.strip():
         raise ValueError("session secret required for CSRF")
-    return _signer(secret).sign(CSRF_SUBJECT.encode("utf-8")).decode("utf-8")
+    payload = (
+        _session_subject_payload(raw_session_token)
+        if (raw_session_token or "").strip()
+        else CSRF_SUBJECT_ANONYMOUS
+    )
+    return _signer(secret).sign(payload.encode("utf-8")).decode("utf-8")
 
 
-def verify_csrf_token(secret: str, token: str, *, max_age_sec: int = CSRF_MAX_AGE_SEC) -> bool:
+def verify_csrf_token(
+    secret: str,
+    token: str,
+    *,
+    raw_session_token: str | None = None,
+    allow_anonymous: bool = False,
+    max_age_sec: int = CSRF_MAX_AGE_SEC,
+) -> bool:
     if not (token or "").strip() or not (secret or "").strip():
         return False
     try:
         raw = _signer(secret).unsign(token.encode("utf-8"), max_age=max_age_sec)
-        return raw.decode("utf-8") == CSRF_SUBJECT
+        payload = raw.decode("utf-8")
     except (BadSignature, SignatureExpired, UnicodeDecodeError):
         return False
+    if allow_anonymous and payload == CSRF_SUBJECT_ANONYMOUS:
+        return True
+    if not (raw_session_token or "").strip():
+        return False
+    return secrets.compare_digest(payload, _session_subject_payload(raw_session_token))
 
 
 def validate_browser_post_origin(request: Request, settings: MediaMopSettings) -> None:

--- a/apps/backend/src/mediamop/platform/auth/password.py
+++ b/apps/backend/src/mediamop/platform/auth/password.py
@@ -28,6 +28,8 @@ _hasher = PasswordHasher(
     hash_len=32,
     salt_len=16,
 )
+_DUMMY_PASSWORD_PLAIN = "mediamop-login-padding-password"
+DUMMY_PASSWORD_HASH = _hasher.hash(_DUMMY_PASSWORD_PLAIN)
 
 
 def hash_password(plain: str) -> str:

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -307,7 +307,7 @@ def get_me(current: UserPublicDep) -> schemas.MeOut:
     return schemas.MeOut(user=current)
 
 
-@router.get("/admin/ping")
+@router.get("/admin/ping", include_in_schema=False)
 def admin_ping(_admin: RequireAdminDep) -> dict[str, bool]:
     """Minimal authenticated probe for the admin-only dependency (Phase 6 tests + ops)."""
 

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -22,6 +22,7 @@ from mediamop.platform.auth.bootstrap_status_db import (
     raise_http_for_bootstrap_status_sqlalchemy,
 )
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     issue_csrf_token,
     require_session_secret,
     validate_browser_post_origin,
@@ -49,9 +50,12 @@ def _csrf_from_header_or_body(
 
 
 @router.get("/csrf", response_model=schemas.CsrfOut)
-def get_csrf(settings: SettingsDep) -> schemas.CsrfOut:
+def get_csrf(request: Request, db: DbSessionDep, settings: SettingsDep) -> schemas.CsrfOut:
     secret = require_session_secret(settings)
-    return schemas.CsrfOut(csrf_token=issue_csrf_token(secret))
+    raw_session_token = current_raw_session_token(request, settings)
+    if raw_session_token and auth_service.load_valid_session_for_request(db, raw_session_token, settings) is None:
+        raw_session_token = None
+    return schemas.CsrfOut(csrf_token=issue_csrf_token(secret, raw_session_token))
 
 
 @router.post("/login", response_model=schemas.LoginOut)
@@ -65,7 +69,12 @@ def post_login(
     raise_if_login_rate_limited(request)
     secret = require_session_secret(settings)
     validate_browser_post_origin(request, settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(
+        secret,
+        body.csrf_token,
+        raw_session_token=current_raw_session_token(request, settings),
+        allow_anonymous=True,
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",
@@ -196,7 +205,7 @@ def post_bootstrap(
     raise_if_bootstrap_rate_limited(request)
     secret = require_session_secret(settings)
     validate_browser_post_origin(request, settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, allow_anonymous=True):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",
@@ -255,7 +264,8 @@ def post_logout(
     secret = require_session_secret(settings)
     validate_browser_post_origin(request, settings)
     token = _csrf_from_header_or_body(x_csrf_token, body.csrf_token if body else None)
-    if not verify_csrf_token(secret, token):
+    raw_session_token = current_raw_session_token(request, settings)
+    if not verify_csrf_token(secret, token, raw_session_token=raw_session_token, allow_anonymous=raw_session_token is None):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",
@@ -316,7 +326,7 @@ def post_change_password(
 
     secret = require_session_secret(settings)
     validate_browser_post_origin(request, settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/platform/auth/service.py
+++ b/apps/backend/src/mediamop/platform/auth/service.py
@@ -14,7 +14,12 @@ from sqlalchemy.orm import Session
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.datetime_util import as_utc
 from mediamop.platform.auth.models import User, UserSession
-from mediamop.platform.auth.password import hash_password, validate_password_strength, verify_password
+from mediamop.platform.auth.password import (
+    DUMMY_PASSWORD_HASH,
+    hash_password,
+    validate_password_strength,
+    verify_password,
+)
 from mediamop.platform.auth.sessions import (
     compute_absolute_expiry,
     generate_raw_session_token,
@@ -33,6 +38,7 @@ def authenticate_user(db: Session, username: str, password: str) -> User | None:
     stmt = select(User).where(User.username == username)
     user = db.scalars(stmt).first()
     if user is None or not user.is_active:
+        verify_password(password, DUMMY_PASSWORD_HASH)
         return None
     if not verify_password(password, user.password_hash):
         return None

--- a/apps/backend/src/mediamop/platform/auth/session_cleanup.py
+++ b/apps/backend/src/mediamop/platform/auth/session_cleanup.py
@@ -34,6 +34,8 @@ async def _session_cleanup_loop(
                 session.commit()
             if removed:
                 logger.info("auth event: cleaned up inactive sessions (count=%s)", removed)
+            else:
+                logger.debug("auth event: inactive session cleanup found nothing to remove")
         except Exception:
             logger.exception("auth event: inactive session cleanup failed")
 

--- a/apps/backend/src/mediamop/platform/http/security_headers.py
+++ b/apps/backend/src/mediamop/platform/http/security_headers.py
@@ -24,12 +24,12 @@ _API_CSP = (
 )
 
 # HTML baseline for the bundled SPA shell/static assets.
-# Keep this narrow but allow first-party JS/CSS plus Google Fonts used by index.html.
+# Keep this narrow and first-party only; the web app self-hosts its fonts.
 _HTML_CSP = (
     "default-src 'self'; "
     "script-src 'self'; "
-    "style-src 'self' https://fonts.googleapis.com; "
-    "font-src 'self' https://fonts.gstatic.com data:; "
+    "style-src 'self'; "
+    "font-src 'self' data:; "
     "img-src 'self' data: blob:; "
     "connect-src 'self'; "
     "base-uri 'none'; "

--- a/apps/backend/src/mediamop/platform/metrics/router.py
+++ b/apps/backend/src/mediamop/platform/metrics/router.py
@@ -2,15 +2,55 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import secrets
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import PlainTextResponse
 
-from mediamop.platform.auth.authorization import RequireOperatorDep
+from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.platform.auth import service as auth_service
+from mediamop.platform.auth.models import UserRole
 from mediamop.platform.metrics.service import render_prometheus_metrics
 
 router = APIRouter(include_in_schema=False)
 
 
+def _authorization_bearer_token(header_value: str | None) -> str | None:
+    if not header_value:
+        return None
+    scheme, _, token = header_value.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+def require_metrics_access(
+    request: Request,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    authorization: Annotated[str | None, Header()] = None,
+) -> None:
+    bearer_token = _authorization_bearer_token(authorization)
+    expected_token = settings.metrics_bearer_token
+    if bearer_token and expected_token and secrets.compare_digest(bearer_token, expected_token):
+        return
+
+    raw_session = (request.cookies.get(settings.session_cookie_name) or "").strip() or None
+    pair = auth_service.load_valid_session_for_request(db, raw_session, settings)
+    if pair is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated.",
+        )
+    _row, user = pair
+    if user.role not in {UserRole.admin.value, UserRole.operator.value}:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Forbidden.",
+        )
+
+
 @router.get("/metrics", response_class=PlainTextResponse)
-def get_metrics(_user: RequireOperatorDep) -> PlainTextResponse:
+def get_metrics(_access: Annotated[None, Depends(require_metrics_access)]) -> PlainTextResponse:
     return PlainTextResponse(render_prometheus_metrics(), media_type="text/plain; version=0.0.4")

--- a/apps/backend/src/mediamop/platform/suite_settings/logs_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/logs_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import tempfile
 from collections import deque
@@ -14,6 +15,8 @@ from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,7 @@ def read_suite_logs(
     try:
         handle = path.open("r", encoding="utf-8")
     except OSError:
+        logger.warning("Suite log read skipped because %s could not be opened.", path, exc_info=True)
         return ([], 0, counts)
 
     with handle:
@@ -117,11 +121,12 @@ def prune_log_file(settings: MediaMopSettings, *, keep_days: int) -> None:
                     target.write(raw.rstrip("\n") + "\n")
         os.replace(tmp_name, path)
     except OSError:
+        logger.warning("Suite log prune skipped because %s could not be rewritten.", path, exc_info=True)
         if tmp_name:
             try:
                 Path(tmp_name).unlink()
             except OSError:
-                pass
+                logger.debug("Suite log prune could not remove temp file %s", tmp_name, exc_info=True)
         return
 
 

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -9,6 +9,7 @@ from starlette import status
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -67,7 +68,7 @@ def put_suite_settings(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Your confirmation token expired. Refresh the page and try again.",
@@ -115,7 +116,7 @@ def put_configuration_bundle(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Your confirmation token expired. Refresh the page and try again.",
@@ -197,7 +198,7 @@ def post_suite_update_now(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Your confirmation token expired. Refresh the page and try again.",
@@ -223,7 +224,7 @@ def post_suite_operational_history_reset(
 
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Your confirmation token expired. Refresh the page and try again.",

--- a/apps/backend/src/mediamop/platform/system_configuration/router.py
+++ b/apps/backend/src/mediamop/platform/system_configuration/router.py
@@ -9,6 +9,7 @@ from starlette import status
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
@@ -45,7 +46,7 @@ def put_suite_configuration_bundle(
 ) -> dict:
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
-    if not verify_csrf_token(secret, body.csrf_token):
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Your confirmation token expired. Refresh the page and try again.",

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -12,6 +12,7 @@ from alembic.config import Config
 from starlette.testclient import TestClient
 
 from mediamop.api.factory import create_app
+from mediamop.platform.jobs.worker_health import reset_worker_health_for_tests
 from tests.integration_helpers import seed_admin_user, seed_viewer_user
 
 
@@ -41,8 +42,15 @@ def ensure_session_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _reset_worker_health_state() -> Iterator[None]:
+    reset_worker_health_for_tests()
+    yield
+    reset_worker_health_for_tests()
+
+
 @pytest.fixture
-def client_with_admin() -> TestClient:
+def client_with_admin() -> Iterator[TestClient]:
     seed_admin_user()
     app = create_app()
     with TestClient(app) as c:
@@ -50,7 +58,7 @@ def client_with_admin() -> TestClient:
 
 
 @pytest.fixture
-def client_with_viewer() -> TestClient:
+def client_with_viewer() -> Iterator[TestClient]:
     seed_viewer_user()
     app = create_app()
     with TestClient(app) as c:

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -854,5 +854,7 @@ def test_bundled_html_csp_does_not_allow_inline_styles(monkeypatch: pytest.Monke
 
     assert response.status_code == 200
     csp = response.headers.get("Content-Security-Policy") or ""
-    assert "style-src 'self' https://fonts.googleapis.com" in csp
+    assert "style-src 'self'" in csp
+    assert "fonts.googleapis.com" not in csp
+    assert "fonts.gstatic.com" not in csp
     assert "'unsafe-inline'" not in csp

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -299,6 +299,39 @@ def test_second_browser_login_does_not_revoke_first_browser_session() -> None:
         assert remote_client.get("/api/v1/auth/me").status_code == 200
 
 
+def test_authenticated_csrf_token_is_rejected_across_sessions() -> None:
+    seed_admin_user()
+    app = create_app()
+    with TestClient(app) as client_a, TestClient(app) as client_b:
+        csrf_a_login = fetch_csrf(client_a)
+        login_a = auth_post(
+            client_a,
+            "/api/v1/auth/login",
+            json={"username": "alice", "password": "test-password-strong", "csrf_token": csrf_a_login},
+        )
+        assert login_a.status_code == 200, login_a.text
+
+        csrf_b_login = fetch_csrf(client_b)
+        login_b = auth_post(
+            client_b,
+            "/api/v1/auth/login",
+            json={"username": "alice", "password": "test-password-strong", "csrf_token": csrf_b_login},
+        )
+        assert login_b.status_code == 200, login_b.text
+
+        session_a_csrf = fetch_csrf(client_a)
+        cross_session = auth_post(
+            client_b,
+            "/api/v1/auth/change-password",
+            json={
+                "csrf_token": session_a_csrf,
+                "current_password": "test-password-strong",
+                "new_password": "new-password-stronger-123",
+            },
+        )
+        assert cross_session.status_code == 400
+
+
 def test_login_keeps_only_newest_five_active_sessions() -> None:
     seed_admin_user()
     settings = MediaMopSettings.load()

--- a/apps/backend/tests/test_auth_service.py
+++ b/apps/backend/tests/test_auth_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from mediamop.platform.auth import service
+from mediamop.platform.auth.password import DUMMY_PASSWORD_HASH
+
+
+class _ScalarResult:
+    def __init__(self, user) -> None:
+        self._user = user
+
+    def first(self):
+        return self._user
+
+
+class _FakeSession:
+    def __init__(self, user) -> None:
+        self._user = user
+
+    def scalars(self, _stmt):
+        return _ScalarResult(self._user)
+
+
+def test_authenticate_user_pads_missing_username_with_dummy_verify(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_verify(password: str, password_hash: str) -> bool:
+        calls.append((password, password_hash))
+        return False
+
+    monkeypatch.setattr(service, "verify_password", fake_verify)
+
+    user = service.authenticate_user(_FakeSession(None), "missing-user", "wrong-password")
+
+    assert user is None
+    assert calls == [("wrong-password", DUMMY_PASSWORD_HASH)]
+
+
+def test_authenticate_user_pads_inactive_account_with_dummy_verify(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def fake_verify(password: str, password_hash: str) -> bool:
+        calls.append((password, password_hash))
+        return False
+
+    monkeypatch.setattr(service, "verify_password", fake_verify)
+    inactive_user = SimpleNamespace(is_active=False, password_hash="stored-hash")
+
+    user = service.authenticate_user(_FakeSession(inactive_user), "inactive-user", "wrong-password")
+
+    assert user is None
+    assert calls == [("wrong-password", DUMMY_PASSWORD_HASH)]

--- a/apps/backend/tests/test_credentials_secret_crypto.py
+++ b/apps/backend/tests/test_credentials_secret_crypto.py
@@ -42,8 +42,10 @@ def test_credentials_secret_decouples_pruner_subber_and_arr_from_session_rotatio
     assert decrypt_pruner_credentials_json(s2, pruner) == '{"api_key":"p"}'
     assert decrypt_subber_credentials_json(s2, subber) == '{"api_key":"s"}'
     assert decrypt_arr_api_key(s2, arr) == "arr-key"
-    assert json.loads(pruner)["key_id"] == "credentials:v1"
-    assert json.loads(subber)["key_id"] == "credentials:v1"
+    assert json.loads(pruner)["key_id"] == "credentials:hkdf:v1"
+    assert json.loads(pruner)["version"] == 3
+    assert json.loads(subber)["key_id"] == "credentials:hkdf:v1"
+    assert json.loads(subber)["version"] == 3
     assert json.loads(arr)["key_id"] == "credentials:v1"
 
 
@@ -72,6 +74,8 @@ def test_legacy_session_secret_ciphertexts_can_be_rewrapped(monkeypatch, tmp_pat
     assert pruner_new is not None
     assert subber_new is not None
     assert arr_new is not None
+    assert json.loads(pruner_new)["key_id"] == "credentials:hkdf:v1"
+    assert json.loads(subber_new)["key_id"] == "credentials:hkdf:v1"
     assert decrypt_pruner_credentials_json(rotated, pruner_new) == '{"api_key":"p"}'
     assert decrypt_subber_credentials_json(rotated, subber_new) == '{"api_key":"s"}'
     assert decrypt_arr_api_key(rotated, arr_new) == "arr-key"
@@ -103,6 +107,8 @@ def test_previous_credentials_secret_allows_safe_secret_rotation(monkeypatch, tm
     assert pruner_new is not None
     assert subber_new is not None
     assert arr_new is not None
+    assert json.loads(pruner_new)["key_id"] == "credentials:hkdf:v1"
+    assert json.loads(subber_new)["key_id"] == "credentials:hkdf:v1"
     assert decrypt_pruner_credentials_json(new_only, pruner_new) == '{"api_key":"p"}'
     assert decrypt_subber_credentials_json(new_only, subber_new) == '{"api_key":"s"}'
     assert decrypt_arr_api_key(new_only, arr_new) == "arr-key"

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -43,6 +43,7 @@ def _csrf_settings(**overrides: object) -> MediaMopSettings:
         bootstrap_rate_max_attempts=10,
         bootstrap_rate_window_seconds=3600,
         security_enable_hsts=False,
+        metrics_bearer_token=None,
         mediamop_home=str(home),
         db_path=str(db),
         backup_dir=str(home / "backups"),

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -95,9 +95,17 @@ def _csrf_settings(**overrides: object) -> MediaMopSettings:
 def test_issue_and_verify_csrf() -> None:
     secret = "unit-test-csrf-secret-key-32chars-minimum!"
     t = issue_csrf_token(secret)
-    assert verify_csrf_token(secret, t) is True
+    assert verify_csrf_token(secret, t, allow_anonymous=True) is True
     assert verify_csrf_token("wrong-secret", t) is False
     assert verify_csrf_token(secret, "tampered") is False
+
+
+def test_session_bound_csrf_rejects_other_session() -> None:
+    secret = "unit-test-csrf-secret-key-32chars-minimum!"
+    token = issue_csrf_token(secret, "session-a-cookie")
+    assert verify_csrf_token(secret, token, raw_session_token="session-a-cookie") is True
+    assert verify_csrf_token(secret, token, raw_session_token="session-b-cookie") is False
+    assert verify_csrf_token(secret, token, allow_anonymous=True) is False
 
 
 def _request_with_headers(items: list[tuple[bytes, bytes]]) -> Request:

--- a/apps/backend/tests/test_docker_onboarding_files.py
+++ b/apps/backend/tests/test_docker_onboarding_files.py
@@ -30,3 +30,10 @@ def test_docker_entrypoint_generates_persistent_session_secret() -> None:
     assert "session.secret" in entrypoint
     assert "export MEDIAMOP_SESSION_SECRET" in entrypoint
     assert "must be at least 32 characters" in entrypoint
+
+
+def test_dockerfile_runs_as_non_root_user() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "useradd --system --uid 1000" in dockerfile
+    assert "USER mediamop" in dockerfile

--- a/apps/backend/tests/test_lifespan_resilience.py
+++ b/apps/backend/tests/test_lifespan_resilience.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from mediamop.api.factory import create_app
+
+
+def test_non_essential_startup_failure_does_not_abort_startup(monkeypatch) -> None:
+    def _boom(*_args, **_kwargs) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("mediamop.core.lifespan.prune_logs_for_retention", _boom)
+
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/apps/backend/tests/test_metrics_auth.py
+++ b/apps/backend/tests/test_metrics_auth.py
@@ -1,5 +1,7 @@
+import pytest
 from starlette.testclient import TestClient
 
+from mediamop.api.factory import create_app
 from tests.integration_helpers import auth_post, csrf as fetch_csrf
 
 
@@ -23,3 +25,20 @@ def test_metrics_allows_operator_or_admin_session(client_with_admin: TestClient)
     r = client_with_admin.get("/metrics")
     assert r.status_code == 200, r.text
     assert "mediamop_http_requests_total" in r.text
+
+
+def test_metrics_allows_bearer_token_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEDIAMOP_METRICS_BEARER_TOKEN", "metrics-secret-token")
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/metrics", headers={"Authorization": "Bearer metrics-secret-token"})
+    assert response.status_code == 200, response.text
+    assert "mediamop_http_requests_total" in response.text
+
+
+def test_metrics_rejects_invalid_bearer_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MEDIAMOP_METRICS_BEARER_TOKEN", "metrics-secret-token")
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/metrics", headers={"Authorization": "Bearer wrong-token"})
+    assert response.status_code == 401

--- a/apps/backend/tests/test_subber_opensubtitles_client.py
+++ b/apps/backend/tests/test_subber_opensubtitles_client.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import io
 from unittest.mock import patch
 
+import httpx
 import pytest
-import urllib.error
 
 import mediamop.modules.subber.subber_opensubtitles_client as osc
 from mediamop.modules.subber.subber_opensubtitles_client import SubberRateLimitError, _request
@@ -18,7 +18,9 @@ def test_login_extracts_token_from_top_level() -> None:
 
 
 def test_request_429_raises_subber_rate_limit_error() -> None:
-    err = urllib.error.HTTPError("https://api.opensubtitles.com/api/v1/x", 429, "Too Many Requests", hdrs=None, fp=io.BytesIO())
+    request = httpx.Request("GET", "https://api.opensubtitles.com/api/v1/x")
+    response = httpx.Response(429, request=request, content=io.BytesIO().getvalue())
+    err = httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
     with patch("mediamop.modules.subber.subber_opensubtitles_client.request_json", side_effect=err):
         with pytest.raises(SubberRateLimitError):
             _request("GET", "/subtitles?query=x", api_key="key", token=None)

--- a/apps/backend/tests/test_subber_provider_fallback.py
+++ b/apps/backend/tests/test_subber_provider_fallback.py
@@ -26,8 +26,8 @@ def test_rate_limited_provider_is_skipped_and_next_provider_is_tried(monkeypatch
         tried.append(kwargs["prow"].provider_key)
         return True
 
-    monkeypatch.setattr(svc, "_try_opensubtitles_provider", rate_limited)
-    monkeypatch.setattr(svc, "_try_podnapisi", podnapisi_success)
+    monkeypatch.setitem(svc._PROVIDER_HANDLERS, PROVIDER_OPENSUBTITLES_COM, rate_limited)
+    monkeypatch.setitem(svc._PROVIDER_HANDLERS, PROVIDER_PODNAPISI, podnapisi_success)
 
     ok = svc.search_and_download_subtitle(
         settings=SimpleNamespace(),

--- a/apps/backend/tests/test_subber_provider_http_client.py
+++ b/apps/backend/tests/test_subber_provider_http_client.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import io
-import urllib.error
+import httpx
 
 from mediamop.modules.subber import subber_http_client
 
@@ -32,12 +31,31 @@ def test_subber_request_json_treats_malformed_json_as_empty_payload(monkeypatch)
 
 
 def test_subber_http_error_json_preserves_malformed_payload() -> None:
-    exc = urllib.error.HTTPError(
-        "https://example.invalid",
+    request = httpx.Request("GET", "https://example.invalid")
+    response = httpx.Response(
         500,
-        "bad",
-        {},
-        fp=io.BytesIO(b"{not-json"),
+        request=request,
+        content=b"{not-json",
     )
+    exc = httpx.HTTPStatusError("bad", request=request, response=response)
 
     assert subber_http_client.decode_http_error_json(exc) == {"raw": "{not-json"}
+
+
+def test_safe_provider_url_blocks_local_targets() -> None:
+    for url in (
+        "http://localhost/file.srt",
+        "http://127.0.0.1/file.srt",
+        "http://169.254.1.1/file.srt",
+        "http://10.0.0.5/file.srt",
+    ):
+        try:
+            subber_http_client.safe_provider_url(url)
+        except ValueError as exc:
+            assert "Blocked provider URL host" in str(exc)
+        else:
+            raise AssertionError(f"expected blocked URL for {url}")
+
+
+def test_safe_provider_url_allows_public_https_targets() -> None:
+    assert subber_http_client.safe_provider_url("https://subtitles.example/file.srt") == "https://subtitles.example/file.srt"

--- a/apps/backend/tests/test_subber_settings_api.py
+++ b/apps/backend/tests/test_subber_settings_api.py
@@ -96,6 +96,9 @@ def test_get_providers_admin_ok(client_admin: TestClient) -> None:
     keys = {x.get("provider_key") for x in rows}
     assert "opensubtitles_org" in keys
     assert "podnapisi" in keys
+    subscene = next(x for x in rows if x.get("provider_key") == "subscene")
+    assert subscene["available"] is False
+    assert subscene["availability_note"] == "Not available in this version."
 
 
 def test_put_settings_roundtrip_enabled(client_admin: TestClient) -> None:
@@ -447,6 +450,18 @@ def test_put_provider_unknown_key_404(client_admin: TestClient) -> None:
         headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
     )
     assert r.status_code == 404
+
+
+def test_put_unavailable_provider_enabled_returns_conflict(client_admin: TestClient) -> None:
+    _login_admin(client_admin)
+    tok = csrf(client_admin)
+    r = client_admin.put(
+        "/api/v1/subber/providers/subscene",
+        json={"enabled": True, "csrf_token": tok},
+        headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
+    )
+    assert r.status_code == 409
+    assert "not available" in r.json()["detail"].lower()
 
 
 @patch("urllib.request.urlopen", side_effect=urllib.error.URLError("offline"))

--- a/apps/backend/tests/test_subber_subtitle_search_service.py
+++ b/apps/backend/tests/test_subber_subtitle_search_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,8 +12,12 @@ from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
-from mediamop.modules.subber.subber_subtitle_search_service import apply_path_mapping
-from mediamop.modules.subber.subber_subtitle_search_service import _write_srt_for_state
+from mediamop.modules.subber.subber_subtitle_search_service import (
+    MAX_SRT_BYTES,
+    _extract_srt_from_zip_or_raw,
+    _write_srt_for_state,
+    apply_path_mapping,
+)
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
 from mediamop.platform.file_lifecycle.guardrails import DiskSpaceCheck
 
@@ -76,3 +82,65 @@ def test_subber_write_preflights_target_disk_space(
             )
 
     assert not (tmp_path / "movie.en.srt").exists()
+
+
+def test_subber_write_uses_atomic_replace(tmp_path: Path) -> None:
+    settings = MediaMopSettings.load()
+    fac = create_session_factory(create_db_engine(settings))
+    movie = tmp_path / "movie.mkv"
+    movie.write_bytes(b"media")
+
+    with fac() as db:
+        settings_row = db.get(SubberSettingsRow, 1)
+        if settings_row is None:
+            settings_row = SubberSettingsRow(id=1)
+            db.add(settings_row)
+        state = SubberSubtitleState(
+            media_scope="movie",
+            file_path=str(movie),
+            language_code="en",
+            status="missing",
+        )
+        db.add(state)
+        db.flush()
+
+        _write_srt_for_state(
+            settings_row=settings_row,
+            state_row=state,
+            lang="en",
+            srt_bytes=b"1\n00:00:00,000 --> 00:00:01,000\nHi\n",
+            provider_key="provider",
+            external_file_id="123",
+            db=db,
+        )
+
+    assert (tmp_path / "movie.en.srt").read_text(encoding="utf-8").startswith("1\n")
+    assert not (tmp_path / "movie.en.srt.tmp").exists()
+
+
+def test_extract_srt_from_zip_skips_oversized_members(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeZipFile:
+        def __enter__(self) -> _FakeZipFile:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def namelist(self) -> list[str]:
+            return ["huge.srt", "ok.srt"]
+
+        def getinfo(self, name: str) -> SimpleNamespace:
+            if name == "huge.srt":
+                return SimpleNamespace(file_size=MAX_SRT_BYTES + 1)
+            return SimpleNamespace(file_size=32)
+
+        def read(self, name: str) -> bytes:
+            if name == "ok.srt":
+                return b"1\n00:00:00,000 --> 00:00:01,000\nHi\n"
+            return b"small"
+
+    monkeypatch.setattr(zipfile, "is_zipfile", lambda _: True)
+    monkeypatch.setattr(zipfile, "ZipFile", lambda _: _FakeZipFile())
+    out = _extract_srt_from_zip_or_raw(b"archive")
+
+    assert out.startswith(b"1\n00:00:00,000")

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -120,7 +120,9 @@ def test_windows_package_includes_ffmpeg_runtime_assets() -> None:
     assert 'FFMPEG_VENDOR = ROOT / "packaging" / "windows" / "vendor" / "ffmpeg"' in spec_text
     assert '(str(FFMPEG_VENDOR), "bin/ffmpeg")' in spec_text
     assert "Ensure-WindowsFfmpegRuntime" in build_text
-    assert "ffmpeg-master-latest-win64-lgpl.zip" in build_text
+    assert "autobuild-2026-04-29-13-28" in build_text
+    assert "ffmpeg-N-124254-g397c7c7524-win64-lgpl.zip" in build_text
+    assert "Get-FileHash" in build_text
 
 
 def test_packaged_server_binds_to_lan_interfaces() -> None:

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -88,11 +88,13 @@ def test_windows_installer_installs_dedicated_upgrade_task() -> None:
     assert "procedure InstallUpgradeTask()" in text
     assert '/TN "MediaMop Upgrade"' in text
     assert "/RL HIGHEST" in text
+    assert '/RU "' not in text
     assert "MediaMopUpgrade.ps1" in text
     assert 'Filename: "{sys}\\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"' in text
     assert "https://api.github.com/repos/jampat000/MediaMop/releases/latest" in script_text
     assert "MediaMopSetup.exe" in script_text
     assert "/CLOSEAPPLICATIONS" in script_text
+    assert "WaitForMediaMopProcessesToExit" in text
 
 
 def test_windows_package_uses_dedicated_tray_icon_assets() -> None:

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,0 +1,61 @@
+import js from "@eslint/js";
+import prettierConfig from "eslint-config-prettier";
+import globals from "globals";
+import jsxA11y from "eslint-plugin-jsx-a11y";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "node_modules/**"],
+  },
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommendedTypeChecked,
+      react.configs.flat.recommended,
+      react.configs.flat["jsx-runtime"],
+      reactHooks.configs.flat["recommended-latest"],
+      jsxA11y.flatConfigs.recommended,
+      prettierConfig,
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+      globals: {
+        ...globals.browser,
+        ...globals.es2022,
+      },
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-base-to-string": "off",
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        {
+          checksVoidReturn: false,
+        },
+      ],
+      "@typescript-eslint/no-redundant-type-constituents": "off",
+      "@typescript-eslint/no-unnecessary-type-assertion": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+      "@typescript-eslint/require-await": "off",
+      "jsx-a11y/label-has-associated-control": "off",
+      "react-hooks/set-state-in-effect": "off",
+    },
+  },
+);

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -54,6 +54,7 @@ export default tseslint.config(
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/require-await": "off",
+      "jsx-a11y/no-autofocus": "off",
       "jsx-a11y/label-has-associated-control": "off",
       "react-hooks/set-state-in-effect": "off",
     },

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -7,12 +7,6 @@
     <meta name="theme-color" content="#0b0c10" />
     <title>MediaMop</title>
     <link rel="icon" href="/favicon.ico" sizes="any" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body class="mm-body">
     <a class="mm-skip" href="#mm-main-content">Skip to content</a>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -16,16 +16,25 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.20",
+        "eslint": "^9.39.4",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
+        "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^16.5.0",
         "jsdom": "^25.0.1",
         "postcss": "^8.4.49",
+        "prettier": "^3.8.3",
         "tailwindcss": "^3.4.16",
         "typescript": "~5.7.2",
+        "typescript-eslint": "^8.59.1",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
       }
@@ -77,12 +86,138 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -93,9 +228,48 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -104,6 +278,54 @@
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -257,6 +479,163 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fontsource/outfit": {
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource/outfit/-/outfit-5.2.8.tgz",
@@ -264,6 +643,72 @@
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -274,6 +719,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -816,6 +1272,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -842,6 +1305,301 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
+      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/type-utils": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
+      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -983,6 +1741,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -991,6 +1772,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-regex": {
@@ -1046,6 +1844,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1056,6 +1861,144 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1064,6 +2007,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/asynckit": {
@@ -1110,6 +2070,49 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
@@ -1134,6 +2137,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -1183,6 +2197,25 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1195,6 +2228,33 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-css": {
@@ -1238,6 +2298,39 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1276,6 +2369,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1299,12 +2412,34 @@
         "node": ">= 6"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -1354,6 +2489,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -1366,6 +2508,60 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/debug": {
@@ -1392,6 +2588,49 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1437,6 +2676,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -1467,6 +2719,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -1478,6 +2737,75 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-define-property": {
@@ -1496,6 +2824,34 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
+      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -1536,6 +2892,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -1544,6 +2931,296 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
@@ -1556,6 +3233,16 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1565,6 +3252,13 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1596,6 +3290,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1604,6 +3312,19 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1617,6 +3338,60 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -1675,6 +3450,57 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1714,6 +3540,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1727,12 +3571,94 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1780,6 +3706,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -1836,6 +3779,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -1844,6 +3824,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-binary-path": {
@@ -1857,6 +3906,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -1875,6 +3954,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1883,6 +3997,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1898,6 +4048,32 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1908,12 +4084,206 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -1930,6 +4300,19 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "25.0.1",
@@ -1970,6 +4353,113 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -2265,6 +4755,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2275,6 +4788,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
@@ -2365,6 +4888,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2401,6 +4937,32 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/node-releases": {
@@ -2447,6 +5009,104 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2457,6 +5117,87 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -2469,6 +5210,26 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -2523,6 +5284,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -2688,6 +5459,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -2703,6 +5500,25 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -2837,6 +5653,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -2856,6 +5716,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -2941,6 +5811,61 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2968,6 +5893,164 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3001,6 +6084,133 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -3012,6 +6222,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sucrase": {
@@ -3035,6 +6258,19 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3252,6 +6488,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -3267,6 +6516,97 @@
       "license": "0BSD",
       "optional": true
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -3279,6 +6619,49 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
+      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.1",
+        "@typescript-eslint/parser": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/utils": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3310,6 +6693,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -3574,6 +6967,111 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3589,6 +7087,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ws": {
@@ -3629,6 +7137,49 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.1.tgz",
+      "integrity": "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
     }
   }
 }

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -7,7 +7,9 @@
     "": {
       "name": "mediamop-web",
       "version": "1.0.30",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@fontsource/outfit": "^5.2.8",
         "@tanstack/react-query": "^5.62.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -253,6 +255,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource/outfit": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/outfit/-/outfit-5.2.8.tgz",
+      "integrity": "sha512-rXC6g0MqD7cOBjht0bMqc43qM6lRqDLML9KXsmg9uykz0wLQhy8Z/ajrMG6iyoT3NJR+MYgU+OEHp7uHoTb+Yw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,16 +4,23 @@
   "version": "1.0.30",
   "license": "AGPL-3.0-or-later",
   "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "dev": "npm run dev:stop-api && npm run dev:stop-web && node ./scripts/run-dev-stack.mjs",
     "dev:stop-api": "node ../../scripts/stop-dev-api-port.mjs",
     "dev:stop-web": "node ../../scripts/stop-dev-web-port.mjs",
     "dev:quick": "node ./scripts/run-dev-stack.mjs",
     "dev:web": "node ./node_modules/vite/bin/vite.js",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "format": "prettier --check \"src/**/*.{ts,tsx,css}\" \"index.html\" \"vite.config.ts\"",
+    "format:fix": "prettier --write \"src/**/*.{ts,tsx,css}\" \"index.html\" \"vite.config.ts\"",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "ci": "npm run build && npm run test"
+    "ci": "npm run lint && npm run format && npm run build && npm run test"
   },
   "dependencies": {
     "@fontsource/outfit": "^5.2.8",
@@ -23,16 +30,25 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.20",
+    "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^16.5.0",
     "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
+    "prettier": "^3.8.3",
     "tailwindcss": "^3.4.16",
     "typescript": "~5.7.2",
+    "typescript-eslint": "^8.59.1",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
   }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "ci": "npm run build && npm run test"
   },
   "dependencies": {
+    "@fontsource/outfit": "^5.2.8",
     "@tanstack/react-query": "^5.62.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -10,8 +10,11 @@ export function AppProviders({ children }: { children: ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 30_000,
-            retry: false,
+            retry: 1,
             refetchOnWindowFocus: true,
+          },
+          mutations: {
+            retry: false,
           },
         },
       }),
@@ -21,7 +24,8 @@ export function AppProviders({ children }: { children: ReactNode }) {
       client.setQueryData(qk.me, null);
       void client.cancelQueries({ queryKey: qk.me });
       if (window.location.pathname.startsWith("/app")) {
-        window.location.assign("/login?session=expired");
+        window.history.replaceState(null, "", "/login?session=expired");
+        window.dispatchEvent(new PopStateEvent("popstate"));
       }
     });
     return () => setUnauthorizedHandler(null);

--- a/apps/web/src/app/require-setup-wizard.tsx
+++ b/apps/web/src/app/require-setup-wizard.tsx
@@ -13,7 +13,9 @@ export function RequireSetupWizard() {
     return <Outlet />;
   }
 
-  const wizardState = (settingsQ.data.setup_wizard_state || "pending").trim().toLowerCase();
+  const wizardState = (settingsQ.data.setup_wizard_state || "pending")
+    .trim()
+    .toLowerCase();
   if (wizardState === "pending" && location.pathname !== "/app/setup-wizard") {
     return <Navigate to="/app/setup-wizard" replace />;
   }

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,4 +1,8 @@
-import { Navigate, RouterProvider, createBrowserRouter } from "react-router-dom";
+import {
+  Navigate,
+  RouterProvider,
+  createBrowserRouter,
+} from "react-router-dom";
 import { RouteErrorScreen } from "../components/error-boundary";
 import { AppShell } from "../layouts/app-shell";
 import { RequireAuth } from "./require-auth";
@@ -8,17 +12,23 @@ const routeErrorElement = <RouteErrorScreen />;
 const router = createBrowserRouter([
   {
     path: "/",
-    lazy: async () => ({ Component: (await import("../pages/root-entry")).RootEntry }),
+    lazy: async () => ({
+      Component: (await import("../pages/root-entry")).RootEntry,
+    }),
     errorElement: routeErrorElement,
   },
   {
     path: "/login",
-    lazy: async () => ({ Component: (await import("../pages/auth/login-page")).LoginPage }),
+    lazy: async () => ({
+      Component: (await import("../pages/auth/login-page")).LoginPage,
+    }),
     errorElement: routeErrorElement,
   },
   {
     path: "/setup",
-    lazy: async () => ({ Component: (await import("../pages/setup/setup-page")).SetupPage }),
+    lazy: async () => ({
+      Component: (await import("../pages/setup/setup-page")).SetupPage,
+    }),
     errorElement: routeErrorElement,
   },
   {
@@ -28,7 +38,10 @@ const router = createBrowserRouter([
     children: [
       {
         path: "setup-wizard",
-        lazy: async () => ({ Component: (await import("../pages/setup/setup-wizard-page")).SetupWizardPage }),
+        lazy: async () => ({
+          Component: (await import("../pages/setup/setup-wizard-page"))
+            .SetupWizardPage,
+        }),
         errorElement: routeErrorElement,
       },
       {
@@ -41,17 +54,26 @@ const router = createBrowserRouter([
             children: [
               {
                 index: true,
-                lazy: async () => ({ Component: (await import("../pages/dashboard/dashboard-page")).DashboardPage }),
+                lazy: async () => ({
+                  Component: (await import("../pages/dashboard/dashboard-page"))
+                    .DashboardPage,
+                }),
                 errorElement: routeErrorElement,
               },
               {
                 path: "activity",
-                lazy: async () => ({ Component: (await import("../pages/activity/activity-page")).ActivityPage }),
+                lazy: async () => ({
+                  Component: (await import("../pages/activity/activity-page"))
+                    .ActivityPage,
+                }),
                 errorElement: routeErrorElement,
               },
               {
                 path: "refiner",
-                lazy: async () => ({ Component: (await import("../pages/refiner/refiner-page")).RefinerPage }),
+                lazy: async () => ({
+                  Component: (await import("../pages/refiner/refiner-page"))
+                    .RefinerPage,
+                }),
                 errorElement: routeErrorElement,
               },
               {
@@ -61,42 +83,65 @@ const router = createBrowserRouter([
                   {
                     index: true,
                     lazy: async () => ({
-                      Component: (await import("../pages/pruner/pruner-instances-list-page")).PrunerInstancesListPage,
+                      Component: (
+                        await import("../pages/pruner/pruner-instances-list-page")
+                      ).PrunerInstancesListPage,
                     }),
                     errorElement: routeErrorElement,
                   },
                   {
                     path: "instances/:instanceId",
-                    lazy: async () => ({ Component: (await import("../pages/pruner/pruner-instance-shell")).PrunerInstanceShell }),
+                    lazy: async () => ({
+                      Component: (
+                        await import("../pages/pruner/pruner-instance-shell")
+                      ).PrunerInstanceShell,
+                    }),
                     errorElement: routeErrorElement,
                     children: [
-                      { index: true, element: <Navigate to="overview" replace /> },
+                      {
+                        index: true,
+                        element: <Navigate to="overview" replace />,
+                      },
                       {
                         path: "overview",
                         lazy: async () => ({
-                          Component: (await import("../pages/pruner/pruner-instance-overview-tab")).PrunerInstanceOverviewTab,
+                          Component: (
+                            await import("../pages/pruner/pruner-instance-overview-tab")
+                          ).PrunerInstanceOverviewTab,
                         }),
                         errorElement: routeErrorElement,
                       },
                       {
                         path: "tv",
                         lazy: async () => {
-                          const mod = await import("../pages/pruner/pruner-scope-tab");
-                          return { Component: () => <mod.PrunerScopeTab scope="tv" /> };
+                          const mod =
+                            await import("../pages/pruner/pruner-scope-tab");
+                          return {
+                            Component: () => <mod.PrunerScopeTab scope="tv" />,
+                          };
                         },
                         errorElement: routeErrorElement,
                       },
                       {
                         path: "movies",
                         lazy: async () => {
-                          const mod = await import("../pages/pruner/pruner-scope-tab");
-                          return { Component: () => <mod.PrunerScopeTab scope="movies" /> };
+                          const mod =
+                            await import("../pages/pruner/pruner-scope-tab");
+                          return {
+                            Component: () => (
+                              <mod.PrunerScopeTab scope="movies" />
+                            ),
+                          };
                         },
                         errorElement: routeErrorElement,
                       },
                       {
                         path: "connection",
-                        lazy: async () => ({ Component: (await import("../pages/pruner/pruner-connection-tab")).PrunerConnectionTab }),
+                        lazy: async () => ({
+                          Component: (
+                            await import("../pages/pruner/pruner-connection-tab")
+                          ).PrunerConnectionTab,
+                        }),
                         errorElement: routeErrorElement,
                       },
                     ],
@@ -105,12 +150,18 @@ const router = createBrowserRouter([
               },
               {
                 path: "subber",
-                lazy: async () => ({ Component: (await import("../pages/subber/subber-page")).SubberPage }),
+                lazy: async () => ({
+                  Component: (await import("../pages/subber/subber-page"))
+                    .SubberPage,
+                }),
                 errorElement: routeErrorElement,
               },
               {
                 path: "settings",
-                lazy: async () => ({ Component: (await import("../pages/settings/settings-page")).SettingsPage }),
+                lazy: async () => ({
+                  Component: (await import("../pages/settings/settings-page"))
+                    .SettingsPage,
+                }),
                 errorElement: routeErrorElement,
               },
             ],
@@ -119,14 +170,20 @@ const router = createBrowserRouter([
       },
     ],
   },
-  { path: "*", element: <Navigate to="/" replace />, errorElement: routeErrorElement },
+  {
+    path: "*",
+    element: <Navigate to="/" replace />,
+    errorElement: routeErrorElement,
+  },
 ]);
 
 function RouteLoadingScreen() {
   return (
     <main className="min-h-screen bg-[var(--mm-bg)] px-6 py-10 text-[var(--mm-text)]">
       <div className="mx-auto flex min-h-[70vh] max-w-xl flex-col justify-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--mm-accent)]">MediaMop</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--mm-accent)]">
+          MediaMop
+        </p>
         <h1 className="mt-4 text-3xl font-semibold">Loading view...</h1>
       </div>
     </main>
@@ -134,5 +191,7 @@ function RouteLoadingScreen() {
 }
 
 export function AppRouter() {
-  return <RouterProvider router={router} fallbackElement={<RouteLoadingScreen />} />;
+  return (
+    <RouterProvider router={router} fallbackElement={<RouteLoadingScreen />} />
+  );
 }

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,68 +1,138 @@
-import { createBrowserRouter, Navigate, RouterProvider } from "react-router-dom";
+import { Navigate, RouterProvider, createBrowserRouter } from "react-router-dom";
+import { RouteErrorScreen } from "../components/error-boundary";
 import { AppShell } from "../layouts/app-shell";
-import { ActivityPage } from "../pages/activity/activity-page";
-import { DashboardPage } from "../pages/dashboard/dashboard-page";
-import { LoginPage } from "../pages/auth/login-page";
-import { RefinerPage } from "../pages/refiner/refiner-page";
-import { RootEntry } from "../pages/root-entry";
-import { SettingsPage } from "../pages/settings/settings-page";
-import { SetupPage } from "../pages/setup/setup-page";
-import { SetupWizardPage } from "../pages/setup/setup-wizard-page";
-import { SubberPage } from "../pages/subber/subber-page";
-import { PrunerConnectionTab } from "../pages/pruner/pruner-connection-tab";
-import { PrunerInstanceOverviewTab } from "../pages/pruner/pruner-instance-overview-tab";
-import { PrunerInstanceShell } from "../pages/pruner/pruner-instance-shell";
-import { PrunerInstancesListPage } from "../pages/pruner/pruner-instances-list-page";
-import { PrunerScopeTab } from "../pages/pruner/pruner-scope-tab";
 import { RequireAuth } from "./require-auth";
 import { RequireSetupWizard } from "./require-setup-wizard";
 
+const routeErrorElement = <RouteErrorScreen />;
 const router = createBrowserRouter([
-  { path: "/", element: <RootEntry /> },
-  { path: "/login", element: <LoginPage /> },
-  { path: "/setup", element: <SetupPage /> },
+  {
+    path: "/",
+    lazy: async () => ({ Component: (await import("../pages/root-entry")).RootEntry }),
+    errorElement: routeErrorElement,
+  },
+  {
+    path: "/login",
+    lazy: async () => ({ Component: (await import("../pages/auth/login-page")).LoginPage }),
+    errorElement: routeErrorElement,
+  },
+  {
+    path: "/setup",
+    lazy: async () => ({ Component: (await import("../pages/setup/setup-page")).SetupPage }),
+    errorElement: routeErrorElement,
+  },
   {
     path: "/app",
     element: <RequireAuth />,
+    errorElement: routeErrorElement,
     children: [
-      { path: "setup-wizard", element: <SetupWizardPage /> },
+      {
+        path: "setup-wizard",
+        lazy: async () => ({ Component: (await import("../pages/setup/setup-wizard-page")).SetupWizardPage }),
+        errorElement: routeErrorElement,
+      },
       {
         element: <RequireSetupWizard />,
+        errorElement: routeErrorElement,
         children: [
           {
             element: <AppShell />,
+            errorElement: routeErrorElement,
             children: [
-              { index: true, element: <DashboardPage /> },
-              { path: "activity", element: <ActivityPage /> },
-              { path: "refiner", element: <RefinerPage /> },
+              {
+                index: true,
+                lazy: async () => ({ Component: (await import("../pages/dashboard/dashboard-page")).DashboardPage }),
+                errorElement: routeErrorElement,
+              },
+              {
+                path: "activity",
+                lazy: async () => ({ Component: (await import("../pages/activity/activity-page")).ActivityPage }),
+                errorElement: routeErrorElement,
+              },
+              {
+                path: "refiner",
+                lazy: async () => ({ Component: (await import("../pages/refiner/refiner-page")).RefinerPage }),
+                errorElement: routeErrorElement,
+              },
               {
                 path: "pruner",
+                errorElement: routeErrorElement,
                 children: [
-                  { index: true, element: <PrunerInstancesListPage /> },
+                  {
+                    index: true,
+                    lazy: async () => ({
+                      Component: (await import("../pages/pruner/pruner-instances-list-page")).PrunerInstancesListPage,
+                    }),
+                    errorElement: routeErrorElement,
+                  },
                   {
                     path: "instances/:instanceId",
-                    element: <PrunerInstanceShell />,
+                    lazy: async () => ({ Component: (await import("../pages/pruner/pruner-instance-shell")).PrunerInstanceShell }),
+                    errorElement: routeErrorElement,
                     children: [
                       { index: true, element: <Navigate to="overview" replace /> },
-                      { path: "overview", element: <PrunerInstanceOverviewTab /> },
-                      { path: "tv", element: <PrunerScopeTab scope="tv" /> },
-                      { path: "movies", element: <PrunerScopeTab scope="movies" /> },
-                      { path: "connection", element: <PrunerConnectionTab /> },
+                      {
+                        path: "overview",
+                        lazy: async () => ({
+                          Component: (await import("../pages/pruner/pruner-instance-overview-tab")).PrunerInstanceOverviewTab,
+                        }),
+                        errorElement: routeErrorElement,
+                      },
+                      {
+                        path: "tv",
+                        lazy: async () => {
+                          const mod = await import("../pages/pruner/pruner-scope-tab");
+                          return { Component: () => <mod.PrunerScopeTab scope="tv" /> };
+                        },
+                        errorElement: routeErrorElement,
+                      },
+                      {
+                        path: "movies",
+                        lazy: async () => {
+                          const mod = await import("../pages/pruner/pruner-scope-tab");
+                          return { Component: () => <mod.PrunerScopeTab scope="movies" /> };
+                        },
+                        errorElement: routeErrorElement,
+                      },
+                      {
+                        path: "connection",
+                        lazy: async () => ({ Component: (await import("../pages/pruner/pruner-connection-tab")).PrunerConnectionTab }),
+                        errorElement: routeErrorElement,
+                      },
                     ],
                   },
                 ],
               },
-              { path: "subber", element: <SubberPage /> },
-              { path: "settings", element: <SettingsPage /> },
+              {
+                path: "subber",
+                lazy: async () => ({ Component: (await import("../pages/subber/subber-page")).SubberPage }),
+                errorElement: routeErrorElement,
+              },
+              {
+                path: "settings",
+                lazy: async () => ({ Component: (await import("../pages/settings/settings-page")).SettingsPage }),
+                errorElement: routeErrorElement,
+              },
             ],
           },
         ],
       },
     ],
   },
-  { path: "*", element: <Navigate to="/" replace /> },
+  { path: "*", element: <Navigate to="/" replace />, errorElement: routeErrorElement },
 ]);
 
+function RouteLoadingScreen() {
+  return (
+    <main className="min-h-screen bg-[var(--mm-bg)] px-6 py-10 text-[var(--mm-text)]">
+      <div className="mx-auto flex min-h-[70vh] max-w-xl flex-col justify-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--mm-accent)]">MediaMop</p>
+        <h1 className="mt-4 text-3xl font-semibold">Loading view...</h1>
+      </div>
+    </main>
+  );
+}
+
 export function AppRouter() {
-  return <RouterProvider router={router} />;
+  return <RouterProvider router={router} fallbackElement={<RouteLoadingScreen />} />;
 }

--- a/apps/web/src/app/startup-gate.test.tsx
+++ b/apps/web/src/app/startup-gate.test.tsx
@@ -21,7 +21,13 @@ describe("StartupGate", () => {
           ready: false,
           status: "starting",
           startup_seconds: 0.1,
-          steps: [{ name: "database", status: "starting", detail: "Preparing database." }],
+          steps: [
+            {
+              name: "database",
+              status: "starting",
+              detail: "Preparing database.",
+            },
+          ],
         }),
       })),
     );
@@ -60,7 +66,9 @@ describe("StartupGate", () => {
       </StartupGate>,
     );
 
-    await waitFor(() => expect(screen.getByText("App mounted")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("App mounted")).toBeInTheDocument(),
+    );
     expect(screen.queryByText("Starting MediaMop...")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/startup-gate.tsx
+++ b/apps/web/src/app/startup-gate.tsx
@@ -64,7 +64,8 @@ export function StartupGate({ children }: { children: ReactNode }) {
         if (elapsedMs >= STARTUP_TIMEOUT_MS) {
           setState({
             kind: "failed",
-            message: "MediaMop did not become ready in time. Check that the MediaMop server is still running, then refresh.",
+            message:
+              "MediaMop did not become ready in time. Check that the MediaMop server is still running, then refresh.",
             steps: payload.steps ?? [],
           });
           return;
@@ -84,7 +85,8 @@ export function StartupGate({ children }: { children: ReactNode }) {
         if (elapsedMs >= STARTUP_TIMEOUT_MS) {
           setState({
             kind: "failed",
-            message: "MediaMop did not respond in time. Check that the MediaMop server is running, then refresh.",
+            message:
+              "MediaMop did not respond in time. Check that the MediaMop server is running, then refresh.",
             steps: [],
           });
           return;
@@ -121,38 +123,55 @@ export function StartupGate({ children }: { children: ReactNode }) {
   return (
     <main className="min-h-screen bg-[var(--mm-bg)] px-6 py-10 text-[var(--mm-text)]">
       <div className="mx-auto flex min-h-[70vh] max-w-xl flex-col justify-center">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--mm-accent)]">MediaMop</p>
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[var(--mm-accent)]">
+          MediaMop
+        </p>
         <h1 className="mt-4 text-3xl font-semibold">{state.message}</h1>
         <p className="mt-3 text-sm leading-6 text-[var(--mm-text3)]">
-          Preparing the local database, background workers, and schedules before opening the app.
+          Preparing the local database, background workers, and schedules before
+          opening the app.
         </p>
         <div className="mt-6 rounded border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-4">
           <div className="h-2 overflow-hidden rounded-full bg-[var(--mm-input-bg)]">
             <div
               className="h-full rounded-full bg-[var(--mm-accent)] transition-all"
-              style={{ width: state.kind === "failed" ? "100%" : `${Math.min(90, 20 + state.elapsedMs / 750)}%` }}
+              style={{
+                width:
+                  state.kind === "failed"
+                    ? "100%"
+                    : `${Math.min(90, 20 + state.elapsedMs / 750)}%`,
+              }}
             />
           </div>
           <ul className="mt-4 space-y-3 text-sm">
-            {(state.steps.length ? state.steps : [{ name: "server", status: "starting", detail: "Waiting for MediaMop to start." }]).map(
-              (step) => (
-                <li key={step.name} className="flex gap-3">
-                  <span
-                    className={
-                      step.status === "ready"
-                        ? "mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"
-                        : state.kind === "failed"
-                          ? "mt-1 h-2.5 w-2.5 rounded-full bg-red-400"
-                          : "mt-1 h-2.5 w-2.5 rounded-full bg-[var(--mm-accent)]"
-                    }
-                  />
-                  <span>
-                    <span className="block font-semibold capitalize text-[var(--mm-text)]">{step.name}</span>
-                    <span className="text-[var(--mm-text3)]">{step.detail}</span>
+            {(state.steps.length
+              ? state.steps
+              : [
+                  {
+                    name: "server",
+                    status: "starting",
+                    detail: "Waiting for MediaMop to start.",
+                  },
+                ]
+            ).map((step) => (
+              <li key={step.name} className="flex gap-3">
+                <span
+                  className={
+                    step.status === "ready"
+                      ? "mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"
+                      : state.kind === "failed"
+                        ? "mt-1 h-2.5 w-2.5 rounded-full bg-red-400"
+                        : "mt-1 h-2.5 w-2.5 rounded-full bg-[var(--mm-accent)]"
+                  }
+                />
+                <span>
+                  <span className="block font-semibold capitalize text-[var(--mm-text)]">
+                    {step.name}
                   </span>
-                </li>
-              ),
-            )}
+                  <span className="text-[var(--mm-text3)]">{step.detail}</span>
+                </span>
+              </li>
+            ))}
           </ul>
         </div>
         {state.kind === "failed" ? (

--- a/apps/web/src/components/brand/auth-brand-stack.tsx
+++ b/apps/web/src/components/brand/auth-brand-stack.tsx
@@ -7,7 +7,9 @@ export function AuthBrandStack() {
       <div className="mm-auth-brand-logo">
         <MediaMopLogo variant="auth" />
       </div>
-      <p className="mm-auth-brand-tagline">Keep your library clean and under control.</p>
+      <p className="mm-auth-brand-tagline">
+        Keep your library clean and under control.
+      </p>
     </div>
   );
 }

--- a/apps/web/src/components/brand/brand-header-link.tsx
+++ b/apps/web/src/components/brand/brand-header-link.tsx
@@ -3,7 +3,10 @@ import { MediaMopLogo } from "./mediamop-logo";
 
 type Props = { to?: string; productTitle?: string };
 
-export function BrandHeaderLink({ to = "/app", productTitle = "MediaMop" }: Props) {
+export function BrandHeaderLink({
+  to = "/app",
+  productTitle = "MediaMop",
+}: Props) {
   const label = `${productTitle} home`;
   return (
     <Link to={to} className="mm-sidebar-brand" aria-label={label}>
@@ -11,7 +14,9 @@ export function BrandHeaderLink({ to = "/app", productTitle = "MediaMop" }: Prop
         <MediaMopLogo variant="sidebar" />
       </div>
       <p className="mm-sidebar-product-title">{productTitle}</p>
-      <p className="mm-sidebar-tagline">Keep your library clean and under control.</p>
+      <p className="mm-sidebar-tagline">
+        Keep your library clean and under control.
+      </p>
     </Link>
   );
 }

--- a/apps/web/src/components/error-boundary.test.tsx
+++ b/apps/web/src/components/error-boundary.test.tsx
@@ -31,15 +31,26 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>,
     );
 
-    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Something went wrong" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Route render failed")).toBeInTheDocument();
-    expect(screen.getByRole("navigation", { name: "Unavailable sections" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reload MediaMop" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: "Unavailable sections" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reload MediaMop" }),
+    ).toBeInTheDocument();
   });
 
   it("lets the user trigger reload from the fallback", () => {
     const onReload = vi.fn();
-    render(<AppErrorScreen error={new Error("Bad route state")} onReload={onReload} />);
+    render(
+      <AppErrorScreen
+        error={new Error("Bad route state")}
+        onReload={onReload}
+      />,
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Reload MediaMop" }));
 

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -10,7 +10,10 @@ type ErrorBoundaryProps = {
   fallback?: ReactNode | ((error: Error) => ReactNode);
 };
 
-export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
   state: ErrorBoundaryState = { error: null };
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
@@ -34,7 +37,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 }
 
-export function AppErrorScreen({ error, onReload }: { error: Error; onReload?: () => void }) {
+export function AppErrorScreen({
+  error,
+  onReload,
+}: {
+  error: Error;
+  onReload?: () => void;
+}) {
   const reload = onReload ?? (() => window.location.reload());
 
   return (
@@ -57,10 +66,14 @@ export function AppErrorScreen({ error, onReload }: { error: Error; onReload?: (
           <p className="mm-section-kicker">Application recovery</p>
           <h1 id="app-error-title">Something went wrong</h1>
           <p className="mm-muted">
-            MediaMop hit a screen error before it could finish loading this view. Reloading usually clears a
-            temporary browser state problem.
+            MediaMop hit a screen error before it could finish loading this
+            view. Reloading usually clears a temporary browser state problem.
           </p>
-          <button className="mm-btn mm-btn-primary" type="button" onClick={reload}>
+          <button
+            className="mm-btn mm-btn-primary"
+            type="button"
+            onClick={reload}
+          >
             Reload MediaMop
           </button>
           <details className="mm-error-details">
@@ -78,7 +91,9 @@ function routeErrorToError(error: unknown): Error {
     return error;
   }
   if (isRouteErrorResponse(error)) {
-    return new Error(error.statusText || error.data || `Route error ${error.status}`);
+    return new Error(
+      error.statusText || error.data || `Route error ${error.status}`,
+    );
   }
   if (typeof error === "string" && error.trim()) {
     return new Error(error);

--- a/apps/web/src/components/error-boundary.tsx
+++ b/apps/web/src/components/error-boundary.tsx
@@ -1,4 +1,5 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
+import { isRouteErrorResponse, useRouteError } from "react-router-dom";
 
 type ErrorBoundaryState = {
   error: Error | null;
@@ -70,4 +71,22 @@ export function AppErrorScreen({ error, onReload }: { error: Error; onReload?: (
       </div>
     </main>
   );
+}
+
+function routeErrorToError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (isRouteErrorResponse(error)) {
+    return new Error(error.statusText || error.data || `Route error ${error.status}`);
+  }
+  if (typeof error === "string" && error.trim()) {
+    return new Error(error);
+  }
+  return new Error("Unknown route error");
+}
+
+export function RouteErrorScreen() {
+  const routeError = useRouteError();
+  return <AppErrorScreen error={routeErrorToError(routeError)} />;
 }

--- a/apps/web/src/components/overview/mm-overview-cards.tsx
+++ b/apps/web/src/components/overview/mm-overview-cards.tsx
@@ -37,7 +37,9 @@ export function MmAtGlanceCard({
       className={[
         "flex min-h-0 min-w-0 flex-col rounded-md border border-[var(--mm-border)] text-sm 2xl:text-[0.9375rem] 2xl:leading-relaxed min-[1760px]:text-base min-[1760px]:leading-relaxed",
         fillRowHeight ? "h-full" : "h-auto self-start w-full",
-        large ? "gap-4 p-5 lg:gap-5 lg:p-6 2xl:gap-5 2xl:p-6" : "gap-3.5 p-5 lg:gap-4 lg:p-6 2xl:gap-4 2xl:p-6",
+        large
+          ? "gap-4 p-5 lg:gap-5 lg:p-6 2xl:gap-5 2xl:p-6"
+          : "gap-3.5 p-5 lg:gap-4 lg:p-6 2xl:gap-4 2xl:p-6",
         emphasis
           ? "bg-[var(--mm-card-bg)] shadow-[inset_0_1px_0_0_rgba(255,255,255,0.04)]"
           : "bg-[var(--mm-card-bg)]/70",
@@ -67,7 +69,10 @@ export function MmAtGlanceCard({
       </div>
       {footer ? (
         <div
-          className={["mt-auto border-t border-[var(--mm-border)]", large ? "pt-4 lg:pt-5" : "pt-3"].join(" ")}
+          className={[
+            "mt-auto border-t border-[var(--mm-border)]",
+            large ? "pt-4 lg:pt-5" : "pt-3",
+          ].join(" ")}
         >
           {footer}
         </div>
@@ -138,7 +143,10 @@ export function MmOverviewSection({
       data-testid={dataTestId}
       data-overview-order={dataOverviewOrder}
     >
-      <h2 id={headingId} className="mm-card__title text-lg 2xl:text-xl min-[1760px]:text-2xl">
+      <h2
+        id={headingId}
+        className="mm-card__title text-lg 2xl:text-xl min-[1760px]:text-2xl"
+      >
         {heading}
       </h2>
       <div className="mm-card__body mt-5">{children}</div>
@@ -181,7 +189,9 @@ export function MmNeedsAttentionList({
 }) {
   if (items.length === 0) {
     return (
-      <p className="text-sm text-[var(--mm-text1)] 2xl:text-[0.9375rem] min-[1760px]:text-base">{emptyMessage}</p>
+      <p className="text-sm text-[var(--mm-text1)] 2xl:text-[0.9375rem] min-[1760px]:text-base">
+        {emptyMessage}
+      </p>
     );
   }
   return (
@@ -196,7 +206,11 @@ export function MmNeedsAttentionList({
           </li>
         ))}
       </ul>
-      {actions ? <div className="mt-5 flex flex-wrap gap-2.5 border-t border-[var(--mm-border)] pt-4">{actions}</div> : null}
+      {actions ? (
+        <div className="mt-5 flex flex-wrap gap-2.5 border-t border-[var(--mm-border)] pt-4">
+          {actions}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -211,7 +225,11 @@ export function MmNextStepsButton({
   onClick: () => void;
 }) {
   return (
-    <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={onClick}>
+    <button
+      type="button"
+      className={mmActionButtonClass({ variant: "secondary" })}
+      onClick={onClick}
+    >
       {label}
     </button>
   );

--- a/apps/web/src/components/shared/api-entry-error.tsx
+++ b/apps/web/src/components/shared/api-entry-error.tsx
@@ -13,24 +13,31 @@ export function ApiEntryError({ error }: { error: unknown }) {
   if (isLikelyNetworkFailure(error) || isLikelyViteProxyUpstreamDown(error)) {
     return (
       <>
-        <h1 className="mm-auth-title mm-auth-title--alert">Cannot reach the API</h1>
+        <h1 className="mm-auth-title mm-auth-title--alert">
+          Cannot reach the API
+        </h1>
         {isLikelyViteProxyUpstreamDown(error) ? (
           <p className="mm-auth-lead">
-            With Vite alone, <code className="text-[0.85em]">/api</code> is proxied to the API port. If
-            nothing is listening there, the dev server often returns <strong>HTTP 500</strong> — that
-            means the API is not up, not a handler bug inside MediaMop.
+            With Vite alone, <code className="text-[0.85em]">/api</code> is
+            proxied to the API port. If nothing is listening there, the dev
+            server often returns <strong>HTTP 500</strong> — that means the API
+            is not up, not a handler bug inside MediaMop.
           </p>
         ) : null}
         <p className="mm-auth-lead">
-          <strong>Easiest:</strong> from <code className="text-[0.85em]">apps/web</code>, run{" "}
+          <strong>Easiest:</strong> from{" "}
+          <code className="text-[0.85em]">apps/web</code>, run{" "}
           <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
             npm run dev
           </code>{" "}
-          — it starts the API, waits until <code className="text-[0.85em]">GET /health</code> succeeds, then
+          — it starts the API, waits until{" "}
+          <code className="text-[0.85em]">GET /health</code> succeeds, then
           starts Vite (ports in{" "}
           <code className="text-[0.85em]">scripts/dev-ports.json</code>
-          ). If you still see this screen, the API never became ready: read the same terminal for Python
-          errors (venv, <code className="text-[0.85em]">MEDIAMOP_SESSION_SECRET</code>, migrations).
+          ). If you still see this screen, the API never became ready: read the
+          same terminal for Python errors (venv,{" "}
+          <code className="text-[0.85em]">MEDIAMOP_SESSION_SECRET</code>,
+          migrations).
         </p>
         <p className="mm-auth-lead">
           <strong>Alternative:</strong> two terminals from the repo root —{" "}
@@ -48,7 +55,8 @@ export function ApiEntryError({ error }: { error: unknown }) {
           in <code className="text-[0.85em]">apps/web</code> for Vite only.
         </p>
         <p className="mm-auth-lead">
-          During <code className="text-[0.85em]">vite dev</code>, the app always uses relative{" "}
+          During <code className="text-[0.85em]">vite dev</code>, the app always
+          uses relative{" "}
           <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
             /api/v1
           </code>{" "}
@@ -71,7 +79,9 @@ export function ApiEntryError({ error }: { error: unknown }) {
     if (status === 503) {
       return (
         <>
-          <h1 className="mm-auth-title mm-auth-title--caution">API is running but not ready</h1>
+          <h1 className="mm-auth-title mm-auth-title--caution">
+            API is running but not ready
+          </h1>
           <p className="mm-auth-lead">
             Auth routes need a migrated SQLite database under{" "}
             <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
@@ -93,28 +103,39 @@ export function ApiEntryError({ error }: { error: unknown }) {
             <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
               alembic upgrade head
             </code>{" "}
-            from <code className="text-[0.85em]">apps/backend</code> with <code className="text-[0.85em]">PYTHONPATH=src</code>
-            ), then restart the backend. See <code className="text-[0.85em]">apps/backend/.env.example</code> and{" "}
+            from <code className="text-[0.85em]">apps/backend</code> with{" "}
+            <code className="text-[0.85em]">PYTHONPATH=src</code>
+            ), then restart the backend. See{" "}
+            <code className="text-[0.85em]">
+              apps/backend/.env.example
+            </code> and{" "}
             <code className="text-[0.85em]">docs/local-development.md</code>.
           </p>
           <p className="mm-auth-lead">
             <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
               GET /health
             </code>{" "}
-            can still return 200 while <code className="text-[0.85em]">/api/v1</code> returns 503 if migrations, session secret, or the database path are not ready.
+            can still return 200 while{" "}
+            <code className="text-[0.85em]">/api/v1</code> returns 503 if
+            migrations, session secret, or the database path are not ready.
           </p>
         </>
       );
     }
     return (
       <>
-        <h1 className="mm-auth-title mm-auth-title--alert">Unexpected API error</h1>
+        <h1 className="mm-auth-title mm-auth-title--alert">
+          Unexpected API error
+        </h1>
         <p className="mm-auth-lead">
           The server responded but the request failed
-          {status != null ? ` (HTTP ${status})` : ""}. Check the backend terminal for details.
+          {status != null ? ` (HTTP ${status})` : ""}. Check the backend
+          terminal for details.
         </p>
         {error instanceof Error ? (
-          <p className="mm-auth-lead font-mono text-sm text-[var(--mm-text3)]">{error.message}</p>
+          <p className="mm-auth-lead font-mono text-sm text-[var(--mm-text3)]">
+            {error.message}
+          </p>
         ) : null}
       </>
     );
@@ -122,16 +143,21 @@ export function ApiEntryError({ error }: { error: unknown }) {
 
   return (
     <>
-      <h1 className="mm-auth-title mm-auth-title--alert">Cannot load the app</h1>
+      <h1 className="mm-auth-title mm-auth-title--alert">
+        Cannot load the app
+      </h1>
       <p className="mm-auth-lead">
-        Something went wrong talking to the API. From <code className="text-[0.85em]">apps/web</code> try{" "}
+        Something went wrong talking to the API. From{" "}
+        <code className="text-[0.85em]">apps/web</code> try{" "}
         <code className="rounded bg-[rgba(0,0,0,0.35)] px-1.5 py-0.5 text-[0.85em] text-[var(--mm-text)]">
           npm run dev
         </code>{" "}
         (API + Vite), or confirm the backend is running, then reload.
       </p>
       {error instanceof Error ? (
-        <p className="mm-auth-lead font-mono text-sm text-[var(--mm-text3)]">{error.message}</p>
+        <p className="mm-auth-lead font-mono text-sm text-[var(--mm-text3)]">
+          {error.message}
+        </p>
       ) : null}
     </>
   );

--- a/apps/web/src/components/shell/nav-icons.tsx
+++ b/apps/web/src/components/shell/nav-icons.tsx
@@ -65,7 +65,13 @@ export function NavIconActivity({ className = "" }: { className?: string }) {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <circle cx="12" cy="12" r="8.25" stroke="currentColor" strokeWidth="1.35" />
+      <circle
+        cx="12"
+        cy="12"
+        r="8.25"
+        stroke="currentColor"
+        strokeWidth="1.35"
+      />
     </svg>
   );
 }
@@ -81,7 +87,12 @@ export function NavIconRefiner({ className = "" }: { className?: string }) {
       xmlns="http://www.w3.org/2000/svg"
       aria-hidden="true"
     >
-      <path d="M3 21h18" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
+      <path
+        d="M3 21h18"
+        stroke="currentColor"
+        strokeWidth="1.35"
+        strokeLinecap="round"
+      />
       <path
         d="M5 21V15L7.5 10 10 15V21H5z"
         stroke="currentColor"
@@ -116,10 +127,32 @@ export function NavIconPruner({ className = "" }: { className?: string }) {
       aria-hidden="true"
     >
       <circle cx="8" cy="17" r="2.4" stroke="currentColor" strokeWidth="1.35" />
-      <circle cx="16" cy="17" r="2.4" stroke="currentColor" strokeWidth="1.35" />
-      <path d="M9.7 15.8L14 6.5" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-      <path d="M14.3 15.8L10 6.5" stroke="currentColor" strokeWidth="1.35" strokeLinecap="round" />
-      <circle cx="12" cy="6.75" r="1.1" stroke="currentColor" strokeWidth="1.2" />
+      <circle
+        cx="16"
+        cy="17"
+        r="2.4"
+        stroke="currentColor"
+        strokeWidth="1.35"
+      />
+      <path
+        d="M9.7 15.8L14 6.5"
+        stroke="currentColor"
+        strokeWidth="1.35"
+        strokeLinecap="round"
+      />
+      <path
+        d="M14.3 15.8L10 6.5"
+        stroke="currentColor"
+        strokeWidth="1.35"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="12"
+        cy="6.75"
+        r="1.1"
+        stroke="currentColor"
+        strokeWidth="1.2"
+      />
     </svg>
   );
 }

--- a/apps/web/src/components/ui/mm-listbox-picker.tsx
+++ b/apps/web/src/components/ui/mm-listbox-picker.tsx
@@ -16,7 +16,11 @@ function useCloseOnOutsideAndEscape(
     }
     const onPointerDown = (event: MouseEvent) => {
       const target = event.target as Node | null;
-      if (containerRef.current && target && !containerRef.current.contains(target)) {
+      if (
+        containerRef.current &&
+        target &&
+        !containerRef.current.contains(target)
+      ) {
         setOpen(false);
       }
     };
@@ -84,7 +88,10 @@ export function MmListboxPicker({
     .join(" ");
 
   return (
-    <div ref={containerRef} className={["relative", className].filter(Boolean).join(" ")}>
+    <div
+      ref={containerRef}
+      className={["relative", className].filter(Boolean).join(" ")}
+    >
       <button
         type="button"
         className={triggerSurface}
@@ -101,12 +108,15 @@ export function MmListboxPicker({
           }
         }}
       >
-        <span className="min-w-0 flex-1 truncate text-left">{triggerLabel}</span>
+        <span className="min-w-0 flex-1 truncate text-left">
+          {triggerLabel}
+        </span>
         <svg
           aria-hidden
-          className={["h-4 w-4 shrink-0 text-[var(--mm-text3)] transition-transform", open ? "rotate-180" : ""].join(
-            " ",
-          )}
+          className={[
+            "h-4 w-4 shrink-0 text-[var(--mm-text3)] transition-transform",
+            open ? "rotate-180" : "",
+          ].join(" ")}
           viewBox="0 0 20 20"
           fill="currentColor"
         >

--- a/apps/web/src/components/ui/mm-multi-listbox-picker.tsx
+++ b/apps/web/src/components/ui/mm-multi-listbox-picker.tsx
@@ -17,7 +17,11 @@ function useCloseOnOutsideAndEscape(
     }
     const onPointerDown = (event: MouseEvent) => {
       const target = event.target as Node | null;
-      if (containerRef.current && target && !containerRef.current.contains(target)) {
+      if (
+        containerRef.current &&
+        target &&
+        !containerRef.current.contains(target)
+      ) {
         setOpen(false);
       }
     };
@@ -68,9 +72,15 @@ export function MmMultiListboxPicker({
   useCloseOnOutsideAndEscape(open, setOpen, containerRef);
 
   const selectedSet = new Set(values);
-  const selectedLabels = options.filter((o) => selectedSet.has(o.value)).map((o) => o.label);
+  const selectedLabels = options
+    .filter((o) => selectedSet.has(o.value))
+    .map((o) => o.label);
   const triggerLabel =
-    summaryText !== undefined ? summaryText : selectedLabels.length > 0 ? selectedLabels.join(", ") : placeholder;
+    summaryText !== undefined
+      ? summaryText
+      : selectedLabels.length > 0
+        ? selectedLabels.join(", ")
+        : placeholder;
   const triggerSurface = [
     mmPickerTriggerClass,
     "flex min-h-[2.5rem] items-center justify-between gap-2",
@@ -82,7 +92,10 @@ export function MmMultiListboxPicker({
     .join(" ");
 
   return (
-    <div ref={containerRef} className={["relative", className].filter(Boolean).join(" ")}>
+    <div
+      ref={containerRef}
+      className={["relative", className].filter(Boolean).join(" ")}
+    >
       <button
         type="button"
         className={triggerSurface}
@@ -99,12 +112,15 @@ export function MmMultiListboxPicker({
           }
         }}
       >
-        <span className="min-w-0 flex-1 truncate text-left">{triggerLabel}</span>
+        <span className="min-w-0 flex-1 truncate text-left">
+          {triggerLabel}
+        </span>
         <svg
           aria-hidden
-          className={["h-4 w-4 shrink-0 text-[var(--mm-text3)] transition-transform", open ? "rotate-180" : ""].join(
-            " ",
-          )}
+          className={[
+            "h-4 w-4 shrink-0 text-[var(--mm-text3)] transition-transform",
+            open ? "rotate-180" : "",
+          ].join(" ")}
           viewBox="0 0 20 20"
           fill="currentColor"
         >
@@ -112,7 +128,12 @@ export function MmMultiListboxPicker({
         </svg>
       </button>
       {open ? (
-        <div id={listboxId} className={mmListboxPanelClass} role="listbox" aria-multiselectable="true">
+        <div
+          id={listboxId}
+          className={mmListboxPanelClass}
+          role="listbox"
+          aria-multiselectable="true"
+        >
           {options.map((opt) => {
             const checked = selectedSet.has(opt.value);
             return (
@@ -134,11 +155,19 @@ export function MmMultiListboxPicker({
                 onClick={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
-                  const next = checked ? values.filter((v) => v !== opt.value) : [...values, opt.value];
+                  const next = checked
+                    ? values.filter((v) => v !== opt.value)
+                    : [...values, opt.value];
                   onChange(next);
                 }}
               >
-                <input type="checkbox" readOnly checked={checked} className={mmCheckboxControlClass} tabIndex={-1} />
+                <input
+                  type="checkbox"
+                  readOnly
+                  checked={checked}
+                  className={mmCheckboxControlClass}
+                  tabIndex={-1}
+                />
                 <span>{opt.label}</span>
               </button>
             );

--- a/apps/web/src/components/ui/mm-multi-option-rows.tsx
+++ b/apps/web/src/components/ui/mm-multi-option-rows.tsx
@@ -63,9 +63,13 @@ export function MmMultiOptionRows({
             onChange={(e) => opt.onCheckedChange(e.target.checked)}
           />
           <span className="min-w-0 flex-1">
-            <span className="block text-sm font-medium text-[var(--mm-text1)]">{opt.title}</span>
+            <span className="block text-sm font-medium text-[var(--mm-text1)]">
+              {opt.title}
+            </span>
             {opt.description ? (
-              <span className="mt-0.5 block text-xs leading-snug text-[var(--mm-text3)]">{opt.description}</span>
+              <span className="mt-0.5 block text-xs leading-snug text-[var(--mm-text3)]">
+                {opt.description}
+              </span>
             ) : null}
           </span>
         </label>

--- a/apps/web/src/components/ui/mm-on-off-switch.tsx
+++ b/apps/web/src/components/ui/mm-on-off-switch.tsx
@@ -24,36 +24,41 @@ export function MmOnOffSwitch({
       role="radiogroup"
       aria-labelledby={id}
     >
-        {(["On", "Off"] as const).map((side) => {
-          const isOn = side === "On";
-          const selected = enabled === isOn;
-          return (
-            <button
-              key={side}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              disabled={disabled}
-              onClick={() => onChange(isOn)}
-              className={[
-                "min-w-[3.25rem] rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
-                selected
-                  ? "bg-[var(--mm-accent-soft)] text-[var(--mm-text1)] shadow-[inset_0_0_0_1px_rgba(212,175,55,0.35)]"
-                  : "text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)]/70",
-                disabled ? "cursor-not-allowed opacity-50 hover:bg-transparent" : "",
-              ].join(" ")}
-            >
-              {side}
-            </button>
-          );
-        })}
+      {(["On", "Off"] as const).map((side) => {
+        const isOn = side === "On";
+        const selected = enabled === isOn;
+        return (
+          <button
+            key={side}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => onChange(isOn)}
+            className={[
+              "min-w-[3.25rem] rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              selected
+                ? "bg-[var(--mm-accent-soft)] text-[var(--mm-text1)] shadow-[inset_0_0_0_1px_rgba(212,175,55,0.35)]"
+                : "text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)]/70",
+              disabled
+                ? "cursor-not-allowed opacity-50 hover:bg-transparent"
+                : "",
+            ].join(" ")}
+          >
+            {side}
+          </button>
+        );
+      })}
     </div>
   );
 
   if (layout === "inline") {
     return (
       <div className="flex w-full min-w-0 flex-row items-center justify-between gap-4">
-        <span className="min-w-0 flex-1 text-sm font-medium text-[var(--mm-text1)]" id={id}>
+        <span
+          className="min-w-0 flex-1 text-sm font-medium text-[var(--mm-text1)]"
+          id={id}
+        >
           {label}
         </span>
         {control}

--- a/apps/web/src/components/ui/mm-schedule-window-controls.tsx
+++ b/apps/web/src/components/ui/mm-schedule-window-controls.tsx
@@ -12,7 +12,15 @@ export const MM_SCHEDULE_TIME_WINDOW_HELPER =
 export const MM_SCHEDULE_DAYS_HELPER =
   "Use a shortcut for common patterns, or tap days to turn them on or off. Every day means this window applies all week.";
 
-export const SCHEDULE_WEEKDAY_TOKENS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+export const SCHEDULE_WEEKDAY_TOKENS = [
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+  "Sun",
+] as const;
 
 export type ScheduleWeekdayToken = (typeof SCHEDULE_WEEKDAY_TOKENS)[number];
 
@@ -27,7 +35,9 @@ export function normalizeScheduleTimeForInput(hhmm: string): string {
   return `${String(h).padStart(2, "0")}:${String(min).padStart(2, "0")}`;
 }
 
-export function daySelectionFromScheduleDaysCsv(csv: string): Set<ScheduleWeekdayToken> {
+export function daySelectionFromScheduleDaysCsv(
+  csv: string,
+): Set<ScheduleWeekdayToken> {
   const raw = csv.trim();
   if (!raw) {
     return new Set(SCHEDULE_WEEKDAY_TOKENS);
@@ -42,7 +52,9 @@ export function daySelectionFromScheduleDaysCsv(csv: string): Set<ScheduleWeekda
   return next.size > 0 ? next : new Set(SCHEDULE_WEEKDAY_TOKENS);
 }
 
-export function scheduleCsvFromDaySelection(selected: Set<ScheduleWeekdayToken>): string {
+export function scheduleCsvFromDaySelection(
+  selected: Set<ScheduleWeekdayToken>,
+): string {
   if (selected.size === 0 || selected.size === SCHEDULE_WEEKDAY_TOKENS.length) {
     return "";
   }
@@ -137,7 +149,9 @@ export function MmScheduleDayChips({
           Clear
         </button>
       </div>
-      <p className="text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_DAYS_HELPER}</p>
+      <p className="text-xs text-[var(--mm-text3)]">
+        {MM_SCHEDULE_DAYS_HELPER}
+      </p>
     </div>
   );
 }
@@ -160,7 +174,9 @@ export function MmScheduleTimeFields({
   return (
     <div className="grid gap-3 sm:grid-cols-2">
       <label className="block text-sm text-[var(--mm-text2)]">
-        <span className="mb-1 block text-xs text-[var(--mm-text3)]">Start time (24-hour)</span>
+        <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+          Start time (24-hour)
+        </span>
         <input
           id={`${idPrefix}-time-start`}
           type="time"
@@ -172,7 +188,9 @@ export function MmScheduleTimeFields({
         />
       </label>
       <label className="block text-sm text-[var(--mm-text2)]">
-        <span className="mb-1 block text-xs text-[var(--mm-text3)]">End time (24-hour)</span>
+        <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+          End time (24-hour)
+        </span>
         <input
           id={`${idPrefix}-time-end`}
           type="time"

--- a/apps/web/src/components/ui/server-folder-picker-button.tsx
+++ b/apps/web/src/components/ui/server-folder-picker-button.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 
-import { fetchServerDirectories, type DirectoryBrowseResponse } from "../../lib/system/directory-browser-api";
+import {
+  fetchServerDirectories,
+  type DirectoryBrowseResponse,
+} from "../../lib/system/directory-browser-api";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
 type Props = {
@@ -10,7 +13,12 @@ type Props = {
   onSelect: (path: string) => void;
 };
 
-export function ServerFolderPickerButton({ title, value, disabled, onSelect }: Props) {
+export function ServerFolderPickerButton({
+  title,
+  value,
+  disabled,
+  onSelect,
+}: Props) {
   const [open, setOpen] = useState(false);
   const [path, setPath] = useState<string | null>(null);
   const [data, setData] = useState<DirectoryBrowseResponse | null>(null);
@@ -47,7 +55,9 @@ export function ServerFolderPickerButton({ title, value, disabled, onSelect }: P
             if (!cancelled) {
               setData(roots);
               setError(null);
-              setNotice(`"${path}" could not be opened. Showing available drives instead.`);
+              setNotice(
+                `"${path}" could not be opened. Showing available drives instead.`,
+              );
             }
             return;
           } catch {
@@ -56,7 +66,9 @@ export function ServerFolderPickerButton({ title, value, disabled, onSelect }: P
         }
         if (!cancelled) {
           setData(null);
-          setError(err instanceof Error ? err.message : "Folder browser unavailable.");
+          setError(
+            err instanceof Error ? err.message : "Folder browser unavailable.",
+          );
           setNotice(null);
         }
       } finally {
@@ -87,18 +99,31 @@ export function ServerFolderPickerButton({ title, value, disabled, onSelect }: P
         Browse
       </button>
       {open ? (
-        <div className="fixed inset-0 z-[9999] flex items-stretch justify-end bg-black/55 p-3 sm:p-6" role="dialog" aria-modal="true">
+        <div
+          className="fixed inset-0 z-[9999] flex items-stretch justify-end bg-black/55 p-3 sm:p-6"
+          role="dialog"
+          aria-modal="true"
+        >
           <div className="flex w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)] shadow-2xl">
-          <div className="border-b border-[var(--mm-border)] p-5">
+            <div className="border-b border-[var(--mm-border)] p-5">
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">Filesystem</p>
-                  <h2 className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">{title}</h2>
+                  <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">
+                    Filesystem
+                  </p>
+                  <h2 className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">
+                    {title}
+                  </h2>
                   <p className="mt-1 text-sm text-[var(--mm-text3)]">
-                    Pick a folder visible to the machine running MediaMop, or jump to a UNC/Docker path directly.
+                    Pick a folder visible to the machine running MediaMop, or
+                    jump to a UNC/Docker path directly.
                   </p>
                 </div>
-                <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => setOpen(false)}>
+                <button
+                  type="button"
+                  className={mmActionButtonClass({ variant: "secondary" })}
+                  onClick={() => setOpen(false)}
+                >
                   Close
                 </button>
               </div>
@@ -118,17 +143,31 @@ export function ServerFolderPickerButton({ title, value, disabled, onSelect }: P
                   className="mm-input w-full"
                   value={manualPath}
                   onChange={(event) => setManualPath(event.target.value)}
-                  placeholder={navigator.platform.toLowerCase().includes("win") ? String.raw`\\nas\media or X:\Media` : "/media/tv"}
+                  placeholder={
+                    navigator.platform.toLowerCase().includes("win")
+                      ? String.raw`\\nas\media or X:\Media`
+                      : "/media/tv"
+                  }
                   aria-label="Folder path"
                 />
-                <button type="submit" className={mmActionButtonClass({ variant: "secondary", disabled: loading })} disabled={loading}>
+                <button
+                  type="submit"
+                  className={mmActionButtonClass({
+                    variant: "secondary",
+                    disabled: loading,
+                  })}
+                  disabled={loading}
+                >
                   Go to path
                 </button>
               </form>
               <div className="flex flex-wrap items-center gap-2">
                 <button
                   type="button"
-                  className={mmActionButtonClass({ variant: "secondary", disabled: loading || !data?.parent_path })}
+                  className={mmActionButtonClass({
+                    variant: "secondary",
+                    disabled: loading || !data?.parent_path,
+                  })}
                   disabled={loading || !data?.parent_path}
                   onClick={() => setPath(data?.parent_path ?? null)}
                 >
@@ -136,51 +175,93 @@ export function ServerFolderPickerButton({ title, value, disabled, onSelect }: P
                 </button>
                 <button
                   type="button"
-                  className={mmActionButtonClass({ variant: "tertiary", disabled: loading || data?.current_path === null })}
+                  className={mmActionButtonClass({
+                    variant: "tertiary",
+                    disabled: loading || data?.current_path === null,
+                  })}
                   disabled={loading || data?.current_path === null}
                   onClick={() => setPath(null)}
                 >
                   Drives
                 </button>
                 {data?.current_path ? (
-                  <button type="button" className={mmActionButtonClass({ variant: "primary" })} onClick={() => choose(data.current_path!)}>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "primary" })}
+                    onClick={() => choose(data.current_path!)}
+                  >
                     Use this folder
                   </button>
                 ) : null}
                 <div className="min-w-0 flex-1 rounded-md border border-[var(--mm-border)] bg-black/15 px-3 py-2 text-sm text-[var(--mm-text3)]">
-                  <span className="block truncate">{data?.current_path ?? "Available drives"}</span>
+                  <span className="block truncate">
+                    {data?.current_path ?? "Available drives"}
+                  </span>
                 </div>
               </div>
               <p className="mt-2 text-xs leading-relaxed text-[var(--mm-text3)]">
-                Windows supports local drives, mapped drives, and UNC shares such as <span className="font-mono">\\nas\media</span>.
-                Docker installs must use container-visible paths such as <span className="font-mono">/media/tv</span>.
+                Windows supports local drives, mapped drives, and UNC shares
+                such as <span className="font-mono">\\nas\media</span>. Docker
+                installs must use container-visible paths such as{" "}
+                <span className="font-mono">/media/tv</span>.
               </p>
-              {notice ? <p className="mt-3 rounded-md border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-sm text-amber-200">{notice}</p> : null}
+              {notice ? (
+                <p className="mt-3 rounded-md border border-amber-400/25 bg-amber-400/10 px-3 py-2 text-sm text-amber-200">
+                  {notice}
+                </p>
+              ) : null}
             </div>
             <div className="min-h-0 flex-1 overflow-auto p-4">
               {loading ? (
-                <div className="rounded-lg border border-dashed border-[var(--mm-border)] p-6 text-sm text-[var(--mm-text3)]">Loading folders...</div>
+                <div className="rounded-lg border border-dashed border-[var(--mm-border)] p-6 text-sm text-[var(--mm-text3)]">
+                  Loading folders...
+                </div>
               ) : error ? (
-                <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>
+                <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+                  {error}
+                </div>
               ) : data && data.entries.length > 0 ? (
                 <div className="space-y-2">
                   {data.entries.map((entry) => (
-                    <div key={entry.path} className="flex items-center justify-between gap-3 rounded-lg border border-[var(--mm-border)] bg-black/10 p-3">
-                      <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setPath(entry.path)}>
-                        <span className="block truncate text-sm font-semibold text-[var(--mm-text1)]">{entry.name}</span>
-                        <span className="block truncate text-xs text-[var(--mm-text3)]">{entry.description ?? entry.path}</span>
+                    <div
+                      key={entry.path}
+                      className="flex items-center justify-between gap-3 rounded-lg border border-[var(--mm-border)] bg-black/10 p-3"
+                    >
+                      <button
+                        type="button"
+                        className="min-w-0 flex-1 text-left"
+                        onClick={() => setPath(entry.path)}
+                      >
+                        <span className="block truncate text-sm font-semibold text-[var(--mm-text1)]">
+                          {entry.name}
+                        </span>
+                        <span className="block truncate text-xs text-[var(--mm-text3)]">
+                          {entry.description ?? entry.path}
+                        </span>
                       </button>
-                      <button type="button" className={mmActionButtonClass({ variant: "tertiary" })} onClick={() => setPath(entry.path)}>
+                      <button
+                        type="button"
+                        className={mmActionButtonClass({ variant: "tertiary" })}
+                        onClick={() => setPath(entry.path)}
+                      >
                         Open
                       </button>
-                      <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => choose(entry.path)}>
+                      <button
+                        type="button"
+                        className={mmActionButtonClass({
+                          variant: "secondary",
+                        })}
+                        onClick={() => choose(entry.path)}
+                      >
                         Select
                       </button>
                     </div>
                   ))}
                 </div>
               ) : (
-                <div className="rounded-lg border border-dashed border-[var(--mm-border)] p-6 text-sm text-[var(--mm-text3)]">No folders found here.</div>
+                <div className="rounded-lg border border-dashed border-[var(--mm-border)] p-6 text-sm text-[var(--mm-text3)]">
+                  No folders found here.
+                </div>
               )}
             </div>
           </div>

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -1,11 +1,22 @@
 import { NavLink, Outlet, useNavigate } from "react-router-dom";
 import { useState } from "react";
 import { BrandHeaderLink } from "../components/brand/brand-header-link";
-import { NavIconActivity, NavIconDashboard, NavIconRefiner, NavIconSettings, NavIconSubber, NavIconPruner } from "../components/shell/nav-icons";
+import {
+  NavIconActivity,
+  NavIconDashboard,
+  NavIconRefiner,
+  NavIconSettings,
+  NavIconSubber,
+  NavIconPruner,
+} from "../components/shell/nav-icons";
 import { useLogoutMutation } from "../lib/auth/queries";
 import { useDashboardStatusQuery } from "../lib/dashboard/queries";
 import { useSuiteSettingsQuery } from "../lib/suite/queries";
-import { persistAppTheme, readStoredAppTheme, type AppTheme } from "../lib/ui/app-theme";
+import {
+  persistAppTheme,
+  readStoredAppTheme,
+  type AppTheme,
+} from "../lib/ui/app-theme";
 
 function sidebarNavClass({ isActive }: { isActive: boolean }) {
   return isActive ? "mm-sidebar-link active" : "mm-sidebar-link";
@@ -17,7 +28,8 @@ export function AppShell() {
   const suite = useSuiteSettingsQuery();
   const dashboard = useDashboardStatusQuery();
   const [theme, setTheme] = useState<AppTheme>(() => readStoredAppTheme());
-  const productTitle = (suite.data?.product_display_name ?? "MediaMop").trim() || "MediaMop";
+  const productTitle =
+    (suite.data?.product_display_name ?? "MediaMop").trim() || "MediaMop";
   const appVersion = dashboard.data?.system.api_version;
   const nextTheme: AppTheme = theme === "dark" ? "light" : "dark";
   const handleSignOut = () => {
@@ -79,7 +91,10 @@ export function AppShell() {
         <div className="mm-sidebar-footer">
           <div className="mm-sidebar-footer-panel">
             <div className="mm-sidebar-meta">{productTitle}</div>
-            <div className="mm-sidebar-version" title="Installed MediaMop version reported by the running server">
+            <div
+              className="mm-sidebar-version"
+              title="Installed MediaMop version reported by the running server"
+            >
               {appVersion ? `Version ${appVersion}` : "Version checking..."}
             </div>
             <button
@@ -109,7 +124,9 @@ export function AppShell() {
               }}
             >
               <span className="mm-theme-toggle__dot" aria-hidden="true" />
-              <span className="mm-theme-toggle__label">{theme === "dark" ? "Dark" : "Light"}</span>
+              <span className="mm-theme-toggle__label">
+                {theme === "dark" ? "Dark" : "Light"}
+              </span>
             </button>
           </div>
           <Outlet />

--- a/apps/web/src/lib/activity/queries.ts
+++ b/apps/web/src/lib/activity/queries.ts
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { fetchActivityRecent, type ActivityRecentFilters } from "../api/activity-api";
+import {
+  fetchActivityRecent,
+  type ActivityRecentFilters,
+} from "../api/activity-api";
 
 export const activityRecentKey = ["activity", "recent"] as const;
 
@@ -12,7 +15,12 @@ export function useActivityRecentQuery(filters?: ActivityRecentFilters) {
 }
 
 /** Narrower feed for Settings → Logs (does not share cache with open-ended ``/recent``). */
-export const activityRecentSettingsKey = ["activity", "recent", "settings", 20] as const;
+export const activityRecentSettingsKey = [
+  "activity",
+  "recent",
+  "settings",
+  20,
+] as const;
 
 export function useActivityRecentForSettingsQuery(enabled: boolean) {
   return useQuery({

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
@@ -24,10 +24,14 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
       ffmpeg_argv: ["/bin/ffmpeg", "-i", "a.mkv", "out.mkv"],
     });
     render(<RefinerFileRemuxPassActivityDetail detail={detail} />);
-    expect(screen.getByTestId("refiner-remux-activity-detail")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("refiner-remux-activity-detail"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Outcome")).toBeInTheDocument();
     expect(screen.getByText("File processed")).toBeInTheDocument();
-    expect(screen.getByText("Show track and cleanup details")).toBeInTheDocument();
+    expect(
+      screen.getByText("Show track and cleanup details"),
+    ).toBeInTheDocument();
     expect(screen.getByText("/data/movies/a.mkv")).toBeInTheDocument();
     expect(screen.getByText("Audio in file")).toBeInTheDocument();
     expect(screen.getByText("A before")).toBeInTheDocument();
@@ -36,7 +40,9 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
 
   it("falls back to raw string when detail is not JSON", () => {
     render(<RefinerFileRemuxPassActivityDetail detail="not-json" />);
-    expect(screen.getByTestId("refiner-remux-activity-detail-raw")).toHaveTextContent("not-json");
+    expect(
+      screen.getByTestId("refiner-remux-activity-detail-raw"),
+    ).toHaveTextContent("not-json");
   });
 
   it("renders live Refiner processing progress in plain language", () => {
@@ -52,16 +58,24 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
       message: "Refiner is writing the cleaned-up file.",
     });
     render(<RefinerFileProcessingProgressDetail detail={detail} />);
-    expect(screen.getByTestId("refiner-processing-progress-detail")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("refiner-processing-progress-detail"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Processing")).toBeInTheDocument();
     expect(screen.getByText("42%")).toBeInTheDocument();
     expect(screen.getByText(/About 1m 11s left/i)).toBeInTheDocument();
-    expect(screen.getByText(/Processing speed 16x realtime/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Processing speed 16x realtime/i),
+    ).toBeInTheDocument();
   });
 
   it("preserves full Refiner speed precision and standardizes realtime units", () => {
-    expect(formatRefinerProcessingSpeed("123.456789x")).toBe("123.456789x realtime");
-    expect(formatRefinerProcessingSpeed(" 0.987654x ")).toBe("0.987654x realtime");
+    expect(formatRefinerProcessingSpeed("123.456789x")).toBe(
+      "123.456789x realtime",
+    );
+    expect(formatRefinerProcessingSpeed(" 0.987654x ")).toBe(
+      "0.987654x realtime",
+    );
     expect(formatRefinerProcessingSpeed("N/A")).toBe("N/A");
   });
 
@@ -79,7 +93,9 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
 
     expect(card).toHaveClass("mm-activity-processing--finished");
     expect(screen.getAllByText("Finished")).toHaveLength(2);
-    expect(screen.getByText("Refiner finished processing this file.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Refiner finished processing this file."),
+    ).toBeInTheDocument();
     expect(screen.getByText("100%")).toBeInTheDocument();
     expect(screen.queryByText(/About 0s left/i)).not.toBeInTheDocument();
   });
@@ -93,8 +109,12 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
     });
     render(<RefinerFileProcessingProgressDetail detail={detail} />);
 
-    expect(screen.getByTestId("refiner-processing-progress-detail")).toHaveClass("mm-activity-processing--failed");
+    expect(
+      screen.getByTestId("refiner-processing-progress-detail"),
+    ).toHaveClass("mm-activity-processing--failed");
     expect(screen.getAllByText("Stopped")).toHaveLength(2);
-    expect(screen.getByText("ffmpeg stopped unexpectedly.")).toBeInTheDocument();
+    expect(
+      screen.getByText("ffmpeg stopped unexpectedly."),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.tsx
@@ -1,6 +1,8 @@
 /** Persisted ``event_type`` for Refiner file remux pass must match backend ``REFINER_FILE_REMUX_PASS_COMPLETED``. */
-export const REFINER_FILE_REMUX_PASS_COMPLETED_EVENT = "refiner.file_remux_pass_completed";
-export const REFINER_FILE_PROCESSING_PROGRESS_EVENT = "refiner.file_processing_progress";
+export const REFINER_FILE_REMUX_PASS_COMPLETED_EVENT =
+  "refiner.file_remux_pass_completed";
+export const REFINER_FILE_PROCESSING_PROGRESS_EVENT =
+  "refiner.file_processing_progress";
 
 type RemuxDetail = {
   outcome?: string;
@@ -70,7 +72,8 @@ function outcomeLabel(outcome: string | undefined): string {
 }
 
 function formatBytes(value: number | null | undefined): string | null {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+    return null;
   const units = ["B", "KB", "MB", "GB", "TB"];
   let size = value;
   let unitIndex = 0;
@@ -83,7 +86,8 @@ function formatBytes(value: number | null | undefined): string | null {
 }
 
 function formatDuration(seconds: number | null | undefined): string | null {
-  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) return null;
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0)
+    return null;
   const rounded = Math.round(seconds);
   const mins = Math.floor(rounded / 60);
   const secs = rounded % 60;
@@ -94,7 +98,9 @@ function formatDuration(seconds: number | null | undefined): string | null {
   return `${hours}h ${remMins.toString().padStart(2, "0")}m`;
 }
 
-export function formatRefinerProcessingSpeed(speed: string | null | undefined): string | null {
+export function formatRefinerProcessingSpeed(
+  speed: string | null | undefined,
+): string | null {
   const value = (speed || "").trim();
   if (!value) return null;
   if (/^[0-9]+(?:\.[0-9]+)?x$/i.test(value)) {
@@ -108,8 +114,16 @@ function filenameFromPath(path: string | undefined): string {
   return path.split(/[\\/]/).filter(Boolean).at(-1) || "this file";
 }
 
-function formatSavings(source: number | null | undefined, output: number | null | undefined): string | null {
-  if (typeof source !== "number" || typeof output !== "number" || !Number.isFinite(source) || !Number.isFinite(output)) {
+function formatSavings(
+  source: number | null | undefined,
+  output: number | null | undefined,
+): string | null {
+  if (
+    typeof source !== "number" ||
+    typeof output !== "number" ||
+    !Number.isFinite(source) ||
+    !Number.isFinite(output)
+  ) {
     return null;
   }
   const delta = source - output;
@@ -122,25 +136,34 @@ function formatSavings(source: number | null | undefined, output: number | null 
     return `Size basically unchanged (${sizeText} ${direction})`;
   }
   if (delta > 0) {
-    return percent != null ? `Saved ${sizeText} (${percent.toFixed(1)}%)` : `Saved ${sizeText}`;
+    return percent != null
+      ? `Saved ${sizeText} (${percent.toFixed(1)}%)`
+      : `Saved ${sizeText}`;
   }
-  return percent != null ? `Grew by ${sizeText} (${percent.toFixed(1)}%)` : `Grew by ${sizeText}`;
+  return percent != null
+    ? `Grew by ${sizeText} (${percent.toFixed(1)}%)`
+    : `Grew by ${sizeText}`;
 }
 
-function cleanupStatus(parsed: RemuxDetail): { label: string; value: string }[] {
+function cleanupStatus(
+  parsed: RemuxDetail,
+): { label: string; value: string }[] {
   if (parsed.media_scope === "movie") {
     return [
       {
         label: "Watched-folder cleanup",
-        value: parsed.source_folder_deleted ? "Removed source release folder" : parsed.source_folder_skip_reason || "Not removed",
+        value: parsed.source_folder_deleted
+          ? "Removed source release folder"
+          : parsed.source_folder_skip_reason || "Not removed",
       },
       {
         label: "Output-folder cleanup",
-        value:
-          parsed.movie_output_folder_deleted
-            ? "Removed output title folder"
-            : parsed.movie_output_folder_skip_reason ||
-              (parsed.movie_output_truth_check ? `Not removed (${parsed.movie_output_truth_check})` : "Not removed"),
+        value: parsed.movie_output_folder_deleted
+          ? "Removed output title folder"
+          : parsed.movie_output_folder_skip_reason ||
+            (parsed.movie_output_truth_check
+              ? `Not removed (${parsed.movie_output_truth_check})`
+              : "Not removed"),
       },
     ];
   }
@@ -148,16 +171,18 @@ function cleanupStatus(parsed: RemuxDetail): { label: string; value: string }[] 
     return [
       {
         label: "Watched-folder cleanup",
-        value:
-          parsed.tv_season_folder_deleted ? "Removed watched season folder" : parsed.tv_season_folder_skip_reason || "Not removed",
+        value: parsed.tv_season_folder_deleted
+          ? "Removed watched season folder"
+          : parsed.tv_season_folder_skip_reason || "Not removed",
       },
       {
         label: "Output-folder cleanup",
-        value:
-          parsed.tv_output_season_folder_deleted
-            ? "Removed output season folder"
-            : parsed.tv_output_season_folder_skip_reason ||
-              (parsed.tv_output_truth_check ? `Not removed (${parsed.tv_output_truth_check})` : "Not removed"),
+        value: parsed.tv_output_season_folder_deleted
+          ? "Removed output season folder"
+          : parsed.tv_output_season_folder_skip_reason ||
+            (parsed.tv_output_truth_check
+              ? `Not removed (${parsed.tv_output_truth_check})`
+              : "Not removed"),
       },
     ];
   }
@@ -182,7 +207,12 @@ function splitTrackList(value: string | undefined): string[] {
     .filter(Boolean);
 }
 
-function trackSection(label: string, values: string[], tone: "before" | "kept" | "removed", emptyLabel = "None") {
+function trackSection(
+  label: string,
+  values: string[],
+  tone: "before" | "kept" | "removed",
+  emptyLabel = "None",
+) {
   if (values.length === 0) {
     return (
       <div key={label} className="mm-activity-remux-detail__tracks-section">
@@ -197,7 +227,10 @@ function trackSection(label: string, values: string[], tone: "before" | "kept" |
       <h5 className="mm-activity-remux-detail__tracks-title">{label}</h5>
       <div className="mm-activity-remux-detail__chips">
         {values.map((value) => (
-          <span key={`${label}-${value}`} className={`mm-activity-remux-detail__chip mm-activity-remux-detail__chip--${tone}`}>
+          <span
+            key={`${label}-${value}`}
+            className={`mm-activity-remux-detail__chip mm-activity-remux-detail__chip--${tone}`}
+          >
             {value}
           </span>
         ))}
@@ -206,11 +239,16 @@ function trackSection(label: string, values: string[], tone: "before" | "kept" |
   );
 }
 
-export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string }) {
+export function RefinerFileRemuxPassActivityDetail({
+  detail,
+}: {
+  detail: string;
+}) {
   let parsed: RemuxDetail | null = null;
   try {
     const raw: unknown = JSON.parse(detail);
-    parsed = typeof raw === "object" && raw !== null ? (raw as RemuxDetail) : null;
+    parsed =
+      typeof raw === "object" && raw !== null ? (raw as RemuxDetail) : null;
   } catch {
     parsed = null;
   }
@@ -228,7 +266,10 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
 
   const sourceSize = formatBytes(parsed.source_size_bytes);
   const outputSize = formatBytes(parsed.output_size_bytes);
-  const savings = formatSavings(parsed.source_size_bytes, parsed.output_size_bytes);
+  const savings = formatSavings(
+    parsed.source_size_bytes,
+    parsed.output_size_bytes,
+  );
   const cleanupRows = cleanupStatus(parsed);
   const streamsInspected = parsed.stream_counts
     ? `Video ${parsed.stream_counts.video ?? 0}, audio ${parsed.stream_counts.audio ?? 0}, subtitles ${parsed.stream_counts.subtitle ?? 0}`
@@ -248,7 +289,10 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
   ].filter((row) => row.value);
 
   const beforeRows = [
-    detailRow("File checked", parsed.inspected_source_path || parsed.relative_media_path),
+    detailRow(
+      "File checked",
+      parsed.inspected_source_path || parsed.relative_media_path,
+    ),
     detailRow("Original size", sourceSize),
     detailRow("Streams inspected", streamsInspected),
   ].filter(Boolean);
@@ -259,7 +303,15 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
   ].filter(Boolean);
 
   const supplementalRows: { k: string; v: string | undefined | null }[] = [
-    { k: "Changes needed", v: parsed.remux_required === undefined ? undefined : parsed.remux_required ? "Yes" : "No" },
+    {
+      k: "Changes needed",
+      v:
+        parsed.remux_required === undefined
+          ? undefined
+          : parsed.remux_required
+            ? "Yes"
+            : "No",
+    },
     { k: "What Refiner planned", v: parsed.plan_summary },
     ...cleanupRows.map((row) => ({ k: row.label, v: row.value })),
     { k: "Safety note", v: parsed.output_completeness_note || undefined },
@@ -267,13 +319,20 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
   ];
 
   return (
-    <div className="mm-activity-remux-detail" data-testid="refiner-remux-activity-detail">
+    <div
+      className="mm-activity-remux-detail"
+      data-testid="refiner-remux-activity-detail"
+    >
       {summaryTiles.length > 0 ? (
         <div className="mm-activity-remux-detail__tiles">
           {summaryTiles.map((tile) => (
             <div key={tile.label} className="mm-activity-remux-detail__tile">
-              <span className="mm-activity-remux-detail__tile-label">{tile.label}</span>
-              <span className="mm-activity-remux-detail__tile-value">{tile.value}</span>
+              <span className="mm-activity-remux-detail__tile-label">
+                {tile.label}
+              </span>
+              <span className="mm-activity-remux-detail__tile-value">
+                {tile.value}
+              </span>
             </div>
           ))}
         </div>
@@ -287,7 +346,11 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
               <dl className="mm-activity-remux-detail__dl">{beforeRows}</dl>
               <div className="mm-activity-remux-detail__tracks">
                 {trackSection("Audio in file", audioBeforeTracks, "before")}
-                {trackSection("Subtitles in file", subtitleBeforeTracks, "before")}
+                {trackSection(
+                  "Subtitles in file",
+                  subtitleBeforeTracks,
+                  "before",
+                )}
               </div>
             </section>
             <section className="mm-activity-remux-detail__column">
@@ -295,15 +358,27 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
               <dl className="mm-activity-remux-detail__dl">{afterRows}</dl>
               <div className="mm-activity-remux-detail__tracks">
                 {trackSection("Audio kept", audioAfterTracks, "kept")}
-                {trackSection("Audio removed", removedAudioTracks, "removed", "None removed")}
+                {trackSection(
+                  "Audio removed",
+                  removedAudioTracks,
+                  "removed",
+                  "None removed",
+                )}
                 {trackSection("Subtitles kept", subtitleAfterTracks, "kept")}
-                {trackSection("Subtitles removed", removedSubtitleTracks, "removed", "None removed")}
+                {trackSection(
+                  "Subtitles removed",
+                  removedSubtitleTracks,
+                  "removed",
+                  "None removed",
+                )}
               </div>
             </section>
           </div>
 
           <div className="mm-activity-remux-detail__supplemental">
-            <h4 className="mm-activity-remux-detail__section-title">Processing notes</h4>
+            <h4 className="mm-activity-remux-detail__section-title">
+              Processing notes
+            </h4>
             <dl className="mm-activity-remux-detail__dl">
               {supplementalRows
                 .filter((r) => r.v !== undefined && r.v !== null && r.v !== "")
@@ -316,13 +391,16 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
             </dl>
           </div>
 
-          {Array.isArray(parsed.ffmpeg_argv) && parsed.ffmpeg_argv.length > 0 ? (
+          {Array.isArray(parsed.ffmpeg_argv) &&
+          parsed.ffmpeg_argv.length > 0 ? (
             <details className="mm-activity-remux-detail__ffmpeg">
               <summary>
                 ffmpeg command line
                 {parsed.ffmpeg_argv_truncated ? " (truncated in log)" : ""}
               </summary>
-              <pre className="mm-activity-remux-detail__pre">{parsed.ffmpeg_argv.join(" ")}</pre>
+              <pre className="mm-activity-remux-detail__pre">
+                {parsed.ffmpeg_argv.join(" ")}
+              </pre>
             </details>
           ) : null}
         </div>
@@ -331,11 +409,18 @@ export function RefinerFileRemuxPassActivityDetail({ detail }: { detail: string 
   );
 }
 
-export function RefinerFileProcessingProgressDetail({ detail }: { detail: string }) {
+export function RefinerFileProcessingProgressDetail({
+  detail,
+}: {
+  detail: string;
+}) {
   let parsed: RefinerProgressDetail | null = null;
   try {
     const raw: unknown = JSON.parse(detail);
-    parsed = typeof raw === "object" && raw !== null ? (raw as RefinerProgressDetail) : null;
+    parsed =
+      typeof raw === "object" && raw !== null
+        ? (raw as RefinerProgressDetail)
+        : null;
   } catch {
     parsed = null;
   }
@@ -344,10 +429,16 @@ export function RefinerFileProcessingProgressDetail({ detail }: { detail: string
     return <p className="text-sm leading-6 text-[var(--mm-text2)]">{detail}</p>;
   }
 
-  const rawPercent = typeof parsed.percent === "number" && Number.isFinite(parsed.percent) ? parsed.percent : null;
-  const percent = rawPercent == null ? null : Math.max(0, Math.min(100, rawPercent));
+  const rawPercent =
+    typeof parsed.percent === "number" && Number.isFinite(parsed.percent)
+      ? parsed.percent
+      : null;
+  const percent =
+    rawPercent == null ? null : Math.max(0, Math.min(100, rawPercent));
   const status = parsed.status || "processing";
-  const fileName = filenameFromPath(parsed.relative_media_path || parsed.inspected_source_path);
+  const fileName = filenameFromPath(
+    parsed.relative_media_path || parsed.inspected_source_path,
+  );
   const eta = formatDuration(parsed.eta_seconds);
   const elapsed = formatDuration(parsed.elapsed_seconds);
   const processed = formatDuration(parsed.processed_seconds);
@@ -387,24 +478,38 @@ export function RefinerFileProcessingProgressDetail({ detail }: { detail: string
             : statusText;
 
   return (
-    <div className={`mm-activity-processing ${statusClass}`} data-testid="refiner-processing-progress-detail">
+    <div
+      className={`mm-activity-processing ${statusClass}`}
+      data-testid="refiner-processing-progress-detail"
+    >
       <div className="mm-activity-processing__header">
         <div>
           <p className="mm-activity-processing__eyebrow">{statusText}</p>
           <p className="mm-activity-processing__title">{message}</p>
         </div>
-        <strong className="mm-activity-processing__percent">{percent == null ? "Working" : `${Math.round(percent)}%`}</strong>
+        <strong className="mm-activity-processing__percent">
+          {percent == null ? "Working" : `${Math.round(percent)}%`}
+        </strong>
       </div>
-      <div className="mm-activity-processing__bar" aria-label={`Processing progress for ${fileName}`}>
+      <div
+        className="mm-activity-processing__bar"
+        aria-label={`Processing progress for ${fileName}`}
+      >
         <span style={{ width: `${percent ?? 8}%` }} />
       </div>
       <div className="mm-activity-processing__metrics">
         <span>{primaryMetric}</span>
         {elapsed ? <span>Running {elapsed}</span> : null}
-        {processed && duration ? <span>Processed {processed} of {duration}</span> : null}
+        {processed && duration ? (
+          <span>
+            Processed {processed} of {duration}
+          </span>
+        ) : null}
         {speed ? <span>Processing speed {speed}</span> : null}
       </div>
-      {parsed.reason ? <p className="mm-activity-processing__error">{parsed.reason}</p> : null}
+      {parsed.reason ? (
+        <p className="mm-activity-processing__error">{parsed.reason}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.test.tsx
@@ -23,7 +23,10 @@ class FakeEventSource {
     this.listeners.set(type, set);
   }
 
-  removeEventListener(type: string, cb: (ev: MessageEvent<string>) => void): void {
+  removeEventListener(
+    type: string,
+    cb: (ev: MessageEvent<string>) => void,
+  ): void {
     this.listeners.get(type)?.delete(cb);
   }
 
@@ -52,7 +55,10 @@ describe("useActivityStreamInvalidation", () => {
   });
 
   it("invalidates activity recent query on activity.latest", () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
     const spy = vi.spyOn(qc, "invalidateQueries");
 
@@ -68,7 +74,10 @@ describe("useActivityStreamInvalidation", () => {
   });
 
   it("invalidates when an existing activity row receives a newer revision", () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
     const spy = vi.spyOn(qc, "invalidateQueries");
 
@@ -77,15 +86,24 @@ describe("useActivityStreamInvalidation", () => {
     });
 
     const src = FakeEventSource.instances[0];
-    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 1 }));
-    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 2 }));
+    src.emit(
+      "activity.latest",
+      JSON.stringify({ latest_event_id: 12, activity_revision: 1 }),
+    );
+    src.emit(
+      "activity.latest",
+      JSON.stringify({ latest_event_id: 12, activity_revision: 2 }),
+    );
 
     expect(spy).toHaveBeenCalledTimes(2);
     expect(spy).toHaveBeenLastCalledWith({ queryKey: activityRecentKey });
   });
 
   it("ignores malformed stream messages instead of breaking live updates", () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
     const spy = vi.spyOn(qc, "invalidateQueries");
 
@@ -96,14 +114,20 @@ describe("useActivityStreamInvalidation", () => {
     const src = FakeEventSource.instances[0];
     src.emit("activity.latest", "{");
     src.emit("activity.latest", JSON.stringify({ activity_revision: 1 }));
-    src.emit("activity.latest", JSON.stringify({ latest_event_id: 12, activity_revision: 2 }));
+    src.emit(
+      "activity.latest",
+      JSON.stringify({ latest_event_id: 12, activity_revision: 2 }),
+    );
 
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({ queryKey: activityRecentKey });
   });
 
   it("invalidates dashboard status query on activity.latest", () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
     const spy = vi.spyOn(qc, "invalidateQueries");
 
@@ -118,16 +142,25 @@ describe("useActivityStreamInvalidation", () => {
   });
 
   it("shares one EventSource across multiple query subscribers", () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
     const spy = vi.spyOn(qc, "invalidateQueries");
 
-    const first = renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
-      wrapper: withQueryClient(qc),
-    });
-    const second = renderHook(() => useActivityStreamInvalidation(dashboardStatusKey), {
-      wrapper: withQueryClient(qc),
-    });
+    const first = renderHook(
+      () => useActivityStreamInvalidation(activityRecentKey),
+      {
+        wrapper: withQueryClient(qc),
+      },
+    );
+    const second = renderHook(
+      () => useActivityStreamInvalidation(dashboardStatusKey),
+      {
+        wrapper: withQueryClient(qc),
+      },
+    );
 
     expect(FakeEventSource.instances).toHaveLength(1);
     const src = FakeEventSource.instances[0];
@@ -144,12 +177,18 @@ describe("useActivityStreamInvalidation", () => {
   });
 
   it("opens a fresh EventSource after all subscribers unmount", async () => {
-    vi.stubGlobal("EventSource", FakeEventSource as unknown as typeof EventSource);
+    vi.stubGlobal(
+      "EventSource",
+      FakeEventSource as unknown as typeof EventSource,
+    );
     const qc = new QueryClient();
 
-    const first = renderHook(() => useActivityStreamInvalidation(activityRecentKey), {
-      wrapper: withQueryClient(qc),
-    });
+    const first = renderHook(
+      () => useActivityStreamInvalidation(activityRecentKey),
+      {
+        wrapper: withQueryClient(qc),
+      },
+    );
     first.unmount();
     await waitFor(() => expect(FakeEventSource.instances[0].closed).toBe(true));
 

--- a/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
+++ b/apps/web/src/lib/activity/use-activity-stream-invalidation.ts
@@ -41,7 +41,9 @@ function ensureActivityStream(): EventSource | null {
   return source;
 }
 
-function subscribeActivityLatest(subscriber: ActivityLatestSubscriber): () => void {
+function subscribeActivityLatest(
+  subscriber: ActivityLatestSubscriber,
+): () => void {
   subscribers.add(subscriber);
   ensureActivityStream();
 
@@ -64,7 +66,9 @@ export function useActivityStreamInvalidation(queryKey: QueryKey): void {
   }, [qc, queryKey]);
 }
 
-export function useActivityStreamInvalidations(queryKeys: readonly QueryKey[]): void {
+export function useActivityStreamInvalidations(
+  queryKeys: readonly QueryKey[],
+): void {
   const qc = useQueryClient();
 
   useEffect(() => {

--- a/apps/web/src/lib/api/activity-api.ts
+++ b/apps/web/src/lib/api/activity-api.ts
@@ -25,7 +25,9 @@ export function activityRecentPath(options?: ActivityRecentFilters): string {
   return qs ? `/api/v1/activity/recent?${qs}` : "/api/v1/activity/recent";
 }
 
-export async function fetchActivityRecent(options?: ActivityRecentFilters): Promise<ActivityRecentResponse> {
+export async function fetchActivityRecent(
+  options?: ActivityRecentFilters,
+): Promise<ActivityRecentResponse> {
   const path = activityRecentPath(options);
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load activity");

--- a/apps/web/src/lib/api/auth-api.ts
+++ b/apps/web/src/lib/api/auth-api.ts
@@ -29,7 +29,10 @@ export async function fetchBootstrapStatus(): Promise<BootstrapStatus> {
 
 export type LoginResult = { user: UserPublic };
 
-export async function postLogin(username: string, password: string): Promise<LoginResult> {
+export async function postLogin(
+  username: string,
+  password: string,
+): Promise<LoginResult> {
   const csrf_token = await fetchCsrfToken();
   const path = "/api/v1/auth/login";
   const r = await apiFetch(path, {

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -22,13 +22,20 @@ describe("apiErrorDetailToString", () => {
   it("joins FastAPI-style validation array messages with field path", () => {
     expect(
       apiErrorDetailToString([
-        { type: "string_too_short", loc: ["body", "new_password"], msg: "Too short", input: "x" },
+        {
+          type: "string_too_short",
+          loc: ["body", "new_password"],
+          msg: "Too short",
+          input: "x",
+        },
       ]),
     ).toBe("new_password: Too short");
   });
 
   it("stringifies plain objects instead of object Object", () => {
-    expect(apiErrorDetailToString({ nested: 1 })).toBe(JSON.stringify({ nested: 1 }));
+    expect(apiErrorDetailToString({ nested: 1 })).toBe(
+      JSON.stringify({ nested: 1 }),
+    );
   });
 
   it("returns empty for nullish", () => {
@@ -39,12 +46,21 @@ describe("apiErrorDetailToString", () => {
 
 describe("apiResponseErrorMessage", () => {
   it("normalizes FastAPI string detail", async () => {
-    const response = new Response(JSON.stringify({ detail: "Wrong password" }), {
-      status: 401,
-      headers: { "Content-Type": "application/json" },
-    });
+    const response = new Response(
+      JSON.stringify({ detail: "Wrong password" }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
 
-    await expect(throwApiResponseError("/api/v1/auth/login", response, "Could not sign in")).rejects.toMatchObject({
+    await expect(
+      throwApiResponseError(
+        "/api/v1/auth/login",
+        response,
+        "Could not sign in",
+      ),
+    ).rejects.toMatchObject({
       name: "ApiHttpError",
       path: "/api/v1/auth/login",
       status: 401,
@@ -54,13 +70,25 @@ describe("apiResponseErrorMessage", () => {
 
   it("normalizes validation arrays without object Object", async () => {
     const response = new Response(
-      JSON.stringify({ detail: [{ loc: ["body", "password"], msg: "String should have at least 8 characters" }] }),
+      JSON.stringify({
+        detail: [
+          {
+            loc: ["body", "password"],
+            msg: "String should have at least 8 characters",
+          },
+        ],
+      }),
       { status: 422, headers: { "Content-Type": "application/json" } },
     );
 
-    const normalized = await apiResponseErrorMessage(response, "Could not save");
+    const normalized = await apiResponseErrorMessage(
+      response,
+      "Could not save",
+    );
 
-    expect(normalized.message).toBe("password: String should have at least 8 characters");
+    expect(normalized.message).toBe(
+      "password: String should have at least 8 characters",
+    );
     expect(normalized.message).not.toContain("[object Object]");
   });
 
@@ -70,22 +98,36 @@ describe("apiResponseErrorMessage", () => {
       headers: { "Content-Type": "application/json" },
     });
 
-    const normalized = await apiResponseErrorMessage(response, "Could not load");
+    const normalized = await apiResponseErrorMessage(
+      response,
+      "Could not load",
+    );
 
-    expect(normalized.message).toBe(JSON.stringify({ reason: "missing-route" }));
+    expect(normalized.message).toBe(
+      JSON.stringify({ reason: "missing-route" }),
+    );
     expect(normalized.message).not.toContain("[object Object]");
   });
 
   it("turns HTML responses into operator-safe proxy guidance", async () => {
-    const response = new Response("<!doctype html><title>Not found</title>", { status: 404 });
+    const response = new Response("<!doctype html><title>Not found</title>", {
+      status: 404,
+    });
 
-    const normalized = await apiResponseErrorMessage(response, "Could not check for updates");
+    const normalized = await apiResponseErrorMessage(
+      response,
+      "Could not check for updates",
+    );
 
     expect(normalized.message).toContain("received HTML instead of JSON");
   });
 
   it("exposes status and path on ApiHttpError", () => {
-    const error = new ApiHttpError("/api/v1/example", 503, "Service unavailable");
+    const error = new ApiHttpError(
+      "/api/v1/example",
+      503,
+      "Service unavailable",
+    );
 
     expect(error.status).toBe(503);
     expect(error.path).toBe("/api/v1/example");
@@ -106,7 +148,11 @@ describe("apiFetch timeouts", () => {
     vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockRejectedValue(new DOMException("The operation was aborted.", "AbortError")),
+      vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException("The operation was aborted.", "AbortError"),
+        ),
     );
 
     await expect(apiFetch("/api/v1/suite/settings")).rejects.toMatchObject({

--- a/apps/web/src/lib/api/client.test.ts
+++ b/apps/web/src/lib/api/client.test.ts
@@ -92,6 +92,33 @@ describe("apiResponseErrorMessage", () => {
   });
 });
 
+describe("apiFetch timeouts", () => {
+  it("turns request timeouts into typed ApiHttpError", async () => {
+    const timeoutSignal = {
+      aborted: true,
+      reason: new DOMException("The operation timed out.", "TimeoutError"),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+      onabort: null,
+      throwIfAborted: vi.fn(),
+    } as unknown as AbortSignal;
+    vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutSignal);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new DOMException("The operation was aborted.", "AbortError")),
+    );
+
+    await expect(apiFetch("/api/v1/suite/settings")).rejects.toMatchObject({
+      name: "ApiHttpError",
+      status: 0,
+      path: "/api/v1/suite/settings",
+      timedOut: true,
+      message: "Request timed out - the backend may be slow or unreachable.",
+    });
+  });
+});
+
 describe("apiFetch unauthorized handling", () => {
   it("calls the central unauthorized handler once for repeated 401s", async () => {
     const handler = vi.fn();

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -4,19 +4,26 @@
  */
 
 const API_PREFIX = "/api/v1";
+const DEFAULT_TIMEOUT_MS = 30_000;
 type UnauthorizedHandler = (path: string) => void;
+
+export type ApiFetchInit = RequestInit & {
+  timeoutMs?: number;
+};
 
 export class ApiHttpError extends Error {
   readonly status: number;
   readonly path: string;
   readonly detail: unknown;
+  readonly timedOut: boolean;
 
-  constructor(path: string, status: number, message: string, detail?: unknown) {
+  constructor(path: string, status: number, message: string, detail?: unknown, timedOut = false) {
     super(message);
     this.name = "ApiHttpError";
     this.status = status;
     this.path = path;
     this.detail = detail;
+    this.timedOut = timedOut;
   }
 }
 
@@ -53,15 +60,57 @@ export function apiUrl(path: string): string {
   return `${baseUrl()}${p}`;
 }
 
-export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
-  const response = await fetch(apiUrl(path), {
-    ...init,
-    credentials: "include",
-    headers: {
-      Accept: "application/json",
-      ...init?.headers,
-    },
-  });
+function buildTimeoutSignal(timeoutMs: number): AbortSignal | null {
+  if (typeof AbortSignal === "undefined") {
+    return null;
+  }
+  if (typeof AbortSignal.timeout === "function") {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  return null;
+}
+
+function combineSignals(callerSignal: AbortSignal | null | undefined, timeoutSignal: AbortSignal | null): AbortSignal | null {
+  if (callerSignal && timeoutSignal && typeof AbortSignal.any === "function") {
+    return AbortSignal.any([callerSignal, timeoutSignal]);
+  }
+  return callerSignal ?? timeoutSignal;
+}
+
+function isTimeoutAbort(error: unknown, timeoutSignal: AbortSignal | null): boolean {
+  if (!error || typeof error !== "object" || !("name" in error) || error.name !== "AbortError") {
+    return false;
+  }
+  return Boolean(timeoutSignal?.aborted);
+}
+
+export async function apiFetch(path: string, init?: ApiFetchInit): Promise<Response> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...requestInit } = init ?? {};
+  const timeoutSignal = buildTimeoutSignal(timeoutMs);
+  const signal = combineSignals(callerSignal ?? null, timeoutSignal);
+  let response: Response;
+  try {
+    response = await fetch(apiUrl(path), {
+      ...requestInit,
+      credentials: "include",
+      signal: signal ?? undefined,
+      headers: {
+        Accept: "application/json",
+        ...requestInit.headers,
+      },
+    });
+  } catch (error) {
+    if (isTimeoutAbort(error, timeoutSignal)) {
+      throw new ApiHttpError(
+        path,
+        0,
+        "Request timed out - the backend may be slow or unreachable.",
+        undefined,
+        true,
+      );
+    }
+    throw error;
+  }
   if (response.status === 401 && unauthorizedHandler && !unauthorizedHandled) {
     unauthorizedHandled = true;
     unauthorizedHandler(path);

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -17,7 +17,13 @@ export class ApiHttpError extends Error {
   readonly detail: unknown;
   readonly timedOut: boolean;
 
-  constructor(path: string, status: number, message: string, detail?: unknown, timedOut = false) {
+  constructor(
+    path: string,
+    status: number,
+    message: string,
+    detail?: unknown,
+    timedOut = false,
+  ) {
     super(message);
     this.name = "ApiHttpError";
     this.status = status;
@@ -30,7 +36,9 @@ export class ApiHttpError extends Error {
 let unauthorizedHandler: UnauthorizedHandler | null = null;
 let unauthorizedHandled = false;
 
-export function setUnauthorizedHandler(handler: UnauthorizedHandler | null): void {
+export function setUnauthorizedHandler(
+  handler: UnauthorizedHandler | null,
+): void {
   unauthorizedHandler = handler;
   unauthorizedHandled = false;
 }
@@ -70,22 +78,40 @@ function buildTimeoutSignal(timeoutMs: number): AbortSignal | null {
   return null;
 }
 
-function combineSignals(callerSignal: AbortSignal | null | undefined, timeoutSignal: AbortSignal | null): AbortSignal | null {
+function combineSignals(
+  callerSignal: AbortSignal | null | undefined,
+  timeoutSignal: AbortSignal | null,
+): AbortSignal | null {
   if (callerSignal && timeoutSignal && typeof AbortSignal.any === "function") {
     return AbortSignal.any([callerSignal, timeoutSignal]);
   }
   return callerSignal ?? timeoutSignal;
 }
 
-function isTimeoutAbort(error: unknown, timeoutSignal: AbortSignal | null): boolean {
-  if (!error || typeof error !== "object" || !("name" in error) || error.name !== "AbortError") {
+function isTimeoutAbort(
+  error: unknown,
+  timeoutSignal: AbortSignal | null,
+): boolean {
+  if (
+    !error ||
+    typeof error !== "object" ||
+    !("name" in error) ||
+    error.name !== "AbortError"
+  ) {
     return false;
   }
   return Boolean(timeoutSignal?.aborted);
 }
 
-export async function apiFetch(path: string, init?: ApiFetchInit): Promise<Response> {
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, signal: callerSignal, ...requestInit } = init ?? {};
+export async function apiFetch(
+  path: string,
+  init?: ApiFetchInit,
+): Promise<Response> {
+  const {
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signal: callerSignal,
+    ...requestInit
+  } = init ?? {};
   const timeoutSignal = buildTimeoutSignal(timeoutMs);
   const signal = combineSignals(callerSignal ?? null, timeoutSignal);
   let response: Response;
@@ -129,7 +155,10 @@ export async function readJson<T>(r: Response): Promise<T> {
   return JSON.parse(text) as T;
 }
 
-function messageFromResponseBody(body: unknown): { message: string; detail?: unknown } {
+function messageFromResponseBody(body: unknown): {
+  message: string;
+  detail?: unknown;
+} {
   if (body === undefined || body === null) {
     return { message: "" };
   }
@@ -143,7 +172,10 @@ function messageFromResponseBody(body: unknown): { message: string; detail?: unk
   return { message: apiErrorDetailToString(body), detail: body };
 }
 
-export async function apiResponseErrorMessage(r: Response, fallback: string): Promise<{ message: string; detail?: unknown }> {
+export async function apiResponseErrorMessage(
+  r: Response,
+  fallback: string,
+): Promise<{ message: string; detail?: unknown }> {
   const ctype = (r.headers.get("content-type") || "").toLowerCase();
   if (ctype.includes("application/json")) {
     try {
@@ -176,12 +208,20 @@ export async function apiResponseErrorMessage(r: Response, fallback: string): Pr
   return { message: `${fallback} (${r.status})` };
 }
 
-export async function throwApiResponseError(path: string, r: Response, fallback: string): Promise<never> {
+export async function throwApiResponseError(
+  path: string,
+  r: Response,
+  fallback: string,
+): Promise<never> {
   const normalized = await apiResponseErrorMessage(r, fallback);
   throw new ApiHttpError(path, r.status, normalized.message, normalized.detail);
 }
 
-export async function requireOk(path: string, r: Response, fallback: string): Promise<void> {
+export async function requireOk(
+  path: string,
+  r: Response,
+  fallback: string,
+): Promise<void> {
   if (!r.ok) {
     await throwApiResponseError(path, r, fallback);
   }
@@ -204,7 +244,9 @@ export function apiErrorDetailToString(detail: unknown): string {
         const o = item as { msg?: unknown; loc?: unknown };
         const m = o.msg;
         if (typeof m === "string") {
-          const loc = Array.isArray(o.loc) ? o.loc.filter((x) => x !== "body").join(".") : "";
+          const loc = Array.isArray(o.loc)
+            ? o.loc.filter((x) => x !== "body").join(".")
+            : "";
           return loc.length > 0 ? `${loc}: ${m}` : m;
         }
       }

--- a/apps/web/src/lib/api/error-guards.test.ts
+++ b/apps/web/src/lib/api/error-guards.test.ts
@@ -17,12 +17,18 @@ describe("error-guards", () => {
   });
 
   it("does not treat HTTP-shaped API errors as network", () => {
-    expect(isLikelyNetworkFailure(new Error("bootstrap status: 503"))).toBe(false);
+    expect(isLikelyNetworkFailure(new Error("bootstrap status: 503"))).toBe(
+      false,
+    );
     expect(isLikelyNetworkFailure(new Error("me: 503"))).toBe(false);
   });
 
   it("detects HTTP errors from auth-api throws", () => {
-    expect(isHttpErrorFromApi(new ApiHttpError("/api/v1/auth/me", 401, "Signed out"))).toBe(true);
+    expect(
+      isHttpErrorFromApi(
+        new ApiHttpError("/api/v1/auth/me", 401, "Signed out"),
+      ),
+    ).toBe(true);
     expect(isHttpErrorFromApi(new Error("bootstrap status: 503"))).toBe(true);
     expect(isHttpErrorFromApi(new Error("me: 401"))).toBe(true);
     expect(isHttpErrorFromApi(new Error("CSRF: 403"))).toBe(true);
@@ -32,23 +38,37 @@ describe("error-guards", () => {
   });
 
   it("parses status from HTTP-shaped errors", () => {
-    expect(httpStatusFromApiError(new ApiHttpError("/api/v1/auth/me", 401, "Signed out"))).toBe(401);
-    expect(httpStatusFromApiError(new Error("bootstrap status: 503"))).toBe(503);
+    expect(
+      httpStatusFromApiError(
+        new ApiHttpError("/api/v1/auth/me", 401, "Signed out"),
+      ),
+    ).toBe(401);
+    expect(httpStatusFromApiError(new Error("bootstrap status: 503"))).toBe(
+      503,
+    );
     expect(httpStatusFromApiError(new Error("me: 422"))).toBe(422);
     expect(httpStatusFromApiError(new Error("CSRF: 400"))).toBe(400);
-    expect(httpStatusFromApiError(new Error("dashboard status: 401"))).toBe(401);
+    expect(httpStatusFromApiError(new Error("dashboard status: 401"))).toBe(
+      401,
+    );
     expect(httpStatusFromApiError(new Error("activity recent: 500"))).toBe(500);
     expect(httpStatusFromApiError(new Error("nope"))).toBe(null);
   });
 
   it("treats bootstrap/me HTTP 500 in Vite dev as proxy upstream down", () => {
     const expectProxyDown = Boolean(import.meta.env.DEV);
-    expect(isLikelyViteProxyUpstreamDown(new Error("bootstrap status: 500"))).toBe(expectProxyDown);
-    expect(isLikelyViteProxyUpstreamDown(new Error("me: 500"))).toBe(expectProxyDown);
+    expect(
+      isLikelyViteProxyUpstreamDown(new Error("bootstrap status: 500")),
+    ).toBe(expectProxyDown);
+    expect(isLikelyViteProxyUpstreamDown(new Error("me: 500"))).toBe(
+      expectProxyDown,
+    );
   });
 
   it("does not treat non-500 API HTTP errors as Vite proxy upstream down", () => {
-    expect(isLikelyViteProxyUpstreamDown(new Error("bootstrap status: 503"))).toBe(false);
+    expect(
+      isLikelyViteProxyUpstreamDown(new Error("bootstrap status: 503")),
+    ).toBe(false);
     expect(isLikelyViteProxyUpstreamDown(new Error("me: 401"))).toBe(false);
   });
 });

--- a/apps/web/src/lib/auth/queries.ts
+++ b/apps/web/src/lib/auth/queries.ts
@@ -34,8 +34,13 @@ export function useBootstrapStatusQuery() {
 export function useLoginMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ username, password }: { username: string; password: string }) =>
-      postLogin(username, password),
+    mutationFn: ({
+      username,
+      password,
+    }: {
+      username: string;
+      password: string;
+    }) => postLogin(username, password),
     onSuccess: (data) => {
       // Anonymous /me is cached as `null` (401). Hydrate from the login response — do not invalidate
       // /me here: an immediate refetch can run before the session cookie is visible to fetch(), get
@@ -68,8 +73,13 @@ export function useLogoutMutation() {
 export function useBootstrapMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ username, password }: { username: string; password: string }) =>
-      postBootstrap(username, password),
+    mutationFn: ({
+      username,
+      password,
+    }: {
+      username: string;
+      password: string;
+    }) => postBootstrap(username, password),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: qk.bootstrap });
       void qc.invalidateQueries({ queryKey: activityRecentKey });
@@ -81,8 +91,13 @@ export function useBootstrapMutation() {
 export function useChangePasswordMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ currentPassword, newPassword }: { currentPassword: string; newPassword: string }) =>
-      postChangePassword(currentPassword, newPassword),
+    mutationFn: ({
+      currentPassword,
+      newPassword,
+    }: {
+      currentPassword: string;
+      newPassword: string;
+    }) => postChangePassword(currentPassword, newPassword),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: qk.me });
       void qc.invalidateQueries({ queryKey: activityRecentKey });

--- a/apps/web/src/lib/pruner/api.test.ts
+++ b/apps/web/src/lib/pruner/api.test.ts
@@ -15,7 +15,13 @@ import {
 
 describe("prunerApplyEligibilityPath", () => {
   it("scopes apply eligibility under instance + media_scope + preview id", () => {
-    expect(prunerApplyEligibilityPath(5, "movies", "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")).toBe(
+    expect(
+      prunerApplyEligibilityPath(
+        5,
+        "movies",
+        "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      ),
+    ).toBe(
       "/api/v1/pruner/instances/5/scopes/movies/preview-runs/aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee/apply-eligibility",
     );
   });
@@ -23,24 +29,34 @@ describe("prunerApplyEligibilityPath", () => {
 
 describe("prunerApplyLabelForRuleFamily", () => {
   it("maps new movie rule families to operator-facing apply labels", () => {
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED)).toBe(
-      PRUNER_REMOVE_WATCHED_LOW_RATING_MOVIE_ENTRIES_LABEL,
-    );
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED)).toBe(
-      PRUNER_REMOVE_UNWATCHED_STALE_MOVIE_ENTRIES_LABEL,
-    );
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_GENRE_MATCH_REPORTED)).toBe("Remove items matching selected genres");
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_STUDIO_MATCH_REPORTED)).toBe("Remove items from selected studios");
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_PEOPLE_MATCH_REPORTED)).toBe("Remove items involving selected people");
-    expect(prunerApplyLabelForRuleFamily(RULE_FAMILY_YEAR_RANGE_MATCH_REPORTED)).toBe(
-      "Remove items from selected year range",
-    );
+    expect(
+      prunerApplyLabelForRuleFamily(
+        RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
+      ),
+    ).toBe(PRUNER_REMOVE_WATCHED_LOW_RATING_MOVIE_ENTRIES_LABEL);
+    expect(
+      prunerApplyLabelForRuleFamily(RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED),
+    ).toBe(PRUNER_REMOVE_UNWATCHED_STALE_MOVIE_ENTRIES_LABEL);
+    expect(
+      prunerApplyLabelForRuleFamily(RULE_FAMILY_GENRE_MATCH_REPORTED),
+    ).toBe("Remove items matching selected genres");
+    expect(
+      prunerApplyLabelForRuleFamily(RULE_FAMILY_STUDIO_MATCH_REPORTED),
+    ).toBe("Remove items from selected studios");
+    expect(
+      prunerApplyLabelForRuleFamily(RULE_FAMILY_PEOPLE_MATCH_REPORTED),
+    ).toBe("Remove items involving selected people");
+    expect(
+      prunerApplyLabelForRuleFamily(RULE_FAMILY_YEAR_RANGE_MATCH_REPORTED),
+    ).toBe("Remove items from selected year range");
   });
 });
 
 describe("prunerPreviewRunsListPath", () => {
   it("builds the list URL and optional query string", () => {
-    expect(prunerPreviewRunsListPath(12)).toBe("/api/v1/pruner/instances/12/preview-runs");
+    expect(prunerPreviewRunsListPath(12)).toBe(
+      "/api/v1/pruner/instances/12/preview-runs",
+    );
     const q = prunerPreviewRunsListPath(3, { media_scope: "tv", limit: 7 });
     expect(q).toContain("/api/v1/pruner/instances/3/preview-runs?");
     expect(q).toContain("media_scope=tv");

--- a/apps/web/src/lib/pruner/api.ts
+++ b/apps/web/src/lib/pruner/api.ts
@@ -91,24 +91,34 @@ export type PrunerApplyEligibility = {
   apply_operator_label: string;
 };
 
-export const RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED = "missing_primary_media_reported";
-export const RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED = "never_played_stale_reported";
+export const RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED =
+  "missing_primary_media_reported";
+export const RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED =
+  "never_played_stale_reported";
 export const RULE_FAMILY_WATCHED_TV_REPORTED = "watched_tv_reported";
 export const RULE_FAMILY_WATCHED_MOVIES_REPORTED = "watched_movies_reported";
-export const RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED = "watched_movie_low_rating_reported";
-export const RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED = "unwatched_movie_stale_reported";
+export const RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED =
+  "watched_movie_low_rating_reported";
+export const RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED =
+  "unwatched_movie_stale_reported";
 export const RULE_FAMILY_GENRE_MATCH_REPORTED = "genre_match_reported";
 export const RULE_FAMILY_STUDIO_MATCH_REPORTED = "studio_match_reported";
 export const RULE_FAMILY_PEOPLE_MATCH_REPORTED = "people_match_reported";
-export const RULE_FAMILY_YEAR_RANGE_MATCH_REPORTED = "year_range_match_reported";
+export const RULE_FAMILY_YEAR_RANGE_MATCH_REPORTED =
+  "year_range_match_reported";
 
-export const PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL = "Delete items missing a main poster or episode image";
+export const PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL =
+  "Delete items missing a main poster or episode image";
 export const PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL =
   "Delete never-started TV or movies older than your age setting";
-export const PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL = "Delete watched TV episodes";
-export const PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL = "Delete watched movies";
-export const PRUNER_REMOVE_WATCHED_LOW_RATING_MOVIE_ENTRIES_LABEL = "Delete watched movies below your score";
-export const PRUNER_REMOVE_UNWATCHED_STALE_MOVIE_ENTRIES_LABEL = "Delete unwatched movies older than your age setting";
+export const PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL =
+  "Delete watched TV episodes";
+export const PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL =
+  "Delete watched movies";
+export const PRUNER_REMOVE_WATCHED_LOW_RATING_MOVIE_ENTRIES_LABEL =
+  "Delete watched movies below your score";
+export const PRUNER_REMOVE_UNWATCHED_STALE_MOVIE_ENTRIES_LABEL =
+  "Delete unwatched movies older than your age setting";
 
 export function prunerApplyLabelForRuleFamily(ruleFamilyId: string): string {
   if (ruleFamilyId === RULE_FAMILY_WATCHED_TV_REPORTED) {
@@ -183,7 +193,11 @@ export async function fetchPrunerApplyEligibility(
   media_scope: "tv" | "movies",
   previewRunId: string,
 ): Promise<PrunerApplyEligibility> {
-  const path = prunerApplyEligibilityPath(instanceId, media_scope, previewRunId);
+  const path = prunerApplyEligibilityPath(
+    instanceId,
+    media_scope,
+    previewRunId,
+  );
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load Pruner apply eligibility");
   return readJson<PrunerApplyEligibility>(r);
@@ -224,7 +238,9 @@ export async function fetchPrunerInstances(): Promise<PrunerServerInstance[]> {
   return readJson<PrunerServerInstance[]>(r);
 }
 
-export async function fetchPrunerInstance(id: number): Promise<PrunerServerInstance> {
+export async function fetchPrunerInstance(
+  id: number,
+): Promise<PrunerServerInstance> {
   const path = `/api/v1/pruner/instances/${id}`;
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load Pruner server");
@@ -234,9 +250,14 @@ export async function fetchPrunerInstance(id: number): Promise<PrunerServerInsta
 export type PrunerStudiosResponse = { studios: string[] };
 
 /** Read-only studio list for Cleanup UI; returns an empty list on any failure (never throws). */
-export async function fetchPrunerStudios(instanceId: number, scope: "tv" | "movies"): Promise<PrunerStudiosResponse> {
+export async function fetchPrunerStudios(
+  instanceId: number,
+  scope: "tv" | "movies",
+): Promise<PrunerStudiosResponse> {
   try {
-    const r = await apiFetch(`/api/v1/pruner/instances/${instanceId}/studios?scope=${encodeURIComponent(scope)}`);
+    const r = await apiFetch(
+      `/api/v1/pruner/instances/${instanceId}/studios?scope=${encodeURIComponent(scope)}`,
+    );
     if (!r.ok) {
       return { studios: [] };
     }
@@ -293,7 +314,9 @@ export async function fetchPrunerPreviewRun(
   return readJson<PrunerPreviewRun>(r);
 }
 
-export async function postPrunerConnectionTest(instanceId: number): Promise<{ pruner_job_id: number }> {
+export async function postPrunerConnectionTest(
+  instanceId: number,
+): Promise<{ pruner_job_id: number }> {
   const csrf_token = await fetchCsrfToken();
   const path = `/api/v1/pruner/instances/${instanceId}/connection-test`;
   const r = await apiFetch(path, {
@@ -384,7 +407,9 @@ export async function postPrunerPreview(
   return readJson<{ pruner_job_id: number }>(r);
 }
 
-export async function fetchPrunerJobsInspection(limit = 50): Promise<PrunerJobsInspectionOut> {
+export async function fetchPrunerJobsInspection(
+  limit = 50,
+): Promise<PrunerJobsInspectionOut> {
   const params = new URLSearchParams({ limit: String(limit) });
   const path = `/api/v1/pruner/jobs/inspection?${params.toString()}`;
   const r = await apiFetch(path);

--- a/apps/web/src/lib/pruner/queries.ts
+++ b/apps/web/src/lib/pruner/queries.ts
@@ -37,7 +37,10 @@ export function usePrunerJobsInspectionQuery(limit = 100) {
   });
 }
 
-export function usePrunerStudiosQuery(instanceId: number, scope: "tv" | "movies") {
+export function usePrunerStudiosQuery(
+  instanceId: number,
+  scope: "tv" | "movies",
+) {
   return useQuery({
     queryKey: ["pruner", "instances", instanceId, "studios", scope],
     queryFn: () => fetchPrunerStudios(instanceId, scope),

--- a/apps/web/src/lib/refiner/file-remux-pass-api.ts
+++ b/apps/web/src/lib/refiner/file-remux-pass-api.ts
@@ -1,8 +1,12 @@
 import { fetchCsrfToken } from "../api/auth-api";
 import { apiFetch, readJson, requireOk } from "../api/client";
-import type { RefinerFileRemuxPassManualEnqueueBody, RefinerFileRemuxPassManualEnqueueOut } from "./types";
+import type {
+  RefinerFileRemuxPassManualEnqueueBody,
+  RefinerFileRemuxPassManualEnqueueOut,
+} from "./types";
 
-export const refinerFileRemuxPassEnqueuePath = () => "/api/v1/refiner/jobs/file-remux-pass/enqueue";
+export const refinerFileRemuxPassEnqueuePath = () =>
+  "/api/v1/refiner/jobs/file-remux-pass/enqueue";
 
 export async function postRefinerFileRemuxPassEnqueue(
   body: RefinerFileRemuxPassManualEnqueueBody,

--- a/apps/web/src/lib/refiner/jobs-inspection/api.test.ts
+++ b/apps/web/src/lib/refiner/jobs-inspection/api.test.ts
@@ -3,11 +3,16 @@ import { refinerJobsInspectionPath } from "./api";
 
 describe("refinerJobsInspectionPath", () => {
   it("builds default recent listing URL", () => {
-    expect(refinerJobsInspectionPath()).toBe("/api/v1/refiner/jobs/inspection?limit=100");
+    expect(refinerJobsInspectionPath()).toBe(
+      "/api/v1/refiner/jobs/inspection?limit=100",
+    );
   });
 
   it("appends repeated status params", () => {
-    const p = refinerJobsInspectionPath({ limit: 10, statuses: ["pending", "leased"] });
+    const p = refinerJobsInspectionPath({
+      limit: 10,
+      statuses: ["pending", "leased"],
+    });
     expect(p).toContain("/api/v1/refiner/jobs/inspection?");
     expect(p).toContain("limit=10");
     expect(p).toContain("status=pending");

--- a/apps/web/src/lib/refiner/jobs-inspection/api.ts
+++ b/apps/web/src/lib/refiner/jobs-inspection/api.ts
@@ -1,13 +1,18 @@
 import { fetchCsrfToken } from "../../api/auth-api";
 import { apiFetch, readJson, requireOk } from "../../api/client";
-import type { RefinerJobCancelPendingOut, RefinerJobsInspectionOut } from "./types";
+import type {
+  RefinerJobCancelPendingOut,
+  RefinerJobsInspectionOut,
+} from "./types";
 
 export type FetchRefinerJobsInspectionOpts = {
   statuses?: string[];
   limit?: number;
 };
 
-export function refinerJobsInspectionPath(opts?: FetchRefinerJobsInspectionOpts): string {
+export function refinerJobsInspectionPath(
+  opts?: FetchRefinerJobsInspectionOpts,
+): string {
   const params = new URLSearchParams();
   const limit = opts?.limit ?? 100;
   params.set("limit", String(limit));
@@ -28,7 +33,9 @@ export async function fetchRefinerJobsInspection(
   return readJson<RefinerJobsInspectionOut>(r);
 }
 
-export async function postRefinerJobCancelPending(jobId: number): Promise<RefinerJobCancelPendingOut> {
+export async function postRefinerJobCancelPending(
+  jobId: number,
+): Promise<RefinerJobCancelPendingOut> {
   const csrf_token = await fetchCsrfToken();
   const path = `/api/v1/refiner/jobs/${jobId}/cancel-pending`;
   const r = await apiFetch(path, {

--- a/apps/web/src/lib/refiner/jobs-inspection/queries.ts
+++ b/apps/web/src/lib/refiner/jobs-inspection/queries.ts
@@ -12,10 +12,13 @@ export type RefinerJobsInspectionFilter =
   | "cancelled"
   | "terminal";
 
-export const refinerJobsInspectionQueryKey = (filter: RefinerJobsInspectionFilter) =>
-  ["refiner", "jobs", "inspection", filter] as const;
+export const refinerJobsInspectionQueryKey = (
+  filter: RefinerJobsInspectionFilter,
+) => ["refiner", "jobs", "inspection", filter] as const;
 
-function statusesForFilter(filter: RefinerJobsInspectionFilter): string[] | undefined {
+function statusesForFilter(
+  filter: RefinerJobsInspectionFilter,
+): string[] | undefined {
   if (filter === "recent") {
     return undefined;
   }
@@ -25,7 +28,9 @@ function statusesForFilter(filter: RefinerJobsInspectionFilter): string[] | unde
   return [filter];
 }
 
-export function useRefinerJobsInspectionQuery(filter: RefinerJobsInspectionFilter) {
+export function useRefinerJobsInspectionQuery(
+  filter: RefinerJobsInspectionFilter,
+) {
   return useQuery({
     queryKey: refinerJobsInspectionQueryKey(filter),
     queryFn: () =>
@@ -42,7 +47,9 @@ export function useRefinerJobCancelPendingMutation() {
   return useMutation({
     mutationFn: (jobId: number) => postRefinerJobCancelPending(jobId),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["refiner", "jobs", "inspection"] });
+      void qc.invalidateQueries({
+        queryKey: ["refiner", "jobs", "inspection"],
+      });
     },
   });
 }

--- a/apps/web/src/lib/refiner/operator-settings-api.ts
+++ b/apps/web/src/lib/refiner/operator-settings-api.ts
@@ -1,8 +1,12 @@
 import { fetchCsrfToken } from "../api/auth-api";
 import { apiFetch, readJson, requireOk } from "../api/client";
-import type { RefinerOperatorSettingsOut, RefinerOperatorSettingsPutBody } from "./types";
+import type {
+  RefinerOperatorSettingsOut,
+  RefinerOperatorSettingsPutBody,
+} from "./types";
 
-export const refinerOperatorSettingsPath = () => "/api/v1/refiner/operator-settings";
+export const refinerOperatorSettingsPath = () =>
+  "/api/v1/refiner/operator-settings";
 
 export async function fetchRefinerOperatorSettings(): Promise<RefinerOperatorSettingsOut> {
   const path = refinerOperatorSettingsPath();

--- a/apps/web/src/lib/refiner/path-settings-api.ts
+++ b/apps/web/src/lib/refiner/path-settings-api.ts
@@ -1,6 +1,9 @@
 import { fetchCsrfToken } from "../api/auth-api";
 import { apiFetch, readJson, requireOk } from "../api/client";
-import type { RefinerPathSettingsOut, RefinerPathSettingsPutBody } from "./types";
+import type {
+  RefinerPathSettingsOut,
+  RefinerPathSettingsPutBody,
+} from "./types";
 
 export const refinerPathSettingsPath = () => "/api/v1/refiner/path-settings";
 
@@ -11,7 +14,9 @@ export async function fetchRefinerPathSettings(): Promise<RefinerPathSettingsOut
   return readJson<RefinerPathSettingsOut>(r);
 }
 
-export async function putRefinerPathSettings(body: RefinerPathSettingsPutBody): Promise<RefinerPathSettingsOut> {
+export async function putRefinerPathSettings(
+  body: RefinerPathSettingsPutBody,
+): Promise<RefinerPathSettingsOut> {
   const csrf_token = await fetchCsrfToken();
   const path = refinerPathSettingsPath();
   const r = await apiFetch(path, {

--- a/apps/web/src/lib/refiner/queries.ts
+++ b/apps/web/src/lib/refiner/queries.ts
@@ -1,9 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { postRefinerFileRemuxPassEnqueue } from "./file-remux-pass-api";
-import { fetchRefinerOperatorSettings, putRefinerOperatorSettings } from "./operator-settings-api";
+import {
+  fetchRefinerOperatorSettings,
+  putRefinerOperatorSettings,
+} from "./operator-settings-api";
 import { fetchRefinerOverviewStats } from "./overview-stats-api";
-import { fetchRefinerPathSettings, putRefinerPathSettings } from "./path-settings-api";
-import { fetchRefinerRemuxRulesSettings, putRefinerRemuxRulesSettings } from "./remux-rules-settings-api";
+import {
+  fetchRefinerPathSettings,
+  putRefinerPathSettings,
+} from "./path-settings-api";
+import {
+  fetchRefinerRemuxRulesSettings,
+  putRefinerRemuxRulesSettings,
+} from "./remux-rules-settings-api";
 import { fetchRefinerRuntimeSettings } from "./runtime-settings-api";
 import { postRefinerWatchedFolderRemuxScanDispatchEnqueue } from "./watched-folder-scan-api";
 import type {
@@ -14,9 +23,18 @@ import type {
   RefinerWatchedFolderRemuxScanDispatchEnqueueBody,
 } from "./types";
 
-export const refinerPathSettingsQueryKey = ["refiner", "path-settings"] as const;
-export const refinerOverviewStatsQueryKey = ["refiner", "overview-stats"] as const;
-export const refinerOperatorSettingsQueryKey = ["refiner", "operator-settings"] as const;
+export const refinerPathSettingsQueryKey = [
+  "refiner",
+  "path-settings",
+] as const;
+export const refinerOverviewStatsQueryKey = [
+  "refiner",
+  "overview-stats",
+] as const;
+export const refinerOperatorSettingsQueryKey = [
+  "refiner",
+  "operator-settings",
+] as const;
 
 export function useRefinerOverviewStatsQuery() {
   return useQuery({
@@ -37,7 +55,8 @@ export function useRefinerOperatorSettingsQuery() {
 export function useRefinerOperatorSettingsSaveMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: RefinerOperatorSettingsPutBody) => putRefinerOperatorSettings(body),
+    mutationFn: (body: RefinerOperatorSettingsPutBody) =>
+      putRefinerOperatorSettings(body),
     onSuccess: (data) => {
       qc.setQueryData(refinerOperatorSettingsQueryKey, data);
       void qc.invalidateQueries({ queryKey: refinerRuntimeSettingsQueryKey });
@@ -56,14 +75,18 @@ export function useRefinerPathSettingsQuery() {
 export function useRefinerPathSettingsSaveMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: RefinerPathSettingsPutBody) => putRefinerPathSettings(body),
+    mutationFn: (body: RefinerPathSettingsPutBody) =>
+      putRefinerPathSettings(body),
     onSuccess: (data) => {
       qc.setQueryData(refinerPathSettingsQueryKey, data);
     },
   });
 }
 
-export const refinerRuntimeSettingsQueryKey = ["refiner", "runtime-settings"] as const;
+export const refinerRuntimeSettingsQueryKey = [
+  "refiner",
+  "runtime-settings",
+] as const;
 
 export function useRefinerRuntimeSettingsQuery() {
   return useQuery({
@@ -80,7 +103,10 @@ export function useRefinerWatchedFolderRemuxScanDispatchEnqueueMutation() {
   });
 }
 
-export const refinerRemuxRulesSettingsQueryKey = ["refiner", "remux-rules-settings"] as const;
+export const refinerRemuxRulesSettingsQueryKey = [
+  "refiner",
+  "remux-rules-settings",
+] as const;
 
 export function useRefinerRemuxRulesSettingsQuery() {
   return useQuery({
@@ -93,7 +119,8 @@ export function useRefinerRemuxRulesSettingsQuery() {
 export function useRefinerRemuxRulesSettingsSaveMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: RefinerRemuxRulesSettingsPutBody) => putRefinerRemuxRulesSettings(body),
+    mutationFn: (body: RefinerRemuxRulesSettingsPutBody) =>
+      putRefinerRemuxRulesSettings(body),
     onSuccess: (data) => {
       qc.setQueryData(refinerRemuxRulesSettingsQueryKey, data);
     },
@@ -103,9 +130,12 @@ export function useRefinerRemuxRulesSettingsSaveMutation() {
 export function useRefinerFileRemuxPassEnqueueMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (body: RefinerFileRemuxPassManualEnqueueBody) => postRefinerFileRemuxPassEnqueue(body),
+    mutationFn: (body: RefinerFileRemuxPassManualEnqueueBody) =>
+      postRefinerFileRemuxPassEnqueue(body),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["refiner", "jobs", "inspection"] });
+      void qc.invalidateQueries({
+        queryKey: ["refiner", "jobs", "inspection"],
+      });
     },
   });
 }

--- a/apps/web/src/lib/refiner/remux-rules-settings-api.ts
+++ b/apps/web/src/lib/refiner/remux-rules-settings-api.ts
@@ -1,8 +1,12 @@
 import { fetchCsrfToken } from "../api/auth-api";
 import { apiFetch, readJson, requireOk } from "../api/client";
-import type { RefinerRemuxRulesSettingsOut, RefinerRemuxRulesSettingsPutBody } from "./types";
+import type {
+  RefinerRemuxRulesSettingsOut,
+  RefinerRemuxRulesSettingsPutBody,
+} from "./types";
 
-export const refinerRemuxRulesSettingsPath = () => "/api/v1/refiner/remux-rules-settings";
+export const refinerRemuxRulesSettingsPath = () =>
+  "/api/v1/refiner/remux-rules-settings";
 
 export async function fetchRefinerRemuxRulesSettings(): Promise<RefinerRemuxRulesSettingsOut> {
   const path = refinerRemuxRulesSettingsPath();

--- a/apps/web/src/lib/refiner/runtime-settings-api.test.ts
+++ b/apps/web/src/lib/refiner/runtime-settings-api.test.ts
@@ -3,6 +3,8 @@ import { refinerRuntimeSettingsPath } from "./runtime-settings-api";
 
 describe("refinerRuntimeSettingsPath", () => {
   it("uses Refiner runtime-settings route", () => {
-    expect(refinerRuntimeSettingsPath()).toBe("/api/v1/refiner/runtime-settings");
+    expect(refinerRuntimeSettingsPath()).toBe(
+      "/api/v1/refiner/runtime-settings",
+    );
   });
 });

--- a/apps/web/src/lib/refiner/runtime-settings-api.ts
+++ b/apps/web/src/lib/refiner/runtime-settings-api.ts
@@ -1,7 +1,8 @@
 import { apiFetch, readJson, requireOk } from "../api/client";
 import type { RefinerRuntimeSettingsOut } from "./types";
 
-export const refinerRuntimeSettingsPath = () => "/api/v1/refiner/runtime-settings";
+export const refinerRuntimeSettingsPath = () =>
+  "/api/v1/refiner/runtime-settings";
 
 export async function fetchRefinerRuntimeSettings(): Promise<RefinerRuntimeSettingsOut> {
   const path = refinerRuntimeSettingsPath();

--- a/apps/web/src/lib/refiner/stream-language-options.ts
+++ b/apps/web/src/lib/refiner/stream-language-options.ts
@@ -1,5 +1,8 @@
 /** ISO-639-3 codes + English labels for operator stream-language picks. */
-export const REFINER_STREAM_LANGUAGE_OPTIONS: readonly { code: string; label: string }[] = [
+export const REFINER_STREAM_LANGUAGE_OPTIONS: readonly {
+  code: string;
+  label: string;
+}[] = [
   { code: "eng", label: "English" },
   { code: "jpn", label: "Japanese" },
   { code: "spa", label: "Spanish" },
@@ -32,7 +35,9 @@ export const REFINER_STREAM_LANGUAGE_OPTIONS: readonly { code: string; label: st
   { code: "und", label: "Undetermined" },
 ] as const;
 
-export function refinerStreamLanguageLabel(code: string | null | undefined): string {
+export function refinerStreamLanguageLabel(
+  code: string | null | undefined,
+): string {
   const c = (code ?? "").trim().toLowerCase();
   if (!c) {
     return "—";

--- a/apps/web/src/lib/refiner/types.ts
+++ b/apps/web/src/lib/refiner/types.ts
@@ -150,12 +150,16 @@ export type RefinerRemuxRulesScopeSettings = {
   subtitle_langs_csv: string;
   preserve_forced_subs: boolean;
   preserve_default_subs: boolean;
-  audio_preference_mode: "preferred_langs_quality" | "preferred_langs_strict" | "quality_all_languages";
+  audio_preference_mode:
+    | "preferred_langs_quality"
+    | "preferred_langs_strict"
+    | "quality_all_languages";
 };
 
-export type RefinerRemuxRulesSettingsPutBody = RefinerRemuxRulesScopeSettings & {
-  media_scope: "movie" | "tv";
-};
+export type RefinerRemuxRulesSettingsPutBody =
+  RefinerRemuxRulesScopeSettings & {
+    media_scope: "movie" | "tv";
+  };
 
 /** POST /api/v1/refiner/jobs/file-remux-pass/enqueue */
 

--- a/apps/web/src/lib/subber/subber-api.ts
+++ b/apps/web/src/lib/subber/subber-api.ts
@@ -172,6 +172,8 @@ export type SubberProviderOut = {
   priority: number | null;
   requires_account: boolean;
   has_credentials: boolean;
+  available: boolean;
+  availability_note: string | null;
 };
 
 export type SubberProviderPutIn = {

--- a/apps/web/src/lib/subber/subber-api.ts
+++ b/apps/web/src/lib/subber/subber-api.ts
@@ -39,7 +39,10 @@ export type SubberMovieRow = {
   languages: SubberSubtitleLangState[];
 };
 
-export type SubberMoviesLibraryOut = { movies: SubberMovieRow[]; total: number };
+export type SubberMoviesLibraryOut = {
+  movies: SubberMovieRow[];
+  total: number;
+};
 
 /** Flat JSON from GET/PUT ``/api/v1/subber/settings``; field groups mirror ``subber_settings_schema_sections`` on the server and the Subber Settings tab UI. */
 export type SubberSettingsOut = {
@@ -197,7 +200,10 @@ export type SubberJobsInspectionRow = {
   updated_at: string;
 };
 
-export type SubberJobsInspectionOut = { jobs: SubberJobsInspectionRow[]; default_recent_slice: boolean };
+export type SubberJobsInspectionOut = {
+  jobs: SubberJobsInspectionRow[];
+  default_recent_slice: boolean;
+};
 
 export async function fetchSubberSettings(): Promise<SubberSettingsOut> {
   const path = "/api/v1/subber/settings";
@@ -206,7 +212,9 @@ export async function fetchSubberSettings(): Promise<SubberSettingsOut> {
   return readJson<SubberSettingsOut>(r);
 }
 
-export async function putSubberSettings(body: SubberSettingsPutIn): Promise<SubberSettingsOut> {
+export async function putSubberSettings(
+  body: SubberSettingsPutIn,
+): Promise<SubberSettingsOut> {
   const path = "/api/v1/subber/settings";
   const r = await apiFetch(path, {
     method: "PUT",
@@ -324,7 +332,9 @@ export async function fetchSubberLibraryMovies(params: {
   return readJson<SubberMoviesLibraryOut>(r);
 }
 
-export async function postSubberSearchNow(stateId: number): Promise<{ status: string }> {
+export async function postSubberSearchNow(
+  stateId: number,
+): Promise<{ status: string }> {
   const csrf = await fetchCsrfToken();
   const path = `/api/v1/subber/library/${stateId}/search-now`;
   const r = await apiFetch(path, {
@@ -336,7 +346,9 @@ export async function postSubberSearchNow(stateId: number): Promise<{ status: st
   return readJson(r);
 }
 
-export async function postSubberSearchAllMissingTv(): Promise<{ status: string }> {
+export async function postSubberSearchAllMissingTv(): Promise<{
+  status: string;
+}> {
   const csrf = await fetchCsrfToken();
   const path = "/api/v1/subber/library/search-all-missing/tv";
   const r = await apiFetch(path, {
@@ -348,7 +360,9 @@ export async function postSubberSearchAllMissingTv(): Promise<{ status: string }
   return readJson(r);
 }
 
-export async function postSubberSearchAllMissingMovies(): Promise<{ status: string }> {
+export async function postSubberSearchAllMissingMovies(): Promise<{
+  status: string;
+}> {
   const csrf = await fetchCsrfToken();
   const path = "/api/v1/subber/library/search-all-missing/movies";
   const r = await apiFetch(path, {
@@ -372,7 +386,9 @@ export async function postSubberLibrarySyncTv(): Promise<{ status: string }> {
   return readJson(r);
 }
 
-export async function postSubberLibrarySyncMovies(): Promise<{ status: string }> {
+export async function postSubberLibrarySyncMovies(): Promise<{
+  status: string;
+}> {
   const csrf = await fetchCsrfToken();
   const path = "/api/v1/subber/library/sync/movies";
   const r = await apiFetch(path, {
@@ -391,7 +407,10 @@ export async function fetchSubberProviders(): Promise<SubberProviderOut[]> {
   return readJson<SubberProviderOut[]>(r);
 }
 
-export async function putSubberProvider(providerKey: string, body: SubberProviderPutIn): Promise<SubberProviderOut> {
+export async function putSubberProvider(
+  providerKey: string,
+  body: SubberProviderPutIn,
+): Promise<SubberProviderOut> {
   const pk = encodeURIComponent(providerKey);
   const path = `/api/v1/subber/providers/${pk}`;
   const r = await apiFetch(path, {
@@ -403,7 +422,9 @@ export async function putSubberProvider(providerKey: string, body: SubberProvide
   return readJson<SubberProviderOut>(r);
 }
 
-export async function postSubberProviderTest(providerKey: string): Promise<SubberTestConnectionOut> {
+export async function postSubberProviderTest(
+  providerKey: string,
+): Promise<SubberTestConnectionOut> {
   const csrf = await fetchCsrfToken();
   const pk = encodeURIComponent(providerKey);
   const path = `/api/v1/subber/providers/${pk}/test`;
@@ -416,7 +437,9 @@ export async function postSubberProviderTest(providerKey: string): Promise<Subbe
   return readJson<SubberTestConnectionOut>(r);
 }
 
-export async function fetchSubberJobs(limit = 50): Promise<SubberJobsInspectionOut> {
+export async function fetchSubberJobs(
+  limit = 50,
+): Promise<SubberJobsInspectionOut> {
   const path = `/api/v1/subber/jobs?limit=${encodeURIComponent(String(limit))}`;
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load Subber jobs");

--- a/apps/web/src/lib/subber/subber-languages.ts
+++ b/apps/web/src/lib/subber/subber-languages.ts
@@ -21,7 +21,9 @@ export const SUBBER_LANGUAGE_BY_CODE: Record<string, string> = {
   tr: "Turkish",
 };
 
-export const SUBBER_LANGUAGE_OPTIONS = Object.entries(SUBBER_LANGUAGE_BY_CODE).map(([code, label]) => ({
+export const SUBBER_LANGUAGE_OPTIONS = Object.entries(
+  SUBBER_LANGUAGE_BY_CODE,
+).map(([code, label]) => ({
   code,
   label,
 }));

--- a/apps/web/src/lib/subber/subber-queries.ts
+++ b/apps/web/src/lib/subber/subber-queries.ts
@@ -97,7 +97,13 @@ export function usePutSubberSettingsMutation() {
 export function usePutSubberProviderMutation() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ providerKey, body }: { providerKey: string; body: SubberProviderPutIn }) => putSubberProvider(providerKey, body),
+    mutationFn: ({
+      providerKey,
+      body,
+    }: {
+      providerKey: string;
+      body: SubberProviderPutIn;
+    }) => putSubberProvider(providerKey, body),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["subber", "providers"] });
     },

--- a/apps/web/src/lib/suite/queries.ts
+++ b/apps/web/src/lib/suite/queries.ts
@@ -13,8 +13,14 @@ import {
 import type { SuiteSettingsPutBody } from "./types";
 
 export const suiteSettingsQueryKey = ["suite", "settings"] as const;
-export const suiteSecurityOverviewQueryKey = ["suite", "security-overview"] as const;
-export const suiteConfigurationBackupsQueryKey = ["suite", "configuration-backups"] as const;
+export const suiteSecurityOverviewQueryKey = [
+  "suite",
+  "security-overview",
+] as const;
+export const suiteConfigurationBackupsQueryKey = [
+  "suite",
+  "configuration-backups",
+] as const;
 export const suiteUpdateStatusQueryKey = ["suite", "update-status"] as const;
 export const suiteLogsQueryKey = ["suite", "logs"] as const;
 export const suiteMetricsQueryKey = ["suite", "metrics"] as const;

--- a/apps/web/src/lib/suite/suite-settings-api.test.ts
+++ b/apps/web/src/lib/suite/suite-settings-api.test.ts
@@ -11,9 +11,17 @@ describe("suite settings API paths", () => {
   it("uses suite settings and security-overview routes", () => {
     expect(suiteSettingsPath()).toBe("/api/v1/suite/settings");
     expect(suiteSecurityOverviewPath()).toBe("/api/v1/suite/security-overview");
-    expect(suiteConfigurationBundlePath()).toBe("/api/v1/suite/configuration-bundle");
-    expect(suiteConfigurationBackupsPath()).toBe("/api/v1/suite/configuration-backups");
-    expect(configurationBundlePaths).toContain("/api/v1/suite/settings/configuration-bundle");
-    expect(configurationBundlePaths).toContain("/api/v1/system/suite-configuration-bundle");
+    expect(suiteConfigurationBundlePath()).toBe(
+      "/api/v1/suite/configuration-bundle",
+    );
+    expect(suiteConfigurationBackupsPath()).toBe(
+      "/api/v1/suite/configuration-backups",
+    );
+    expect(configurationBundlePaths).toContain(
+      "/api/v1/suite/settings/configuration-bundle",
+    );
+    expect(configurationBundlePaths).toContain(
+      "/api/v1/system/suite-configuration-bundle",
+    );
   });
 });

--- a/apps/web/src/lib/suite/suite-settings-api.ts
+++ b/apps/web/src/lib/suite/suite-settings-api.ts
@@ -1,5 +1,10 @@
 import { fetchCsrfToken } from "../api/auth-api";
-import { apiFetch, readJson, requireOk, throwApiResponseError } from "../api/client";
+import {
+  apiFetch,
+  readJson,
+  requireOk,
+  throwApiResponseError,
+} from "../api/client";
 import type {
   SuiteConfigurationBackupListOut,
   SuiteLogsOut,
@@ -13,14 +18,22 @@ import type {
 } from "./types";
 
 export const suiteSettingsPath = () => "/api/v1/suite/settings";
-export const suiteSecurityOverviewPath = () => "/api/v1/suite/security-overview";
-export const suiteUpdateStatusPaths = ["/api/v1/suite/update-status", "/api/v1/suite/settings/update-status"] as const;
-export const suiteUpdateNowPaths = ["/api/v1/suite/update-now", "/api/v1/suite/settings/update-now"] as const;
+export const suiteSecurityOverviewPath = () =>
+  "/api/v1/suite/security-overview";
+export const suiteUpdateStatusPaths = [
+  "/api/v1/suite/update-status",
+  "/api/v1/suite/settings/update-status",
+] as const;
+export const suiteUpdateNowPaths = [
+  "/api/v1/suite/update-now",
+  "/api/v1/suite/settings/update-now",
+] as const;
 export const suiteUpdateStatusPath = () => suiteUpdateStatusPaths[0];
 export const suiteUpdateNowPath = () => suiteUpdateNowPaths[0];
 export const suiteLogsPath = () => "/api/v1/suite/logs";
 export const suiteMetricsPath = () => "/api/v1/suite/metrics";
-export const suiteOperationalHistoryResetPath = () => "/api/v1/suite/operational-history/reset";
+export const suiteOperationalHistoryResetPath = () =>
+  "/api/v1/suite/operational-history/reset";
 
 /**
  * GET/PUT configuration bundle: same handler on the backend, several URL aliases for older builds
@@ -34,9 +47,12 @@ export const configurationBundlePaths = [
 
 /** Preferred path (first entry in {@link configurationBundlePaths}). */
 export const suiteConfigurationBundlePath = () => configurationBundlePaths[0];
-export const suiteConfigurationBackupsPath = () => "/api/v1/suite/configuration-backups";
+export const suiteConfigurationBackupsPath = () =>
+  "/api/v1/suite/configuration-backups";
 
-export type ConfigurationBundle = Record<string, unknown> & { format_version: number };
+export type ConfigurationBundle = Record<string, unknown> & {
+  format_version: number;
+};
 
 export async function fetchSuiteSettings(): Promise<SuiteSettingsOut> {
   const path = suiteSettingsPath();
@@ -45,7 +61,9 @@ export async function fetchSuiteSettings(): Promise<SuiteSettingsOut> {
   return readJson<SuiteSettingsOut>(r);
 }
 
-export async function putSuiteSettings(body: SuiteSettingsPutBody): Promise<SuiteSettingsOut> {
+export async function putSuiteSettings(
+  body: SuiteSettingsPutBody,
+): Promise<SuiteSettingsOut> {
   const csrf_token = await fetchCsrfToken();
   const path = suiteSettingsPath();
   const r = await apiFetch(path, {
@@ -77,7 +95,11 @@ export async function fetchSuiteUpdateStatus(): Promise<SuiteUpdateStatusOut> {
     }
     return readJson<SuiteUpdateStatusOut>(r);
   }
-  return throwApiResponseError(suiteUpdateStatusPath(), last!, "Could not check for updates");
+  return throwApiResponseError(
+    suiteUpdateStatusPath(),
+    last!,
+    "Could not check for updates",
+  );
 }
 
 export async function startSuiteUpdateNow(): Promise<SuiteUpdateStartOut> {
@@ -98,7 +120,11 @@ export async function startSuiteUpdateNow(): Promise<SuiteUpdateStartOut> {
     }
     return readJson<SuiteUpdateStartOut>(r);
   }
-  return throwApiResponseError(suiteUpdateNowPath(), last!, "Could not start upgrade");
+  return throwApiResponseError(
+    suiteUpdateNowPath(),
+    last!,
+    "Could not start upgrade",
+  );
 }
 
 export async function fetchSuiteLogs(filters?: {
@@ -110,9 +136,14 @@ export async function fetchSuiteLogs(filters?: {
   const params = new URLSearchParams();
   if (filters?.level) params.set("level", filters.level);
   if (filters?.search) params.set("search", filters.search);
-  if (typeof filters?.has_exception === "boolean") params.set("has_exception", String(filters.has_exception));
-  if (typeof filters?.limit === "number") params.set("limit", String(filters.limit));
-  const path = params.size > 0 ? `${suiteLogsPath()}?${params.toString()}` : suiteLogsPath();
+  if (typeof filters?.has_exception === "boolean")
+    params.set("has_exception", String(filters.has_exception));
+  if (typeof filters?.limit === "number")
+    params.set("limit", String(filters.limit));
+  const path =
+    params.size > 0
+      ? `${suiteLogsPath()}?${params.toString()}`
+      : suiteLogsPath();
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load logs");
   return readJson<SuiteLogsOut>(r);
@@ -125,7 +156,9 @@ export async function fetchSuiteMetrics(): Promise<SuiteMetricsOut> {
   return readJson<SuiteMetricsOut>(r);
 }
 
-export async function resetSuiteOperationalHistory(confirm: string): Promise<SuiteOperationalHistoryResetOut> {
+export async function resetSuiteOperationalHistory(
+  confirm: string,
+): Promise<SuiteOperationalHistoryResetOut> {
   const csrf_token = await fetchCsrfToken();
   const path = suiteOperationalHistoryResetPath();
   const r = await apiFetch(path, {
@@ -150,10 +183,16 @@ export async function fetchConfigurationBundle(): Promise<ConfigurationBundle> {
     }
     return readJson<ConfigurationBundle>(r);
   }
-  return throwApiResponseError(suiteConfigurationBundlePath(), last!, "Could not export configuration");
+  return throwApiResponseError(
+    suiteConfigurationBundlePath(),
+    last!,
+    "Could not export configuration",
+  );
 }
 
-export async function putConfigurationBundle(bundle: ConfigurationBundle): Promise<ConfigurationBundle> {
+export async function putConfigurationBundle(
+  bundle: ConfigurationBundle,
+): Promise<ConfigurationBundle> {
   const csrf_token = await fetchCsrfToken();
   let last: Response | undefined;
   for (const path of configurationBundlePaths) {
@@ -171,7 +210,11 @@ export async function putConfigurationBundle(bundle: ConfigurationBundle): Promi
     }
     return readJson<ConfigurationBundle>(r);
   }
-  return throwApiResponseError(suiteConfigurationBundlePath(), last!, "Could not restore configuration");
+  return throwApiResponseError(
+    suiteConfigurationBundlePath(),
+    last!,
+    "Could not restore configuration",
+  );
 }
 
 export async function fetchConfigurationBackupList(): Promise<SuiteConfigurationBackupListOut> {
@@ -181,7 +224,9 @@ export async function fetchConfigurationBackupList(): Promise<SuiteConfiguration
   return readJson<SuiteConfigurationBackupListOut>(r);
 }
 
-export async function fetchStoredConfigurationBackupBlob(backupId: number): Promise<Blob> {
+export async function fetchStoredConfigurationBackupBlob(
+  backupId: number,
+): Promise<Blob> {
   const path = `${suiteConfigurationBackupsPath()}/${backupId}/download`;
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not download automatic snapshot");

--- a/apps/web/src/lib/suite/timezone-options.ts
+++ b/apps/web/src/lib/suite/timezone-options.ts
@@ -6,41 +6,138 @@ export type CuratedTimezoneOption = {
 };
 
 export const CURATED_TIMEZONE_OPTIONS: readonly CuratedTimezoneOption[] = [
-  { id: "Australia/Sydney", country: "Australia", city: "Sydney", zoneName: "" },
-  { id: "Australia/Melbourne", country: "Australia", city: "Melbourne", zoneName: "" },
-  { id: "Australia/Brisbane", country: "Australia", city: "Brisbane", zoneName: "" },
-  { id: "Australia/Adelaide", country: "Australia", city: "Adelaide", zoneName: "" },
-  { id: "Australia/Darwin", country: "Australia", city: "Darwin", zoneName: "" },
+  {
+    id: "Australia/Sydney",
+    country: "Australia",
+    city: "Sydney",
+    zoneName: "",
+  },
+  {
+    id: "Australia/Melbourne",
+    country: "Australia",
+    city: "Melbourne",
+    zoneName: "",
+  },
+  {
+    id: "Australia/Brisbane",
+    country: "Australia",
+    city: "Brisbane",
+    zoneName: "",
+  },
+  {
+    id: "Australia/Adelaide",
+    country: "Australia",
+    city: "Adelaide",
+    zoneName: "",
+  },
+  {
+    id: "Australia/Darwin",
+    country: "Australia",
+    city: "Darwin",
+    zoneName: "",
+  },
   { id: "Australia/Perth", country: "Australia", city: "Perth", zoneName: "" },
-  { id: "America/New_York", country: "United States", city: "New York", zoneName: "Eastern" },
-  { id: "America/Chicago", country: "United States", city: "Chicago", zoneName: "Central" },
-  { id: "America/Denver", country: "United States", city: "Denver", zoneName: "Mountain" },
-  { id: "America/Los_Angeles", country: "United States", city: "Los Angeles", zoneName: "Pacific" },
-  { id: "America/Anchorage", country: "United States", city: "Anchorage", zoneName: "Alaska" },
-  { id: "Pacific/Honolulu", country: "United States", city: "Honolulu", zoneName: "Hawaii" },
+  {
+    id: "America/New_York",
+    country: "United States",
+    city: "New York",
+    zoneName: "Eastern",
+  },
+  {
+    id: "America/Chicago",
+    country: "United States",
+    city: "Chicago",
+    zoneName: "Central",
+  },
+  {
+    id: "America/Denver",
+    country: "United States",
+    city: "Denver",
+    zoneName: "Mountain",
+  },
+  {
+    id: "America/Los_Angeles",
+    country: "United States",
+    city: "Los Angeles",
+    zoneName: "Pacific",
+  },
+  {
+    id: "America/Anchorage",
+    country: "United States",
+    city: "Anchorage",
+    zoneName: "Alaska",
+  },
+  {
+    id: "Pacific/Honolulu",
+    country: "United States",
+    city: "Honolulu",
+    zoneName: "Hawaii",
+  },
   { id: "Asia/Shanghai", country: "China", city: "Shanghai", zoneName: "" },
   { id: "Asia/Kolkata", country: "India", city: "Mumbai", zoneName: "" },
   { id: "Asia/Tokyo", country: "Japan", city: "Tokyo", zoneName: "" },
   { id: "Europe/Berlin", country: "Germany", city: "Berlin", zoneName: "" },
-  { id: "Europe/London", country: "United Kingdom", city: "London", zoneName: "" },
+  {
+    id: "Europe/London",
+    country: "United Kingdom",
+    city: "London",
+    zoneName: "",
+  },
   { id: "Europe/Paris", country: "France", city: "Paris", zoneName: "" },
   { id: "Europe/Rome", country: "Italy", city: "Rome", zoneName: "" },
-  { id: "America/Sao_Paulo", country: "Brazil", city: "Sao Paulo", zoneName: "" },
+  {
+    id: "America/Sao_Paulo",
+    country: "Brazil",
+    city: "Sao Paulo",
+    zoneName: "",
+  },
   { id: "America/Toronto", country: "Canada", city: "Toronto", zoneName: "" },
   { id: "Europe/Moscow", country: "Russia", city: "Moscow", zoneName: "" },
   { id: "Asia/Seoul", country: "South Korea", city: "Seoul", zoneName: "" },
-  { id: "Asia/Singapore", country: "Singapore", city: "Singapore", zoneName: "" },
+  {
+    id: "Asia/Singapore",
+    country: "Singapore",
+    city: "Singapore",
+    zoneName: "",
+  },
   { id: "Asia/Jakarta", country: "Indonesia", city: "Jakarta", zoneName: "" },
   { id: "Asia/Bangkok", country: "Thailand", city: "Bangkok", zoneName: "" },
-  { id: "Asia/Dubai", country: "United Arab Emirates", city: "Dubai", zoneName: "" },
-  { id: "Europe/Amsterdam", country: "Netherlands", city: "Amsterdam", zoneName: "" },
+  {
+    id: "Asia/Dubai",
+    country: "United Arab Emirates",
+    city: "Dubai",
+    zoneName: "",
+  },
+  {
+    id: "Europe/Amsterdam",
+    country: "Netherlands",
+    city: "Amsterdam",
+    zoneName: "",
+  },
   { id: "Europe/Madrid", country: "Spain", city: "Madrid", zoneName: "" },
-  { id: "Africa/Johannesburg", country: "South Africa", city: "Johannesburg", zoneName: "" },
-  { id: "Asia/Hong_Kong", country: "Hong Kong", city: "Hong Kong", zoneName: "" },
-  { id: "Pacific/Auckland", country: "New Zealand", city: "Auckland", zoneName: "" },
+  {
+    id: "Africa/Johannesburg",
+    country: "South Africa",
+    city: "Johannesburg",
+    zoneName: "",
+  },
+  {
+    id: "Asia/Hong_Kong",
+    country: "Hong Kong",
+    city: "Hong Kong",
+    zoneName: "",
+  },
+  {
+    id: "Pacific/Auckland",
+    country: "New Zealand",
+    city: "Auckland",
+    zoneName: "",
+  },
 ];
 
-export const CURATED_TIMEZONE_ID_SET: Set<string> = new Set(CURATED_TIMEZONE_OPTIONS.map((o) => o.id));
+export const CURATED_TIMEZONE_ID_SET: Set<string> = new Set(
+  CURATED_TIMEZONE_OPTIONS.map((o) => o.id),
+);
 
 function timezoneOffsetLabel(tz: string): string {
   try {
@@ -50,7 +147,9 @@ function timezoneOffsetLabel(tz: string): string {
       timeZoneName: "shortOffset",
       timeZone: tz,
     });
-    const part = formatter.formatToParts(new Date()).find((p) => p.type === "timeZoneName");
+    const part = formatter
+      .formatToParts(new Date())
+      .find((p) => p.type === "timeZoneName");
     return (part?.value || "UTC+0").replace("GMT", "UTC");
   } catch {
     return "UTC+0";
@@ -66,7 +165,10 @@ export function curatedTimezoneLabelById(tz: string): string | null {
   return `${option.country} — ${option.city}${zone} (${timezoneOffsetLabel(option.id)})`;
 }
 
-export function curatedTimezoneOptionsSorted(): Array<{ id: string; label: string }> {
+export function curatedTimezoneOptionsSorted(): Array<{
+  id: string;
+  label: string;
+}> {
   return CURATED_TIMEZONE_OPTIONS.map((o) => {
     const zone = o.zoneName ? ` (${o.zoneName})` : "";
     return {

--- a/apps/web/src/lib/system/directory-browser-api.ts
+++ b/apps/web/src/lib/system/directory-browser-api.ts
@@ -13,7 +13,9 @@ export type DirectoryBrowseResponse = {
   entries: DirectoryBrowseEntry[];
 };
 
-export async function fetchServerDirectories(path?: string | null): Promise<DirectoryBrowseResponse> {
+export async function fetchServerDirectories(
+  path?: string | null,
+): Promise<DirectoryBrowseResponse> {
   const qs = path?.trim() ? `?path=${encodeURIComponent(path.trim())}` : "";
   const apiPath = `/api/v1/system/directories${qs}`;
   const r = await apiFetch(apiPath);

--- a/apps/web/src/lib/ui/app-theme.test.ts
+++ b/apps/web/src/lib/ui/app-theme.test.ts
@@ -30,7 +30,9 @@ describe("app-theme", () => {
 
   it("applies and persists the document theme", () => {
     applyAppThemeToDocument("light");
-    expect(document.documentElement.getAttribute("data-mm-theme")).toBe("light");
+    expect(document.documentElement.getAttribute("data-mm-theme")).toBe(
+      "light",
+    );
     persistAppTheme("dark");
     expect(localStorage.getItem(APP_THEME_STORAGE_KEY)).toBe("dark");
     expect(document.documentElement.getAttribute("data-mm-theme")).toBe("dark");

--- a/apps/web/src/lib/ui/app-theme.ts
+++ b/apps/web/src/lib/ui/app-theme.ts
@@ -28,4 +28,3 @@ export function persistAppTheme(theme: AppTheme): void {
   }
   applyAppThemeToDocument(theme);
 }
-

--- a/apps/web/src/lib/ui/display-density.test.ts
+++ b/apps/web/src/lib/ui/display-density.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { DISPLAY_DENSITY_STORAGE_KEY, parseDisplayDensity, readStoredDisplayDensity } from "./display-density";
+import {
+  DISPLAY_DENSITY_STORAGE_KEY,
+  parseDisplayDensity,
+  readStoredDisplayDensity,
+} from "./display-density";
 
 describe("display-density", () => {
   it("parses stored values", () => {

--- a/apps/web/src/lib/ui/display-density.ts
+++ b/apps/web/src/lib/ui/display-density.ts
@@ -13,7 +13,9 @@ export function parseDisplayDensity(raw: string | null): DisplayDensity {
 
 export function readStoredDisplayDensity(): DisplayDensity {
   try {
-    return parseDisplayDensity(localStorage.getItem(DISPLAY_DENSITY_STORAGE_KEY));
+    return parseDisplayDensity(
+      localStorage.getItem(DISPLAY_DENSITY_STORAGE_KEY),
+    );
   } catch {
     return "default";
   }

--- a/apps/web/src/lib/ui/mm-control-roles.ts
+++ b/apps/web/src/lib/ui/mm-control-roles.ts
@@ -55,7 +55,8 @@ export function mmListboxOptionButtonClass(selected: boolean): string {
 }
 
 /** Monospace for read-only technical strings (resolved paths, env keys, raw ids). */
-export const mmTechnicalMonoSmallClass = "font-mono text-xs break-all text-[var(--mm-text2)]";
+export const mmTechnicalMonoSmallClass =
+  "font-mono text-xs break-all text-[var(--mm-text2)]";
 
 /** In-page section tabs (e.g. module Overview / Connections). Not sidebar navigation. */
 export function mmSectionTabClass(active: boolean): string {

--- a/apps/web/src/lib/ui/mm-format-date.ts
+++ b/apps/web/src/lib/ui/mm-format-date.ts
@@ -7,7 +7,9 @@ function parseIso(iso: string): Date {
   return new Date(s);
 }
 
-export function useAppDateFormatter(): (iso: string | null | undefined) => string {
+export function useAppDateFormatter(): (
+  iso: string | null | undefined,
+) => string {
   const q = useSuiteSettingsQuery();
   const tz = q.data?.app_timezone || undefined;
 
@@ -28,7 +30,10 @@ export function useAppDateFormatter(): (iso: string | null | undefined) => strin
   );
 }
 
-export function formatAppDate(iso: string | null | undefined, tz?: string): string {
+export function formatAppDate(
+  iso: string | null | undefined,
+  tz?: string,
+): string {
   if (!iso) return "—";
   try {
     return new Intl.DateTimeFormat(undefined, {

--- a/apps/web/src/lib/ui/mm-module-tab-blurb.ts
+++ b/apps/web/src/lib/ui/mm-module-tab-blurb.ts
@@ -3,7 +3,9 @@
  * Same visual rhythm as Suite Settings tab blurbs: double horizontal rule and even vertical padding.
  */
 
-export const mmModuleTabBlurbBandClass = "border-t border-b border-[var(--mm-border)] py-5";
+export const mmModuleTabBlurbBandClass =
+  "border-t border-b border-[var(--mm-border)] py-5";
 
 /** One-line tab context copy (no `mt-*` — the band’s `py-5` sets vertical rhythm). */
-export const mmModuleTabBlurbTextClass = "max-w-3xl text-sm leading-snug text-[var(--mm-text2)]";
+export const mmModuleTabBlurbTextClass =
+  "max-w-3xl text-sm leading-snug text-[var(--mm-text2)]";

--- a/apps/web/src/lib/ui/pruner-schedule-interval.ts
+++ b/apps/web/src/lib/ui/pruner-schedule-interval.ts
@@ -4,10 +4,15 @@ export const PRUNER_RUN_INTERVAL_MIN_MINUTES = 1;
 export const PRUNER_RUN_INTERVAL_MAX_MINUTES = 7 * 24 * 60;
 
 export function committedPrunerRunIntervalMinutes(seconds: number): string {
-  return String(Math.max(PRUNER_RUN_INTERVAL_MIN_MINUTES, Math.round(seconds / 60)));
+  return String(
+    Math.max(PRUNER_RUN_INTERVAL_MIN_MINUTES, Math.round(seconds / 60)),
+  );
 }
 
-export function finalizePrunerRunIntervalMinutesDraft(draft: string, committedSeconds: number): number {
+export function finalizePrunerRunIntervalMinutesDraft(
+  draft: string,
+  committedSeconds: number,
+): number {
   const raw = draft.trim();
   if (raw === "") {
     return Math.max(60, committedSeconds);

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,5 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "@fontsource/outfit/400.css";
+import "@fontsource/outfit/500.css";
+import "@fontsource/outfit/600.css";
+import "@fontsource/outfit/700.css";
 import { AppRouter } from "./app/router";
 import { AppProviders } from "./app/providers";
 import { StartupGate } from "./app/startup-gate";

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -8,8 +8,14 @@ import { AppRouter } from "./app/router";
 import { AppProviders } from "./app/providers";
 import { StartupGate } from "./app/startup-gate";
 import { AppErrorScreen, ErrorBoundary } from "./components/error-boundary";
-import { applyAppThemeToDocument, readStoredAppTheme } from "./lib/ui/app-theme";
-import { applyDisplayDensityToDocument, readStoredDisplayDensity } from "./lib/ui/display-density";
+import {
+  applyAppThemeToDocument,
+  readStoredAppTheme,
+} from "./lib/ui/app-theme";
+import {
+  applyDisplayDensityToDocument,
+  readStoredDisplayDensity,
+} from "./lib/ui/display-density";
 import "./index.css";
 
 applyAppThemeToDocument(readStoredAppTheme());

--- a/apps/web/src/pages/activity/activity-page.test.tsx
+++ b/apps/web/src/pages/activity/activity-page.test.tsx
@@ -6,7 +6,8 @@ const useActivityRecentQuery = vi.fn();
 
 vi.mock("../../lib/activity/queries", () => ({
   activityRecentKey: ["activity", "recent"],
-  useActivityRecentQuery: (...args: unknown[]) => useActivityRecentQuery(...args),
+  useActivityRecentQuery: (...args: unknown[]) =>
+    useActivityRecentQuery(...args),
 }));
 
 vi.mock("../../lib/activity/use-activity-stream-invalidation", () => ({
@@ -60,7 +61,9 @@ describe("ActivityPage", () => {
     expect(screen.getByDisplayValue("All modules")).toBeInTheDocument();
     expect(screen.getByDisplayValue("All events")).toBeInTheDocument();
     expect(screen.getByText("Movies library scan checked")).toBeInTheDocument();
-    expect(screen.getByText("No new movies needed a subtitle scan.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No new movies needed a subtitle scan."),
+    ).toBeInTheDocument();
     expect(screen.getByText("Nothing new found")).toBeInTheDocument();
   });
 
@@ -74,7 +77,9 @@ describe("ActivityPage", () => {
     render(<ActivityPage />);
 
     fireEvent.click(screen.getByRole("button", { name: "Apply filters" }));
-    expect(screen.getByText("No activity matched the current filters.")).toBeInTheDocument();
+    expect(
+      screen.getByText("No activity matched the current filters."),
+    ).toBeInTheDocument();
   });
 
   it("includes system in the module filter", () => {

--- a/apps/web/src/pages/activity/activity-page.tsx
+++ b/apps/web/src/pages/activity/activity-page.tsx
@@ -6,10 +6,16 @@ import {
   RefinerFileProcessingProgressDetail,
   RefinerFileRemuxPassActivityDetail,
 } from "../../lib/activity/refiner-file-remux-pass-detail";
-import { activityRecentKey, useActivityRecentQuery } from "../../lib/activity/queries";
+import {
+  activityRecentKey,
+  useActivityRecentQuery,
+} from "../../lib/activity/queries";
 import { useActivityStreamInvalidation } from "../../lib/activity/use-activity-stream-invalidation";
 import type { ActivityEventItem } from "../../lib/api/types";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
@@ -57,9 +63,11 @@ const EVENT_LABELS: Record<string, string> = {
   "auth.password_changed": "Password changed",
   "arr_library.connection_test_succeeded": "Connection check finished",
   "arr_library.connection_test_failed": "Connection check failed",
-  "refiner.supplied_payload_evaluation_completed": "Manual queue check finished",
+  "refiner.supplied_payload_evaluation_completed":
+    "Manual queue check finished",
   "refiner.candidate_gate_completed": "Queue check finished",
-  "refiner.watched_folder_remux_scan_dispatch_completed": "Watched-folder scan finished",
+  "refiner.watched_folder_remux_scan_dispatch_completed":
+    "Watched-folder scan finished",
   "refiner.file_processing_progress": "File processing",
   "refiner.file_remux_pass_completed": "File processing finished",
   "refiner.work_temp_stale_sweep_completed": "Temporary files cleanup finished",
@@ -79,7 +87,10 @@ const EVENT_LABELS: Record<string, string> = {
 };
 
 function eventOptionLabel(eventType: string): string {
-  return EVENT_LABELS[eventType] ?? eventType.split(".").slice(-1)[0].replaceAll("_", " ");
+  return (
+    EVENT_LABELS[eventType] ??
+    eventType.split(".").slice(-1)[0].replaceAll("_", " ")
+  );
 }
 
 function titleCase(value: string): string {
@@ -96,7 +107,9 @@ function parseDetail(detail: string | null | undefined): ParsedDetail | null {
   if (!detail?.trim().startsWith("{")) return null;
   try {
     const parsed = JSON.parse(detail) as unknown;
-    return parsed && typeof parsed === "object" ? (parsed as ParsedDetail) : null;
+    return parsed && typeof parsed === "object"
+      ? (parsed as ParsedDetail)
+      : null;
   } catch {
     return null;
   }
@@ -110,7 +123,12 @@ function asString(value: unknown): string | null {
 
 function asNumber(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) return Number(value);
+  if (
+    typeof value === "string" &&
+    value.trim() !== "" &&
+    Number.isFinite(Number(value))
+  )
+    return Number(value);
   return null;
 }
 
@@ -161,7 +179,9 @@ function chipToneClasses(tone: ActivityTone): string {
 
 function normalizeSubberSummary(ev: ActivityEventItem): ActivityDisplay | null {
   const parsed = parseDetail(ev.detail);
-  const mediaScope = asString(parsed?.media_scope) ?? (/movie/i.test(ev.title) ? "movies" : "tv");
+  const mediaScope =
+    asString(parsed?.media_scope) ??
+    (/movie/i.test(ev.title) ? "movies" : "tv");
   const prettyScope = scopeLabel(mediaScope);
   const enqueued = asNumber(parsed?.enqueued);
   const reason = asString(parsed?.reason);
@@ -295,24 +315,42 @@ function normalizePrunerSummary(ev: ActivityEventItem): ActivityDisplay | null {
     };
   }
 
-  if (ev.event_type === "pruner.apply_library_removal_completed" || ev.event_type === "pruner.apply_library_removal_failed") {
+  if (
+    ev.event_type === "pruner.apply_library_removal_completed" ||
+    ev.event_type === "pruner.apply_library_removal_failed"
+  ) {
     return {
       title: "Cleanup finished",
       summary: "Cleanup run result",
       detail: error ?? ev.detail,
-      chip: ev.event_type === "pruner.apply_library_removal_failed" ? "Cleanup failed" : "Cleanup complete",
-      tone: ev.event_type === "pruner.apply_library_removal_failed" ? "error" : "success",
+      chip:
+        ev.event_type === "pruner.apply_library_removal_failed"
+          ? "Cleanup failed"
+          : "Cleanup complete",
+      tone:
+        ev.event_type === "pruner.apply_library_removal_failed"
+          ? "error"
+          : "success",
       compact: true,
     };
   }
 
-  if (ev.event_type === "pruner.connection_test_succeeded" || ev.event_type === "pruner.connection_test_failed") {
+  if (
+    ev.event_type === "pruner.connection_test_succeeded" ||
+    ev.event_type === "pruner.connection_test_failed"
+  ) {
     return {
       title: "Media server connection check",
       summary: "Media server connection check",
       detail: ev.detail,
-      chip: ev.event_type === "pruner.connection_test_failed" ? "Connection failed" : "Connection checked",
-      tone: ev.event_type === "pruner.connection_test_failed" ? "warning" : "success",
+      chip:
+        ev.event_type === "pruner.connection_test_failed"
+          ? "Connection failed"
+          : "Connection checked",
+      tone:
+        ev.event_type === "pruner.connection_test_failed"
+          ? "warning"
+          : "success",
       compact: false,
     };
   }
@@ -320,12 +358,18 @@ function normalizePrunerSummary(ev: ActivityEventItem): ActivityDisplay | null {
   return null;
 }
 
-function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null {
+function normalizeRefinerSummary(
+  ev: ActivityEventItem,
+): ActivityDisplay | null {
   if (ev.event_type === REFINER_FILE_PROCESSING_PROGRESS_EVENT) {
     const parsed = parseDetail(ev.detail);
     const status = asString(parsed?.status);
     const percent = asNumber(parsed?.percent);
-    const name = asString(parsed?.relative_media_path)?.split(/[\\/]/).filter(Boolean).at(-1) ?? "file";
+    const name =
+      asString(parsed?.relative_media_path)
+        ?.split(/[\\/]/)
+        .filter(Boolean)
+        .at(-1) ?? "file";
     return {
       title:
         status === "finished"
@@ -338,8 +382,18 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
           ? "Refiner is preparing the cleaned-up file"
           : `Refiner is writing the cleaned-up file (${Math.round(percent)}%)`,
       detail: ev.detail,
-      chip: status === "failed" ? "Processing stopped" : status === "finished" ? "Processing finished" : "Processing now",
-      tone: status === "failed" ? "error" : status === "finished" ? "success" : "info",
+      chip:
+        status === "failed"
+          ? "Processing stopped"
+          : status === "finished"
+            ? "Processing finished"
+            : "Processing now",
+      tone:
+        status === "failed"
+          ? "error"
+          : status === "finished"
+            ? "success"
+            : "info",
       compact: false,
     };
   }
@@ -348,8 +402,14 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
     const outcome = asString(parsed?.outcome);
     const remuxNeeded = asBoolean(parsed?.remux_required);
     const fileName =
-      asString(parsed?.relative_media_path)?.split(/[\\/]/).filter(Boolean).at(-1) ??
-      asString(parsed?.inspected_source_path)?.split(/[\\/]/).filter(Boolean).at(-1) ??
+      asString(parsed?.relative_media_path)
+        ?.split(/[\\/]/)
+        .filter(Boolean)
+        .at(-1) ??
+      asString(parsed?.inspected_source_path)
+        ?.split(/[\\/]/)
+        .filter(Boolean)
+        .at(-1) ??
       "File";
     return {
       title:
@@ -373,7 +433,7 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
           : outcome?.startsWith("failed")
             ? "Processing failed"
             : "File processed",
-      tone: ev.detail?.includes("\"ok\":false") ? "error" : "success",
+      tone: ev.detail?.includes('"ok":false') ? "error" : "success",
       compact: false,
     };
   }
@@ -397,7 +457,9 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
       compact: true,
     };
   }
-  if (ev.event_type === "refiner.watched_folder_remux_scan_dispatch_completed") {
+  if (
+    ev.event_type === "refiner.watched_folder_remux_scan_dispatch_completed"
+  ) {
     const parsed = parseDetail(ev.detail);
     const queued = asNumber(parsed?.remux_jobs_enqueued) ?? 0;
     const seen = asNumber(parsed?.media_candidates_seen) ?? 0;
@@ -406,7 +468,11 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
     const waitingMessage = asString(parsed?.waiting_message);
     const label = asString(parsed?.scan_result_label);
     const paths = asStringArray(parsed?.enqueued_relative_paths_sample);
-    const details = [userMessage, waitingMessage, paths.length ? `Added: ${paths.join(", ")}` : null]
+    const details = [
+      userMessage,
+      waitingMessage,
+      paths.length ? `Added: ${paths.join(", ")}` : null,
+    ]
       .filter(Boolean)
       .join(" ");
     return {
@@ -448,16 +514,20 @@ function normalizeRefinerSummary(ev: ActivityEventItem): ActivityDisplay | null 
 }
 
 function normalizeAuthSummary(ev: ActivityEventItem): ActivityDisplay | null {
-  if (!ev.module.startsWith("auth") && !ev.module.startsWith("arr_library")) return null;
+  if (!ev.module.startsWith("auth") && !ev.module.startsWith("arr_library"))
+    return null;
   return {
     title: eventOptionLabel(ev.event_type),
-    summary: ev.module.startsWith("arr_library") ? "Service connection check" : "Account and sign-in activity",
+    summary: ev.module.startsWith("arr_library")
+      ? "Service connection check"
+      : "Account and sign-in activity",
     detail: ev.detail,
     chip: "System event",
     tone:
       ev.event_type.includes("failed") || ev.event_type.includes("denied")
         ? "warning"
-        : ev.event_type.includes("succeeded") || ev.event_type.includes("changed")
+        : ev.event_type.includes("succeeded") ||
+            ev.event_type.includes("changed")
           ? "success"
           : "info",
     compact: false,
@@ -499,20 +569,40 @@ function eventDisplay(ev: ActivityEventItem): ActivityDisplay {
   };
 }
 
-function ActivitySummaryCard({ label, value }: { label: string; value: string }) {
+function ActivitySummaryCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
   return (
     <section className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{label}</p>
-      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">
+        {value}
+      </p>
     </section>
   );
 }
 
-function StructuredMetric({ label, value }: { label: string; value: string | number }) {
+function StructuredMetric({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number;
+}) {
   return (
     <div className="rounded-md border border-[var(--mm-border)] bg-black/10 px-3 py-2">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{label}</p>
-      <p className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+        {label}
+      </p>
+      <p className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+        {value}
+      </p>
     </div>
   );
 }
@@ -521,10 +611,15 @@ function ChipsRow({ label, items }: { label: string; items: string[] }) {
   if (items.length === 0) return null;
   return (
     <div className="space-y-2">
-      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{label}</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+        {label}
+      </p>
       <div className="flex flex-wrap gap-2">
         {items.map((item) => (
-          <span key={`${label}-${item}`} className="rounded-full border border-[var(--mm-border)] bg-black/10 px-2.5 py-1 text-xs text-[var(--mm-text2)]">
+          <span
+            key={`${label}-${item}`}
+            className="rounded-full border border-[var(--mm-border)] bg-black/10 px-2.5 py-1 text-xs text-[var(--mm-text2)]"
+          >
             {item}
           </span>
         ))}
@@ -551,35 +646,74 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
     return (
       <div className="space-y-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <StructuredMetric label="Candidates" value={asNumber(parsed.candidate_count) ?? 0} />
-          <StructuredMetric label="Trigger" value={asString(parsed.trigger) ?? "Manual"} />
-          <StructuredMetric label="Scope" value={scopeLabel(asString(parsed.media_scope))} />
-          <StructuredMetric label="Rule" value={asString(parsed.rule_family_id) ?? "General preview"} />
+          <StructuredMetric
+            label="Candidates"
+            value={asNumber(parsed.candidate_count) ?? 0}
+          />
+          <StructuredMetric
+            label="Trigger"
+            value={asString(parsed.trigger) ?? "Manual"}
+          />
+          <StructuredMetric
+            label="Scope"
+            value={scopeLabel(asString(parsed.media_scope))}
+          />
+          <StructuredMetric
+            label="Rule"
+            value={asString(parsed.rule_family_id) ?? "General preview"}
+          />
         </div>
         {filters.length > 0 ? (
           <details className="rounded-md border border-[var(--mm-border)] bg-black/10 px-3 py-2">
-            <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">Show preview filters</summary>
+            <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">
+              Show preview filters
+            </summary>
             <div className="mt-3">
               <ChipsRow label="Applied filters" items={filters} />
             </div>
           </details>
         ) : null}
-        {asString(parsed.error) ? <p className="text-sm text-red-200">{asString(parsed.error)}</p> : null}
-        {asString(parsed.unsupported_detail) ? <p className="text-sm text-amber-100">{asString(parsed.unsupported_detail)}</p> : null}
+        {asString(parsed.error) ? (
+          <p className="text-sm text-red-200">{asString(parsed.error)}</p>
+        ) : null}
+        {asString(parsed.unsupported_detail) ? (
+          <p className="text-sm text-amber-100">
+            {asString(parsed.unsupported_detail)}
+          </p>
+        ) : null}
       </div>
     );
   }
 
-  if (ev.event_type === "pruner.apply_library_removal_completed" || ev.event_type === "pruner.apply_library_removal_failed") {
+  if (
+    ev.event_type === "pruner.apply_library_removal_completed" ||
+    ev.event_type === "pruner.apply_library_removal_failed"
+  ) {
     return (
       <div className="space-y-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <StructuredMetric label="Removed" value={asNumber(parsed.removed) ?? 0} />
-          <StructuredMetric label="Skipped" value={asNumber(parsed.skipped) ?? 0} />
-          <StructuredMetric label="Failed" value={asNumber(parsed.failed) ?? 0} />
-          <StructuredMetric label="Action" value={asString(parsed.action) ?? "Delete"} />
+          <StructuredMetric
+            label="Removed"
+            value={asNumber(parsed.removed) ?? 0}
+          />
+          <StructuredMetric
+            label="Skipped"
+            value={asNumber(parsed.skipped) ?? 0}
+          />
+          <StructuredMetric
+            label="Failed"
+            value={asNumber(parsed.failed) ?? 0}
+          />
+          <StructuredMetric
+            label="Action"
+            value={asString(parsed.action) ?? "Delete"}
+          />
         </div>
-        {asString(parsed.note) ? <p className="text-sm text-[var(--mm-text2)]">{asString(parsed.note)}</p> : null}
+        {asString(parsed.note) ? (
+          <p className="text-sm text-[var(--mm-text2)]">
+            {asString(parsed.note)}
+          </p>
+        ) : null}
       </div>
     );
   }
@@ -590,16 +724,38 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
     const series = asNumber(parsed.series);
     const episodes = asNumber(parsed.episodes);
     const found = asNumber(parsed.subtitles_found);
-    if (movies != null) metrics.push({ label: "Movies processed", value: movies });
-    if (series != null) metrics.push({ label: "Series processed", value: series });
-    if (episodes != null) metrics.push({ label: "Episodes with files", value: episodes });
+    if (movies != null)
+      metrics.push({ label: "Movies processed", value: movies });
+    if (series != null)
+      metrics.push({ label: "Series processed", value: series });
+    if (episodes != null)
+      metrics.push({ label: "Episodes with files", value: episodes });
     if (found != null) metrics.push({ label: "Subtitles found", value: found });
-    if (metrics.length === 0 && !asString(parsed.error) && !asString(parsed.reason)) return null;
+    if (
+      metrics.length === 0 &&
+      !asString(parsed.error) &&
+      !asString(parsed.reason)
+    )
+      return null;
     return (
       <div className="space-y-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
-        {metrics.length > 0 ? <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">{metrics.map((row) => <StructuredMetric key={row.label} label={row.label} value={row.value} />)}</div> : null}
-        {asString(parsed.reason) ? <p className="text-sm text-amber-100">{asString(parsed.reason)}</p> : null}
-        {asString(parsed.error) ? <p className="text-sm text-red-200">{asString(parsed.error)}</p> : null}
+        {metrics.length > 0 ? (
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            {metrics.map((row) => (
+              <StructuredMetric
+                key={row.label}
+                label={row.label}
+                value={row.value}
+              />
+            ))}
+          </div>
+        ) : null}
+        {asString(parsed.reason) ? (
+          <p className="text-sm text-amber-100">{asString(parsed.reason)}</p>
+        ) : null}
+        {asString(parsed.error) ? (
+          <p className="text-sm text-red-200">{asString(parsed.error)}</p>
+        ) : null}
       </div>
     );
   }
@@ -607,8 +763,14 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
   if (ev.event_type === "subber.subtitle_search_completed") {
     return (
       <div className="grid gap-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3 sm:grid-cols-2 xl:grid-cols-3">
-        <StructuredMetric label="Scope" value={scopeLabel(asString(parsed.media_scope))} />
-        <StructuredMetric label="State ID" value={asNumber(parsed.state_id) ?? "-"} />
+        <StructuredMetric
+          label="Scope"
+          value={scopeLabel(asString(parsed.media_scope))}
+        />
+        <StructuredMetric
+          label="State ID"
+          value={asNumber(parsed.state_id) ?? "-"}
+        />
         <StructuredMetric
           label="Outcome"
           value={
@@ -626,8 +788,14 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
   if (ev.event_type === "subber.subtitle_upgrade_completed") {
     return (
       <div className="grid gap-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3 sm:grid-cols-2">
-        <StructuredMetric label="Checked" value={asNumber(parsed.attempted) ?? 0} />
-        <StructuredMetric label="Upgraded" value={asNumber(parsed.upgraded) ?? 0} />
+        <StructuredMetric
+          label="Checked"
+          value={asNumber(parsed.attempted) ?? 0}
+        />
+        <StructuredMetric
+          label="Upgraded"
+          value={asNumber(parsed.upgraded) ?? 0}
+        />
       </div>
     );
   }
@@ -636,10 +804,20 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
     return (
       <div className="space-y-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
         <div className="grid gap-3 sm:grid-cols-2">
-          <StructuredMetric label="Queued" value={asNumber(parsed.enqueued) ?? 0} />
-          <StructuredMetric label="Scope" value={scopeLabel(asString(parsed.media_scope))} />
+          <StructuredMetric
+            label="Queued"
+            value={asNumber(parsed.enqueued) ?? 0}
+          />
+          <StructuredMetric
+            label="Scope"
+            value={scopeLabel(asString(parsed.media_scope))}
+          />
         </div>
-        {asString(parsed.file_path) ? <p className="text-sm text-[var(--mm-text2)] break-all">{asString(parsed.file_path)}</p> : null}
+        {asString(parsed.file_path) ? (
+          <p className="text-sm text-[var(--mm-text2)] break-all">
+            {asString(parsed.file_path)}
+          </p>
+        ) : null}
       </div>
     );
   }
@@ -647,7 +825,13 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
   return null;
 }
 
-function ActivityEventDetails({ ev, display }: { ev: ActivityEventItem; display: ActivityDisplay }) {
+function ActivityEventDetails({
+  ev,
+  display,
+}: {
+  ev: ActivityEventItem;
+  display: ActivityDisplay;
+}) {
   if (!display.detail) return null;
   if (ev.event_type === REFINER_FILE_PROCESSING_PROGRESS_EVENT) {
     return <RefinerFileProcessingProgressDetail detail={display.detail} />;
@@ -660,17 +844,27 @@ function ActivityEventDetails({ ev, display }: { ev: ActivityEventItem; display:
     return structured;
   }
   if (!display.compact) {
-    return <p className="text-sm leading-6 text-[var(--mm-text2)]">{display.detail}</p>;
+    return (
+      <p className="text-sm leading-6 text-[var(--mm-text2)]">
+        {display.detail}
+      </p>
+    );
   }
   return (
     <details className="rounded-md border border-[var(--mm-border)] bg-black/10 px-3 py-2">
-      <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">Show event detail</summary>
-      <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--mm-text2)]">{display.detail}</p>
+      <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">
+        Show event detail
+      </summary>
+      <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[var(--mm-text2)]">
+        {display.detail}
+      </p>
     </details>
   );
 }
 
-function collectEventOptions(items: ActivityEventItem[]): ActivityEventOption[] {
+function collectEventOptions(
+  items: ActivityEventItem[],
+): ActivityEventOption[] {
   const seen = new Map<string, string>();
   for (const item of items) {
     if (!seen.has(item.event_type)) {
@@ -734,7 +928,9 @@ export function ActivityPage() {
           </p>
         </header>
         {err instanceof Error ? (
-          <p className="mm-page__lead font-mono text-sm text-[var(--mm-text3)]">{err.message}</p>
+          <p className="mm-page__lead font-mono text-sm text-[var(--mm-text3)]">
+            {err.message}
+          </p>
         ) : null}
       </div>
     );
@@ -742,24 +938,42 @@ export function ActivityPage() {
 
   const items = recent.data.items;
   const eventOptions = collectEventOptions(items);
-  const filtersActive = Boolean(applied.eventType || applied.search.trim() || applied.from || applied.to || applied.module !== "all");
+  const filtersActive = Boolean(
+    applied.eventType ||
+    applied.search.trim() ||
+    applied.from ||
+    applied.to ||
+    applied.module !== "all",
+  );
 
   return (
     <div className="mm-page">
       <header className="mm-page__intro">
         <p className="mm-page__eyebrow">Overview</p>
         <h1 className="mm-page__title">Activity</h1>
-        <p className="mm-page__subtitle">Live activity timeline for MediaMop, newest first.</p>
+        <p className="mm-page__subtitle">
+          Live activity timeline for MediaMop, newest first.
+        </p>
         <p className="mm-page__lead">
-          Use this page to understand what just happened across Refiner, Pruner, Subber, and the platform. It updates
-          live and keeps the language focused on what the action means.
+          Use this page to understand what just happened across Refiner, Pruner,
+          Subber, and the platform. It updates live and keeps the language
+          focused on what the action means.
         </p>
       </header>
 
       <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <ActivitySummaryCard label="Showing now" value={`${items.length} events`} />
-        <ActivitySummaryCard label="Matches in store" value={`${recent.data.total} events`} />
-        <ActivitySummaryCard label="System events" value={String(recent.data.system_events)} />
+        <ActivitySummaryCard
+          label="Showing now"
+          value={`${items.length} events`}
+        />
+        <ActivitySummaryCard
+          label="Matches in store"
+          value={`${recent.data.total} events`}
+        />
+        <ActivitySummaryCard
+          label="System events"
+          value={String(recent.data.system_events)}
+        />
         <ActivitySummaryCard label="Refresh" value="Live" />
       </section>
 
@@ -770,7 +984,12 @@ export function ActivityPage() {
             <select
               className="mm-input"
               value={filters.module}
-              onChange={(e) => setFilters((prev) => ({ ...prev, module: e.target.value as ActivityModuleFilter }))}
+              onChange={(e) =>
+                setFilters((prev) => ({
+                  ...prev,
+                  module: e.target.value as ActivityModuleFilter,
+                }))
+              }
             >
               {MODULE_OPTIONS.map((option) => (
                 <option key={option.value} value={option.value}>
@@ -784,7 +1003,9 @@ export function ActivityPage() {
             <select
               className="mm-input"
               value={filters.eventType}
-              onChange={(e) => setFilters((prev) => ({ ...prev, eventType: e.target.value }))}
+              onChange={(e) =>
+                setFilters((prev) => ({ ...prev, eventType: e.target.value }))
+              }
             >
               <option value="">All events</option>
               {eventOptions.map((option) => (
@@ -799,7 +1020,9 @@ export function ActivityPage() {
             <input
               className="mm-input"
               value={filters.search}
-              onChange={(e) => setFilters((prev) => ({ ...prev, search: e.target.value }))}
+              onChange={(e) =>
+                setFilters((prev) => ({ ...prev, search: e.target.value }))
+              }
               placeholder="Search titles and details"
             />
           </label>
@@ -809,7 +1032,9 @@ export function ActivityPage() {
               type="datetime-local"
               className="mm-input"
               value={filters.from}
-              onChange={(e) => setFilters((prev) => ({ ...prev, from: e.target.value }))}
+              onChange={(e) =>
+                setFilters((prev) => ({ ...prev, from: e.target.value }))
+              }
             />
           </label>
           <label className="flex flex-col gap-1 text-xs font-medium uppercase tracking-[0.12em] text-[var(--mm-text3)]">
@@ -818,7 +1043,9 @@ export function ActivityPage() {
               type="datetime-local"
               className="mm-input"
               value={filters.to}
-              onChange={(e) => setFilters((prev) => ({ ...prev, to: e.target.value }))}
+              onChange={(e) =>
+                setFilters((prev) => ({ ...prev, to: e.target.value }))
+              }
             />
           </label>
           <div className="flex items-end gap-2">
@@ -831,10 +1058,19 @@ export function ActivityPage() {
             </button>
             <button
               type="button"
-              className={mmActionButtonClass({ variant: "tertiary", disabled: !filtersActive })}
+              className={mmActionButtonClass({
+                variant: "tertiary",
+                disabled: !filtersActive,
+              })}
               disabled={!filtersActive}
               onClick={() => {
-                const reset = { module: "all", eventType: "", search: "", from: "", to: "" } as ActivityFiltersState;
+                const reset = {
+                  module: "all",
+                  eventType: "",
+                  search: "",
+                  from: "",
+                  to: "",
+                } as ActivityFiltersState;
                 setFilters(reset);
                 setApplied(reset);
               }}
@@ -873,16 +1109,28 @@ export function ActivityPage() {
                   <div className="space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-gold)]">
-                        {ev.module === "system" || ev.module === "auth" || ev.module === "arr_library" ? "System" : titleCase(ev.module)}
+                        {ev.module === "system" ||
+                        ev.module === "auth" ||
+                        ev.module === "arr_library"
+                          ? "System"
+                          : titleCase(ev.module)}
                       </span>
-                      <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${chipToneClasses(display.tone)}`}>
+                      <span
+                        className={`rounded-full border px-2.5 py-1 text-xs font-medium ${chipToneClasses(display.tone)}`}
+                      >
                         {display.chip}
                       </span>
                     </div>
-                    <h2 className="text-lg font-semibold text-[var(--mm-text1)]">{display.title}</h2>
-                    <p className="text-sm text-[var(--mm-text3)]">{display.summary}</p>
+                    <h2 className="text-lg font-semibold text-[var(--mm-text1)]">
+                      {display.title}
+                    </h2>
+                    <p className="text-sm text-[var(--mm-text3)]">
+                      {display.summary}
+                    </p>
                   </div>
-                  <time className="text-sm text-[var(--mm-text3)]">{fmt(ev.created_at)}</time>
+                  <time className="text-sm text-[var(--mm-text3)]">
+                    {fmt(ev.created_at)}
+                  </time>
                 </div>
                 <div className="mt-3">
                   <ActivityEventDetails ev={ev} display={display} />

--- a/apps/web/src/pages/auth/login-page.test.tsx
+++ b/apps/web/src/pages/auth/login-page.test.tsx
@@ -7,7 +7,12 @@ import { describe, expect, it, vi } from "vitest";
 import { LoginPage } from "./login-page";
 
 vi.mock("../../lib/auth/queries", () => ({
-  useMeQuery: () => ({ isPending: false, data: null, isError: false, error: null }),
+  useMeQuery: () => ({
+    isPending: false,
+    data: null,
+    isError: false,
+    error: null,
+  }),
   useBootstrapStatusQuery: () => ({
     isPending: false,
     isError: false,

--- a/apps/web/src/pages/auth/login-page.test.tsx
+++ b/apps/web/src/pages/auth/login-page.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+
+import { LoginPage } from "./login-page";
+
+vi.mock("../../lib/auth/queries", () => ({
+  useMeQuery: () => ({ isPending: false, data: null, isError: false, error: null }),
+  useBootstrapStatusQuery: () => ({
+    isPending: false,
+    isError: false,
+    data: { bootstrap_allowed: false, reason: "admin_exists" },
+    error: null,
+  }),
+  useLoginMutation: () => ({
+    isPending: false,
+    isError: false,
+    error: null,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+function wrap(ui: ReactNode, initialEntry = "/login") {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe("LoginPage", () => {
+  it("shows the bootstrap-created banner from the query string", () => {
+    render(wrap(<LoginPage />, "/login?bootstrap=created"));
+
+    expect(
+      screen.getByText(
+        "Initial account created. Sign in with the credentials you chose.",
+      ),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/src/pages/auth/login-page.tsx
+++ b/apps/web/src/pages/auth/login-page.tsx
@@ -3,11 +3,22 @@ import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import { AuthBrandStack } from "../../components/brand/auth-brand-stack";
 import { ApiEntryError } from "../../components/shared/api-entry-error";
 import { PageLoading } from "../../components/shared/page-loading";
-import { useBootstrapStatusQuery, useLoginMutation, useMeQuery } from "../../lib/auth/queries";
+import {
+  useBootstrapStatusQuery,
+  useLoginMutation,
+  useMeQuery,
+} from "../../lib/auth/queries";
 
 function EyeIcon() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+    >
       <path
         d="M2 12s4-7 10-7 10 7 10 7-4 7-10 7S2 12 2 12Z"
         stroke="currentColor"
@@ -22,7 +33,14 @@ function EyeIcon() {
 
 function EyeOffIcon() {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden
+    >
       <path
         d="M10.73 5.08A10.4 10.4 0 0 1 12 5c7 0 10 7 10 7a13.2 13.2 0 0 1-1.67 2.68M6.61 6.61A13.5 13.5 0 0 0 2 12s4 7 10 7c1.38 0 2.65-.21 3.78-.6M9.88 9.88a3 3 0 1 0 4.24 4.24"
         stroke="currentColor"
@@ -30,7 +48,12 @@ function EyeOffIcon() {
         strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="m2 2 20 20" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path
+        d="m2 2 20 20"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
     </svg>
   );
 }
@@ -41,7 +64,8 @@ export function LoginPage() {
   const fromSetup = Boolean(
     (location.state as { fromSetup?: boolean } | null)?.fromSetup,
   );
-  const sessionExpired = new URLSearchParams(location.search).get("session") === "expired";
+  const sessionExpired =
+    new URLSearchParams(location.search).get("session") === "expired";
   const me = useMeQuery();
   const boot = useBootstrapStatusQuery();
   const login = useLoginMutation();
@@ -87,7 +111,8 @@ export function LoginPage() {
           <p className="mm-auth-eyebrow">MediaMop</p>
           <h1 className="mm-auth-title">Sign in</h1>
           <p className="mm-auth-lead">
-            Server-side session sign-in — MediaMop keeps your sign-in on the backend, not browser storage.
+            Server-side session sign-in — MediaMop keeps your sign-in on the
+            backend, not browser storage.
           </p>
 
           {fromSetup ? (
@@ -104,14 +129,21 @@ export function LoginPage() {
           {boot.data?.bootstrap_allowed ? (
             <p className="mm-auth-lead mt-2">
               First-time setup?{" "}
-              <Link to="/setup" className="font-medium text-[var(--mm-accent-bright)] hover:underline">
+              <Link
+                to="/setup"
+                className="font-medium text-[var(--mm-accent-bright)] hover:underline"
+              >
                 Create the admin account
               </Link>
               .
             </p>
           ) : null}
 
-          <form data-testid="login-form" className="mm-auth-form mt-4" onSubmit={onSubmit}>
+          <form
+            data-testid="login-form"
+            className="mm-auth-form mt-4"
+            onSubmit={onSubmit}
+          >
             <label className="mm-auth-label" htmlFor="login-user">
               Username
             </label>
@@ -157,7 +189,9 @@ export function LoginPage() {
             </div>
             {login.isError ? (
               <p className="mm-auth-banner" role="alert">
-                {login.error instanceof Error ? login.error.message : "Sign-in failed."}
+                {login.error instanceof Error
+                  ? login.error.message
+                  : "Sign-in failed."}
               </p>
             ) : null}
             <button

--- a/apps/web/src/pages/auth/login-page.tsx
+++ b/apps/web/src/pages/auth/login-page.tsx
@@ -66,11 +66,10 @@ export function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const fromSetup = Boolean(
-    (location.state as { fromSetup?: boolean } | null)?.fromSetup,
-  ) || searchParams.get("bootstrap") === "created";
-  const sessionExpired =
-    searchParams.get("session") === "expired";
+  const fromSetup =
+    Boolean((location.state as { fromSetup?: boolean } | null)?.fromSetup) ||
+    searchParams.get("bootstrap") === "created";
+  const sessionExpired = searchParams.get("session") === "expired";
   const me = useMeQuery();
   const boot = useBootstrapStatusQuery();
   const login = useLoginMutation();

--- a/apps/web/src/pages/auth/login-page.tsx
+++ b/apps/web/src/pages/auth/login-page.tsx
@@ -65,11 +65,12 @@ function EyeOffIcon() {
 export function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
   const fromSetup = Boolean(
     (location.state as { fromSetup?: boolean } | null)?.fromSetup,
-  );
+  ) || searchParams.get("bootstrap") === "created";
   const sessionExpired =
-    new URLSearchParams(location.search).get("session") === "expired";
+    searchParams.get("session") === "expired";
   const me = useMeQuery();
   const boot = useBootstrapStatusQuery();
   const login = useLoginMutation();

--- a/apps/web/src/pages/auth/login-page.tsx
+++ b/apps/web/src/pages/auth/login-page.tsx
@@ -1,8 +1,12 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useId, useState } from "react";
 import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
 import { AuthBrandStack } from "../../components/brand/auth-brand-stack";
 import { ApiEntryError } from "../../components/shared/api-entry-error";
 import { PageLoading } from "../../components/shared/page-loading";
+import {
+  httpStatusFromApiError,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import {
   useBootstrapStatusQuery,
   useLoginMutation,
@@ -69,6 +73,7 @@ export function LoginPage() {
   const me = useMeQuery();
   const boot = useBootstrapStatusQuery();
   const login = useLoginMutation();
+  const fieldId = useId();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
@@ -102,6 +107,33 @@ export function LoginPage() {
       /* mutation error surfaces below */
     }
   };
+
+  const loginUserId = `${fieldId}-user`;
+  const loginPasswordId = `${fieldId}-pass`;
+  const loginErrorMessage = (() => {
+    if (!login.isError) {
+      return null;
+    }
+    const status = httpStatusFromApiError(login.error);
+    if (status === 400 || status === 401) {
+      return login.error instanceof Error
+        ? login.error.message
+        : "Sign-in failed.";
+    }
+    if (
+      isLikelyNetworkFailure(login.error) ||
+      status === 500 ||
+      status === 503
+    ) {
+      console.error("MediaMop login failed against the backend.", login.error);
+      return "Sign-in failed. Check that the MediaMop server is running.";
+    }
+    console.error(
+      "MediaMop login failed with an unexpected error.",
+      login.error,
+    );
+    return "Sign-in failed. Check that the MediaMop server is running.";
+  })();
 
   return (
     <main className="mm-auth-body" id="mm-main-content" tabIndex={-1}>
@@ -144,25 +176,26 @@ export function LoginPage() {
             className="mm-auth-form mt-4"
             onSubmit={onSubmit}
           >
-            <label className="mm-auth-label" htmlFor="login-user">
+            <label className="mm-auth-label" htmlFor={loginUserId}>
               Username
             </label>
             <input
-              id="login-user"
+              id={loginUserId}
               data-testid="login-username"
               name="username"
               autoComplete="username"
               className="mm-auth-input"
+              autoFocus
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               required
             />
-            <label className="mm-auth-label" htmlFor="login-pass">
+            <label className="mm-auth-label" htmlFor={loginPasswordId}>
               Password
             </label>
             <div className="mm-auth-password-field">
               <input
-                id="login-pass"
+                id={loginPasswordId}
                 data-testid="login-password"
                 name="password"
                 type={showPassword ? "text" : "password"}
@@ -187,11 +220,9 @@ export function LoginPage() {
                 {showPassword ? <EyeOffIcon /> : <EyeIcon />}
               </button>
             </div>
-            {login.isError ? (
+            {loginErrorMessage ? (
               <p className="mm-auth-banner" role="alert">
-                {login.error instanceof Error
-                  ? login.error.message
-                  : "Sign-in failed."}
+                {loginErrorMessage}
               </p>
             ) : null}
             <button

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -18,12 +18,14 @@ const useSubberJobsQuery = vi.fn();
 
 vi.mock("../../lib/activity/queries", () => ({
   activityRecentKey: ["activity", "recent"],
-  useActivityRecentQuery: (...args: unknown[]) => useActivityRecentQuery(...args),
+  useActivityRecentQuery: (...args: unknown[]) =>
+    useActivityRecentQuery(...args),
 }));
 
 vi.mock("../../lib/dashboard/queries", () => ({
   dashboardStatusKey: ["dashboard", "status"],
-  useDashboardStatusQuery: (...args: unknown[]) => useDashboardStatusQuery(...args),
+  useDashboardStatusQuery: (...args: unknown[]) =>
+    useDashboardStatusQuery(...args),
 }));
 
 vi.mock("../../lib/activity/use-activity-stream-invalidation", () => ({
@@ -32,24 +34,33 @@ vi.mock("../../lib/activity/use-activity-stream-invalidation", () => ({
 }));
 
 vi.mock("../../lib/refiner/queries", () => ({
-  useRefinerOverviewStatsQuery: (...args: unknown[]) => useRefinerOverviewStatsQuery(...args),
-  useRefinerPathSettingsQuery: (...args: unknown[]) => useRefinerPathSettingsQuery(...args),
+  useRefinerOverviewStatsQuery: (...args: unknown[]) =>
+    useRefinerOverviewStatsQuery(...args),
+  useRefinerPathSettingsQuery: (...args: unknown[]) =>
+    useRefinerPathSettingsQuery(...args),
 }));
 
 vi.mock("../../lib/refiner/jobs-inspection/queries", () => ({
-  useRefinerJobsInspectionQuery: (...args: unknown[]) => useRefinerJobsInspectionQuery(...args),
+  useRefinerJobsInspectionQuery: (...args: unknown[]) =>
+    useRefinerJobsInspectionQuery(...args),
 }));
 
 vi.mock("../../lib/pruner/queries", () => ({
-  usePrunerOverviewStatsQuery: (...args: unknown[]) => usePrunerOverviewStatsQuery(...args),
-  usePrunerInstancesQuery: (...args: unknown[]) => usePrunerInstancesQuery(...args),
-  usePrunerJobsInspectionQuery: (...args: unknown[]) => usePrunerJobsInspectionQuery(...args),
+  usePrunerOverviewStatsQuery: (...args: unknown[]) =>
+    usePrunerOverviewStatsQuery(...args),
+  usePrunerInstancesQuery: (...args: unknown[]) =>
+    usePrunerInstancesQuery(...args),
+  usePrunerJobsInspectionQuery: (...args: unknown[]) =>
+    usePrunerJobsInspectionQuery(...args),
 }));
 
 vi.mock("../../lib/subber/subber-queries", () => ({
-  useSubberOverviewQuery: (...args: unknown[]) => useSubberOverviewQuery(...args),
-  useSubberSettingsQuery: (...args: unknown[]) => useSubberSettingsQuery(...args),
-  useSubberProvidersQuery: (...args: unknown[]) => useSubberProvidersQuery(...args),
+  useSubberOverviewQuery: (...args: unknown[]) =>
+    useSubberOverviewQuery(...args),
+  useSubberSettingsQuery: (...args: unknown[]) =>
+    useSubberSettingsQuery(...args),
+  useSubberProvidersQuery: (...args: unknown[]) =>
+    useSubberProvidersQuery(...args),
   useSubberJobsQuery: (...args: unknown[]) => useSubberJobsQuery(...args),
 }));
 
@@ -128,7 +139,14 @@ describe("DashboardPage", () => {
         upgrades_last_30_days: 0,
       },
     });
-    useSubberSettingsQuery.mockReturnValue({ data: { sonarr_base_url: "", sonarr_api_key_set: false, radarr_base_url: "", radarr_api_key_set: false } });
+    useSubberSettingsQuery.mockReturnValue({
+      data: {
+        sonarr_base_url: "",
+        sonarr_api_key_set: false,
+        radarr_base_url: "",
+        radarr_api_key_set: false,
+      },
+    });
     useSubberProvidersQuery.mockReturnValue({ data: [] });
     useSubberJobsQuery.mockReturnValue({ data: { jobs: [] } });
   });
@@ -144,11 +162,15 @@ describe("DashboardPage", () => {
     expect(screen.getByTestId("dashboard-needs-attention")).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-active-work")).toBeInTheDocument();
     expect(screen.getByTestId("dashboard-global-jobs")).toBeInTheDocument();
-    expect(screen.queryByTestId("dashboard-runtime-health")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("dashboard-runtime-health"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("Refiner")).toBeInTheDocument();
     expect(screen.getByText("Pruner")).toBeInTheDocument();
     expect(screen.getByText("Subber")).toBeInTheDocument();
-    expect(screen.getByText("Needs setup: Refiner, Pruner, Subber.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Needs setup: Refiner, Pruner, Subber."),
+    ).toBeInTheDocument();
     expect(screen.getByText("Net space saved")).toBeInTheDocument();
     expect(screen.getByText("Removal rate")).toBeInTheDocument();
     expect(screen.getByText("Coverage")).toBeInTheDocument();
@@ -216,7 +238,9 @@ describe("DashboardPage", () => {
     );
 
     expect(screen.getByText("Files handled")).toBeInTheDocument();
-    expect(screen.getByText("2 changed - 0 needed no changes")).toBeInTheDocument();
+    expect(
+      screen.getByText("2 changed - 0 needed no changes"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("Scan watched folders")).not.toBeInTheDocument();
     expect(screen.getByText("Process file")).toBeInTheDocument();
   });
@@ -239,7 +263,8 @@ describe("DashboardPage", () => {
               stale_workers: 1,
               stopped_workers: 0,
               status: "degraded",
-              detail: "Refiner expected 1 worker(s), but 1 are stale, stopped, or missing.",
+              detail:
+                "Refiner expected 1 worker(s), but 1 are stale, stopped, or missing.",
             },
           ],
         },
@@ -254,6 +279,8 @@ describe("DashboardPage", () => {
     );
 
     expect(screen.getAllByText("Review needed").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Refiner workers: Refiner expected 1 worker/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Refiner workers: Refiner expected 1 worker/),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -1,14 +1,35 @@
 import { Link } from "react-router-dom";
 import { PageLoading } from "../../components/shared/page-loading";
-import { activityRecentKey, useActivityRecentQuery } from "../../lib/activity/queries";
+import {
+  activityRecentKey,
+  useActivityRecentQuery,
+} from "../../lib/activity/queries";
 import { useActivityStreamInvalidations } from "../../lib/activity/use-activity-stream-invalidation";
 import type { ActivityEventItem } from "../../lib/api/types";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
-import { dashboardStatusKey, useDashboardStatusQuery } from "../../lib/dashboard/queries";
-import { usePrunerInstancesQuery, usePrunerJobsInspectionQuery, usePrunerOverviewStatsQuery } from "../../lib/pruner/queries";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
+import {
+  dashboardStatusKey,
+  useDashboardStatusQuery,
+} from "../../lib/dashboard/queries";
+import {
+  usePrunerInstancesQuery,
+  usePrunerJobsInspectionQuery,
+  usePrunerOverviewStatsQuery,
+} from "../../lib/pruner/queries";
 import { useRefinerJobsInspectionQuery } from "../../lib/refiner/jobs-inspection/queries";
-import { useRefinerOverviewStatsQuery, useRefinerPathSettingsQuery } from "../../lib/refiner/queries";
-import { useSubberJobsQuery, useSubberOverviewQuery, useSubberProvidersQuery, useSubberSettingsQuery } from "../../lib/subber/subber-queries";
+import {
+  useRefinerOverviewStatsQuery,
+  useRefinerPathSettingsQuery,
+} from "../../lib/refiner/queries";
+import {
+  useSubberJobsQuery,
+  useSubberOverviewQuery,
+  useSubberProvidersQuery,
+  useSubberSettingsQuery,
+} from "../../lib/subber/subber-queries";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
 
@@ -65,15 +86,20 @@ const REFINER_DASHBOARD_JOB_KINDS = new Set([
   "refiner.supplied_payload_evaluation.v1",
 ]);
 
-function shortLastActivity(items: ActivityEventItem[], fmt: (iso: string) => string): string {
+function shortLastActivity(
+  items: ActivityEventItem[],
+  fmt: (iso: string) => string,
+): string {
   if (items.length === 0) return "No recent activity";
   const ev = items[0];
   return `${ev.title} - ${fmt(ev.created_at)}`;
 }
 
 function healthTone(status: ModuleStatus): string {
-  if (status === "Review needed") return "border-amber-400/30 bg-amber-400/10 text-amber-100";
-  if (status === "Active") return "border-sky-400/30 bg-sky-400/10 text-sky-100";
+  if (status === "Review needed")
+    return "border-amber-400/30 bg-amber-400/10 text-amber-100";
+  if (status === "Active")
+    return "border-sky-400/30 bg-sky-400/10 text-sky-100";
   return "border-emerald-500/30 bg-emerald-500/10 text-emerald-100";
 }
 
@@ -109,22 +135,41 @@ function formatPercent(value: number): string {
 
 function describeNetSizeChange(bytes: number, percent: number): string {
   if (!Number.isFinite(bytes) || bytes === 0) return "No net size change";
-  if (Number.isFinite(percent) && (Math.abs(percent) < 0.1 || Math.abs(bytes) < 1024 * 1024)) {
+  if (
+    Number.isFinite(percent) &&
+    (Math.abs(percent) < 0.1 || Math.abs(bytes) < 1024 * 1024)
+  ) {
     return bytes > 0
       ? `Size basically unchanged (${formatBytesCompact(bytes)} saved)`
       : `Size basically unchanged (${formatBytesCompact(Math.abs(bytes))} container overhead)`;
   }
-  if (bytes > 0) return `Saved ${formatBytesCompact(bytes)} (${formatPercent(percent)})`;
+  if (bytes > 0)
+    return `Saved ${formatBytesCompact(bytes)} (${formatPercent(percent)})`;
   return `Grew by ${formatBytesCompact(Math.abs(bytes))} (${formatPercent(Math.abs(percent))})`;
 }
 
-function MetricCard({ label, value, detail }: { label: string; value: string; detail?: string }) {
+function MetricCard({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+}) {
   return (
     <section className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{label}</p>
-      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">
+        {value}
+      </p>
       {detail ? (
-        <p className="mt-1 truncate text-xs text-[var(--mm-text3)]" title={detail}>
+        <p
+          className="mt-1 truncate text-xs text-[var(--mm-text3)]"
+          title={detail}
+        >
           {detail}
         </p>
       ) : null}
@@ -136,8 +181,14 @@ function ModuleCard({ card }: { card: ModuleCardData }) {
   return (
     <article className="mm-card mm-dash-card flex h-full flex-col gap-4">
       <div className="flex items-start justify-between gap-2">
-        <h2 className="text-lg font-semibold text-[var(--mm-text1)]">{card.name}</h2>
-        <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${healthTone(card.status)}`}>{card.status}</span>
+        <h2 className="text-lg font-semibold text-[var(--mm-text1)]">
+          {card.name}
+        </h2>
+        <span
+          className={`rounded-full border px-2.5 py-1 text-xs font-medium ${healthTone(card.status)}`}
+        >
+          {card.status}
+        </span>
       </div>
       <p className="text-sm leading-6 text-[var(--mm-text2)]">{card.summary}</p>
       <div className="grid gap-3 sm:grid-cols-2">
@@ -146,9 +197,17 @@ function ModuleCard({ card }: { card: ModuleCardData }) {
             key={`${card.key}-${metric.label}`}
             className="rounded-lg border border-[var(--mm-border)] bg-black/10 px-3 py-2.5"
           >
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{metric.label}</p>
-            <p className="mt-1 text-base font-semibold text-[var(--mm-text1)]">{metric.value}</p>
-            {metric.detail ? <p className="mt-1 text-xs text-[var(--mm-text3)]">{metric.detail}</p> : null}
+            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+              {metric.label}
+            </p>
+            <p className="mt-1 text-base font-semibold text-[var(--mm-text1)]">
+              {metric.value}
+            </p>
+            {metric.detail ? (
+              <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                {metric.detail}
+              </p>
+            ) : null}
           </section>
         ))}
       </div>
@@ -158,7 +217,10 @@ function ModuleCard({ card }: { card: ModuleCardData }) {
         ))}
       </div>
       <div className="mt-auto pt-2">
-        <Link to={card.actionTo} className={mmActionButtonClass({ variant: "secondary" })}>
+        <Link
+          to={card.actionTo}
+          className={mmActionButtonClass({ variant: "secondary" })}
+        >
           {card.actionLabel}
         </Link>
       </div>
@@ -189,7 +251,8 @@ function isDashboardVisibleRefinerJob(jobKind: string): boolean {
 function refinerJobTitle(jobKind: string): string {
   if (jobKind === REFINER_FILE_REMUX_PASS_JOB_KIND) return "Process file";
   if (jobKind === "refiner.candidate_gate.v1") return "Check file readiness";
-  if (jobKind === "refiner.supplied_payload_evaluation.v1") return "Check new media";
+  if (jobKind === "refiner.supplied_payload_evaluation.v1")
+    return "Check new media";
   return "Refiner job";
 }
 
@@ -221,7 +284,11 @@ function buildRefinerCard(args: {
   tvFolder: string | null | undefined;
 }): ModuleCardData {
   const attention = !args.movieFolder && !args.tvFolder;
-  const active = args.processed > 0 || args.failed > 0 || args.outputWritten > 0 || args.alreadyOptimized > 0;
+  const active =
+    args.processed > 0 ||
+    args.failed > 0 ||
+    args.outputWritten > 0 ||
+    args.alreadyOptimized > 0;
 
   return {
     key: "refiner",
@@ -235,9 +302,24 @@ function buildRefinerCard(args: {
           ? "Remux activity and watched-folder processing are active."
           : "Ready. No recent remux work recorded.",
     metrics: [
-      { label: "Completed jobs", value: formatCount(args.processed), detail: `Success rate ${formatPercent(args.successRatePercent)}` },
-      { label: "Output written", value: formatCount(args.outputWritten), detail: `No-change files ${formatCount(args.alreadyOptimized)}` },
-      { label: "Net space saved", value: formatBytesCompact(args.netSpaceSavedBytes), detail: describeNetSizeChange(args.netSpaceSavedBytes, args.netSpaceSavedPercent) },
+      {
+        label: "Completed jobs",
+        value: formatCount(args.processed),
+        detail: `Success rate ${formatPercent(args.successRatePercent)}`,
+      },
+      {
+        label: "Output written",
+        value: formatCount(args.outputWritten),
+        detail: `No-change files ${formatCount(args.alreadyOptimized)}`,
+      },
+      {
+        label: "Net space saved",
+        value: formatBytesCompact(args.netSpaceSavedBytes),
+        detail: describeNetSizeChange(
+          args.netSpaceSavedBytes,
+          args.netSpaceSavedPercent,
+        ),
+      },
       { label: "Failures", value: formatCount(args.failed) },
     ],
     facts: [
@@ -259,9 +341,11 @@ function buildPrunerCard(args: {
   failedApplies: number;
 }): ModuleCardData {
   const attention = args.enabledServers === 0 || args.failedApplies > 0;
-  const active = args.previewRuns > 0 || args.applyRuns > 0 || args.itemsRemoved > 0;
+  const active =
+    args.previewRuns > 0 || args.applyRuns > 0 || args.itemsRemoved > 0;
   const reviewedItems = args.itemsRemoved + args.itemsSkipped;
-  const removalRate = reviewedItems > 0 ? (args.itemsRemoved / reviewedItems) * 100.0 : 0;
+  const removalRate =
+    reviewedItems > 0 ? (args.itemsRemoved / reviewedItems) * 100.0 : 0;
 
   return {
     key: "pruner",
@@ -277,9 +361,21 @@ function buildPrunerCard(args: {
             : "Ready. No recent preview or delete work recorded.",
     metrics: [
       { label: "Items removed", value: formatCount(args.itemsRemoved) },
-      { label: "Cleanup runs", value: formatCount(args.applyRuns), detail: `Failed cleanups ${formatCount(args.failedApplies)}` },
-      { label: "Candidates reviewed", value: formatCount(reviewedItems), detail: `Preview runs ${formatCount(args.previewRuns)}` },
-      { label: "Removal rate", value: formatPercent(removalRate), detail: `${formatCount(args.itemsRemoved)} removed - ${formatCount(args.itemsSkipped)} skipped` },
+      {
+        label: "Cleanup runs",
+        value: formatCount(args.applyRuns),
+        detail: `Failed cleanups ${formatCount(args.failedApplies)}`,
+      },
+      {
+        label: "Candidates reviewed",
+        value: formatCount(reviewedItems),
+        detail: `Preview runs ${formatCount(args.previewRuns)}`,
+      },
+      {
+        label: "Removal rate",
+        value: formatPercent(removalRate),
+        detail: `${formatCount(args.itemsRemoved)} removed - ${formatCount(args.itemsSkipped)} skipped`,
+      },
     ],
     facts: [
       `Servers enabled: ${formatCount(args.enabledServers)} of ${formatCount(args.totalServers)}`,
@@ -305,11 +401,16 @@ function buildSubberCard(args: {
   tvMissing: number;
   moviesMissing: number;
 }): ModuleCardData {
-  const attention = !args.sonarrConfigured || !args.radarrConfigured || args.enabledProviders === 0;
+  const attention =
+    !args.sonarrConfigured ||
+    !args.radarrConfigured ||
+    args.enabledProviders === 0;
   const trackedTotal = args.tvTracked + args.moviesTracked;
-  const active = trackedTotal > 0 || args.downloaded > 0 || args.foundRecently > 0;
+  const active =
+    trackedTotal > 0 || args.downloaded > 0 || args.foundRecently > 0;
   const coveredItems = Math.max(0, trackedTotal - args.stillMissing);
-  const coveragePercent = trackedTotal > 0 ? (coveredItems / trackedTotal) * 100.0 : 0;
+  const coveragePercent =
+    trackedTotal > 0 ? (coveredItems / trackedTotal) * 100.0 : 0;
 
   return {
     key: "subber",
@@ -323,8 +424,16 @@ function buildSubberCard(args: {
     metrics: [
       { label: "Downloaded", value: formatCount(args.downloaded) },
       { label: "Still missing", value: formatCount(args.stillMissing) },
-      { label: "Coverage", value: formatPercent(coveragePercent), detail: `${formatCount(coveredItems)} of ${formatCount(trackedTotal)} covered` },
-      { label: "Found recently", value: formatCount(args.foundRecently), detail: `Not found ${formatCount(args.notFoundRecently)} - Upgrades ${formatCount(args.upgradesRecently)}` },
+      {
+        label: "Coverage",
+        value: formatPercent(coveragePercent),
+        detail: `${formatCount(coveredItems)} of ${formatCount(trackedTotal)} covered`,
+      },
+      {
+        label: "Found recently",
+        value: formatCount(args.foundRecently),
+        detail: `Not found ${formatCount(args.notFoundRecently)} - Upgrades ${formatCount(args.upgradesRecently)}`,
+      },
     ],
     facts: [
       `TV missing: ${formatCount(args.tvMissing)} - Movies missing: ${formatCount(args.moviesMissing)}`,
@@ -388,7 +497,8 @@ export function DashboardPage() {
     tvFolder: refinerPaths.data?.refiner_tv_watched_folder,
   });
   const prunerCard = buildPrunerCard({
-    enabledServers: prunerInstances.data?.filter((row) => row.enabled).length ?? 0,
+    enabledServers:
+      prunerInstances.data?.filter((row) => row.enabled).length ?? 0,
     totalServers: prunerInstances.data?.length ?? 0,
     previewRuns: prunerStats.data?.preview_runs ?? 0,
     applyRuns: prunerStats.data?.apply_runs ?? 0,
@@ -397,9 +507,16 @@ export function DashboardPage() {
     failedApplies: prunerStats.data?.failed_applies ?? 0,
   });
   const subberCard = buildSubberCard({
-    sonarrConfigured: Boolean(subberSettings.data?.sonarr_base_url?.trim() && subberSettings.data?.sonarr_api_key_set),
-    radarrConfigured: Boolean(subberSettings.data?.radarr_base_url?.trim() && subberSettings.data?.radarr_api_key_set),
-    enabledProviders: subberProviders.data?.filter((row) => row.enabled).length ?? 0,
+    sonarrConfigured: Boolean(
+      subberSettings.data?.sonarr_base_url?.trim() &&
+      subberSettings.data?.sonarr_api_key_set,
+    ),
+    radarrConfigured: Boolean(
+      subberSettings.data?.radarr_base_url?.trim() &&
+      subberSettings.data?.radarr_api_key_set,
+    ),
+    enabledProviders:
+      subberProviders.data?.filter((row) => row.enabled).length ?? 0,
     providerTotal: subberProviders.data?.length ?? 0,
     tvTracked: subberOverview.data?.tv_tracked ?? 0,
     moviesTracked: subberOverview.data?.movies_tracked ?? 0,
@@ -412,7 +529,9 @@ export function DashboardPage() {
     moviesMissing: subberOverview.data?.movies_missing ?? 0,
   });
 
-  const refinerFileOutcomes = (refinerStats.data?.output_written_count ?? 0) + (refinerStats.data?.already_optimized_count ?? 0);
+  const refinerFileOutcomes =
+    (refinerStats.data?.output_written_count ?? 0) +
+    (refinerStats.data?.already_optimized_count ?? 0);
   const refinerCardForDashboard = {
     ...refinerCard,
     metrics: refinerCard.metrics.map((metric) =>
@@ -430,22 +549,41 @@ export function DashboardPage() {
   };
 
   const moduleCards = [refinerCardForDashboard, prunerCard, subberCard];
-  const modulesNeedingAttentionTotal = moduleCards.filter((m) => m.status === "Review needed").length;
-  const activeModuleCount = moduleCards.filter((m) => m.status === "Active").length;
-  const workerIssues = (dash.data.system.worker_health ?? []).filter((row) => row.status === "degraded");
+  const modulesNeedingAttentionTotal = moduleCards.filter(
+    (m) => m.status === "Review needed",
+  ).length;
+  const activeModuleCount = moduleCards.filter(
+    (m) => m.status === "Active",
+  ).length;
+  const workerIssues = (dash.data.system.worker_health ?? []).filter(
+    (row) => row.status === "degraded",
+  );
   const attentionItems = [
-    ...moduleCards.filter((m) => m.status === "Review needed").map((m) => `${m.name}: ${m.summary}`),
-    ...workerIssues.map((row) => `${row.module[0].toUpperCase()}${row.module.slice(1)} workers: ${row.detail}`),
+    ...moduleCards
+      .filter((m) => m.status === "Review needed")
+      .map((m) => `${m.name}: ${m.summary}`),
+    ...workerIssues.map(
+      (row) =>
+        `${row.module[0].toUpperCase()}${row.module.slice(1)} workers: ${row.detail}`,
+    ),
   ];
-  const activeItems = moduleCards.filter((m) => m.status === "Active").map((m) => `${m.name}: ${m.summary}`);
+  const activeItems = moduleCards
+    .filter((m) => m.status === "Active")
+    .map((m) => `${m.name}: ${m.summary}`);
   const overallStatus =
-    !dash.data.system.healthy || modulesNeedingAttentionTotal > 0 || workerIssues.length > 0
+    !dash.data.system.healthy ||
+    modulesNeedingAttentionTotal > 0 ||
+    workerIssues.length > 0
       ? "Review needed"
       : activeModuleCount > 0
         ? "Active"
         : "Healthy";
-  const moduleAttentionNames = moduleCards.filter((m) => m.status === "Review needed").map((m) => m.name);
-  const workerIssueNames = workerIssues.map((row) => `${row.module[0].toUpperCase()}${row.module.slice(1)} workers`);
+  const moduleAttentionNames = moduleCards
+    .filter((m) => m.status === "Review needed")
+    .map((m) => m.name);
+  const workerIssueNames = workerIssues.map(
+    (row) => `${row.module[0].toUpperCase()}${row.module.slice(1)} workers`,
+  );
   const overallStatusDetail =
     moduleAttentionNames.length > 0 && workerIssueNames.length > 0
       ? `Needs setup: ${moduleAttentionNames.join(", ")}. Worker issues: ${workerIssueNames.join(", ")}.`
@@ -453,23 +591,25 @@ export function DashboardPage() {
         ? `Needs setup: ${moduleAttentionNames.join(", ")}.`
         : workerIssueNames.length > 0
           ? `Worker issues: ${workerIssueNames.join(", ")}.`
-      : activeItems.length > 0
-        ? `Active: ${moduleCards
-            .filter((m) => m.status === "Active")
-            .map((m) => m.name)
-            .join(", ")}.`
-        : "No module or worker issues detected.";
+          : activeItems.length > 0
+            ? `Active: ${moduleCards
+                .filter((m) => m.status === "Active")
+                .map((m) => m.name)
+                .join(", ")}.`
+            : "No module or worker issues detected.";
 
-  const refinerDashboardJobs: DashboardJobRow[] = (refinerJobs.data?.jobs ?? []).filter((job) =>
-    isDashboardVisibleRefinerJob(job.job_kind),
-  );
+  const refinerDashboardJobs: DashboardJobRow[] = (
+    refinerJobs.data?.jobs ?? []
+  ).filter((job) => isDashboardVisibleRefinerJob(job.job_kind));
   const globalJobs: GlobalJobRow[] = [
     ...(refinerDashboardJobs.slice(0, 4).map((job) => ({
       key: `refiner-${job.id}`,
       module: "Refiner",
       status: jobStatusLabel(job.status),
       title: refinerJobTitle(job.job_kind),
-      detail: job.last_error ? job.last_error : `${refinerJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
+      detail: job.last_error
+        ? job.last_error
+        : `${refinerJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
       updatedAt: job.updated_at,
     })) ?? []),
     ...(prunerJobs.data?.jobs.slice(0, 4).map((job) => ({
@@ -477,7 +617,9 @@ export function DashboardPage() {
       module: "Pruner",
       status: jobStatusLabel(job.status),
       title: prunerJobTitle(job.job_kind),
-      detail: job.last_error ? job.last_error : `${prunerJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
+      detail: job.last_error
+        ? job.last_error
+        : `${prunerJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
       updatedAt: job.updated_at,
     })) ?? []),
     ...(subberJobs.data?.jobs.slice(0, 4).map((job) => ({
@@ -485,7 +627,9 @@ export function DashboardPage() {
       module: "Subber",
       status: jobStatusLabel(job.status),
       title: subberJobTitle(job.job_kind),
-      detail: job.last_error ? job.last_error : `${subberJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
+      detail: job.last_error
+        ? job.last_error
+        : `${subberJobTitle(job.job_kind)} is ${jobStatusLabel(job.status).toLowerCase()}.`,
       updatedAt: job.updated_at,
     })) ?? []),
   ]
@@ -496,65 +640,120 @@ export function DashboardPage() {
     <div className="mm-page" data-testid="dashboard-page">
       <header className="mm-page__intro">
         <h1 className="mm-page__title">Dashboard</h1>
-        <p className="mm-page__lead">See what needs attention across MediaMop and what the modules are doing right now.</p>
+        <p className="mm-page__lead">
+          See what needs attention across MediaMop and what the modules are
+          doing right now.
+        </p>
       </header>
 
-      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4" data-testid="dashboard-status-strip">
-        <MetricCard label="Overall status" value={overallStatus} detail={overallStatusDetail} />
+      <section
+        className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4"
+        data-testid="dashboard-status-strip"
+      >
+        <MetricCard
+          label="Overall status"
+          value={overallStatus}
+          detail={overallStatusDetail}
+        />
         <MetricCard
           label="Modules needing attention"
-          value={modulesNeedingAttentionTotal === 0 ? "None detected" : String(modulesNeedingAttentionTotal)}
+          value={
+            modulesNeedingAttentionTotal === 0
+              ? "None detected"
+              : String(modulesNeedingAttentionTotal)
+          }
         />
-        <MetricCard label="Active modules" value={activeModuleCount === 0 ? "None" : String(activeModuleCount)} />
-        <MetricCard label="Last activity" value={shortLastActivity(recentItems, fmt)} />
+        <MetricCard
+          label="Active modules"
+          value={activeModuleCount === 0 ? "None" : String(activeModuleCount)}
+        />
+        <MetricCard
+          label="Last activity"
+          value={shortLastActivity(recentItems, fmt)}
+        />
       </section>
 
-      <section className="mt-5 grid gap-4 xl:grid-cols-3" data-testid="dashboard-module-cards">
+      <section
+        className="mt-5 grid gap-4 xl:grid-cols-3"
+        data-testid="dashboard-module-cards"
+      >
         {moduleCards.map((card) => (
           <ModuleCard key={card.key} card={card} />
         ))}
       </section>
 
       <section className="mt-6 grid gap-4 xl:grid-cols-2">
-        <article className="mm-card mm-dash-card" data-testid="dashboard-needs-attention">
+        <article
+          className="mm-card mm-dash-card"
+          data-testid="dashboard-needs-attention"
+        >
           <h2 className="mm-card__title">Needs attention</h2>
           <div className="mm-card__body space-y-2 text-sm text-[var(--mm-text2)]">
-            {attentionItems.length > 0 ? attentionItems.map((line) => <p key={line}>{line}</p>) : <p>Nothing needs attention right now.</p>}
+            {attentionItems.length > 0 ? (
+              attentionItems.map((line) => <p key={line}>{line}</p>)
+            ) : (
+              <p>Nothing needs attention right now.</p>
+            )}
           </div>
         </article>
-        <article className="mm-card mm-dash-card" data-testid="dashboard-active-work">
+        <article
+          className="mm-card mm-dash-card"
+          data-testid="dashboard-active-work"
+        >
           <h2 className="mm-card__title">Active work</h2>
           <div className="mm-card__body space-y-2 text-sm text-[var(--mm-text2)]">
-            {activeItems.length > 0 ? activeItems.map((line) => <p key={line}>{line}</p>) : <p>No modules are actively processing right now.</p>}
+            {activeItems.length > 0 ? (
+              activeItems.map((line) => <p key={line}>{line}</p>)
+            ) : (
+              <p>No modules are actively processing right now.</p>
+            )}
           </div>
         </article>
       </section>
 
-      <section className="mm-card mm-dash-card mt-6" data-testid="dashboard-global-jobs">
+      <section
+        className="mm-card mm-dash-card mt-6"
+        data-testid="dashboard-global-jobs"
+      >
         <div className="flex items-start justify-between gap-3">
           <div>
             <h2 className="mm-card__title">Global jobs</h2>
-            <p className="mt-1 text-sm text-[var(--mm-text2)]">Recent background work across Refiner, Pruner, and Subber.</p>
+            <p className="mt-1 text-sm text-[var(--mm-text2)]">
+              Recent background work across Refiner, Pruner, and Subber.
+            </p>
           </div>
         </div>
         <div className="mm-card__body space-y-3">
           {globalJobs.length === 0 ? (
-            <p className="text-sm text-[var(--mm-text2)]">No recent jobs are recorded.</p>
+            <p className="text-sm text-[var(--mm-text2)]">
+              No recent jobs are recorded.
+            </p>
           ) : (
             globalJobs.map((job) => (
-              <article key={job.key} className="rounded-lg border border-[var(--mm-border)] bg-black/10 p-3">
+              <article
+                key={job.key}
+                className="rounded-lg border border-[var(--mm-border)] bg-black/10 p-3"
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1">
                     <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-gold)]">{job.module}</span>
+                      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-gold)]">
+                        {job.module}
+                      </span>
                       <span className="rounded-full border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-2 py-0.5 text-xs text-[var(--mm-text2)]">
                         {job.status}
                       </span>
                     </div>
-                    <h3 className="text-sm font-semibold text-[var(--mm-text1)]">{job.title}</h3>
-                    <p className="text-sm text-[var(--mm-text2)]">{job.detail}</p>
+                    <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+                      {job.title}
+                    </h3>
+                    <p className="text-sm text-[var(--mm-text2)]">
+                      {job.detail}
+                    </p>
                   </div>
-                  <time className="text-sm text-[var(--mm-text3)]">{fmt(job.updatedAt)}</time>
+                  <time className="text-sm text-[var(--mm-text3)]">
+                    {fmt(job.updatedAt)}
+                  </time>
                 </div>
               </article>
             ))

--- a/apps/web/src/pages/pruner/pruner-apply-ui.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-apply-ui.test.tsx
@@ -1,11 +1,20 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { qk } from "../../lib/auth/queries";
 import type { UserPublic } from "../../lib/api/types";
 import * as prunerApi from "../../lib/pruner/api";
-import type { PrunerPreviewRunSummary, PrunerServerInstance } from "../../lib/pruner/api";
+import type {
+  PrunerPreviewRunSummary,
+  PrunerServerInstance,
+} from "../../lib/pruner/api";
 import {
   PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
   PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL,
@@ -114,24 +123,28 @@ const embyInstance: PrunerServerInstance = {
 
 describe("PrunerScopeTab apply (preview → apply)", () => {
   it("exposes Remove broken library entries only on preview history for Jellyfin success rows", async () => {
-    const spyElig = vi.spyOn(prunerApi, "fetchPrunerApplyEligibility").mockResolvedValue({
-      eligible: true,
-      reasons: [],
-      apply_feature_enabled: true,
-      preview_run_id: runId,
-      server_instance_id: 2,
-      media_scope: "tv",
-      provider: "jellyfin",
-      display_name: "JF Home",
-      preview_created_at: previewRun.created_at,
-      candidate_count: 2,
-      preview_outcome: "success",
-      rule_family_id: "missing_primary_media_reported",
-      apply_operator_label: PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
-    });
+    const spyElig = vi
+      .spyOn(prunerApi, "fetchPrunerApplyEligibility")
+      .mockResolvedValue({
+        eligible: true,
+        reasons: [],
+        apply_feature_enabled: true,
+        preview_run_id: runId,
+        server_instance_id: 2,
+        media_scope: "tv",
+        provider: "jellyfin",
+        display_name: "JF Home",
+        preview_created_at: previewRun.created_at,
+        candidate_count: 2,
+        preview_outcome: "success",
+        rule_family_id: "missing_primary_media_reported",
+        apply_operator_label: PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
+      });
     try {
       const qc = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+        defaultOptions: {
+          queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+        },
       });
       qc.setQueryData(qk.me, operator);
       await qc.prefetchQuery({
@@ -161,22 +174,28 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-preview-runs-history")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-preview-runs-history"),
+        ).toBeInTheDocument();
       });
 
       const openBtn = screen.getByTestId(`pruner-apply-open-${runId}`);
-      expect(openBtn.textContent).toBe(PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL);
+      expect(openBtn.textContent).toBe(
+        PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
+      );
 
       fireEvent.click(openBtn);
 
       const modal = await screen.findByTestId("pruner-apply-modal");
       await waitFor(() => {
-        expect(within(modal).getByRole("heading", { level: 3 })).toHaveTextContent(
-          PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
-        );
+        expect(
+          within(modal).getByRole("heading", { level: 3 }),
+        ).toHaveTextContent(PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL);
       });
 
-      const titles = screen.getAllByText(PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL);
+      const titles = screen.getAllByText(
+        PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
+      );
       expect(titles.length).toBeGreaterThanOrEqual(2);
       expect(modal.textContent).toMatch(/saved list/i);
       expect(modal.textContent).toMatch(/saved list of up to/i);
@@ -190,7 +209,8 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       ...previewRun,
       preview_run_id: "660e8400-e29b-41d4-a716-446655440001",
       outcome: "unsupported",
-      unsupported_detail: "Plex: never-played stale library candidacy is not implemented on MediaMop",
+      unsupported_detail:
+        "Plex: never-played stale library candidacy is not implemented on MediaMop",
       candidate_count: 0,
     };
     const emptyOk: PrunerPreviewRunSummary = {
@@ -201,7 +221,9 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       unsupported_detail: null,
     };
     const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+      defaultOptions: {
+        queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+      },
     });
     qc.setQueryData(qk.me, operator);
     await qc.prefetchQuery({
@@ -230,34 +252,45 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(screen.getByTestId("pruner-preview-runs-history")).toBeInTheDocument());
-    expect(screen.getByTestId(`pruner-preview-run-caption-${unsupportedRun.preview_run_id}`).textContent).toMatch(
-      /Not available on this server/i,
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-preview-runs-history"),
+      ).toBeInTheDocument(),
     );
-    expect(screen.getByTestId(`pruner-preview-run-caption-${emptyOk.preview_run_id}`).textContent).toMatch(
-      /nothing matched/i,
-    );
+    expect(
+      screen.getByTestId(
+        `pruner-preview-run-caption-${unsupportedRun.preview_run_id}`,
+      ).textContent,
+    ).toMatch(/Not available on this server/i);
+    expect(
+      screen.getByTestId(`pruner-preview-run-caption-${emptyOk.preview_run_id}`)
+        .textContent,
+    ).toMatch(/nothing matched/i);
   });
 
   it("exposes Remove broken library entries for eligible Emby preview history rows", async () => {
-    const spyElig = vi.spyOn(prunerApi, "fetchPrunerApplyEligibility").mockResolvedValue({
-      eligible: true,
-      reasons: [],
-      apply_feature_enabled: true,
-      preview_run_id: runId,
-      server_instance_id: 3,
-      media_scope: "tv",
-      provider: "emby",
-      display_name: "Emby Home",
-      preview_created_at: previewRun.created_at,
-      candidate_count: 2,
-      preview_outcome: "success",
-      rule_family_id: "missing_primary_media_reported",
-      apply_operator_label: PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
-    });
+    const spyElig = vi
+      .spyOn(prunerApi, "fetchPrunerApplyEligibility")
+      .mockResolvedValue({
+        eligible: true,
+        reasons: [],
+        apply_feature_enabled: true,
+        preview_run_id: runId,
+        server_instance_id: 3,
+        media_scope: "tv",
+        provider: "emby",
+        display_name: "Emby Home",
+        preview_created_at: previewRun.created_at,
+        candidate_count: 2,
+        preview_outcome: "success",
+        rule_family_id: "missing_primary_media_reported",
+        apply_operator_label: PRUNER_REMOVE_BROKEN_LIBRARY_ENTRIES_LABEL,
+      });
     try {
       const qc = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+        defaultOptions: {
+          queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+        },
       });
       qc.setQueryData(qk.me, operator);
       await qc.prefetchQuery({
@@ -287,7 +320,9 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId(`pruner-apply-open-${runId}`)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`pruner-apply-open-${runId}`),
+        ).toBeInTheDocument();
       });
     } finally {
       spyElig.mockRestore();
@@ -296,24 +331,29 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
 
   it("uses Remove stale never-played library entries for never-played preview rows", async () => {
     const neverRunId = "22222222-2222-4222-8222-222222222222";
-    const spyElig = vi.spyOn(prunerApi, "fetchPrunerApplyEligibility").mockResolvedValue({
-      eligible: true,
-      reasons: [],
-      apply_feature_enabled: true,
-      preview_run_id: neverRunId,
-      server_instance_id: 2,
-      media_scope: "tv",
-      provider: "jellyfin",
-      display_name: "JF Home",
-      preview_created_at: previewRun.created_at,
-      candidate_count: 1,
-      preview_outcome: "success",
-      rule_family_id: "never_played_stale_reported",
-      apply_operator_label: PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL,
-    });
+    const spyElig = vi
+      .spyOn(prunerApi, "fetchPrunerApplyEligibility")
+      .mockResolvedValue({
+        eligible: true,
+        reasons: [],
+        apply_feature_enabled: true,
+        preview_run_id: neverRunId,
+        server_instance_id: 2,
+        media_scope: "tv",
+        provider: "jellyfin",
+        display_name: "JF Home",
+        preview_created_at: previewRun.created_at,
+        candidate_count: 1,
+        preview_outcome: "success",
+        rule_family_id: "never_played_stale_reported",
+        apply_operator_label:
+          PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL,
+      });
     try {
       const qc = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+        defaultOptions: {
+          queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+        },
       });
       qc.setQueryData(qk.me, operator);
       await qc.prefetchQuery({
@@ -351,14 +391,20 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId(`pruner-apply-open-${neverRunId}`)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`pruner-apply-open-${neverRunId}`),
+        ).toBeInTheDocument();
       });
       const openBtn = screen.getByTestId(`pruner-apply-open-${neverRunId}`);
-      expect(openBtn.textContent).toBe(PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL);
+      expect(openBtn.textContent).toBe(
+        PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL,
+      );
       fireEvent.click(openBtn);
       const modal = await screen.findByTestId("pruner-apply-modal");
       await waitFor(() => {
-        expect(within(modal).getByRole("heading", { level: 3 })).toHaveTextContent(
+        expect(
+          within(modal).getByRole("heading", { level: 3 }),
+        ).toHaveTextContent(
           PRUNER_REMOVE_STALE_NEVER_PLAYED_LIBRARY_ENTRIES_LABEL,
         );
       });
@@ -369,24 +415,28 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
 
   it("uses Remove watched TV entries for watched TV preview rows", async () => {
     const watchedRunId = "33333333-3333-4333-8333-333333333333";
-    const spyElig = vi.spyOn(prunerApi, "fetchPrunerApplyEligibility").mockResolvedValue({
-      eligible: true,
-      reasons: [],
-      apply_feature_enabled: true,
-      preview_run_id: watchedRunId,
-      server_instance_id: 2,
-      media_scope: "tv",
-      provider: "jellyfin",
-      display_name: "JF Home",
-      preview_created_at: previewRun.created_at,
-      candidate_count: 1,
-      preview_outcome: "success",
-      rule_family_id: RULE_FAMILY_WATCHED_TV_REPORTED,
-      apply_operator_label: PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL,
-    });
+    const spyElig = vi
+      .spyOn(prunerApi, "fetchPrunerApplyEligibility")
+      .mockResolvedValue({
+        eligible: true,
+        reasons: [],
+        apply_feature_enabled: true,
+        preview_run_id: watchedRunId,
+        server_instance_id: 2,
+        media_scope: "tv",
+        provider: "jellyfin",
+        display_name: "JF Home",
+        preview_created_at: previewRun.created_at,
+        candidate_count: 1,
+        preview_outcome: "success",
+        rule_family_id: RULE_FAMILY_WATCHED_TV_REPORTED,
+        apply_operator_label: PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL,
+      });
     try {
       const qc = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+        defaultOptions: {
+          queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+        },
       });
       qc.setQueryData(qk.me, operator);
       await qc.prefetchQuery({
@@ -424,16 +474,18 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId(`pruner-apply-open-${watchedRunId}`)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`pruner-apply-open-${watchedRunId}`),
+        ).toBeInTheDocument();
       });
       const openBtn = screen.getByTestId(`pruner-apply-open-${watchedRunId}`);
       expect(openBtn.textContent).toBe(PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL);
       fireEvent.click(openBtn);
       const modal = await screen.findByTestId("pruner-apply-modal");
       await waitFor(() => {
-        expect(within(modal).getByRole("heading", { level: 3 })).toHaveTextContent(
-          PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL,
-        );
+        expect(
+          within(modal).getByRole("heading", { level: 3 }),
+        ).toHaveTextContent(PRUNER_REMOVE_WATCHED_TV_ENTRIES_LABEL);
       });
     } finally {
       spyElig.mockRestore();
@@ -442,24 +494,28 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
 
   it("uses Remove watched movie entries for watched movies preview rows (Movies tab)", async () => {
     const moviesRunId = "44444444-4444-4444-8444-444444444444";
-    const spyElig = vi.spyOn(prunerApi, "fetchPrunerApplyEligibility").mockResolvedValue({
-      eligible: true,
-      reasons: [],
-      apply_feature_enabled: true,
-      preview_run_id: moviesRunId,
-      server_instance_id: 2,
-      media_scope: "movies",
-      provider: "jellyfin",
-      display_name: "JF Home",
-      preview_created_at: previewRun.created_at,
-      candidate_count: 1,
-      preview_outcome: "success",
-      rule_family_id: RULE_FAMILY_WATCHED_MOVIES_REPORTED,
-      apply_operator_label: PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL,
-    });
+    const spyElig = vi
+      .spyOn(prunerApi, "fetchPrunerApplyEligibility")
+      .mockResolvedValue({
+        eligible: true,
+        reasons: [],
+        apply_feature_enabled: true,
+        preview_run_id: moviesRunId,
+        server_instance_id: 2,
+        media_scope: "movies",
+        provider: "jellyfin",
+        display_name: "JF Home",
+        preview_created_at: previewRun.created_at,
+        candidate_count: 1,
+        preview_outcome: "success",
+        rule_family_id: RULE_FAMILY_WATCHED_MOVIES_REPORTED,
+        apply_operator_label: PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL,
+      });
     try {
       const qc = new QueryClient({
-        defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+        defaultOptions: {
+          queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+        },
       });
       qc.setQueryData(qk.me, operator);
       await qc.prefetchQuery({
@@ -484,7 +540,9 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/2/movies"] },
@@ -497,16 +555,20 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId(`pruner-apply-open-${moviesRunId}`)).toBeInTheDocument();
+        expect(
+          screen.getByTestId(`pruner-apply-open-${moviesRunId}`),
+        ).toBeInTheDocument();
       });
       const openBtn = screen.getByTestId(`pruner-apply-open-${moviesRunId}`);
-      expect(openBtn.textContent).toBe(PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL);
+      expect(openBtn.textContent).toBe(
+        PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL,
+      );
       fireEvent.click(openBtn);
       const modal = await screen.findByTestId("pruner-apply-modal");
       await waitFor(() => {
-        expect(within(modal).getByRole("heading", { level: 3 })).toHaveTextContent(
-          PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL,
-        );
+        expect(
+          within(modal).getByRole("heading", { level: 3 }),
+        ).toHaveTextContent(PRUNER_REMOVE_WATCHED_MOVIES_ENTRIES_LABEL);
       });
     } finally {
       spyElig.mockRestore();
@@ -583,7 +645,9 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
       ],
     };
     const qc = new QueryClient({
-      defaultOptions: { queries: { retry: false, staleTime: 60_000, refetchOnMount: false } },
+      defaultOptions: {
+        queries: { retry: false, staleTime: 60_000, refetchOnMount: false },
+      },
     });
     qc.setQueryData(qk.me, operator);
     await qc.prefetchQuery({
@@ -622,7 +686,9 @@ describe("PrunerScopeTab apply (preview → apply)", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId("pruner-preview-runs-history")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-preview-runs-history"),
+      ).toBeInTheDocument();
     });
 
     expect(screen.queryByTestId(`pruner-apply-open-${runId}`)).toBeNull();

--- a/apps/web/src/pages/pruner/pruner-connection-tab.tsx
+++ b/apps/web/src/pages/pruner/pruner-connection-tab.tsx
@@ -24,7 +24,9 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
     setBusy(true);
     try {
       const { pruner_job_id } = await postPrunerConnectionTest(instanceId);
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setMsg(
         `Connection test started. When it finishes, this panel and Activity update for this server only (task #${pruner_job_id}).`,
       );
@@ -36,13 +38,18 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
   }
 
   return (
-    <div className="mm-bubble-stack max-w-3xl" data-testid="pruner-connection-tab">
+    <div
+      className="mm-bubble-stack max-w-3xl"
+      data-testid="pruner-connection-tab"
+    >
       <header className="mm-page__intro !mb-0 border-0 p-0 shadow-none">
         <p className="mm-page__eyebrow">This server</p>
         <h2 className="mm-page__title text-xl sm:text-2xl">Connection</h2>
         <p className="mm-page__subtitle max-w-3xl">
-          Check that MediaMop can reach <strong className="text-[var(--mm-text)]">this</strong> server only. Jellyfin and
-          Emby use a small public info check; Plex checks identity with your saved token when you have one.
+          Check that MediaMop can reach{" "}
+          <strong className="text-[var(--mm-text)]">this</strong> server only.
+          Jellyfin and Emby use a small public info check; Plex checks identity
+          with your saved token when you have one.
         </p>
       </header>
 
@@ -50,7 +57,10 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
         className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-4 text-sm text-[var(--mm-text2)]"
         aria-labelledby="pruner-conn-status"
       >
-        <h3 id="pruner-conn-status" className="text-sm font-semibold text-[var(--mm-text1)]">
+        <h3
+          id="pruner-conn-status"
+          className="text-sm font-semibold text-[var(--mm-text1)]"
+        >
           Last completed test
         </h3>
         {instance ? (
@@ -64,12 +74,18 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
             <div className="flex flex-wrap gap-x-2">
               <dt className="text-[var(--mm-text3)]">OK</dt>
               <dd className="font-medium text-[var(--mm-text1)]">
-                {instance.last_connection_test_ok === null ? "—" : instance.last_connection_test_ok ? "Yes" : "No"}
+                {instance.last_connection_test_ok === null
+                  ? "—"
+                  : instance.last_connection_test_ok
+                    ? "Yes"
+                    : "No"}
               </dd>
             </div>
             <div>
               <dt className="text-[var(--mm-text3)]">Detail</dt>
-              <dd className="mt-0.5 text-[var(--mm-text2)]">{instance.last_connection_test_detail ?? "—"}</dd>
+              <dd className="mt-0.5 text-[var(--mm-text2)]">
+                {instance.last_connection_test_detail ?? "—"}
+              </dd>
             </div>
           </dl>
         ) : (
@@ -87,7 +103,9 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
           Run connection test
         </button>
       ) : (
-        <p className="text-sm text-[var(--mm-text2)]">Sign in as an operator to run connection tests.</p>
+        <p className="text-sm text-[var(--mm-text2)]">
+          Sign in as an operator to run connection tests.
+        </p>
       )}
       {err ? (
         <p className="text-sm text-red-600" role="alert">
@@ -98,7 +116,10 @@ export function PrunerConnectionTab(props: { contextOverride?: Ctx }) {
 
       <p className="text-xs text-[var(--mm-text2)]">
         Job outcomes:{" "}
-        <Link className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline" to="/app/activity">
+        <Link
+          className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline"
+          to="/app/activity"
+        >
           Activity
         </Link>
       </p>

--- a/apps/web/src/pages/pruner/pruner-genre-multi-select.tsx
+++ b/apps/web/src/pages/pruner/pruner-genre-multi-select.tsx
@@ -26,10 +26,14 @@ export const PRUNER_RULE_GENRE_OPTIONS = [
   "Western",
 ] as const;
 
-const GENRE_LISTBOX_OPTIONS: MmListboxOption[] = PRUNER_RULE_GENRE_OPTIONS.map((g) => ({ value: g, label: g }));
+const GENRE_LISTBOX_OPTIONS: MmListboxOption[] = PRUNER_RULE_GENRE_OPTIONS.map(
+  (g) => ({ value: g, label: g }),
+);
 
 /** Map saved API genres onto canonical list entries (case-insensitive). */
-export function prunerGenresFromApi(api: string[] | undefined | null): string[] {
+export function prunerGenresFromApi(
+  api: string[] | undefined | null,
+): string[] {
   if (!api?.length) return [];
   const out: string[] = [];
   for (const canon of PRUNER_RULE_GENRE_OPTIONS) {
@@ -44,7 +48,9 @@ function genreTriggerSummary(values: string[]): string {
   if (values.length === 0) return "No genres selected";
   if (values.length <= 3) {
     const lower = new Set(values.map((v) => v.toLowerCase()));
-    return PRUNER_RULE_GENRE_OPTIONS.filter((g) => lower.has(g.toLowerCase())).join(", ");
+    return PRUNER_RULE_GENRE_OPTIONS.filter((g) =>
+      lower.has(g.toLowerCase()),
+    ).join(", ");
   }
   return `${values.length} genres selected`;
 }
@@ -74,7 +80,10 @@ export function PrunerGenreMultiSelect({
   const placeholder = pickerPlaceholder ?? "No genres selected";
 
   return (
-    <div className="space-y-2" data-testid={testId ?? "pruner-genre-multiselect"}>
+    <div
+      className="space-y-2"
+      data-testid={testId ?? "pruner-genre-multiselect"}
+    >
       <span className="sr-only" data-testid="pruner-genre-multiselect-summary">
         {summary}
       </span>
@@ -85,9 +94,13 @@ export function PrunerGenreMultiSelect({
         disabled={disabled}
         placeholder={placeholder}
         summaryText={summary}
-        data-testid={testId ? `${testId}-picker` : "pruner-genre-multiselect-picker"}
+        data-testid={
+          testId ? `${testId}-picker` : "pruner-genre-multiselect-picker"
+        }
       />
-      {helper ? <p className="text-xs text-[var(--mm-text3)]">{helper}</p> : null}
+      {helper ? (
+        <p className="text-xs text-[var(--mm-text3)]">{helper}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/pages/pruner/pruner-instance-overview-tab.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-instance-overview-tab.test.tsx
@@ -96,13 +96,17 @@ function OverviewLayout({ instance }: { instance: PrunerServerInstance }) {
 
 describe("PrunerInstanceOverviewTab", () => {
   it("renders TV and Movies cards with active rules, filter counts, and last preview for Jellyfin", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     const router = createMemoryRouter(
       [
         {
           path: "/instances/:instanceId",
           element: <OverviewLayout instance={jellyfinInstance} />,
-          children: [{ path: "overview", element: <PrunerInstanceOverviewTab /> }],
+          children: [
+            { path: "overview", element: <PrunerInstanceOverviewTab /> },
+          ],
         },
       ],
       { initialEntries: ["/instances/77/overview"] },
@@ -114,26 +118,42 @@ describe("PrunerInstanceOverviewTab", () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(screen.getByTestId("pruner-instance-overview")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-instance-overview"),
+      ).toBeInTheDocument(),
+    );
     expect(screen.getByTestId("pruner-overview-scope-tv")).toBeInTheDocument();
-    expect(screen.getByTestId("pruner-overview-scope-movies")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pruner-overview-scope-movies"),
+    ).toBeInTheDocument();
     expect(screen.getByText(/Delete watched TV episodes/)).toBeInTheDocument();
     const tvCard = screen.getByTestId("pruner-overview-scope-tv");
     expect(tvCard.textContent).toMatch(/success/);
     expect(tvCard.textContent).toMatch(/2026/);
     expect(tvCard.textContent).toMatch(/Automatic previews are off/i);
-    expect(screen.getByRole("link", { name: /open activity/i })).toHaveAttribute("href", "/app/activity");
-    expect(screen.getByText(/Removed, skipped, and failed counts for each cleanup run/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open activity/i }),
+    ).toHaveAttribute("href", "/app/activity");
+    expect(
+      screen.getByText(
+        /Removed, skipped, and failed counts for each cleanup run/i,
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows Plex-only unsupported callouts on the TV scope card", async () => {
-    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     const router = createMemoryRouter(
       [
         {
           path: "/instances/:instanceId",
           element: <OverviewLayout instance={plexInstance} />,
-          children: [{ path: "overview", element: <PrunerInstanceOverviewTab /> }],
+          children: [
+            { path: "overview", element: <PrunerInstanceOverviewTab /> },
+          ],
         },
       ],
       { initialEntries: ["/instances/88/overview"] },
@@ -145,7 +165,11 @@ describe("PrunerInstanceOverviewTab", () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(screen.getByTestId("pruner-overview-scope-tv")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-overview-scope-tv"),
+      ).toBeInTheDocument(),
+    );
     const tvCard = screen.getByTestId("pruner-overview-scope-tv");
     expect(tvCard.textContent).toMatch(/Not available for this Plex library/i);
     expect(tvCard.textContent).toMatch(/Watched TV episodes/i);

--- a/apps/web/src/pages/pruner/pruner-instance-overview-tab.tsx
+++ b/apps/web/src/pages/pruner/pruner-instance-overview-tab.tsx
@@ -1,6 +1,12 @@
 import { Link, useOutletContext } from "react-router-dom";
-import type { PrunerScopeSummary, PrunerServerInstance } from "../../lib/pruner/api";
-import { formatPrunerDateTime, plexUnsupportedRuleFamilies } from "./pruner-ui-utils";
+import type {
+  PrunerScopeSummary,
+  PrunerServerInstance,
+} from "../../lib/pruner/api";
+import {
+  formatPrunerDateTime,
+  plexUnsupportedRuleFamilies,
+} from "./pruner-ui-utils";
 
 type Ctx = { instanceId: number; instance: PrunerServerInstance | undefined };
 
@@ -8,19 +14,27 @@ function scopeHeading(media: string): string {
   return media === "tv" ? "TV shows" : "Movies";
 }
 
-function activeRuleLines(scope: PrunerScopeSummary, provider: string): string[] {
+function activeRuleLines(
+  scope: PrunerScopeSummary,
+  provider: string,
+): string[] {
   const lines: string[] = [];
   if (scope.missing_primary_media_reported_enabled) {
-    lines.push("Delete items missing a main poster or episode image when the server supports it.");
+    lines.push(
+      "Delete items missing a main poster or episode image when the server supports it.",
+    );
   }
   if (scope.never_played_stale_reported_enabled) {
-    lines.push(`Delete never-started titles older than ${scope.never_played_min_age_days} days.`);
+    lines.push(
+      `Delete never-started titles older than ${scope.never_played_min_age_days} days.`,
+    );
   }
   if (scope.media_scope === "tv" && scope.watched_tv_reported_enabled) {
     lines.push("Delete watched TV episodes.");
   }
   if (scope.media_scope === "movies") {
-    if (scope.watched_movies_reported_enabled) lines.push("Delete watched movies.");
+    if (scope.watched_movies_reported_enabled)
+      lines.push("Delete watched movies.");
     if (scope.watched_movie_low_rating_reported_enabled) {
       lines.push(
         provider === "plex"
@@ -29,32 +43,46 @@ function activeRuleLines(scope: PrunerScopeSummary, provider: string): string[] 
       );
     }
     if (scope.unwatched_movie_stale_reported_enabled) {
-      lines.push(`Delete unwatched movies older than ${scope.unwatched_movie_stale_min_age_days} days.`);
+      lines.push(
+        `Delete unwatched movies older than ${scope.unwatched_movie_stale_min_age_days} days.`,
+      );
     }
   }
-  return lines.length > 0 ? lines : ["No cleanup rules are turned on for this library yet."];
+  return lines.length > 0
+    ? lines
+    : ["No cleanup rules are turned on for this library yet."];
 }
 
 function scheduleLine(scope: PrunerScopeSummary): string {
   if (!scope.scheduled_preview_enabled) return "Automatic previews are off.";
-  const every = Math.max(1, Math.floor(scope.scheduled_preview_interval_seconds / 60));
+  const every = Math.max(
+    1,
+    Math.floor(scope.scheduled_preview_interval_seconds / 60),
+  );
   const window = scope.scheduled_preview_hours_limited
     ? `Window: ${scope.scheduled_preview_days || "Every day"} ${scope.scheduled_preview_start || "00:00"}-${scope.scheduled_preview_end || "23:59"}`
     : "No hour limit";
   return `Automatic previews run every ${every} minutes. ${window}`;
 }
 
-function connectionStatus(instance: PrunerServerInstance): { title: string; detail: string } {
+function connectionStatus(instance: PrunerServerInstance): {
+  title: string;
+  detail: string;
+} {
   if (instance.last_connection_test_ok === true) {
     return {
       title: "Connection tested",
-      detail: instance.last_connection_test_detail || "The most recent media server connection test succeeded.",
+      detail:
+        instance.last_connection_test_detail ||
+        "The most recent media server connection test succeeded.",
     };
   }
   if (instance.last_connection_test_ok === false) {
     return {
       title: "Connection needs review",
-      detail: instance.last_connection_test_detail || "The most recent media server connection test failed.",
+      detail:
+        instance.last_connection_test_detail ||
+        "The most recent media server connection test failed.",
     };
   }
   return {
@@ -74,7 +102,9 @@ function ScopeWorkspaceCard({
 }) {
   const toTab = scope.media_scope === "tv" ? "tv" : "movies";
   const unsupported =
-    provider === "plex" ? plexUnsupportedRuleFamilies(scope.media_scope as "tv" | "movies") : [];
+    provider === "plex"
+      ? plexUnsupportedRuleFamilies(scope.media_scope as "tv" | "movies")
+      : [];
 
   return (
     <div
@@ -83,8 +113,12 @@ function ScopeWorkspaceCard({
     >
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>
-          <h3 className="text-sm font-semibold text-[var(--mm-text1)]">{scopeHeading(scope.media_scope)}</h3>
-          <p className="mt-1 text-xs text-[var(--mm-text3)]">{scheduleLine(scope)}</p>
+          <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+            {scopeHeading(scope.media_scope)}
+          </h3>
+          <p className="mt-1 text-xs text-[var(--mm-text3)]">
+            {scheduleLine(scope)}
+          </p>
         </div>
         <Link
           to={`/app/pruner/instances/${instanceId}/${toTab}`}
@@ -95,7 +129,9 @@ function ScopeWorkspaceCard({
       </div>
 
       <div>
-        <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">Rules turned on</p>
+        <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+          Rules turned on
+        </p>
         <ul className="mt-1 list-inside list-disc space-y-1 text-[var(--mm-text2)]">
           {activeRuleLines(scope, provider).map((line) => (
             <li key={line}>{line}</li>
@@ -104,16 +140,26 @@ function ScopeWorkspaceCard({
       </div>
 
       <div className="rounded-md border border-[var(--mm-border)] bg-black/10 px-3 py-3">
-        <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">Last library scan</p>
+        <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+          Last library scan
+        </p>
         <p className="mt-1 text-sm text-[var(--mm-text2)]">
-          <span className="font-medium text-[var(--mm-text1)]">{formatPrunerDateTime(scope.last_preview_at)}</span>
+          <span className="font-medium text-[var(--mm-text1)]">
+            {formatPrunerDateTime(scope.last_preview_at)}
+          </span>
         </p>
         <p className="mt-1 text-xs text-[var(--mm-text2)]">
-          Result: <span className="font-medium text-[var(--mm-text1)]">{scope.last_preview_outcome ?? "No scan yet"}</span>
+          Result:{" "}
+          <span className="font-medium text-[var(--mm-text1)]">
+            {scope.last_preview_outcome ?? "No scan yet"}
+          </span>
           {scope.last_preview_candidate_count != null ? (
             <>
               {" "}
-              · Candidates: <span className="font-medium text-[var(--mm-text1)]">{scope.last_preview_candidate_count}</span>
+              · Candidates:{" "}
+              <span className="font-medium text-[var(--mm-text1)]">
+                {scope.last_preview_candidate_count}
+              </span>
             </>
           ) : null}
         </p>
@@ -126,7 +172,9 @@ function ScopeWorkspaceCard({
 
       {unsupported.length ? (
         <div className="rounded-md border border-amber-900/40 bg-amber-950/20 px-3 py-3 text-xs text-amber-100/95">
-          <p className="font-semibold text-amber-50">Not available for this Plex library</p>
+          <p className="font-semibold text-amber-50">
+            Not available for this Plex library
+          </p>
           <ul className="mt-2 list-inside list-disc space-y-1">
             {unsupported.map((u) => (
               <li key={u}>{u}</li>
@@ -151,14 +199,19 @@ export function PrunerInstanceOverviewTab(props: { contextOverride?: Ctx }) {
   const connection = connectionStatus(instance);
 
   return (
-    <div className="mm-bubble-stack w-full min-w-0" data-testid="pruner-instance-overview">
+    <div
+      className="mm-bubble-stack w-full min-w-0"
+      data-testid="pruner-instance-overview"
+    >
       <header className="mm-page__intro !mb-0 border-0 p-0 shadow-none">
         <p className="mm-page__eyebrow">This server</p>
         <h2 className="mm-page__title text-xl sm:text-2xl">Overview</h2>
         <p className="mm-page__subtitle max-w-3xl">
-          One <strong className="text-[var(--mm-text)]">{instance.provider}</strong> library connection. TV shows and
-          movies are separate tabs under this server. Each scan saves a list you can review. Cleanup runs only use the
-          saved preview you confirm.
+          One{" "}
+          <strong className="text-[var(--mm-text)]">{instance.provider}</strong>{" "}
+          library connection. TV shows and movies are separate tabs under this
+          server. Each scan saves a list you can review. Cleanup runs only use
+          the saved preview you confirm.
         </p>
       </header>
 
@@ -166,22 +219,37 @@ export function PrunerInstanceOverviewTab(props: { contextOverride?: Ctx }) {
         className="mm-card mm-dash-card mm-module-surface border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-4 sm:p-5"
         aria-labelledby="pruner-overview-status-heading"
       >
-        <h3 id="pruner-overview-status-heading" className="text-sm font-semibold text-[var(--mm-text1)]">
+        <h3
+          id="pruner-overview-status-heading"
+          className="text-sm font-semibold text-[var(--mm-text1)]"
+        >
           Server status
         </h3>
         <div className="mt-3 grid gap-4 lg:grid-cols-2">
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 px-4 py-4">
-            <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">Connection</p>
-            <p className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">{connection.title}</p>
-            <p className="mt-2 text-sm text-[var(--mm-text2)]">{connection.detail}</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+              Connection
+            </p>
+            <p className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+              {connection.title}
+            </p>
+            <p className="mt-2 text-sm text-[var(--mm-text2)]">
+              {connection.detail}
+            </p>
             <p className="mt-2 text-xs text-[var(--mm-text3)]">
-              Last checked: <span className="font-medium text-[var(--mm-text2)]">{formatPrunerDateTime(instance.last_connection_test_at)}</span>
+              Last checked:{" "}
+              <span className="font-medium text-[var(--mm-text2)]">
+                {formatPrunerDateTime(instance.last_connection_test_at)}
+              </span>
             </p>
           </div>
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 px-4 py-4">
-            <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">Next step</p>
+            <p className="text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+              Next step
+            </p>
             <p className="mt-1 text-sm text-[var(--mm-text2)]">
-              Open the TV or Movies tab to review filters, schedules, and the most recent preview before running cleanup.
+              Open the TV or Movies tab to review filters, schedules, and the
+              most recent preview before running cleanup.
             </p>
           </div>
         </div>
@@ -191,12 +259,27 @@ export function PrunerInstanceOverviewTab(props: { contextOverride?: Ctx }) {
         className="mm-card mm-dash-card mm-module-surface border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-4 sm:p-5"
         aria-labelledby="pruner-overview-at-a-glance"
       >
-        <h3 id="pruner-overview-at-a-glance" className="text-sm font-semibold text-[var(--mm-text1)]">
+        <h3
+          id="pruner-overview-at-a-glance"
+          className="text-sm font-semibold text-[var(--mm-text1)]"
+        >
           At a glance
         </h3>
         <div className="mt-3 grid gap-4 md:grid-cols-2">
-          {tv ? <ScopeWorkspaceCard instanceId={instanceId} provider={instance.provider} scope={tv} /> : null}
-          {movies ? <ScopeWorkspaceCard instanceId={instanceId} provider={instance.provider} scope={movies} /> : null}
+          {tv ? (
+            <ScopeWorkspaceCard
+              instanceId={instanceId}
+              provider={instance.provider}
+              scope={tv}
+            />
+          ) : null}
+          {movies ? (
+            <ScopeWorkspaceCard
+              instanceId={instanceId}
+              provider={instance.provider}
+              scope={movies}
+            />
+          ) : null}
         </div>
       </section>
 
@@ -204,15 +287,22 @@ export function PrunerInstanceOverviewTab(props: { contextOverride?: Ctx }) {
         className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)]/40 px-4 py-3 text-sm text-[var(--mm-text2)]"
         aria-labelledby="pruner-overview-apply-note"
       >
-        <h3 id="pruner-overview-apply-note" className="text-sm font-semibold text-[var(--mm-text)]">
+        <h3
+          id="pruner-overview-apply-note"
+          className="text-sm font-semibold text-[var(--mm-text)]"
+        >
           After cleanup runs
         </h3>
         <p className="mt-1 text-xs sm:text-sm">
-          Removed, skipped, and failed counts for each cleanup run are written to <strong className="text-[var(--mm-text)]">Activity</strong> when the
-          job finishes.
+          Removed, skipped, and failed counts for each cleanup run are written
+          to <strong className="text-[var(--mm-text)]">Activity</strong> when
+          the job finishes.
         </p>
         <p className="mt-2">
-          <Link className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline" to="/app/activity">
+          <Link
+            className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline"
+            to="/app/activity"
+          >
             Open Activity
           </Link>
         </p>
@@ -220,4 +310,3 @@ export function PrunerInstanceOverviewTab(props: { contextOverride?: Ctx }) {
     </div>
   );
 }
-

--- a/apps/web/src/pages/pruner/pruner-instance-shell.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-instance-shell.test.tsx
@@ -29,7 +29,9 @@ describe("PrunerInstanceShell", () => {
         {
           path: "/instances/:instanceId/*",
           element: <PrunerInstanceShell />,
-          children: [{ path: "overview", element: <div>Overview content</div> }],
+          children: [
+            { path: "overview", element: <div>Overview content</div> },
+          ],
         },
       ],
       { initialEntries: ["/instances/9/overview"] },
@@ -41,14 +43,26 @@ describe("PrunerInstanceShell", () => {
       </QueryClientProvider>,
     );
 
-    await waitFor(() => expect(screen.getByTestId("pruner-instance-section-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-instance-section-tabs"),
+      ).toBeInTheDocument(),
+    );
     const tabs = screen.getByTestId("pruner-instance-section-tabs");
     expect(tabs.textContent).toMatch(/Overview/);
     expect(tabs.textContent).toMatch(/Movies/);
     expect(tabs.textContent).toMatch(/TV/);
     expect(tabs.textContent).toMatch(/Connection/);
-    expect(screen.getByRole("link", { name: "Movies" })).toHaveAttribute("href", "/app/pruner/instances/9/movies");
-    expect(screen.getByRole("link", { name: "TV" })).toHaveAttribute("href", "/app/pruner/instances/9/tv");
-    expect(screen.getByTestId("pruner-instance-shell").textContent ?? "").toMatch(/Emby, Jellyfin, and Plex/i);
+    expect(screen.getByRole("link", { name: "Movies" })).toHaveAttribute(
+      "href",
+      "/app/pruner/instances/9/movies",
+    );
+    expect(screen.getByRole("link", { name: "TV" })).toHaveAttribute(
+      "href",
+      "/app/pruner/instances/9/tv",
+    );
+    expect(
+      screen.getByTestId("pruner-instance-shell").textContent ?? "",
+    ).toMatch(/Emby, Jellyfin, and Plex/i);
   });
 });

--- a/apps/web/src/pages/pruner/pruner-instance-shell.tsx
+++ b/apps/web/src/pages/pruner/pruner-instance-shell.tsx
@@ -21,17 +21,25 @@ export function PrunerInstanceShell() {
     <div className="mm-page w-full min-w-0" data-testid="pruner-instance-shell">
       <header className="mm-page__intro !mb-0">
         <p className="mm-page__eyebrow">MediaMop</p>
-        {q.isLoading ? <h1 className="mm-page__title">Pruner — loading…</h1> : null}
+        {q.isLoading ? (
+          <h1 className="mm-page__title">Pruner — loading…</h1>
+        ) : null}
         {q.data ? (
           <>
             <h1 className="mm-page__title">Pruner — {q.data.display_name}</h1>
             <p className="mm-page__subtitle max-w-3xl">
-              Pruner helps clean up Emby, Jellyfin, and Plex libraries. This page is for{" "}
-              <strong className="text-[var(--mm-text)]">one</strong>{" "}
-              <strong className="text-[var(--mm-text)]">{q.data.provider}</strong> server (
-              <span className="font-mono text-[0.9em]">{q.data.base_url}</span>). Use the{" "}
-              <strong className="text-[var(--mm-text)]">Movies</strong> and <strong className="text-[var(--mm-text)]">TV</strong>{" "}
-              tabs for rules, scans, and deletes — nothing is shared between servers or between providers.
+              Pruner helps clean up Emby, Jellyfin, and Plex libraries. This
+              page is for <strong className="text-[var(--mm-text)]">one</strong>{" "}
+              <strong className="text-[var(--mm-text)]">
+                {q.data.provider}
+              </strong>{" "}
+              server (
+              <span className="font-mono text-[0.9em]">{q.data.base_url}</span>
+              ). Use the{" "}
+              <strong className="text-[var(--mm-text)]">Movies</strong> and{" "}
+              <strong className="text-[var(--mm-text)]">TV</strong> tabs for
+              rules, scans, and deletes — nothing is shared between servers or
+              between providers.
             </p>
           </>
         ) : null}
@@ -47,16 +55,29 @@ export function PrunerInstanceShell() {
         aria-label="Pruner server sections"
         data-testid="pruner-instance-section-tabs"
       >
-        <NavLink to={`${base}/overview`} className={({ isActive }) => mmSectionTabClass(isActive)} end>
+        <NavLink
+          to={`${base}/overview`}
+          className={({ isActive }) => mmSectionTabClass(isActive)}
+          end
+        >
           Overview
         </NavLink>
-        <NavLink to={`${base}/movies`} className={({ isActive }) => mmSectionTabClass(isActive)}>
+        <NavLink
+          to={`${base}/movies`}
+          className={({ isActive }) => mmSectionTabClass(isActive)}
+        >
           Movies
         </NavLink>
-        <NavLink to={`${base}/tv`} className={({ isActive }) => mmSectionTabClass(isActive)}>
+        <NavLink
+          to={`${base}/tv`}
+          className={({ isActive }) => mmSectionTabClass(isActive)}
+        >
           TV
         </NavLink>
-        <NavLink to={`${base}/connection`} className={({ isActive }) => mmSectionTabClass(isActive)}>
+        <NavLink
+          to={`${base}/connection`}
+          className={({ isActive }) => mmSectionTabClass(isActive)}
+        >
           Connection
         </NavLink>
       </nav>

--- a/apps/web/src/pages/pruner/pruner-instances-list-page.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-instances-list-page.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,7 +27,9 @@ function wrap(ui: ReactNode, client: QueryClient) {
 
 describe("PrunerInstancesListPage", () => {
   beforeEach(() => {
-    vi.spyOn(prunerApi, "fetchPrunerStudios").mockResolvedValue({ studios: ["Acme Studio", "Beta Pictures"] });
+    vi.spyOn(prunerApi, "fetchPrunerStudios").mockResolvedValue({
+      studios: ["Acme Studio", "Beta Pictures"],
+    });
     vi.spyOn(prunerApi, "fetchPrunerOverviewStats").mockResolvedValue({
       window_days: 30,
       items_removed: 0,
@@ -39,11 +47,16 @@ describe("PrunerInstancesListPage", () => {
   it("renders top-level tabs Overview, Emby, Jellyfin, Plex, Jobs without Connections or Schedules", async () => {
     const client = new QueryClient();
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     const tabs = screen.getByTestId("pruner-top-level-tabs");
     expect(tabs.textContent).toMatch(/Overview/);
     expect(tabs.textContent).not.toMatch(/Connections/);
@@ -57,20 +70,39 @@ describe("PrunerInstancesListPage", () => {
   it("each provider tab exposes Connection, Cleanup, and Schedule sub-tabs with a credential panel on Connection", async () => {
     const client = new QueryClient();
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
 
     for (const name of ["Emby", "Jellyfin", "Plex"] as const) {
       fireEvent.click(screen.getByRole("tab", { name }));
-      await waitFor(() => expect(screen.getByTestId(`pruner-provider-tab-${name.toLowerCase()}`)).toBeInTheDocument());
-      const sub = screen.getByTestId(`pruner-provider-subnav-${name.toLowerCase()}`);
-      expect(within(sub).getByRole("button", { name: "Connection" })).toBeInTheDocument();
-      expect(within(sub).getByRole("button", { name: "Cleanup" })).toBeInTheDocument();
-      expect(within(sub).getByRole("button", { name: "Schedule" })).toBeInTheDocument();
-      expect(screen.getByTestId(`pruner-connection-panel-${name.toLowerCase()}`)).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`pruner-provider-tab-${name.toLowerCase()}`),
+        ).toBeInTheDocument(),
+      );
+      const sub = screen.getByTestId(
+        `pruner-provider-subnav-${name.toLowerCase()}`,
+      );
+      expect(
+        within(sub).getByRole("button", { name: "Connection" }),
+      ).toBeInTheDocument();
+      expect(
+        within(sub).getByRole("button", { name: "Cleanup" }),
+      ).toBeInTheDocument();
+      expect(
+        within(sub).getByRole("button", { name: "Schedule" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(`pruner-connection-panel-${name.toLowerCase()}`),
+      ).toBeInTheDocument();
       expect(screen.getByLabelText(/^Base URL$/i)).toBeInTheDocument();
     }
   });
@@ -78,15 +110,24 @@ describe("PrunerInstancesListPage", () => {
   it("Plex Connection sub-tab uses Token label, not API key", async () => {
     const client = new QueryClient();
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
     fireEvent.click(screen.getByRole("tab", { name: "Plex" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-connection-panel-plex")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-connection-panel-plex"),
+      ).toBeInTheDocument(),
+    );
     const plexPanel = screen.getByTestId("pruner-connection-panel-plex");
     expect(within(plexPanel).getByLabelText(/^Token$/i)).toBeInTheDocument();
-    expect(within(plexPanel).queryByLabelText(/^API key$/i)).not.toBeInTheDocument();
+    expect(
+      within(plexPanel).queryByLabelText(/^API key$/i),
+    ).not.toBeInTheDocument();
   });
 
   it("Emby tab shows Cleanup sub-navigation, TV/Movies columns, and no nested top-level tabs inside the workspace", async () => {
@@ -137,32 +178,74 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-emby")).toBeInTheDocument());
-    expect(screen.getByTestId("pruner-provider-subnav-emby")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Connection" })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-emby"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId("pruner-provider-subnav-emby"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connection" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cleanup" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Filters" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Filters" }),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-configuration-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-configuration-emby"),
+      ).toBeInTheDocument(),
+    );
     const rulesCard = screen.getByTestId("pruner-provider-configuration-emby");
-    expect(within(screen.getByTestId("pruner-provider-tab-emby")).queryByRole("heading", { level: 2, name: /^Emby$/ })).not.toBeInTheDocument();
-    expect(within(rulesCard).getAllByText(/^TV$/).length).toBeGreaterThanOrEqual(1);
-    expect(within(rulesCard).getAllByText(/^Movies$/).length).toBeGreaterThanOrEqual(1);
+    expect(
+      within(screen.getByTestId("pruner-provider-tab-emby")).queryByRole(
+        "heading",
+        { level: 2, name: /^Emby$/ },
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rulesCard).getAllByText(/^TV$/).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      within(rulesCard).getAllByText(/^Movies$/).length,
+    ).toBeGreaterThanOrEqual(1);
     expect(rulesCard).toBeInTheDocument();
     expect(within(rulesCard).queryByRole("tab")).toBeNull();
-    expect(screen.queryByRole("button", { name: /Save watched TV rule/i })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save TV settings" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Save Movies settings" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Save watched TV rule/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save TV settings" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save Movies settings" }),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-schedule-wrap")).toBeInTheDocument());
-    expect(screen.getByTestId("pruner-schedule-emby-run-tv-btn")).toBeInTheDocument();
-    expect(screen.getByTestId("pruner-schedule-emby-run-movies-btn")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-schedule-wrap"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId("pruner-schedule-emby-run-tv-btn"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pruner-schedule-emby-run-movies-btn"),
+    ).toBeInTheDocument();
   });
 
   it("Cleanup tab shows TV and Movies people fields; Schedule tab shows run controls", async () => {
@@ -213,26 +296,59 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-emby"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-configuration-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-configuration-emby"),
+      ).toBeInTheDocument(),
+    );
     const cleanupWrap = screen.getByTestId("pruner-provider-cleanup-wrap");
-    expect(within(cleanupWrap).queryByTestId("pruner-provider-inline-connection-status")).not.toBeInTheDocument();
+    expect(
+      within(cleanupWrap).queryByTestId(
+        "pruner-provider-inline-connection-status",
+      ),
+    ).not.toBeInTheDocument();
     const card = screen.getByTestId("pruner-provider-configuration-emby");
-    expect(within(card).getAllByPlaceholderText(/Alex Carter/i)).toHaveLength(2);
+    expect(within(card).getAllByPlaceholderText(/Alex Carter/i)).toHaveLength(
+      2,
+    );
     fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-schedule-wrap")).toBeInTheDocument());
-    expect(screen.getAllByText(/creates review snapshots/i).length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByRole("button", { name: "Scan TV for cleanup review" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Scan Movies for cleanup review" })).toBeInTheDocument();
-    expect(screen.getByTestId("pruner-schedule-emby-run-tv-btn")).toBeInTheDocument();
-    expect(screen.getByTestId("pruner-schedule-emby-run-movies-btn")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-schedule-wrap"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getAllByText(/creates review snapshots/i).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByRole("button", { name: "Scan TV for cleanup review" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Scan Movies for cleanup review" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pruner-schedule-emby-run-tv-btn"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pruner-schedule-emby-run-movies-btn"),
+    ).toBeInTheDocument();
   });
 
   it("Connection sub-tab shows Connected in status when last Emby test passed", async () => {
@@ -283,14 +399,23 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
     fireEvent.click(screen.getByRole("button", { name: "Connection" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-connection-panel-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-connection-panel-emby"),
+      ).toBeInTheDocument(),
+    );
     const statusBox = screen.getByTestId("pruner-connection-status-emby");
     expect(within(statusBox).getByText("Connected")).toBeInTheDocument();
   });
@@ -299,19 +424,38 @@ describe("PrunerInstancesListPage", () => {
     const client = new QueryClient();
     client.setQueryData(qk.me, adminUser);
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-emby"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-configuration-emby")).toBeInTheDocument());
-    expect(screen.queryByTestId("pruner-provider-inline-connection-status")).not.toBeInTheDocument();
-    expect(screen.queryByText(/Save a connection first to enable these settings/i)).not.toBeInTheDocument();
-    const disabledFieldsets = screen.getByTestId("pruner-provider-configuration-emby").querySelectorAll("fieldset[disabled]");
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-configuration-emby"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("pruner-provider-inline-connection-status"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Save a connection first to enable these settings/i),
+    ).not.toBeInTheDocument();
+    const disabledFieldsets = screen
+      .getByTestId("pruner-provider-configuration-emby")
+      .querySelectorAll("fieldset[disabled]");
     expect(disabledFieldsets.length).toBe(0);
-    expect(screen.getByText(/Delete TV episodes you have already watched/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Delete TV episodes you have already watched/i),
+    ).toBeInTheDocument();
   });
 
   it("Plex Cleanup tab shows only supported controls: TV missing-primary + filters + people; Movies without missing-primary toggle", async () => {
@@ -394,26 +538,57 @@ describe("PrunerInstancesListPage", () => {
         ],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
     fireEvent.click(screen.getByRole("tab", { name: "Plex" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-plex")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-plex"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-configuration-plex")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-configuration-plex"),
+      ).toBeInTheDocument(),
+    );
     const plexTvNote = screen.getByTestId("pruner-plex-tv-rules-scope-note");
     expect(plexTvNote).toHaveTextContent(/Plex TV — limited options/i);
-    expect(plexTvNote).toHaveTextContent(/missing poster rule is available here/i);
-    expect(screen.queryByTestId("pruner-provider-plex-tv-unsupported-rules")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("pruner-plex-tv-filters-scope-note")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("pruner-plex-other-rules-note")).not.toBeInTheDocument();
+    expect(plexTvNote).toHaveTextContent(
+      /missing poster rule is available here/i,
+    );
+    expect(
+      screen.queryByTestId("pruner-provider-plex-tv-unsupported-rules"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pruner-plex-tv-filters-scope-note"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pruner-plex-other-rules-note"),
+    ).not.toBeInTheDocument();
     const tvSection = screen.getByTestId("pruner-provider-tv-config-plex");
-    expect(within(tvSection).queryByText(/Delete TV episodes you have already watched/i)).not.toBeInTheDocument();
-    expect(within(tvSection).getByTestId("pruner-provider-tv-people-plex")).toBeInTheDocument();
-    const moviesSection = screen.getByTestId("pruner-provider-movies-config-plex");
-    expect(within(moviesSection).getByText(/Plex audience rating/i)).toBeInTheDocument();
-    expect(within(moviesSection).queryByText(/Delete movies missing a main poster/i)).not.toBeInTheDocument();
+    expect(
+      within(tvSection).queryByText(
+        /Delete TV episodes you have already watched/i,
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      within(tvSection).getByTestId("pruner-provider-tv-people-plex"),
+    ).toBeInTheDocument();
+    const moviesSection = screen.getByTestId(
+      "pruner-provider-movies-config-plex",
+    );
+    expect(
+      within(moviesSection).getByText(/Plex audience rating/i),
+    ).toBeInTheDocument();
+    expect(
+      within(moviesSection).queryByText(/Delete movies missing a main poster/i),
+    ).not.toBeInTheDocument();
   });
 
   it("Plex Cleanup tab TV people roles show Cast, Directors, and Writers only", async () => {
@@ -465,18 +640,33 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Plex" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-plex")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-plex"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-configuration-plex")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-configuration-plex"),
+      ).toBeInTheDocument(),
+    );
     const card = screen.getByTestId("pruner-provider-configuration-plex");
     expect(within(card).getAllByText("Cast (actors)")).toHaveLength(2);
-    const tvRoles = within(card).getByTestId("pruner-provider-tv-people-roles-plex");
+    const tvRoles = within(card).getByTestId(
+      "pruner-provider-tv-people-roles-plex",
+    );
     expect(within(tvRoles).getByText("Directors")).toBeInTheDocument();
     expect(within(tvRoles).getByText("Writers")).toBeInTheDocument();
     expect(within(card).queryByText(/Producers/i)).not.toBeInTheDocument();
@@ -563,38 +753,72 @@ describe("PrunerInstancesListPage", () => {
         ],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
     vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
 
     render(wrap(<PrunerInstancesListPage />, client));
 
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-tab-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-tab-emby"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("button", { name: "Cleanup" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-movies-config-emby")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-movies-config-emby"),
+      ).toBeInTheDocument(),
+    );
     const movies = screen.getByTestId("pruner-provider-movies-config-emby");
     expect(within(movies).getByText(/community rating/i)).toBeInTheDocument();
-    expect(within(movies).queryByText(/Plex audienceRating/i)).not.toBeInTheDocument();
+    expect(
+      within(movies).queryByText(/Plex audienceRating/i),
+    ).not.toBeInTheDocument();
   });
 
   it("Emby Schedule sub-tab shows TV/Movies schedule cards when no instances exist", async () => {
     const client = new QueryClient();
     client.setQueryData(qk.me, adminUser);
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
     fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-provider-schedule-wrap")).toBeInTheDocument());
-    expect(screen.queryByTestId("pruner-provider-schedule-hint")).not.toBeInTheDocument();
-    await waitFor(() => expect(screen.getByTestId("pruner-schedule-row-emby-tv")).toBeInTheDocument());
-    expect(screen.getByTestId("pruner-schedule-row-emby-movies")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-provider-schedule-wrap"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByTestId("pruner-provider-schedule-hint"),
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-schedule-row-emby-tv"),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId("pruner-schedule-row-emby-movies"),
+    ).toBeInTheDocument();
     const tvCard = screen.getByTestId("pruner-schedule-row-emby-tv");
-    expect(within(tvCard).getAllByText("Schedule window").length).toBeGreaterThanOrEqual(1);
-    expect(within(tvCard).queryByLabelText(/Run interval in minutes/i)).not.toBeInTheDocument();
+    expect(
+      within(tvCard).getAllByText("Schedule window").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      within(tvCard).queryByLabelText(/Run interval in minutes/i),
+    ).not.toBeInTheDocument();
   });
 
   it("each provider Schedule sub-tab renders TV and Movies schedule rows when instances exist", async () => {
@@ -667,23 +891,38 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     for (const label of ["Emby", "Jellyfin", "Plex"] as const) {
       fireEvent.click(screen.getByRole("tab", { name: label }));
       fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
       const p = label.toLowerCase();
-      await waitFor(() => expect(screen.getByTestId(`pruner-schedule-row-${p}-tv`)).toBeInTheDocument());
-      expect(screen.getByTestId(`pruner-schedule-row-${p}-movies`)).toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`pruner-schedule-row-${p}-tv`),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByTestId(`pruner-schedule-row-${p}-movies`),
+      ).toBeInTheDocument();
     }
   });
 
   it("Emby Schedule sub-tab save PATCHes schedule window fields", async () => {
-    const csrfSpy = vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf-test");
-    const patchSpy = vi.spyOn(prunerApi, "patchPrunerScope").mockResolvedValue({} as never);
+    const csrfSpy = vi
+      .spyOn(authApi, "fetchCsrfToken")
+      .mockResolvedValue("csrf-test");
+    const patchSpy = vi
+      .spyOn(prunerApi, "patchPrunerScope")
+      .mockResolvedValue({} as never);
     const client = new QueryClient();
     client.setQueryData(qk.me, adminUser);
     const scope = (media_scope: "tv" | "movies") => ({
@@ -753,19 +992,32 @@ describe("PrunerInstancesListPage", () => {
         scopes: [scope("tv"), scope("movies")],
       },
     ]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("pruner-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "Emby" }));
     fireEvent.click(screen.getByRole("button", { name: "Schedule" }));
-    await waitFor(() => expect(screen.getByTestId("pruner-schedule-row-emby-tv")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-schedule-row-emby-tv"),
+      ).toBeInTheDocument(),
+    );
 
     const embyTv = screen.getByTestId("pruner-schedule-row-emby-tv");
-    const hoursGroup = within(embyTv).getByRole("radiogroup", { name: /Limit to these hours/i });
+    const hoursGroup = within(embyTv).getByRole("radiogroup", {
+      name: /Limit to these hours/i,
+    });
     fireEvent.click(within(hoursGroup).getByRole("radio", { name: "On" }));
-    fireEvent.click(within(embyTv).getByRole("button", { name: /Save TV schedule/i }));
+    fireEvent.click(
+      within(embyTv).getByRole("button", { name: /Save TV schedule/i }),
+    );
 
     await waitFor(() => {
       expect(patchSpy).toHaveBeenCalledWith(
@@ -791,12 +1043,21 @@ describe("PrunerInstancesListPage", () => {
   it("Overview shows At a glance cards without connection forms", async () => {
     const client = new QueryClient();
     vi.spyOn(prunerApi, "fetchPrunerInstances").mockResolvedValue([]);
-    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({ jobs: [], default_recent_slice: true });
+    vi.spyOn(prunerApi, "fetchPrunerJobsInspection").mockResolvedValue({
+      jobs: [],
+      default_recent_slice: true,
+    });
 
     render(wrap(<PrunerInstancesListPage />, client));
 
-    await waitFor(() => expect(screen.getByTestId("pruner-overview-at-a-glance")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("pruner-overview-at-a-glance"),
+      ).toBeInTheDocument(),
+    );
     expect(screen.getByText(/At a glance/i)).toBeInTheDocument();
-    expect(screen.queryByTestId("pruner-connection-panel-emby")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("pruner-connection-panel-emby"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/pruner/pruner-instances-list-page.tsx
+++ b/apps/web/src/pages/pruner/pruner-instances-list-page.tsx
@@ -18,20 +18,41 @@ import {
   MmScheduleDayChips,
   MmScheduleTimeFields,
 } from "../../components/ui/mm-schedule-window-controls";
-import { mmModuleTabBlurbBandClass, mmModuleTabBlurbTextClass } from "../../lib/ui/mm-module-tab-blurb";
+import {
+  mmModuleTabBlurbBandClass,
+  mmModuleTabBlurbTextClass,
+} from "../../lib/ui/mm-module-tab-blurb";
 import { MmListboxPicker } from "../../components/ui/mm-listbox-picker";
-import { mmActionButtonClass, mmSectionTabClass } from "../../lib/ui/mm-control-roles";
+import {
+  mmActionButtonClass,
+  mmSectionTabClass,
+} from "../../lib/ui/mm-control-roles";
 import { fetchCsrfToken } from "../../lib/api/auth-api";
-import type { PrunerJobsInspectionRow, PrunerServerInstance } from "../../lib/pruner/api";
-import { patchPrunerInstance, patchPrunerScope, postPrunerConnectionTest, postPrunerInstance } from "../../lib/pruner/api";
+import type {
+  PrunerJobsInspectionRow,
+  PrunerServerInstance,
+} from "../../lib/pruner/api";
+import {
+  patchPrunerInstance,
+  patchPrunerScope,
+  postPrunerConnectionTest,
+  postPrunerInstance,
+} from "../../lib/pruner/api";
 import { useMeQuery } from "../../lib/auth/queries";
-import { usePrunerInstancesQuery, usePrunerJobsInspectionQuery, usePrunerOverviewStatsQuery } from "../../lib/pruner/queries";
+import {
+  usePrunerInstancesQuery,
+  usePrunerJobsInspectionQuery,
+  usePrunerOverviewStatsQuery,
+} from "../../lib/pruner/queries";
 import {
   PrunerDryRunControls,
   PrunerProviderRulesCard,
   type PrunerProviderRulesCardHandle,
 } from "./pruner-provider-operator-workspace";
-import { formatPrunerDateTime, prunerJobKindOperatorLabel } from "./pruner-ui-utils";
+import {
+  formatPrunerDateTime,
+  prunerJobKindOperatorLabel,
+} from "./pruner-ui-utils";
 type TopTab = "overview" | "emby" | "jellyfin" | "plex" | "jobs" | "schedule";
 type ProviderTab = "emby" | "jellyfin" | "plex";
 
@@ -39,10 +60,12 @@ const PRUNER_TAB_BLURBS: Record<TopTab, string> = {
   overview:
     "See cross-provider status for connections, cleanup coverage, and items that need attention.",
   emby: "Manage one Emby server: test connection, set cleanup rules, and control run windows.",
-  jellyfin: "Manage one Jellyfin server: test connection, set cleanup rules, and control run windows.",
+  jellyfin:
+    "Manage one Jellyfin server: test connection, set cleanup rules, and control run windows.",
   plex: "Manage one Plex server: test connection, set cleanup rules, and control run windows.",
   jobs: "View queued, running, and recent Pruner jobs across providers.",
-  schedule: "Edit scheduled prune windows in the provider workspace and save changes per library.",
+  schedule:
+    "Edit scheduled prune windows in the provider workspace and save changes per library.",
 };
 
 function providerLabel(p: ProviderTab): string {
@@ -54,7 +77,9 @@ function providerLabel(p: ProviderTab): string {
 function parseServerInstanceId(job: PrunerJobsInspectionRow): number | null {
   if (!job.payload_json) return null;
   try {
-    const parsed = JSON.parse(job.payload_json) as { server_instance_id?: unknown };
+    const parsed = JSON.parse(job.payload_json) as {
+      server_instance_id?: unknown;
+    };
     const sid = parsed.server_instance_id;
     return typeof sid === "number" && Number.isFinite(sid) ? sid : null;
   } catch {
@@ -70,7 +95,9 @@ const PRUNER_JOB_FILTER_OPTIONS = [
   { value: "completed", label: "Completed" },
 ] as const;
 
-function activeRuleCount(scope: PrunerServerInstance["scopes"][number]): number {
+function activeRuleCount(
+  scope: PrunerServerInstance["scopes"][number],
+): number {
   return [
     scope.missing_primary_media_reported_enabled,
     scope.never_played_stale_reported_enabled,
@@ -174,12 +201,23 @@ function PrunerConnectionCredentialPanel({
   const q = useQueryClient();
   const canOperate = me.data?.role === "admin" || me.data?.role === "operator";
   const providerName = providerLabel(provider);
-  const providerInstances = useMemo(() => allInstances.filter((x) => x.provider === provider), [allInstances, provider]);
-  const [internalSelectedInstanceId, setInternalSelectedInstanceId] = useState<number | null>(providerInstances[0]?.id ?? null);
+  const providerInstances = useMemo(
+    () => allInstances.filter((x) => x.provider === provider),
+    [allInstances, provider],
+  );
+  const [internalSelectedInstanceId, setInternalSelectedInstanceId] = useState<
+    number | null
+  >(providerInstances[0]?.id ?? null);
   const controlled = Boolean(instanceSelection);
-  const selectedInstanceId = controlled ? instanceSelection!.selectedId : internalSelectedInstanceId;
-  const setSelectedInstanceId = controlled ? instanceSelection!.onSelectedIdChange : setInternalSelectedInstanceId;
-  const selectedInstance = providerInstances.find((x) => x.id === selectedInstanceId) ?? providerInstances[0];
+  const selectedInstanceId = controlled
+    ? instanceSelection!.selectedId
+    : internalSelectedInstanceId;
+  const setSelectedInstanceId = controlled
+    ? instanceSelection!.onSelectedIdChange
+    : setInternalSelectedInstanceId;
+  const selectedInstance =
+    providerInstances.find((x) => x.id === selectedInstanceId) ??
+    providerInstances[0];
   const hasInstance = Boolean(selectedInstance);
   const [baseUrlDraft, setBaseUrlDraft] = useState("");
   const [credentialDraft, setCredentialDraft] = useState("");
@@ -191,7 +229,12 @@ function PrunerConnectionCredentialPanel({
   const [testJustSucceeded, setTestJustSucceeded] = useState(false);
 
   const savedUrl = selectedInstance?.base_url ?? "";
-  const dirty = prunerConnectionDirty(hasInstance, savedUrl, baseUrlDraft, credentialDraft);
+  const dirty = prunerConnectionDirty(
+    hasInstance,
+    savedUrl,
+    baseUrlDraft,
+    credentialDraft,
+  );
   const panelBusy = savePending || testPending;
   const credentialPlaceholder =
     hasInstance && credentialDraft === ""
@@ -244,10 +287,14 @@ function PrunerConnectionCredentialPanel({
       const trimmedUrl = baseUrlDraft.trim();
       if (!trimmedUrl) throw new Error("Base URL is required.");
       if (!hasInstance && !credentialDraft.trim()) {
-        throw new Error(`${providerCredentialLabel(provider)} is required to create a new ${providerName} connection.`);
+        throw new Error(
+          `${providerCredentialLabel(provider)} is required to create a new ${providerName} connection.`,
+        );
       }
       const credentialKey = provider === "plex" ? "auth_token" : "api_key";
-      const credentials = credentialDraft.trim() ? { [credentialKey]: credentialDraft.trim() } : undefined;
+      const credentials = credentialDraft.trim()
+        ? { [credentialKey]: credentialDraft.trim() }
+        : undefined;
       if (selectedInstance) {
         await patchPrunerInstance(selectedInstance.id, {
           base_url: trimmedUrl,
@@ -304,96 +351,112 @@ function PrunerConnectionCredentialPanel({
       data-testid={`pruner-connection-panel-${provider}`}
     >
       <div className="mm-card-action-body flex-1 min-h-0">
-      {!controlled && providerInstances.length > 1 ? (
+        {!controlled && providerInstances.length > 1 ? (
+          <label className="block text-sm text-[var(--mm-text2)]">
+            <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+              Server
+            </span>
+            <select
+              className="mm-input mt-1 w-full"
+              value={selectedInstance?.id ?? ""}
+              onChange={(e) => setSelectedInstanceId(Number(e.target.value))}
+              disabled={panelBusy || !canOperate}
+            >
+              {providerInstances.map((inst) => (
+                <option key={inst.id} value={inst.id}>
+                  {inst.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
         <label className="block text-sm text-[var(--mm-text2)]">
-          <span className="mb-1 block text-xs text-[var(--mm-text3)]">Server</span>
-          <select
-            className="mm-input mt-1 w-full"
-            value={selectedInstance?.id ?? ""}
-            onChange={(e) => setSelectedInstanceId(Number(e.target.value))}
-            disabled={panelBusy || !canOperate}
-          >
-            {providerInstances.map((inst) => (
-              <option key={inst.id} value={inst.id}>
-                {inst.display_name}
-              </option>
-            ))}
-          </select>
-        </label>
-      ) : null}
-      <label className="block text-sm text-[var(--mm-text2)]">
-        <span className="mb-1 block text-xs text-[var(--mm-text3)]">Base URL</span>
-        <input
-          type="url"
-          autoComplete="off"
-          value={baseUrlDraft}
-          onChange={(e) => setBaseUrlDraft(e.target.value)}
-          disabled={panelBusy || !canOperate}
-          placeholder={prunerConnectionPlaceholderUrl(provider)}
-          className="mm-input w-full"
-        />
-      </label>
-
-      <div className="space-y-1">
-        <label className="block text-sm text-[var(--mm-text2)]" htmlFor={`pruner-conn-key-${provider}`}>
-          <span className="mb-1 block text-xs text-[var(--mm-text3)]">{providerCredentialLabel(provider)}</span>
-        </label>
-        <div className="flex flex-wrap gap-2">
+          <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+            Base URL
+          </span>
           <input
-            id={`pruner-conn-key-${provider}`}
-            type={showCredential ? "text" : "password"}
-            autoComplete="new-password"
-            placeholder={credentialPlaceholder}
-            className="mm-input min-w-[12rem] flex-1 text-sm tracking-normal text-[var(--mm-text)]"
+            type="url"
+            autoComplete="off"
+            value={baseUrlDraft}
+            onChange={(e) => setBaseUrlDraft(e.target.value)}
             disabled={panelBusy || !canOperate}
-            value={credentialDraft}
-            aria-describedby={hasInstance ? `pruner-conn-key-hint-${provider}` : undefined}
-            onChange={(e) => {
-              const next = e.target.value;
-              setCredentialDraft(next);
-              if (next.trim() === "") {
-                setShowCredential(false);
-              }
-            }}
+            placeholder={prunerConnectionPlaceholderUrl(provider)}
+            className="mm-input w-full"
           />
-          <button
-            type="button"
-            className={mmActionButtonClass({
-              variant: "tertiary",
-              disabled: !canOperate || panelBusy,
-            })}
-            disabled={!canOperate || panelBusy}
-            onClick={() => setShowCredential((v) => !v)}
+        </label>
+
+        <div className="space-y-1">
+          <label
+            className="block text-sm text-[var(--mm-text2)]"
+            htmlFor={`pruner-conn-key-${provider}`}
           >
-            {showCredential ? "Hide" : "Show"}
-          </button>
+            <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+              {providerCredentialLabel(provider)}
+            </span>
+          </label>
+          <div className="flex flex-wrap gap-2">
+            <input
+              id={`pruner-conn-key-${provider}`}
+              type={showCredential ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder={credentialPlaceholder}
+              className="mm-input min-w-[12rem] flex-1 text-sm tracking-normal text-[var(--mm-text)]"
+              disabled={panelBusy || !canOperate}
+              value={credentialDraft}
+              aria-describedby={
+                hasInstance ? `pruner-conn-key-hint-${provider}` : undefined
+              }
+              onChange={(e) => {
+                const next = e.target.value;
+                setCredentialDraft(next);
+                if (next.trim() === "") {
+                  setShowCredential(false);
+                }
+              }}
+            />
+            <button
+              type="button"
+              className={mmActionButtonClass({
+                variant: "tertiary",
+                disabled: !canOperate || panelBusy,
+              })}
+              disabled={!canOperate || panelBusy}
+              onClick={() => setShowCredential((v) => !v)}
+            >
+              {showCredential ? "Hide" : "Show"}
+            </button>
+          </div>
+          {hasInstance ? (
+            <p
+              id={`pruner-conn-key-hint-${provider}`}
+              className="text-xs text-[var(--mm-text3)]"
+            >
+              Leave blank to keep your saved{" "}
+              {provider === "plex" ? "token" : "key"}, or type a new one to
+              replace it.
+            </p>
+          ) : null}
         </div>
-        {hasInstance ? (
-          <p id={`pruner-conn-key-hint-${provider}`} className="text-xs text-[var(--mm-text3)]">
-            Leave blank to keep your saved {provider === "plex" ? "token" : "key"}, or type a new one to replace it.
+
+        {saveJustSucceeded ? (
+          <p
+            className="rounded-md border border-[rgba(212,175,55,0.45)] bg-[var(--mm-accent-soft)] px-3 py-2 text-sm font-medium text-[var(--mm-text1)]"
+            role="status"
+            data-testid={`pruner-connection-save-ok-${provider}`}
+          >
+            Saved.
           </p>
         ) : null}
-      </div>
 
-      {saveJustSucceeded ? (
-        <p
-          className="rounded-md border border-[rgba(212,175,55,0.45)] bg-[var(--mm-accent-soft)] px-3 py-2 text-sm font-medium text-[var(--mm-text1)]"
-          role="status"
-          data-testid={`pruner-connection-save-ok-${provider}`}
-        >
-          Saved.
-        </p>
-      ) : null}
-
-      {testJustSucceeded ? (
-        <p
-          className="rounded-md border border-[rgba(212,175,55,0.45)] bg-[var(--mm-accent-soft)] px-3 py-2 text-sm font-medium text-[var(--mm-text1)]"
-          role="status"
-          data-testid={`pruner-connection-test-ok-${provider}`}
-        >
-          Test started — results appear here when it finishes.
-        </p>
-      ) : null}
+        {testJustSucceeded ? (
+          <p
+            className="rounded-md border border-[rgba(212,175,55,0.45)] bg-[var(--mm-accent-soft)] px-3 py-2 text-sm font-medium text-[var(--mm-text1)]"
+            role="status"
+            data-testid={`pruner-connection-test-ok-${provider}`}
+          >
+            Test started — results appear here when it finishes.
+          </p>
+        ) : null}
       </div>
 
       <div className="mm-card-action-footer mm-card-action-footer--row">
@@ -425,12 +488,20 @@ function PrunerConnectionCredentialPanel({
         className="mt-4 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-3.5 text-sm text-[var(--mm-text2)]"
         data-testid={`pruner-connection-status-${provider}`}
       >
-        <p className="text-sm font-medium text-[var(--mm-text1)]">{connectionStatusMain}</p>
-        <p className="mt-1 text-xs text-[var(--mm-text3)]">
-          Last completed check: {formatPrunerDateTime(selectedInstance?.last_connection_test_at ?? null)}
+        <p className="text-sm font-medium text-[var(--mm-text1)]">
+          {connectionStatusMain}
         </p>
-        {selectedInstance?.last_connection_test_detail && selectedInstance.last_connection_test_ok !== true ? (
-          <p className="mt-1 text-xs text-[var(--mm-text3)]">{selectedInstance.last_connection_test_detail}</p>
+        <p className="mt-1 text-xs text-[var(--mm-text3)]">
+          Last completed check:{" "}
+          {formatPrunerDateTime(
+            selectedInstance?.last_connection_test_at ?? null,
+          )}
+        </p>
+        {selectedInstance?.last_connection_test_detail &&
+        selectedInstance.last_connection_test_ok !== true ? (
+          <p className="mt-1 text-xs text-[var(--mm-text3)]">
+            {selectedInstance.last_connection_test_detail}
+          </p>
         ) : null}
         {err ? (
           <p className="mt-2 text-sm text-red-400" role="alert">
@@ -439,7 +510,10 @@ function PrunerConnectionCredentialPanel({
         ) : null}
         <p className="mt-2 text-xs text-[var(--mm-text3)]">
           Each test adds a line to{" "}
-          <Link to="/app/activity" className="text-[var(--mm-accent)] underline-offset-2 hover:underline">
+          <Link
+            to="/app/activity"
+            className="text-[var(--mm-accent)] underline-offset-2 hover:underline"
+          >
             Activity
           </Link>{" "}
           for your records.
@@ -461,15 +535,24 @@ function ProviderConfigurationWorkspace({
   initialSection?: ProviderWorkspaceSection;
 }) {
   const providerName = providerLabel(provider);
-  const providerInstances = useMemo(() => allInstances.filter((x) => x.provider === provider), [allInstances, provider]);
-  const [selectedInstanceId, setSelectedInstanceId] = useState<number | null>(providerInstances[0]?.id ?? null);
-  const [providerSection, setProviderSection] = useState<ProviderWorkspaceSection>(initialSection);
-  const selectedInstance = providerInstances.find((x) => x.id === selectedInstanceId) ?? providerInstances[0];
+  const providerInstances = useMemo(
+    () => allInstances.filter((x) => x.provider === provider),
+    [allInstances, provider],
+  );
+  const [selectedInstanceId, setSelectedInstanceId] = useState<number | null>(
+    providerInstances[0]?.id ?? null,
+  );
+  const [providerSection, setProviderSection] =
+    useState<ProviderWorkspaceSection>(initialSection);
+  const selectedInstance =
+    providerInstances.find((x) => x.id === selectedInstanceId) ??
+    providerInstances[0];
   const rulesCardRef = useRef<PrunerProviderRulesCardHandle>(null);
 
   useEffect(() => {
     setSelectedInstanceId((prev) => {
-      if (prev != null && providerInstances.some((x) => x.id === prev)) return prev;
+      if (prev != null && providerInstances.some((x) => x.id === prev))
+        return prev;
       return providerInstances[0]?.id ?? null;
     });
   }, [provider, providerInstances]);
@@ -478,17 +561,25 @@ function ProviderConfigurationWorkspace({
     setProviderSection(initialSection);
   }, [provider, initialSection]);
 
-  const disabledCtx = { instanceId: 0, instance: providerDisabledInstance(provider) } as const;
+  const disabledCtx = {
+    instanceId: 0,
+    instance: providerDisabledInstance(provider),
+  } as const;
   const instanceSelection = {
     selectedId: selectedInstanceId,
     onSelectedIdChange: setSelectedInstanceId,
   };
 
   return (
-    <section className="mm-bubble-stack" data-testid={`pruner-provider-tab-${provider}`}>
+    <section
+      className="mm-bubble-stack"
+      data-testid={`pruner-provider-tab-${provider}`}
+    >
       {providerInstances.length > 1 ? (
         <label className="block max-w-md text-sm text-[var(--mm-text2)]">
-          <span className="mb-1 block text-xs text-[var(--mm-text3)]">Server</span>
+          <span className="mb-1 block text-xs text-[var(--mm-text3)]">
+            Server
+          </span>
           <select
             className="mm-input mt-1 w-full"
             value={selectedInstance?.id ?? ""}
@@ -529,13 +620,21 @@ function ProviderConfigurationWorkspace({
 
       <div data-testid={`pruner-provider-sections-${provider}`}>
         {providerSection === "connection" ? (
-          <PrunerConnectionCredentialPanel provider={provider} allInstances={allInstances} instanceSelection={instanceSelection} />
+          <PrunerConnectionCredentialPanel
+            provider={provider}
+            allInstances={allInstances}
+            instanceSelection={instanceSelection}
+          />
         ) : null}
 
         {providerSection === "cleanup" || providerSection === "schedule" ? (
           <div
             className={providerSection !== "cleanup" ? "hidden" : undefined}
-            data-testid={providerSection === "cleanup" ? "pruner-provider-cleanup-wrap" : undefined}
+            data-testid={
+              providerSection === "cleanup"
+                ? "pruner-provider-cleanup-wrap"
+                : undefined
+            }
             aria-hidden={providerSection !== "cleanup"}
           >
             <PrunerProviderRulesCard
@@ -548,7 +647,10 @@ function ProviderConfigurationWorkspace({
         ) : null}
 
         {providerSection === "schedule" ? (
-          <div className="mm-dash-grid" data-testid="pruner-provider-schedule-wrap">
+          <div
+            className="mm-dash-grid"
+            data-testid="pruner-provider-schedule-wrap"
+          >
             <PrunerGlobalScheduleRow
               provider={provider}
               scope="tv"
@@ -581,7 +683,9 @@ function scanOutcomeReadable(o: string | null | undefined): string {
   return o;
 }
 
-function buildPrunerNeedsAttention(instances: PrunerServerInstance[]): { text: string; tab: ProviderTab }[] {
+function buildPrunerNeedsAttention(
+  instances: PrunerServerInstance[],
+): { text: string; tab: ProviderTab }[] {
   const items: { text: string; tab: ProviderTab }[] = [];
   if (instances.length === 0) {
     items.push({
@@ -599,7 +703,9 @@ function buildPrunerNeedsAttention(instances: PrunerServerInstance[]): { text: s
       });
     }
   }
-  const allRulesZero = instances.every((inst) => inst.scopes.every((sc) => activeRuleCount(sc) === 0));
+  const allRulesZero = instances.every((inst) =>
+    inst.scopes.every((sc) => activeRuleCount(sc) === 0),
+  );
   if (allRulesZero) {
     items.push({
       text: "No cleanup rules are enabled — turn on rules in the Cleanup tab.",
@@ -639,7 +745,11 @@ function PrunerLast30StatsTiles({
 const PRUNER_NEXT_STEPS_BODY =
   "Use Emby, Jellyfin, or Plex to connect your media server and configure cleanup rules. Check Jobs for recent activity. Use Schedule for timed scans and optional hour limits.";
 
-function PrunerOverviewNextSteps({ onNavigate }: { onNavigate: (tab: TopTab) => void }) {
+function PrunerOverviewNextSteps({
+  onNavigate,
+}: {
+  onNavigate: (tab: TopTab) => void;
+}) {
   return (
     <MmOverviewSection
       headingId="pruner-overview-next-steps-heading"
@@ -651,10 +761,16 @@ function PrunerOverviewNextSteps({ onNavigate }: { onNavigate: (tab: TopTab) => 
         <p className="leading-relaxed">{PRUNER_NEXT_STEPS_BODY}</p>
         <div className="flex flex-wrap gap-2.5 border-t border-[var(--mm-border)] pt-4">
           <MmNextStepsButton label="Emby" onClick={() => onNavigate("emby")} />
-          <MmNextStepsButton label="Jellyfin" onClick={() => onNavigate("jellyfin")} />
+          <MmNextStepsButton
+            label="Jellyfin"
+            onClick={() => onNavigate("jellyfin")}
+          />
           <MmNextStepsButton label="Plex" onClick={() => onNavigate("plex")} />
           <MmNextStepsButton label="Jobs" onClick={() => onNavigate("jobs")} />
-          <MmNextStepsButton label="Schedule" onClick={() => onNavigate("schedule")} />
+          <MmNextStepsButton
+            label="Schedule"
+            onClick={() => onNavigate("schedule")}
+          />
         </div>
       </div>
     </MmOverviewSection>
@@ -668,7 +784,9 @@ function PrunerOverviewNeedsAttention({
   items: { text: string; tab: ProviderTab }[];
   onOpenProviderTab: (tab: ProviderTab) => void;
 }) {
-  const actionTabs = PRUNER_ATTENTION_TAB_ORDER.filter((t) => items.some((row) => row.tab === t));
+  const actionTabs = PRUNER_ATTENTION_TAB_ORDER.filter((t) =>
+    items.some((row) => row.tab === t),
+  );
   return (
     <MmOverviewSection
       headingId="pruner-overview-needs-attention-heading"
@@ -682,7 +800,11 @@ function PrunerOverviewNeedsAttention({
           actionTabs.length > 0 ? (
             <>
               {actionTabs.map((tab) => (
-                <MmNextStepsButton key={tab} label={prunerAttentionOpenLabel(tab)} onClick={() => onOpenProviderTab(tab)} />
+                <MmNextStepsButton
+                  key={tab}
+                  label={prunerAttentionOpenLabel(tab)}
+                  onClick={() => onOpenProviderTab(tab)}
+                />
               ))}
             </>
           ) : undefined
@@ -708,17 +830,32 @@ function TopLevelOverview({
     const rows = instances.filter((x) => x.provider === provider);
     const first = rows[0];
     const scopeRows = first?.scopes ?? [];
-    const activeRules = scopeRows.reduce((acc, scope) => acc + activeRuleCount(scope), 0);
+    const activeRules = scopeRows.reduce(
+      (acc, scope) => acc + activeRuleCount(scope),
+      0,
+    );
     const previews = scopeRows.filter((scope) => scope.last_preview_at);
     const latestPreview = previews.sort((a, b) =>
-      String(b.last_preview_at ?? "").localeCompare(String(a.last_preview_at ?? "")),
+      String(b.last_preview_at ?? "").localeCompare(
+        String(a.last_preview_at ?? ""),
+      ),
     )[0];
     const providerJobs = jobsQ.data?.jobs?.filter((j) => {
       const sid = parseServerInstanceId(j);
       return sid != null && rows.some((row) => row.id === sid);
     });
-    const latestApplyLike = providerJobs?.find((j) => String(j.job_kind).toLowerCase().includes("apply")) ?? providerJobs?.[0];
-    return { provider, rows, first, activeRules, latestPreview, latestJob: latestApplyLike };
+    const latestApplyLike =
+      providerJobs?.find((j) =>
+        String(j.job_kind).toLowerCase().includes("apply"),
+      ) ?? providerJobs?.[0];
+    return {
+      provider,
+      rows,
+      first,
+      activeRules,
+      latestPreview,
+      latestJob: latestApplyLike,
+    };
   });
 
   const attentionItems = buildPrunerNeedsAttention(instances);
@@ -760,17 +897,29 @@ function TopLevelOverview({
             const body = card.first ? (
               <div className="space-y-1.5">
                 <p>
-                  <span className="text-[var(--mm-text3)]">Connection test:</span>{" "}
+                  <span className="text-[var(--mm-text3)]">
+                    Connection test:
+                  </span>{" "}
                   <span className="font-medium text-[var(--mm-text1)]">
-                    {card.first.last_connection_test_ok == null ? "Not run yet" : card.first.last_connection_test_ok ? "OK" : "Failed"}
+                    {card.first.last_connection_test_ok == null
+                      ? "Not run yet"
+                      : card.first.last_connection_test_ok
+                        ? "OK"
+                        : "Failed"}
                   </span>
                 </p>
                 <p>
-                  <span className="text-[var(--mm-text3)]">Cleanup rules on:</span>{" "}
-                  <span className="font-medium text-[var(--mm-text1)]">{card.activeRules}</span>
+                  <span className="text-[var(--mm-text3)]">
+                    Cleanup rules on:
+                  </span>{" "}
+                  <span className="font-medium text-[var(--mm-text1)]">
+                    {card.activeRules}
+                  </span>
                 </p>
                 <p>
-                  <span className="text-[var(--mm-text3)]">Last library scan:</span>{" "}
+                  <span className="text-[var(--mm-text3)]">
+                    Last library scan:
+                  </span>{" "}
                   <span className="font-medium text-[var(--mm-text1)]">
                     {card.latestPreview
                       ? `${card.latestPreview.media_scope === "tv" ? "TV" : "Movies"} · ${scanOutcomeReadable(card.latestPreview.last_preview_outcome)}`
@@ -787,7 +936,10 @@ function TopLevelOverview({
                 </p>
               </div>
             ) : (
-              <p className="text-[var(--mm-text2)]">No server saved yet. Add the address and key on that provider’s Connection tab.</p>
+              <p className="text-[var(--mm-text2)]">
+                No server saved yet. Add the address and key on that provider’s
+                Connection tab.
+              </p>
             );
             return (
               <MmAtGlanceCard
@@ -798,11 +950,20 @@ function TopLevelOverview({
                 gridClassName={providerGridClass}
                 footer={
                   card.provider === "emby" ? (
-                    <MmNextStepsButton label="Open Emby" onClick={() => onNavigateTopTab("emby")} />
+                    <MmNextStepsButton
+                      label="Open Emby"
+                      onClick={() => onNavigateTopTab("emby")}
+                    />
                   ) : card.provider === "jellyfin" ? (
-                    <MmNextStepsButton label="Open Jellyfin" onClick={() => onNavigateTopTab("jellyfin")} />
+                    <MmNextStepsButton
+                      label="Open Jellyfin"
+                      onClick={() => onNavigateTopTab("jellyfin")}
+                    />
                   ) : (
-                    <MmNextStepsButton label="Open Plex" onClick={() => onNavigateTopTab("plex")} />
+                    <MmNextStepsButton
+                      label="Open Plex"
+                      onClick={() => onNavigateTopTab("plex")}
+                    />
                   )
                 }
               />
@@ -811,7 +972,10 @@ function TopLevelOverview({
         </MmAtGlanceGrid>
       </MmOverviewSection>
 
-      <PrunerOverviewNeedsAttention items={attentionItems} onOpenProviderTab={onOpenProviderTab} />
+      <PrunerOverviewNeedsAttention
+        items={attentionItems}
+        onOpenProviderTab={onOpenProviderTab}
+      />
 
       <PrunerOverviewNextSteps onNavigate={onNavigateTopTab} />
     </section>
@@ -871,7 +1035,8 @@ function PrunerGlobalScheduleRow({
 
   const scheduleFieldsDirty =
     scopeRow != null &&
-    (schedHoursLimited !== (scopeRow.scheduled_preview_hours_limited ?? false) ||
+    (schedHoursLimited !==
+      (scopeRow.scheduled_preview_hours_limited ?? false) ||
       schedDays !== (scopeRow.scheduled_preview_days ?? "") ||
       schedStart !== (scopeRow.scheduled_preview_start ?? "00:00") ||
       schedEnd !== (scopeRow.scheduled_preview_end ?? "23:59") ||
@@ -881,7 +1046,9 @@ function PrunerGlobalScheduleRow({
     if (!scopeRow) return;
     if (!persistable) {
       setMsg(null);
-      setErr("Save a server on the Connection tab first, then you can save this schedule to that server.");
+      setErr(
+        "Save a server on the Connection tab first, then you can save this schedule to that server.",
+      );
       return;
     }
     setMsg(null);
@@ -892,7 +1059,8 @@ function PrunerGlobalScheduleRow({
       const cap = Math.max(1, Math.min(5000, Number(previewCap) || 500));
       await patchPrunerScope(instance!.id, scope, {
         scheduled_preview_enabled: scopeRow.scheduled_preview_enabled,
-        scheduled_preview_interval_seconds: scopeRow.scheduled_preview_interval_seconds,
+        scheduled_preview_interval_seconds:
+          scopeRow.scheduled_preview_interval_seconds,
         scheduled_preview_hours_limited: schedHoursLimited,
         scheduled_preview_days: schedDays,
         scheduled_preview_start: schedStart,
@@ -914,78 +1082,108 @@ function PrunerGlobalScheduleRow({
   const testId = `pruner-schedule-row-${provider}-${scope}`;
   const idPrefix = `pruner-sched-${provider}-${scope}`;
 
-  const saveScheduleLabel = scope === "tv" ? "Save TV schedule" : "Save Movies schedule";
+  const saveScheduleLabel =
+    scope === "tv" ? "Save TV schedule" : "Save Movies schedule";
 
-  const laneTitle = scope === "tv" ? "TV automatic scan window" : "Movies automatic scan window";
+  const laneTitle =
+    scope === "tv"
+      ? "TV automatic scan window"
+      : "Movies automatic scan window";
   const laneIntro =
     scope === "tv"
       ? "Limit which days and times Pruner may run scheduled TV cleanup previews for this provider."
       : "Limit which days and times Pruner may run scheduled Movies cleanup previews for this provider.";
 
   return (
-    <section className="mm-card mm-dash-card flex h-full min-h-0 min-w-0 flex-col p-6" data-testid={testId}>
+    <section
+      className="mm-card mm-dash-card flex h-full min-h-0 min-w-0 flex-col p-6"
+      data-testid={testId}
+    >
       <div className="mm-card-action-body flex-1 min-h-0">
-      <div>
-        <h3 className="text-base font-semibold text-[var(--mm-text1)]">{laneTitle}</h3>
-        <p className="mt-1 text-sm text-[var(--mm-text2)]">{laneIntro}</p>
-      </div>
-      <div className="space-y-3">
         <div>
-          <span className="text-sm font-medium text-[var(--mm-text1)]">Schedule window</span>
-          <p className="mt-1 text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_TIME_WINDOW_HELPER}</p>
+          <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+            {laneTitle}
+          </h3>
+          <p className="mt-1 text-sm text-[var(--mm-text2)]">{laneIntro}</p>
         </div>
-        <div className="space-y-4">
-          <MmOnOffSwitch
-            id={`${idPrefix}-hours-limited`}
-            label="Limit to these hours"
-            enabled={schedHoursLimited}
-            disabled={controlsDisabled}
-            onChange={setSchedHoursLimited}
-          />
-          <div className="space-y-2">
-            <span className="text-sm font-medium text-[var(--mm-text1)]">Days</span>
-            <MmScheduleDayChips scheduleDaysCsv={schedDays} disabled={controlsDisabled} onChangeCsv={setSchedDays} />
+        <div className="space-y-3">
+          <div>
+            <span className="text-sm font-medium text-[var(--mm-text1)]">
+              Schedule window
+            </span>
+            <p className="mt-1 text-xs text-[var(--mm-text3)]">
+              {MM_SCHEDULE_TIME_WINDOW_HELPER}
+            </p>
           </div>
-          <MmScheduleTimeFields
-            idPrefix={idPrefix}
-            start={schedStart}
-            end={schedEnd}
+          <div className="space-y-4">
+            <MmOnOffSwitch
+              id={`${idPrefix}-hours-limited`}
+              label="Limit to these hours"
+              enabled={schedHoursLimited}
+              disabled={controlsDisabled}
+              onChange={setSchedHoursLimited}
+            />
+            <div className="space-y-2">
+              <span className="text-sm font-medium text-[var(--mm-text1)]">
+                Days
+              </span>
+              <MmScheduleDayChips
+                scheduleDaysCsv={schedDays}
+                disabled={controlsDisabled}
+                onChangeCsv={setSchedDays}
+              />
+            </div>
+            <MmScheduleTimeFields
+              idPrefix={idPrefix}
+              start={schedStart}
+              end={schedEnd}
+              disabled={controlsDisabled}
+              onStart={setSchedStart}
+              onEnd={setSchedEnd}
+            />
+          </div>
+        </div>
+        <div>
+          <span className="text-sm font-medium text-[var(--mm-text1)]">
+            Items to scan per run
+          </span>
+          <p className="mt-1 text-xs text-[var(--mm-text3)]">
+            How many items to check each time the scan runs. Higher numbers take
+            longer. Maximum 5,000.
+          </p>
+          <input
+            type="number"
+            min={1}
+            max={5000}
+            className="mm-input mt-2 w-full"
+            value={previewCap}
             disabled={controlsDisabled}
-            onStart={setSchedStart}
-            onEnd={setSchedEnd}
+            onChange={(e) =>
+              setPreviewCap(
+                Math.max(1, Math.min(5000, Number(e.target.value) || 500)),
+              )
+            }
+            aria-label="Items to scan per run"
           />
         </div>
-      </div>
-      <div>
-        <span className="text-sm font-medium text-[var(--mm-text1)]">Items to scan per run</span>
-        <p className="mt-1 text-xs text-[var(--mm-text3)]">
-          How many items to check each time the scan runs. Higher numbers take longer. Maximum 5,000.
+        <p className="text-xs text-[var(--mm-text3)]">
+          Last automatic scan:{" "}
+          <span className="font-medium text-[var(--mm-text1)]">
+            {scopeRow?.last_scheduled_preview_enqueued_at
+              ? formatPrunerDateTime(
+                  scopeRow.last_scheduled_preview_enqueued_at,
+                )
+              : "Never run"}
+          </span>
         </p>
-        <input
-          type="number"
-          min={1}
-          max={5000}
-          className="mm-input mt-2 w-full"
-          value={previewCap}
-          disabled={controlsDisabled}
-          onChange={(e) => setPreviewCap(Math.max(1, Math.min(5000, Number(e.target.value) || 500)))}
-          aria-label="Items to scan per run"
-        />
-      </div>
-      <p className="text-xs text-[var(--mm-text3)]">
-        Last automatic scan:{" "}
-        <span className="font-medium text-[var(--mm-text1)]">
-          {scopeRow?.last_scheduled_preview_enqueued_at
-            ? formatPrunerDateTime(scopeRow.last_scheduled_preview_enqueued_at)
-            : "Never run"}
-        </span>
-      </p>
-      {!canOperate && msg ? <p className="text-xs text-green-600">{msg}</p> : null}
-      {!canOperate && err ? (
-        <p className="text-xs text-red-500" role="alert">
-          {err}
-        </p>
-      ) : null}
+        {!canOperate && msg ? (
+          <p className="text-xs text-green-600">{msg}</p>
+        ) : null}
+        {!canOperate && err ? (
+          <p className="text-xs text-red-500" role="alert">
+            {err}
+          </p>
+        ) : null}
       </div>
       {canOperate ? (
         <div className="mm-card-action-footer">
@@ -1007,10 +1205,13 @@ function PrunerGlobalScheduleRow({
       ) : null}
 
       <div className="mt-4 border-t border-[var(--mm-border)] pt-6">
-        <h4 className="text-base font-semibold text-[var(--mm-text1)]">Run now</h4>
+        <h4 className="text-base font-semibold text-[var(--mm-text1)]">
+          Run now
+        </h4>
         <p className="mt-1 text-xs text-[var(--mm-text3)]">
-          Scan your saved cleanup criteria immediately without waiting for the schedule. This creates review snapshots;
-          deletion still requires a saved snapshot confirmation.
+          Scan your saved cleanup criteria immediately without waiting for the
+          schedule. This creates review snapshots; deletion still requires a
+          saved snapshot confirmation.
         </p>
         <div className="mt-4">
           <PrunerDryRunControls
@@ -1032,13 +1233,18 @@ function PrunerGlobalScheduleRow({
 function TopLevelJobs({ instances }: { instances: PrunerServerInstance[] }) {
   const PAGE_SIZE_OPTIONS = [20, 50, 100] as const;
   const jobsQ = usePrunerJobsInspectionQuery(100);
-  const byId = useMemo(() => new Map(instances.map((x) => [x.id, x])), [instances]);
+  const byId = useMemo(
+    () => new Map(instances.map((x) => [x.id, x])),
+    [instances],
+  );
   const [statusFilter, setStatusFilter] = useState("recent");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<number>(PAGE_SIZE_OPTIONS[0]);
   const filterLabelId = useId();
   const jobs =
-    statusFilter === "recent" ? (jobsQ.data?.jobs ?? []) : (jobsQ.data?.jobs ?? []).filter((j) => j.status === statusFilter);
+    statusFilter === "recent"
+      ? (jobsQ.data?.jobs ?? [])
+      : (jobsQ.data?.jobs ?? []).filter((j) => j.status === statusFilter);
   const totalPages = Math.max(1, Math.ceil(jobs.length / pageSize));
   const pagedRows = jobs.slice((page - 1) * pageSize, page * pageSize);
 
@@ -1057,74 +1263,111 @@ function TopLevelJobs({ instances }: { instances: PrunerServerInstance[] }) {
       data-testid="pruner-top-jobs-tab"
     >
       <header className="border-b border-[var(--mm-border)] bg-black/10 px-4 py-3.5 sm:px-5 sm:py-4">
-        <h2 className="text-lg font-semibold tracking-tight text-[var(--mm-text)]">Jobs</h2>
-        <p className="mt-1 text-sm text-[var(--mm-text2)]">Pending, running, and recent Pruner work.</p>
+        <h2 className="text-lg font-semibold tracking-tight text-[var(--mm-text)]">
+          Jobs
+        </h2>
+        <p className="mt-1 text-sm text-[var(--mm-text2)]">
+          Pending, running, and recent Pruner work.
+        </p>
       </header>
       <div className="space-y-4 px-4 py-4 sm:px-5 sm:py-5">
         <div className="flex flex-col gap-3 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3.5 py-3.5 sm:flex-row sm:items-end sm:justify-between sm:px-5 sm:py-4">
           <label className="block min-w-0 flex-1">
-            <span id={filterLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+            <span
+              id={filterLabelId}
+              className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+            >
               Show jobs
             </span>
             <MmListboxPicker
               className="mt-2 max-w-xl"
               ariaLabelledBy={filterLabelId}
               placeholder="Recent (all statuses, newest first)"
-              options={PRUNER_JOB_FILTER_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+              options={PRUNER_JOB_FILTER_OPTIONS.map((o) => ({
+                value: o.value,
+                label: o.label,
+              }))}
               value={statusFilter}
               onChange={(v) => setStatusFilter(v)}
             />
           </label>
         </div>
-        {jobsQ.isLoading ? <p className="text-sm text-[var(--mm-text2)]">Loading jobs…</p> : null}
-        {jobsQ.isError ? <p className="text-sm text-red-600">{(jobsQ.error as Error).message}</p> : null}
+        {jobsQ.isLoading ? (
+          <p className="text-sm text-[var(--mm-text2)]">Loading jobs…</p>
+        ) : null}
+        {jobsQ.isError ? (
+          <p className="text-sm text-red-600">
+            {(jobsQ.error as Error).message}
+          </p>
+        ) : null}
         {jobs.length ? (
           <>
             <div className="overflow-x-auto rounded-md border border-[var(--mm-border)]">
-            <table className="w-full min-w-[32rem] border-collapse text-left text-sm">
-              <thead className="bg-black/20 text-[var(--mm-text2)]">
-              <tr>
-                <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">Id</th>
-                <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">What ran</th>
-                <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Status</th>
-                <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Server</th>
-                <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Updated</th>
-              </tr>
-            </thead>
-            <tbody>
-              {pagedRows.map((job) => {
-                const sid = parseServerInstanceId(job);
-                const inst = sid ? byId.get(sid) : undefined;
-                return (
-                  <tr key={job.id} className="border-t border-[var(--mm-border)]">
-                    <td className="sticky left-0 z-[1] bg-[var(--mm-card-bg)] px-3 py-2 align-top font-mono text-xs text-[var(--mm-text1)]">
-                      #{job.id}
-                    </td>
-                    <td className="max-w-[14rem] break-words px-3 py-2 align-top text-xs">{prunerJobKindOperatorLabel(job.job_kind)}</td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top">
-                      <span
-                        className={
-                          job.status === "completed"
-                            ? "text-emerald-500"
-                            : job.status === "failed"
-                              ? "text-red-400"
-                              : job.status === "running"
-                                ? "text-amber-400"
-                                : "text-[var(--mm-text2)]"
-                        }
-                      >
-                        {job.status}
-                      </span>
-                    </td>
-                    <td className="max-w-[14rem] break-words px-3 py-2 align-top text-xs">
-                      {inst ? inst.display_name : sid ? `Server #${sid}` : "—"}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top text-xs text-[var(--mm-text2)]">{job.updated_at}</td>
+              <table className="w-full min-w-[32rem] border-collapse text-left text-sm">
+                <thead className="bg-black/20 text-[var(--mm-text2)]">
+                  <tr>
+                    <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">
+                      Id
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      What ran
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Status
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Server
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Updated
+                    </th>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                </thead>
+                <tbody>
+                  {pagedRows.map((job) => {
+                    const sid = parseServerInstanceId(job);
+                    const inst = sid ? byId.get(sid) : undefined;
+                    return (
+                      <tr
+                        key={job.id}
+                        className="border-t border-[var(--mm-border)]"
+                      >
+                        <td className="sticky left-0 z-[1] bg-[var(--mm-card-bg)] px-3 py-2 align-top font-mono text-xs text-[var(--mm-text1)]">
+                          #{job.id}
+                        </td>
+                        <td className="max-w-[14rem] break-words px-3 py-2 align-top text-xs">
+                          {prunerJobKindOperatorLabel(job.job_kind)}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 align-top">
+                          <span
+                            className={
+                              job.status === "completed"
+                                ? "text-emerald-500"
+                                : job.status === "failed"
+                                  ? "text-red-400"
+                                  : job.status === "running"
+                                    ? "text-amber-400"
+                                    : "text-[var(--mm-text2)]"
+                            }
+                          >
+                            {job.status}
+                          </span>
+                        </td>
+                        <td className="max-w-[14rem] break-words px-3 py-2 align-top text-xs">
+                          {inst
+                            ? inst.display_name
+                            : sid
+                              ? `Server #${sid}`
+                              : "—"}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 align-top text-xs text-[var(--mm-text2)]">
+                          {job.updated_at}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
             <MmJobsPagination
               page={page}
@@ -1137,7 +1380,9 @@ function TopLevelJobs({ instances }: { instances: PrunerServerInstance[] }) {
           </>
         ) : jobsQ.data ? (
           <div className="space-y-1 rounded border border-[var(--mm-border)] bg-black/10 px-5 py-10 text-center">
-            <p className="text-sm font-medium text-[var(--mm-text)]">No jobs match this view</p>
+            <p className="text-sm font-medium text-[var(--mm-text)]">
+              No jobs match this view
+            </p>
             <p className="text-xs text-[var(--mm-text2)]">
               {statusFilter !== "recent"
                 ? `Nothing with status "${statusFilter}" yet. Try Recent (all statuses) for the latest rows.`
@@ -1147,7 +1392,10 @@ function TopLevelJobs({ instances }: { instances: PrunerServerInstance[] }) {
         ) : null}
         <p className="text-xs text-[var(--mm-text2)]">
           Full detail on what was deleted, skipped, or failed is in the{" "}
-          <Link to="/app/activity" className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline">
+          <Link
+            to="/app/activity"
+            className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline"
+          >
             Activity log
           </Link>
           .
@@ -1167,10 +1415,11 @@ export function PrunerInstancesListPage() {
         <p className="mm-page__eyebrow">MediaMop</p>
         <h1 className="mm-page__title">Pruner</h1>
         <p className="mm-page__subtitle max-w-3xl">
-          Library cleanup for <strong className="text-[var(--mm-text)]">Emby</strong>,{" "}
+          Library cleanup for{" "}
+          <strong className="text-[var(--mm-text)]">Emby</strong>,{" "}
           <strong className="text-[var(--mm-text)]">Jellyfin</strong>, and{" "}
-          <strong className="text-[var(--mm-text)]">Plex</strong>. Each provider tab has Connection, Cleanup, and Schedule
-          for that server.
+          <strong className="text-[var(--mm-text)]">Plex</strong>. Each provider
+          tab has Connection, Cleanup, and Schedule for that server.
         </p>
       </header>
 
@@ -1179,19 +1428,25 @@ export function PrunerInstancesListPage() {
         aria-label="Pruner sections"
         data-testid="pruner-top-level-tabs"
       >
-        {([
-          ["overview", "Overview"],
-          ["emby", "Emby"],
-          ["jellyfin", "Jellyfin"],
-          ["plex", "Plex"],
-          ["jobs", "Jobs"],
-        ] as const).map(([id, label]) => (
+        {(
+          [
+            ["overview", "Overview"],
+            ["emby", "Emby"],
+            ["jellyfin", "Jellyfin"],
+            ["plex", "Plex"],
+            ["jobs", "Jobs"],
+          ] as const
+        ).map(([id, label]) => (
           <button
             key={id}
             type="button"
             role="tab"
-            aria-selected={topTab === id || (topTab === "schedule" && id === "emby")}
-            className={mmSectionTabClass(topTab === id || (topTab === "schedule" && id === "emby"))}
+            aria-selected={
+              topTab === id || (topTab === "schedule" && id === "emby")
+            }
+            className={mmSectionTabClass(
+              topTab === id || (topTab === "schedule" && id === "emby"),
+            )}
             onClick={() => setTopTab(id)}
           >
             {label}
@@ -1215,12 +1470,23 @@ export function PrunerInstancesListPage() {
           )[topTab]
         }
       >
-        <div className={mmModuleTabBlurbBandClass} data-testid="pruner-tab-blurb">
-          <p className={mmModuleTabBlurbTextClass}>{PRUNER_TAB_BLURBS[topTab]}</p>
+        <div
+          className={mmModuleTabBlurbBandClass}
+          data-testid="pruner-tab-blurb"
+        >
+          <p className={mmModuleTabBlurbTextClass}>
+            {PRUNER_TAB_BLURBS[topTab]}
+          </p>
         </div>
         <div className="min-w-0">
-          {q.isLoading ? <p className="text-sm text-[var(--mm-text2)]">Loading provider instances…</p> : null}
-          {q.isError ? <p className="text-sm text-red-600">{(q.error as Error).message}</p> : null}
+          {q.isLoading ? (
+            <p className="text-sm text-[var(--mm-text2)]">
+              Loading provider instances…
+            </p>
+          ) : null}
+          {q.isError ? (
+            <p className="text-sm text-red-600">{(q.error as Error).message}</p>
+          ) : null}
           {!q.isLoading && !q.isError ? (
             topTab === "overview" ? (
               <TopLevelOverview
@@ -1231,9 +1497,16 @@ export function PrunerInstancesListPage() {
             ) : topTab === "jobs" ? (
               <TopLevelJobs instances={instances} />
             ) : topTab === "schedule" ? (
-              <ProviderConfigurationWorkspace provider="emby" allInstances={instances} initialSection="schedule" />
+              <ProviderConfigurationWorkspace
+                provider="emby"
+                allInstances={instances}
+                initialSection="schedule"
+              />
             ) : (
-              <ProviderConfigurationWorkspace provider={topTab} allInstances={instances} />
+              <ProviderConfigurationWorkspace
+                provider={topTab}
+                allInstances={instances}
+              />
             )
           ) : null}
         </div>

--- a/apps/web/src/pages/pruner/pruner-operator-scan-utils.ts
+++ b/apps/web/src/pages/pruner/pruner-operator-scan-utils.ts
@@ -146,7 +146,10 @@ export async function resolvePreviewRunIdForJob(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (opts.signal?.aborted) throw new Error("Aborted");
-    const runs = await fetchPrunerPreviewRuns(instanceId, { media_scope: mediaScope, limit: 40 });
+    const runs = await fetchPrunerPreviewRuns(instanceId, {
+      media_scope: mediaScope,
+      limit: 40,
+    });
     const hit = runs.find((r) => r.pruner_job_id === jobId);
     if (hit?.preview_run_id) return hit.preview_run_id;
     await sleep(pollMs);
@@ -173,7 +176,11 @@ export async function waitForApplyActivity(
         const removed = Number(o.removed);
         const skipped = Number(o.skipped);
         const failed = Number(o.failed);
-        if (Number.isFinite(removed) && Number.isFinite(skipped) && Number.isFinite(failed)) {
+        if (
+          Number.isFinite(removed) &&
+          Number.isFinite(skipped) &&
+          Number.isFinite(failed)
+        ) {
           return { removed, skipped, failed };
         }
       } catch {
@@ -195,7 +202,10 @@ export function tvRuleFamiliesToScan(
     out.push(RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED);
   }
   if (p === "jellyfin" || p === "emby") {
-    if (tv.never_played_stale_reported_enabled && tv.never_played_min_age_days >= 7) {
+    if (
+      tv.never_played_stale_reported_enabled &&
+      tv.never_played_min_age_days >= 7
+    ) {
       out.push(RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED);
     }
     if (tv.watched_tv_reported_enabled) {
@@ -230,7 +240,10 @@ export function moviesRuleFamiliesToScan(
   if (movies.watched_movie_low_rating_reported_enabled) {
     out.push(RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED);
   }
-  if (movies.unwatched_movie_stale_reported_enabled && movies.unwatched_movie_stale_min_age_days >= 7) {
+  if (
+    movies.unwatched_movie_stale_reported_enabled &&
+    movies.unwatched_movie_stale_min_age_days >= 7
+  ) {
     out.push(RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED);
   }
   if ((movies.preview_include_genres as string[] | undefined)?.length) {

--- a/apps/web/src/pages/pruner/pruner-people-roles.tsx
+++ b/apps/web/src/pages/pruner/pruner-people-roles.tsx
@@ -1,10 +1,20 @@
 /** Wire tokens stored per scope (API + backend). */
 import { MmOnOffSwitch } from "../../components/ui/mm-on-off-switch";
 
-export const PRUNER_PEOPLE_ROLE_IDS = ["cast", "director", "writer", "producer", "guest_star"] as const;
+export const PRUNER_PEOPLE_ROLE_IDS = [
+  "cast",
+  "director",
+  "writer",
+  "producer",
+  "guest_star",
+] as const;
 export type PrunerPeopleRoleId = (typeof PRUNER_PEOPLE_ROLE_IDS)[number];
 
-const PLEX_UI_ROLE_IDS: readonly PrunerPeopleRoleId[] = ["cast", "director", "writer"];
+const PLEX_UI_ROLE_IDS: readonly PrunerPeopleRoleId[] = [
+  "cast",
+  "director",
+  "writer",
+];
 
 const ROLE_LABELS: Record<PrunerPeopleRoleId, string> = {
   cast: "Cast (actors)",
@@ -14,11 +24,16 @@ const ROLE_LABELS: Record<PrunerPeopleRoleId, string> = {
   guest_star: "Guest stars",
 };
 
-const PLEX_UNAVAILABLE: ReadonlySet<PrunerPeopleRoleId> = new Set(["producer", "guest_star"]);
+const PLEX_UNAVAILABLE: ReadonlySet<PrunerPeopleRoleId> = new Set([
+  "producer",
+  "guest_star",
+]);
 
 export const DEFAULT_PRUNER_PEOPLE_ROLES: PrunerPeopleRoleId[] = [];
 
-export function normalizePeopleRolesFromApi(raw: string[] | undefined | null): PrunerPeopleRoleId[] {
+export function normalizePeopleRolesFromApi(
+  raw: string[] | undefined | null,
+): PrunerPeopleRoleId[] {
   const out: PrunerPeopleRoleId[] = [];
   const seen = new Set<string>();
   for (const id of PRUNER_PEOPLE_ROLE_IDS) {
@@ -31,13 +46,19 @@ export function normalizePeopleRolesFromApi(raw: string[] | undefined | null): P
 }
 
 /** Plex PATCH: omit tags Plex cannot supply. */
-export function peopleRolesForPlexPersist(roles: readonly PrunerPeopleRoleId[]): PrunerPeopleRoleId[] {
+export function peopleRolesForPlexPersist(
+  roles: readonly PrunerPeopleRoleId[],
+): PrunerPeopleRoleId[] {
   return roles.filter((r) => !PLEX_UNAVAILABLE.has(r));
 }
 
 /** Hydrate Plex People UI: drop roles Plex cannot supply. */
-export function peopleRolesForPlexUiState(raw: string[] | undefined | null): PrunerPeopleRoleId[] {
-  return normalizePeopleRolesFromApi(raw).filter((r) => !PLEX_UNAVAILABLE.has(r));
+export function peopleRolesForPlexUiState(
+  raw: string[] | undefined | null,
+): PrunerPeopleRoleId[] {
+  return normalizePeopleRolesFromApi(raw).filter(
+    (r) => !PLEX_UNAVAILABLE.has(r),
+  );
 }
 
 type PrunerPeopleRoleCheckboxesProps = {
@@ -63,7 +84,9 @@ export function PrunerPeopleRoleCheckboxes({
 }: PrunerPeopleRoleCheckboxesProps) {
   const isPlex = variant === "plex";
   const baseTestId = testId ?? "pruner-people-role-toggles";
-  const roleIds: readonly PrunerPeopleRoleId[] = isPlex ? PLEX_UI_ROLE_IDS : PRUNER_PEOPLE_ROLE_IDS;
+  const roleIds: readonly PrunerPeopleRoleId[] = isPlex
+    ? PLEX_UI_ROLE_IDS
+    : PRUNER_PEOPLE_ROLE_IDS;
 
   function setRoleEnabled(id: PrunerPeopleRoleId, enabled: boolean) {
     let next: PrunerPeopleRoleId[];
@@ -100,7 +123,9 @@ export function PrunerPeopleRoleCheckboxes({
         })}
       </div>
       <p className="text-xs text-[var(--mm-text3)]">{helper}</p>
-      {footerHelper ? <p className="text-xs text-[var(--mm-text3)]">{footerHelper}</p> : null}
+      {footerHelper ? (
+        <p className="text-xs text-[var(--mm-text3)]">{footerHelper}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/pages/pruner/pruner-provider-operator-workspace.tsx
+++ b/apps/web/src/pages/pruner/pruner-provider-operator-workspace.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { Link } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { fetchCsrfToken } from "../../lib/api/auth-api";
@@ -14,7 +21,10 @@ import {
 import type { PrunerServerInstance } from "../../lib/pruner/api";
 import { MmOnOffSwitch } from "../../components/ui/mm-on-off-switch";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
-import { PrunerGenreMultiSelect, prunerGenresFromApi } from "./pruner-genre-multi-select";
+import {
+  PrunerGenreMultiSelect,
+  prunerGenresFromApi,
+} from "./pruner-genre-multi-select";
 import { PrunerStudioMultiSelect } from "./pruner-studio-multi-select";
 import {
   PrunerPeopleRoleCheckboxes,
@@ -42,7 +52,10 @@ import {
 
 type ProviderKey = "emby" | "jellyfin" | "plex";
 
-function scopeRow(inst: PrunerServerInstance | undefined, media_scope: "tv" | "movies") {
+function scopeRow(
+  inst: PrunerServerInstance | undefined,
+  media_scope: "tv" | "movies",
+) {
   return inst?.scopes.find((s) => s.media_scope === media_scope);
 }
 
@@ -71,18 +84,27 @@ async function evaluateEligibilityForSnapshots(
   instanceId: number,
   mediaScope: "tv" | "movies",
   snaps: PreviewSnapshot[],
-): Promise<{ elig: Record<string, boolean>; reasons: Record<string, string[]> }> {
+): Promise<{
+  elig: Record<string, boolean>;
+  reasons: Record<string, string[]>;
+}> {
   const elig: Record<string, boolean> = {};
   const reasons: Record<string, string[]> = {};
   for (const s of snaps) {
     if (s.outcome !== "success" || s.rows.length === 0) continue;
     try {
-      const r = await fetchPrunerApplyEligibility(instanceId, mediaScope, s.previewRunId);
+      const r = await fetchPrunerApplyEligibility(
+        instanceId,
+        mediaScope,
+        s.previewRunId,
+      );
       elig[s.previewRunId] = r.eligible;
       reasons[s.previewRunId] = r.reasons;
     } catch {
       elig[s.previewRunId] = false;
-      reasons[s.previewRunId] = ["Could not confirm whether these items can be deleted safely."];
+      reasons[s.previewRunId] = [
+        "Could not confirm whether these items can be deleted safely.",
+      ];
     }
   }
   return { elig, reasons };
@@ -103,11 +125,17 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
   } = props;
   const qc = useQueryClient();
   void onDryRunEnabledChange;
-  const [phase, setPhase] = useState<"idle" | "scanning" | "results" | "deleting">("idle");
+  const [phase, setPhase] = useState<
+    "idle" | "scanning" | "results" | "deleting"
+  >("idle");
   const [err, setErr] = useState<string | null>(null);
   const [snapshots, setSnapshots] = useState<PreviewSnapshot[]>([]);
-  const [deleteEligible, setDeleteEligible] = useState<Record<string, boolean>>({});
-  const [deleteReasons, setDeleteReasons] = useState<Record<string, string[]>>({});
+  const [deleteEligible, setDeleteEligible] = useState<Record<string, boolean>>(
+    {},
+  );
+  const [deleteReasons, setDeleteReasons] = useState<Record<string, string[]>>(
+    {},
+  );
   const [applySummary, setApplySummary] = useState<string | null>(null);
 
   const allRows = useMemo(() => {
@@ -131,15 +159,21 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
     setEmptyBecauseNoRules(false);
     try {
       await ensureSaved();
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       const fresh = await fetchPrunerInstance(instanceId);
       const tv = scopeRow(fresh, "tv");
       const movies = scopeRow(fresh, "movies");
       if (!tv || !movies) {
-        throw new Error("TV and movie settings for this server are missing. Try reloading the page.");
+        throw new Error(
+          "TV and movie settings for this server are missing. Try reloading the page.",
+        );
       }
       const families =
-        mediaScope === "tv" ? tvRuleFamiliesToScan(fresh.provider, tv) : moviesRuleFamiliesToScan(movies);
+        mediaScope === "tv"
+          ? tvRuleFamiliesToScan(fresh.provider, tv)
+          : moviesRuleFamiliesToScan(movies);
       if (families.length === 0) {
         setSnapshots([]);
         setEmptyBecauseNoRules(true);
@@ -148,7 +182,11 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
       }
       const collected: PreviewSnapshot[] = [];
       for (const ruleFamilyId of families) {
-        const { pruner_job_id } = await postPrunerPreview(instanceId, mediaScope, { rule_family_id: ruleFamilyId });
+        const { pruner_job_id } = await postPrunerPreview(
+          instanceId,
+          mediaScope,
+          { rule_family_id: ruleFamilyId },
+        );
         let terminal: "completed" | "failed";
         try {
           terminal = await waitForPrunerJobTerminal(pruner_job_id, {
@@ -156,7 +194,9 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
             timeoutMs: PRUNER_SCAN_TIMEOUT_MS,
           });
         } catch {
-          setErr("Scan is taking longer than expected. Check Activity for results.");
+          setErr(
+            "Scan is taking longer than expected. Check Activity for results.",
+          );
           setPhase("idle");
           return;
         }
@@ -165,12 +205,19 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
           setPhase("idle");
           return;
         }
-        const previewRunId = await resolvePreviewRunIdForJob(instanceId, mediaScope, pruner_job_id, {
-          pollMs: PRUNER_SCAN_POLL_MS,
-          timeoutMs: PRUNER_SCAN_TIMEOUT_MS,
-        });
+        const previewRunId = await resolvePreviewRunIdForJob(
+          instanceId,
+          mediaScope,
+          pruner_job_id,
+          {
+            pollMs: PRUNER_SCAN_POLL_MS,
+            timeoutMs: PRUNER_SCAN_TIMEOUT_MS,
+          },
+        );
         if (!previewRunId) {
-          setErr("Scan is taking longer than expected. Check Activity for results.");
+          setErr(
+            "Scan is taking longer than expected. Check Activity for results.",
+          );
           setPhase("idle");
           return;
         }
@@ -190,31 +237,44 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
         });
       }
 
-      const { elig, reasons } = await evaluateEligibilityForSnapshots(instanceId, mediaScope, collected);
+      const { elig, reasons } = await evaluateEligibilityForSnapshots(
+        instanceId,
+        mediaScope,
+        collected,
+      );
       setSnapshots(collected);
       setDeleteEligible(elig);
       setDeleteReasons(reasons);
 
       const rowsCount = collected.reduce((acc, s) => acc + s.rows.length, 0);
       const eligibleAny = collected.some(
-        (s) => s.outcome === "success" && s.rows.length > 0 && elig[s.previewRunId] === true,
+        (s) =>
+          s.outcome === "success" &&
+          s.rows.length > 0 &&
+          elig[s.previewRunId] === true,
       );
 
-      if (dryRunEnabled || true) {
+      if (dryRunEnabled) {
         setPhase("results");
-        await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+        await qc.invalidateQueries({
+          queryKey: ["pruner", "instances", instanceId],
+        });
         return;
       }
 
       if (rowsCount === 0) {
         setPhase("results");
-        await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+        await qc.invalidateQueries({
+          queryKey: ["pruner", "instances", instanceId],
+        });
         return;
       }
 
       if (!eligibleAny) {
         setPhase("results");
-        await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+        await qc.invalidateQueries({
+          queryKey: ["pruner", "instances", instanceId],
+        });
         return;
       }
 
@@ -225,7 +285,11 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
       for (const s of collected) {
         if (s.outcome !== "success" || s.rows.length === 0) continue;
         if (!elig[s.previewRunId]) continue;
-        const { pruner_job_id } = await postPrunerApplyFromPreview(instanceId, mediaScope, s.previewRunId);
+        const { pruner_job_id } = await postPrunerApplyFromPreview(
+          instanceId,
+          mediaScope,
+          s.previewRunId,
+        );
         try {
           await waitForPrunerJobTerminal(pruner_job_id, {
             pollMs: PRUNER_SCAN_POLL_MS,
@@ -236,7 +300,9 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
             "Delete is taking longer than expected. Check Activity — your server may still be processing items.",
           );
           setPhase("results");
-          await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+          await qc.invalidateQueries({
+            queryKey: ["pruner", "instances", instanceId],
+          });
           await qc.invalidateQueries({ queryKey: ["activity"] });
           return;
         }
@@ -251,9 +317,13 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
       setSnapshots([]);
       setDeleteEligible({});
       setDeleteReasons({});
-      setApplySummary(`Deleted ${removed} items. Skipped ${skipped}. Failed ${failed}.`);
+      setApplySummary(
+        `Deleted ${removed} items. Skipped ${skipped}. Failed ${failed}.`,
+      );
       setPhase("results");
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: ["activity"] });
     } catch (e) {
       setErr((e as Error).message);
@@ -261,15 +331,22 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
     }
   }
 
-  const runLabel = mediaScope === "tv" ? "Scan TV for cleanup review" : "Scan Movies for cleanup review";
+  const runLabel =
+    mediaScope === "tv"
+      ? "Scan TV for cleanup review"
+      : "Scan Movies for cleanup review";
   const runBusy = phase === "scanning" || phase === "deleting";
   const runBtnDisabled = runDisabled || controlsDisabled || runBusy;
 
   return (
-    <div className="min-w-0 space-y-4" data-testid={`${testIdPrefix}-run-${mediaScope}`}>
+    <div
+      className="min-w-0 space-y-4"
+      data-testid={`${testIdPrefix}-run-${mediaScope}`}
+    >
       <p className="text-xs text-[var(--mm-text3)]">
-        This scans your saved rules and creates a review snapshot. Nothing is deleted from this button; deletion only
-        happens when you open and confirm a saved snapshot.
+        This scans your saved rules and creates a review snapshot. Nothing is
+        deleted from this button; deletion only happens when you open and
+        confirm a saved snapshot.
       </p>
       <div>
         <button
@@ -294,27 +371,46 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
       {phase === "results" || phase === "deleting" ? (
         <div className="mt-4 space-y-3">
           {phase === "deleting" ? (
-            <p className="text-sm font-medium text-[var(--mm-text1)]">Deleting…</p>
-          ) : null}
-          {snapshots.length === 0 && phase === "results" && !err && emptyBecauseNoRules ? (
-            <p className="text-sm text-[var(--mm-text2)]">
-              No cleanup rules are turned on for this column, so there is nothing to scan.
+            <p className="text-sm font-medium text-[var(--mm-text1)]">
+              Deleting…
             </p>
           ) : null}
-          {!dryRunEnabled && phase === "results" && snapshots.length > 0 && totalCount === 0 ? (
-            <p className="text-sm text-[var(--mm-text2)]">No items matched your criteria.</p>
+          {snapshots.length === 0 &&
+          phase === "results" &&
+          !err &&
+          emptyBecauseNoRules ? (
+            <p className="text-sm text-[var(--mm-text2)]">
+              No cleanup rules are turned on for this column, so there is
+              nothing to scan.
+            </p>
+          ) : null}
+          {!dryRunEnabled &&
+          phase === "results" &&
+          snapshots.length > 0 &&
+          totalCount === 0 ? (
+            <p className="text-sm text-[var(--mm-text2)]">
+              No items matched your criteria.
+            </p>
           ) : null}
           {(dryRunEnabled || !applySummary) &&
             snapshots.map((s) => (
-              <div key={s.previewRunId} className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)]/30 p-3">
+              <div
+                key={s.previewRunId}
+                className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)]/30 p-3"
+              >
                 <p className="text-sm font-medium text-[var(--mm-text1)]">
                   {s.ruleLabel}
                   {s.outcome === "unsupported" ? (
-                    <span className="ml-2 text-xs font-normal text-[var(--mm-text3)]"> — not available for this scan</span>
+                    <span className="ml-2 text-xs font-normal text-[var(--mm-text3)]">
+                      {" "}
+                      — not available for this scan
+                    </span>
                   ) : null}
                 </p>
                 {s.outcome === "unsupported" && s.unsupportedDetail ? (
-                  <p className="mt-1 text-xs text-[var(--mm-text3)]">{s.unsupportedDetail}</p>
+                  <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                    {s.unsupportedDetail}
+                  </p>
                 ) : null}
                 {s.outcome === "failed" && s.errorMessage ? (
                   <p className="mt-1 text-xs text-red-400">{s.errorMessage}</p>
@@ -322,7 +418,9 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
                 {s.outcome === "success" ? (
                   <p className="mt-1 text-xs text-[var(--mm-text2)]">
                     {s.rows.length} item{s.rows.length === 1 ? "" : "s"} matched
-                    {s.truncated ? " (list stopped at your scan limit — more may exist on the server)" : ""}
+                    {s.truncated
+                      ? " (list stopped at your scan limit — more may exist on the server)"
+                      : ""}
                   </p>
                 ) : null}
               </div>
@@ -331,30 +429,51 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
             totalCount > 0 ? (
               <>
                 <p className="text-sm text-[var(--mm-text1)]">
-                  <span className="font-semibold">{totalCount}</span> item{totalCount === 1 ? "" : "s"} matched your
-                  criteria.
+                  <span className="font-semibold">{totalCount}</span> item
+                  {totalCount === 1 ? "" : "s"} matched your criteria.
                 </p>
                 <ul className="max-h-64 divide-y divide-[var(--mm-border)] overflow-y-auto rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] text-sm">
                   {allRows.map((r) => (
-                    <li key={r.key} className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
+                    <li
+                      key={r.key}
+                      className="flex flex-col gap-0.5 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                    >
                       <span className="text-[var(--mm-text1)]">{r.title}</span>
-                      <span className="text-xs text-[var(--mm-text3)]">{r.ruleLabel}</span>
+                      <span className="text-xs text-[var(--mm-text3)]">
+                        {r.ruleLabel}
+                      </span>
                     </li>
                   ))}
                 </ul>
               </>
             ) : (
-              <p className="text-sm text-[var(--mm-text2)]">No items matched your criteria.</p>
+              <p className="text-sm text-[var(--mm-text2)]">
+                No items matched your criteria.
+              </p>
             )
           ) : null}
-          {!dryRunEnabled && snapshots.some((s) => s.outcome === "success" && s.rows.length > 0 && deleteEligible[s.previewRunId] === false) ? (
+          {!dryRunEnabled &&
+          snapshots.some(
+            (s) =>
+              s.outcome === "success" &&
+              s.rows.length > 0 &&
+              deleteEligible[s.previewRunId] === false,
+          ) ? (
             <div className="text-xs text-[var(--mm-text3)]">
               {snapshots.map((s) => {
-                if (s.outcome !== "success" || s.rows.length === 0 || deleteEligible[s.previewRunId] !== false) return null;
+                if (
+                  s.outcome !== "success" ||
+                  s.rows.length === 0 ||
+                  deleteEligible[s.previewRunId] !== false
+                )
+                  return null;
                 const rs = deleteReasons[s.previewRunId] ?? [];
                 return (
                   <p key={s.previewRunId} className="mt-1">
-                    <span className="font-medium text-[var(--mm-text2)]">{s.ruleLabel}:</span> {rs.join(" ")}
+                    <span className="font-medium text-[var(--mm-text2)]">
+                      {s.ruleLabel}:
+                    </span>{" "}
+                    {rs.join(" ")}
                   </p>
                 );
               })}
@@ -367,7 +486,10 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
               ) : (
                 <>
                   {applySummary}{" "}
-                  <Link to="/app/activity" className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline">
+                  <Link
+                    to="/app/activity"
+                    className="font-semibold text-[var(--mm-accent)] underline-offset-2 hover:underline"
+                  >
                     Activity log
                   </Link>{" "}
                   has full detail.
@@ -378,7 +500,10 @@ export function PrunerDryRunControls(props: PrunerDryRunControlsProps) {
           {dryRunEnabled && phase === "results" && totalCount > 0 ? (
             <p className="text-xs text-[var(--mm-text3)]">
               Full detail:{" "}
-              <Link to="/app/activity" className="font-medium text-[var(--mm-accent)] underline-offset-2 hover:underline">
+              <Link
+                to="/app/activity"
+                className="font-medium text-[var(--mm-accent)] underline-offset-2 hover:underline"
+              >
                 Activity log
               </Link>
             </p>
@@ -400,8 +525,10 @@ export type PrunerProviderRulesCardHandle = {
   ensureMoviesSaved: () => Promise<void>;
 };
 
-export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle, RulesCardProps>(
-  function PrunerProviderRulesCard({ provider, instanceId, instance }, ref) {
+export const PrunerProviderRulesCard = forwardRef<
+  PrunerProviderRulesCardHandle,
+  RulesCardProps
+>(function PrunerProviderRulesCard({ provider, instanceId, instance }, ref) {
   const qc = useQueryClient();
   const me = useMeQuery();
   const canOperate = me.data?.role === "admin" || me.data?.role === "operator";
@@ -442,13 +569,25 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
     if (!tv) return;
     setMissingPrimaryTv(tv.missing_primary_media_reported_enabled);
     setWatchedTv(tv.watched_tv_reported_enabled);
-    setNeverTvDays(!tv.never_played_stale_reported_enabled ? "0" : String(tv.never_played_min_age_days));
+    setNeverTvDays(
+      !tv.never_played_stale_reported_enabled
+        ? "0"
+        : String(tv.never_played_min_age_days),
+    );
     setGenreTv(prunerGenresFromApi(tv.preview_include_genres));
-    setYearMinTv(tv.preview_year_min != null ? String(tv.preview_year_min) : "");
-    setYearMaxTv(tv.preview_year_max != null ? String(tv.preview_year_max) : "");
+    setYearMinTv(
+      tv.preview_year_min != null ? String(tv.preview_year_min) : "",
+    );
+    setYearMaxTv(
+      tv.preview_year_max != null ? String(tv.preview_year_max) : "",
+    );
     setStudioTv([...(tv.preview_include_studios ?? [])]);
     setTvPeople(((tv.preview_include_people ?? []) as string[]).join("\n"));
-    setTvRoles(isPlex ? peopleRolesForPlexUiState(tv.preview_include_people_roles) : normalizePeopleRolesFromApi(tv.preview_include_people_roles));
+    setTvRoles(
+      isPlex
+        ? peopleRolesForPlexUiState(tv.preview_include_people_roles)
+        : normalizePeopleRolesFromApi(tv.preview_include_people_roles),
+    );
   }, [tv, isPlex]);
 
   useEffect(() => {
@@ -464,14 +603,26 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               : movies.watched_movie_low_rating_max_jellyfin_emby_community_rating,
           ),
     );
-    setUnwatchedDays(!movies.unwatched_movie_stale_reported_enabled ? "0" : String(movies.unwatched_movie_stale_min_age_days));
+    setUnwatchedDays(
+      !movies.unwatched_movie_stale_reported_enabled
+        ? "0"
+        : String(movies.unwatched_movie_stale_min_age_days),
+    );
     setGenreMovies(prunerGenresFromApi(movies.preview_include_genres));
-    setYearMinMovies(movies.preview_year_min != null ? String(movies.preview_year_min) : "");
-    setYearMaxMovies(movies.preview_year_max != null ? String(movies.preview_year_max) : "");
+    setYearMinMovies(
+      movies.preview_year_min != null ? String(movies.preview_year_min) : "",
+    );
+    setYearMaxMovies(
+      movies.preview_year_max != null ? String(movies.preview_year_max) : "",
+    );
     setStudioMovies([...(movies.preview_include_studios ?? [])]);
-    setMoviesPeople(((movies.preview_include_people ?? []) as string[]).join("\n"));
+    setMoviesPeople(
+      ((movies.preview_include_people ?? []) as string[]).join("\n"),
+    );
     setMoviesRoles(
-      isPlex ? peopleRolesForPlexUiState(movies.preview_include_people_roles) : normalizePeopleRolesFromApi(movies.preview_include_people_roles),
+      isPlex
+        ? peopleRolesForPlexUiState(movies.preview_include_people_roles)
+        : normalizePeopleRolesFromApi(movies.preview_include_people_roles),
     );
     setMoviesCollections((movies.preview_include_collections ?? []).join(", "));
   }, [movies, isPlex]);
@@ -487,17 +638,27 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
     const yMin = parseYear(yMinStr);
     const yMax = parseYear(yMaxStrStr);
     if (yMin === "bad" || yMax === "bad") {
-      throw new Error("Each year must be a whole number between 1900 and 2100, or left empty.");
+      throw new Error(
+        "Each year must be a whole number between 1900 and 2100, or left empty.",
+      );
     }
     if (yMin != null && yMax != null && yMin > yMax) {
-      throw new Error("Minimum year must be less than or equal to maximum year.");
+      throw new Error(
+        "Minimum year must be less than or equal to maximum year.",
+      );
     }
     return {
       preview_include_genres: [...genres],
       preview_year_min: yMinStr.trim() ? yMin : null,
       preview_year_max: yMaxStrStr.trim() ? yMax : null,
       preview_include_studios: [...studios],
-      ...(isPlex && scope === "movies" ? { preview_include_collections: parseCommaTokens(collectionsText ?? "") } : {}),
+      ...(isPlex && scope === "movies"
+        ? {
+            preview_include_collections: parseCommaTokens(
+              collectionsText ?? "",
+            ),
+          }
+        : {}),
     };
   }
 
@@ -507,8 +668,16 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
     const raw = parseInt(neverTvDays.trim(), 10);
     const neverOn = !isPlex && Number.isFinite(raw) && raw >= 7;
     const neverDays = neverOn ? Math.max(7, Math.min(3650, raw)) : 90;
-    const filters = buildFilterPatch("tv", genreTv, yearMinTv, yearMaxTv, studioTv);
-    const rolesPersist = isPlex ? peopleRolesForPlexPersist(tvRoles) : [...tvRoles];
+    const filters = buildFilterPatch(
+      "tv",
+      genreTv,
+      yearMinTv,
+      yearMaxTv,
+      studioTv,
+    );
+    const rolesPersist = isPlex
+      ? peopleRolesForPlexPersist(tvRoles)
+      : [...tvRoles];
     await patchPrunerScope(instanceId, "tv", {
       missing_primary_media_reported_enabled: missingPrimaryTv,
       watched_tv_reported_enabled: watchedTv,
@@ -519,7 +688,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
       preview_include_people_roles: rolesPersist,
       csrf_token,
     });
-    await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+    await qc.invalidateQueries({
+      queryKey: ["pruner", "instances", instanceId],
+    });
   }
 
   async function persistMovies(): Promise<void> {
@@ -531,8 +702,17 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
     const uwRaw = parseInt(unwatchedDays.trim(), 10);
     const uwOn = Number.isFinite(uwRaw) && uwRaw >= 7;
     const uwDays = uwOn ? Math.max(7, Math.min(3650, uwRaw)) : 90;
-    const filters = buildFilterPatch("movies", genreMovies, yearMinMovies, yearMaxMovies, studioMovies, moviesCollections);
-    const rolesPersist = isPlex ? peopleRolesForPlexPersist(moviesRoles) : [...moviesRoles];
+    const filters = buildFilterPatch(
+      "movies",
+      genreMovies,
+      yearMinMovies,
+      yearMaxMovies,
+      studioMovies,
+      moviesCollections,
+    );
+    const rolesPersist = isPlex
+      ? peopleRolesForPlexPersist(moviesRoles)
+      : [...moviesRoles];
     await patchPrunerScope(instanceId, "movies", {
       missing_primary_media_reported_enabled: missingPrimaryMovies,
       watched_movies_reported_enabled: watchedMovies,
@@ -547,7 +727,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
       ...filters,
       csrf_token,
     });
-    await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+    await qc.invalidateQueries({
+      queryKey: ["pruner", "instances", instanceId],
+    });
   }
 
   async function saveTv() {
@@ -580,17 +762,13 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
     }
   }
 
-  const persistTvRef = useRef(persistTv);
-  persistTvRef.current = persistTv;
-  const persistMoviesRef = useRef(persistMovies);
-  persistMoviesRef.current = persistMovies;
   useImperativeHandle(
     ref,
     () => ({
-      ensureTvSaved: () => persistTvRef.current(),
-      ensureMoviesSaved: () => persistMoviesRef.current(),
+      ensureTvSaved: persistTv,
+      ensureMoviesSaved: persistMovies,
     }),
-    [],
+    [persistMovies, persistTv],
   );
 
   const tvControlsDisabled = !canOperate || busyTv || busyMovies;
@@ -598,7 +776,8 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
   const saveDisabledTv = busyTv || !canOperate || instanceId <= 0;
   const saveDisabledMovies = busyMovies || !canOperate || instanceId <= 0;
 
-  const narrowingLabelClass = "text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]";
+  const narrowingLabelClass =
+    "text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]";
 
   return (
     <div
@@ -606,14 +785,19 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
       data-testid={`pruner-provider-configuration-${provider}`}
       data-provider-section="cleanup"
     >
-        <fieldset
-          disabled={tvControlsDisabled}
-          className="mm-card mm-dash-card min-w-0 border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-5 sm:p-6"
+      <fieldset
+        disabled={tvControlsDisabled}
+        className="mm-card mm-dash-card min-w-0 border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-5 sm:p-6"
+      >
+        <div
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+          data-testid={`pruner-provider-tv-config-${provider}`}
         >
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid={`pruner-provider-tv-config-${provider}`}>
-            <div className="mm-card-action-body min-h-0 flex-1">
+          <div className="mm-card-action-body min-h-0 flex-1">
             <div className="space-y-1 border-b border-[var(--mm-border)] pb-2">
-              <span className="text-sm font-semibold uppercase tracking-wide text-[var(--mm-text1)]">TV</span>
+              <span className="text-sm font-semibold uppercase tracking-wide text-[var(--mm-text1)]">
+                TV
+              </span>
             </div>
             <p className={narrowingLabelClass}>Rules</p>
             {isPlex ? (
@@ -622,7 +806,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 data-testid="pruner-plex-tv-rules-scope-note"
                 role="note"
               >
-                <p className="font-semibold text-amber-100">Plex TV — limited options</p>
+                <p className="font-semibold text-amber-100">
+                  Plex TV — limited options
+                </p>
                 <p className="mt-2 text-sm text-[var(--mm-text2)]">
                   {
                     "Plex doesn't provide a watched signal for TV shows, so only the missing poster rule is available here. Watched TV cleanup is not supported on Plex."
@@ -663,10 +849,15 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               onChange={setMissingPrimaryTv}
             />
 
-            <div className="border-t border-[var(--mm-border)] pt-4 mt-1" aria-hidden="true" />
+            <div
+              className="border-t border-[var(--mm-border)] pt-4 mt-1"
+              aria-hidden="true"
+            />
 
             <div className="space-y-1">
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content in these genres</span>
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content in these genres
+              </span>
               <PrunerGenreMultiSelect
                 value={genreTv}
                 onChange={setGenreTv}
@@ -674,8 +865,13 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 testId={`pruner-rules-genre-tv-${provider}`}
               />
             </div>
-            <label className="block text-sm text-[var(--mm-text2)]" data-testid={`pruner-provider-tv-people-${provider}`}>
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content involving these people</span>
+            <label
+              className="block text-sm text-[var(--mm-text2)]"
+              data-testid={`pruner-provider-tv-people-${provider}`}
+            >
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content involving these people
+              </span>
               <textarea
                 className="mm-input min-h-[6rem] w-full font-sans text-sm"
                 rows={5}
@@ -684,7 +880,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 disabled={tvControlsDisabled}
                 onChange={(e) => setTvPeople(e.target.value)}
               />
-              <span className="mt-1 block text-xs text-[var(--mm-text3)]">Leave empty to skip.</span>
+              <span className="mt-1 block text-xs text-[var(--mm-text3)]">
+                Leave empty to skip.
+              </span>
             </label>
             <PrunerPeopleRoleCheckboxes
               value={tvRoles}
@@ -695,7 +893,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               rolesHeading="Check these credits when matching names"
             />
             <div className="space-y-1">
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content from these studios</span>
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content from these studios
+              </span>
               <PrunerStudioMultiSelect
                 value={studioTv}
                 onChange={setStudioTv}
@@ -714,41 +914,48 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               title="Delete content released in these years"
               helperText="Leave empty to skip."
             />
-
-            </div>
-            <div className="mm-card-action-footer">
-              {canOperate ? (
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: "primary", disabled: saveDisabledTv })}
-                  disabled={saveDisabledTv}
-                  onClick={() => void saveTv()}
-                >
-                  {busyTv ? "Saving…" : "Save TV settings"}
-                </button>
-              ) : null}
-              {msgTv ? (
-                <p className="text-sm text-green-600" role="status">
-                  {msgTv}
-                </p>
-              ) : null}
-              {errTv ? (
-                <p className="text-sm text-red-500" role="alert">
-                  {errTv}
-                </p>
-              ) : null}
-            </div>
           </div>
-        </fieldset>
+          <div className="mm-card-action-footer">
+            {canOperate ? (
+              <button
+                type="button"
+                className={mmActionButtonClass({
+                  variant: "primary",
+                  disabled: saveDisabledTv,
+                })}
+                disabled={saveDisabledTv}
+                onClick={() => void saveTv()}
+              >
+                {busyTv ? "Saving…" : "Save TV settings"}
+              </button>
+            ) : null}
+            {msgTv ? (
+              <p className="text-sm text-green-600" role="status">
+                {msgTv}
+              </p>
+            ) : null}
+            {errTv ? (
+              <p className="text-sm text-red-500" role="alert">
+                {errTv}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </fieldset>
 
-        <fieldset
-          disabled={moviesControlsDisabled}
-          className="mm-card mm-dash-card min-w-0 border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-5 sm:p-6"
+      <fieldset
+        disabled={moviesControlsDisabled}
+        className="mm-card mm-dash-card min-w-0 border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-5 sm:p-6"
+      >
+        <div
+          className="flex min-h-0 min-w-0 flex-1 flex-col"
+          data-testid={`pruner-provider-movies-config-${provider}`}
         >
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col" data-testid={`pruner-provider-movies-config-${provider}`}>
-            <div className="mm-card-action-body min-h-0 flex-1">
+          <div className="mm-card-action-body min-h-0 flex-1">
             <div className="flex items-center gap-2 border-b border-[var(--mm-border)] pb-2">
-              <span className="text-sm font-semibold uppercase tracking-wide text-[var(--mm-text1)]">Movies</span>
+              <span className="text-sm font-semibold uppercase tracking-wide text-[var(--mm-text1)]">
+                Movies
+              </span>
             </div>
             <p className={narrowingLabelClass}>Rules</p>
             <MmOnOffSwitch
@@ -758,7 +965,10 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               disabled={moviesControlsDisabled}
               onChange={setWatchedMovies}
             />
-            <label className="block text-sm text-[var(--mm-text1)]" htmlFor={`pruner-op-mov-lowrating-${provider}`}>
+            <label
+              className="block text-sm text-[var(--mm-text1)]"
+              htmlFor={`pruner-op-mov-lowrating-${provider}`}
+            >
               <span className="mb-1 block text-xs text-[var(--mm-text3)]">
                 {isPlex
                   ? "Delete watched movies rated below this score — uses Plex audience rating (0–10, 0 = off)"
@@ -778,7 +988,8 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
             </label>
             <label className="block text-sm text-[var(--mm-text2)]">
               <span className="mb-1 block text-xs text-[var(--mm-text3)]">
-                Delete movies you have not watched that are older than ___ days (0 = off)
+                Delete movies you have not watched that are older than ___ days
+                (0 = off)
               </span>
               <input
                 type="number"
@@ -800,10 +1011,15 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               />
             ) : null}
 
-            <div className="border-t border-[var(--mm-border)] pt-4 mt-1" aria-hidden="true" />
+            <div
+              className="border-t border-[var(--mm-border)] pt-4 mt-1"
+              aria-hidden="true"
+            />
 
             <div className="space-y-1">
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content in these genres</span>
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content in these genres
+              </span>
               <PrunerGenreMultiSelect
                 value={genreMovies}
                 onChange={setGenreMovies}
@@ -811,8 +1027,13 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 testId={`pruner-rules-genre-movies-${provider}`}
               />
             </div>
-            <label className="block text-sm text-[var(--mm-text2)]" data-testid={`pruner-provider-movies-people-${provider}`}>
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content involving these people</span>
+            <label
+              className="block text-sm text-[var(--mm-text2)]"
+              data-testid={`pruner-provider-movies-people-${provider}`}
+            >
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content involving these people
+              </span>
               <textarea
                 className="mm-input min-h-[6rem] w-full font-sans text-sm"
                 rows={5}
@@ -821,7 +1042,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 disabled={moviesControlsDisabled}
                 onChange={(e) => setMoviesPeople(e.target.value)}
               />
-              <span className="mt-1 block text-xs text-[var(--mm-text3)]">Leave empty to skip.</span>
+              <span className="mt-1 block text-xs text-[var(--mm-text3)]">
+                Leave empty to skip.
+              </span>
             </label>
             <PrunerPeopleRoleCheckboxes
               value={moviesRoles}
@@ -832,7 +1055,9 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
               rolesHeading="Check these credits when matching names"
             />
             <div className="space-y-1">
-              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">Delete content from these studios</span>
+              <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+                Delete content from these studios
+              </span>
               <PrunerStudioMultiSelect
                 value={studioMovies}
                 onChange={setStudioMovies}
@@ -861,36 +1086,37 @@ export const PrunerProviderRulesCard = forwardRef<PrunerProviderRulesCardHandle,
                 disabled={moviesControlsDisabled}
               />
             ) : null}
-
-            </div>
-            <div className="mm-card-action-footer">
-              {canOperate ? (
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: "primary", disabled: saveDisabledMovies })}
-                  disabled={saveDisabledMovies}
-                  onClick={() => void saveMovies()}
-                >
-                  {busyMovies ? "Saving…" : "Save Movies settings"}
-                </button>
-              ) : null}
-              {msgMovies ? (
-                <p className="text-sm text-green-600" role="status">
-                  {msgMovies}
-                </p>
-              ) : null}
-              {errMovies ? (
-                <p className="text-sm text-red-500" role="alert">
-                  {errMovies}
-                </p>
-              ) : null}
-            </div>
           </div>
-        </fieldset>
+          <div className="mm-card-action-footer">
+            {canOperate ? (
+              <button
+                type="button"
+                className={mmActionButtonClass({
+                  variant: "primary",
+                  disabled: saveDisabledMovies,
+                })}
+                disabled={saveDisabledMovies}
+                onClick={() => void saveMovies()}
+              >
+                {busyMovies ? "Saving…" : "Save Movies settings"}
+              </button>
+            ) : null}
+            {msgMovies ? (
+              <p className="text-sm text-green-600" role="status">
+                {msgMovies}
+              </p>
+            ) : null}
+            {errMovies ? (
+              <p className="text-sm text-red-500" role="alert">
+                {errMovies}
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </fieldset>
     </div>
   );
-  },
-);
+});
 
 /**
  * People controls were merged into {@link PrunerProviderRulesCard}. Kept as a no-op export for compatibility with
@@ -917,7 +1143,9 @@ function CommaField({
 }) {
   return (
     <label className="block text-sm text-[var(--mm-text2)]">
-      <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">{label}</span>
+      <span className="mb-1 block text-xs font-medium text-[var(--mm-text3)]">
+        {label}
+      </span>
       <input
         type="text"
         className="mm-input w-full"
@@ -926,7 +1154,9 @@ function CommaField({
         disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
       />
-      <span className="mt-1 block text-xs text-[var(--mm-text3)]">{helper}</span>
+      <span className="mt-1 block text-xs text-[var(--mm-text3)]">
+        {helper}
+      </span>
     </label>
   );
 }
@@ -951,18 +1181,36 @@ function YearRange({
 }) {
   return (
     <div className="space-y-1">
-      <span className="text-xs font-medium text-[var(--mm-text3)]">{title ?? "Only these years"}</span>
+      <span className="text-xs font-medium text-[var(--mm-text3)]">
+        {title ?? "Only these years"}
+      </span>
       <div className="flex flex-wrap items-end gap-3">
         <label className="text-sm text-[var(--mm-text2)]">
           Min year
-          <input type="text" inputMode="numeric" className="mm-input ml-2 w-28" value={min} disabled={disabled} onChange={(e) => onMin(e.target.value)} />
+          <input
+            type="text"
+            inputMode="numeric"
+            className="mm-input ml-2 w-28"
+            value={min}
+            disabled={disabled}
+            onChange={(e) => onMin(e.target.value)}
+          />
         </label>
         <label className="text-sm text-[var(--mm-text2)]">
           Max year
-          <input type="text" inputMode="numeric" className="mm-input ml-2 w-28" value={max} disabled={disabled} onChange={(e) => onMax(e.target.value)} />
+          <input
+            type="text"
+            inputMode="numeric"
+            className="mm-input ml-2 w-28"
+            value={max}
+            disabled={disabled}
+            onChange={(e) => onMax(e.target.value)}
+          />
         </label>
       </div>
-      <p className="text-xs text-[var(--mm-text3)]">{helperText ?? "Leave blank for all years."}</p>
+      <p className="text-xs text-[var(--mm-text3)]">
+        {helperText ?? "Leave blank for all years."}
+      </p>
     </div>
   );
 }

--- a/apps/web/src/pages/pruner/pruner-scope-schedule.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-schedule.test.tsx
@@ -60,10 +60,16 @@ const embyInstance: PrunerServerInstance = {
 
 describe("PrunerScopeTab scheduled preview", () => {
   it("shows per-tab schedule controls without a global shortcut", async () => {
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(embyInstance);
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(embyInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
 
       const router = createMemoryRouter(
@@ -84,12 +90,16 @@ describe("PrunerScopeTab scheduled preview", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-scope-scheduled-preview")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-scope-scheduled-preview"),
+        ).toBeInTheDocument();
       });
       const block = screen.getByTestId("pruner-scope-scheduled-preview");
       expect(block.textContent).toMatch(/TV shows/i);
       expect(block.textContent).not.toMatch(/both scopes/i);
-      expect(screen.getByRole("button", { name: /save tv schedule/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /save tv schedule/i }),
+      ).toBeInTheDocument();
     } finally {
       spyRuns.mockRestore();
       spyInst.mockRestore();

--- a/apps/web/src/pages/pruner/pruner-scope-tab-genre-filters.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-genre-filters.test.tsx
@@ -1,5 +1,11 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import * as authApi from "../../lib/api/auth-api";
@@ -83,16 +89,24 @@ const jf: PrunerServerInstance = {
 
 describe("PrunerScopeTab genre filters", () => {
   it("saves preview_include_genres via scope PATCH", async () => {
-    const csrfSpy = vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf-test");
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jf);
+    const csrfSpy = vi
+      .spyOn(authApi, "fetchCsrfToken")
+      .mockResolvedValue("csrf-test");
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(jf);
     const spyPatch = vi.spyOn(prunerApi, "patchPrunerScope").mockResolvedValue({
       ...jf.scopes[0],
       preview_include_genres: ["Drama", "Noir"],
       preview_include_people: [],
     });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 51], jf);
 
@@ -113,18 +127,32 @@ describe("PrunerScopeTab genre filters", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-genre-filters-panel")).toBeInTheDocument());
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-genre-filters-panel"),
+        ).toBeInTheDocument(),
+      );
       const multi = screen.getByTestId("pruner-genre-multiselect-51-tv");
-      expect(within(multi).queryByRole("button", { name: /^Comedy$/ })).not.toBeInTheDocument();
+      expect(
+        within(multi).queryByRole("button", { name: /^Comedy$/ }),
+      ).not.toBeInTheDocument();
       fireEvent.click(within(multi).getByRole("button", { name: /^Drama$/ }));
-      await waitFor(() => expect(screen.getByRole("option", { name: /^Comedy$/ })).toBeInTheDocument());
+      await waitFor(() =>
+        expect(
+          screen.getByRole("option", { name: /^Comedy$/ }),
+        ).toBeInTheDocument(),
+      );
       fireEvent.click(screen.getByRole("option", { name: /^Comedy$/ }));
-      fireEvent.click(screen.getByRole("button", { name: /save genre filters/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /save genre filters/i }),
+      );
       await waitFor(() => {
         expect(spyPatch).toHaveBeenCalledWith(
           51,
           "tv",
-          expect.objectContaining({ preview_include_genres: ["Drama", "Comedy"] }),
+          expect.objectContaining({
+            preview_include_genres: ["Drama", "Comedy"],
+          }),
         );
       });
     } finally {

--- a/apps/web/src/pages/pruner/pruner-scope-tab-movies-low-rating-stale.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-movies-low-rating-stale.test.tsx
@@ -87,11 +87,19 @@ const jellyfinMovies: PrunerServerInstance = {
 
 describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
   it("queues previews with watched_movie_low_rating_reported and unwatched_movie_stale_reported", async () => {
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jellyfinMovies);
-    const spyPreview = vi.spyOn(prunerApi, "postPrunerPreview").mockResolvedValue({ pruner_job_id: 902 });
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(jellyfinMovies);
+    const spyPreview = vi
+      .spyOn(prunerApi, "postPrunerPreview")
+      .mockResolvedValue({ pruner_job_id: 902 });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 44], jellyfinMovies);
 
@@ -100,7 +108,9 @@ describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/44/movies"] },
@@ -112,14 +122,24 @@ describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-watched-low-rating-panel")).toBeInTheDocument());
-      fireEvent.click(screen.getByRole("button", { name: /Scan for low-score watched movies/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-watched-low-rating-panel"),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /Scan for low-score watched movies/i,
+        }),
+      );
       await waitFor(() => {
         expect(spyPreview).toHaveBeenCalledWith(44, "movies", {
           rule_family_id: RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
         });
       });
-      fireEvent.click(screen.getByRole("button", { name: /Scan for old unwatched movies/i }));
+      fireEvent.click(
+        screen.getByRole("button", { name: /Scan for old unwatched movies/i }),
+      );
       await waitFor(() => {
         expect(spyPreview).toHaveBeenCalledWith(44, "movies", {
           rule_family_id: RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED,
@@ -134,11 +154,19 @@ describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
 
   it("saves low-rating ceiling using Jellyfin/Emby CommunityRating field only (not Plex audienceRating)", async () => {
     vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf-test");
-    const spyPatch = vi.spyOn(prunerApi, "patchPrunerScope").mockResolvedValue(jellyfinMovies.scopes[1]!);
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jellyfinMovies);
+    const spyPatch = vi
+      .spyOn(prunerApi, "patchPrunerScope")
+      .mockResolvedValue(jellyfinMovies.scopes[1]!);
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(jellyfinMovies);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 44], jellyfinMovies);
 
@@ -147,7 +175,9 @@ describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/44/movies"] },
@@ -159,14 +189,25 @@ describe("PrunerScopeTab Movies / low-rating and unwatched stale", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-watched-low-rating-panel")).toBeInTheDocument());
-      fireEvent.click(screen.getByRole("button", { name: /save low-rating rule/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-watched-low-rating-panel"),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /save low-rating rule/i }),
+      );
       await waitFor(() => expect(spyPatch).toHaveBeenCalled());
       const body = spyPatch.mock.calls[0]![2] as Record<string, unknown>;
-      expect(body.watched_movie_low_rating_max_jellyfin_emby_community_rating).toBe(4);
-      expect(Object.prototype.hasOwnProperty.call(body, "watched_movie_low_rating_max_plex_audience_rating")).toBe(
-        false,
-      );
+      expect(
+        body.watched_movie_low_rating_max_jellyfin_emby_community_rating,
+      ).toBe(4);
+      expect(
+        Object.prototype.hasOwnProperty.call(
+          body,
+          "watched_movie_low_rating_max_plex_audience_rating",
+        ),
+      ).toBe(false);
     } finally {
       spyPatch.mockRestore();
       spyRuns.mockRestore();

--- a/apps/web/src/pages/pruner/pruner-scope-tab-movies-watched.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-movies-watched.test.tsx
@@ -83,11 +83,19 @@ const jellyfinMovies: PrunerServerInstance = {
 
 describe("PrunerScopeTab Movies / watched movies", () => {
   it("shows Jellyfin/Emby watched-movies panel and queues preview with watched_movies_reported", async () => {
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jellyfinMovies);
-    const spyPreview = vi.spyOn(prunerApi, "postPrunerPreview").mockResolvedValue({ pruner_job_id: 901 });
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(jellyfinMovies);
+    const spyPreview = vi
+      .spyOn(prunerApi, "postPrunerPreview")
+      .mockResolvedValue({ pruner_job_id: 901 });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 22], jellyfinMovies);
 
@@ -96,7 +104,9 @@ describe("PrunerScopeTab Movies / watched movies", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/22/movies"] },
@@ -108,12 +118,26 @@ describe("PrunerScopeTab Movies / watched movies", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-watched-movies-panel")).toBeInTheDocument());
-      expect(screen.getByTestId("pruner-scope-trust-banner")).toBeInTheDocument();
-      expect(screen.getByTestId("pruner-filters-section-heading").textContent ?? "").toMatch(/optional filters for scans/i);
-      expect(screen.getByTestId("pruner-rules-section-heading").textContent ?? "").toMatch(/cleanup rules/i);
-      expect(screen.getByTestId("pruner-actions-history-heading").textContent ?? "").toMatch(/scan and delete actions/i);
-      fireEvent.click(screen.getByRole("button", { name: /Scan for watched movies/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-watched-movies-panel"),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByTestId("pruner-scope-trust-banner"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-filters-section-heading").textContent ?? "",
+      ).toMatch(/optional filters for scans/i);
+      expect(
+        screen.getByTestId("pruner-rules-section-heading").textContent ?? "",
+      ).toMatch(/cleanup rules/i);
+      expect(
+        screen.getByTestId("pruner-actions-history-heading").textContent ?? "",
+      ).toMatch(/scan and delete actions/i);
+      fireEvent.click(
+        screen.getByRole("button", { name: /Scan for watched movies/i }),
+      );
       await waitFor(() => {
         expect(spyPreview).toHaveBeenCalledWith(22, "movies", {
           rule_family_id: RULE_FAMILY_WATCHED_MOVIES_REPORTED,

--- a/apps/web/src/pages/pruner/pruner-scope-tab-people-filters.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-people-filters.test.tsx
@@ -83,15 +83,23 @@ const jf: PrunerServerInstance = {
 
 describe("PrunerScopeTab people filters", () => {
   it("saves preview_include_people via scope PATCH and shows Jellyfin note", async () => {
-    const csrfSpy = vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf-test");
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jf);
+    const csrfSpy = vi
+      .spyOn(authApi, "fetchCsrfToken")
+      .mockResolvedValue("csrf-test");
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(jf);
     const spyPatch = vi.spyOn(prunerApi, "patchPrunerScope").mockResolvedValue({
       ...jf.scopes[0],
       preview_include_people: ["Ada Lovelace", "Grace Hopper"],
     });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 61], jf);
 
@@ -112,12 +120,24 @@ describe("PrunerScopeTab people filters", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-people-filters-panel")).toBeInTheDocument());
-      expect(screen.getByTestId("pruner-people-jf-emby-note")).toBeInTheDocument();
-      expect(screen.queryByTestId("pruner-people-plex-note")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-people-filters-panel"),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByTestId("pruner-people-jf-emby-note"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("pruner-people-plex-note"),
+      ).not.toBeInTheDocument();
       const input = screen.getByPlaceholderText(/Alex Carter/i);
-      fireEvent.change(input, { target: { value: "Ada Lovelace, Grace Hopper" } });
-      fireEvent.click(screen.getByRole("button", { name: /save people filters/i }));
+      fireEvent.change(input, {
+        target: { value: "Ada Lovelace, Grace Hopper" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /save people filters/i }),
+      );
       await waitFor(() => {
         expect(spyPatch).toHaveBeenCalledWith(
           61,
@@ -205,10 +225,16 @@ describe("PrunerScopeTab people filters", () => {
         },
       ],
     };
-    const spyRuns = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plex);
+    const spyRuns = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plex);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 62], plex);
 
@@ -229,9 +255,17 @@ describe("PrunerScopeTab people filters", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-people-plex-note")).toBeInTheDocument());
-      expect(screen.getByTestId("pruner-people-plex-note").textContent).toMatch(/Role|Writer|Director|allLeaves/i);
-      expect(screen.queryByTestId("pruner-people-jf-emby-note")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-people-plex-note"),
+        ).toBeInTheDocument(),
+      );
+      expect(screen.getByTestId("pruner-people-plex-note").textContent).toMatch(
+        /Role|Writer|Director|allLeaves/i,
+      );
+      expect(
+        screen.queryByTestId("pruner-people-jf-emby-note"),
+      ).not.toBeInTheDocument();
     } finally {
       spyRuns.mockRestore();
       spyInst.mockRestore();

--- a/apps/web/src/pages/pruner/pruner-scope-tab-plex.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-plex.test.tsx
@@ -87,10 +87,16 @@ const plexInstance: PrunerServerInstance = {
 
 describe("PrunerScopeTab (Plex)", () => {
   it("Movies tab: shows watched / low-rating / unwatched stale panels for Plex (allLeaves-backed)", async () => {
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -99,7 +105,9 @@ describe("PrunerScopeTab (Plex)", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/9/movies"] },
@@ -112,12 +120,22 @@ describe("PrunerScopeTab (Plex)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-watched-movies-panel")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-watched-movies-panel"),
+        ).toBeInTheDocument();
       });
-      expect(screen.getByTestId("pruner-scope-trust-banner")).toBeInTheDocument();
-      expect(screen.getByTestId("pruner-watched-low-rating-panel")).toBeInTheDocument();
-      expect(screen.getByTestId("pruner-unwatched-stale-panel")).toBeInTheDocument();
-      expect(screen.getByTestId("pruner-watched-low-rating-panel").textContent ?? "").toMatch(/audience rating/i);
+      expect(
+        screen.getByTestId("pruner-scope-trust-banner"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-watched-low-rating-panel"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-unwatched-stale-panel"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-watched-low-rating-panel").textContent ?? "",
+      ).toMatch(/audience rating/i);
     } finally {
       spy.mockRestore();
       spyInst.mockRestore();
@@ -125,10 +143,16 @@ describe("PrunerScopeTab (Plex)", () => {
   });
 
   it("uses preview-first flow for missing primary: queue enabled, no live-only surface, other rules called out", async () => {
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -150,13 +174,25 @@ describe("PrunerScopeTab (Plex)", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-plex-other-rules-note")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-plex-other-rules-note"),
+        ).toBeInTheDocument();
       });
-      expect(screen.queryByTestId("pruner-plex-live-surface")).not.toBeInTheDocument();
-      expect(screen.getByTestId("pruner-plex-genre-empty-preview-note")).toBeInTheDocument();
-      expect(screen.getByTestId("pruner-plex-genre-empty-preview-note").textContent).toMatch(/nothing listed/i);
-      expect(screen.getByTestId("pruner-plex-other-rules-note").textContent).toMatch(/Plex does not support/i);
-      const btn = screen.getByRole("button", { name: /Scan for broken posters/i });
+      expect(
+        screen.queryByTestId("pruner-plex-live-surface"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-plex-genre-empty-preview-note"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("pruner-plex-genre-empty-preview-note").textContent,
+      ).toMatch(/nothing listed/i);
+      expect(
+        screen.getByTestId("pruner-plex-other-rules-note").textContent,
+      ).toMatch(/Plex does not support/i);
+      const btn = screen.getByRole("button", {
+        name: /Scan for broken posters/i,
+      });
       expect(btn).not.toBeDisabled();
     } finally {
       spy.mockRestore();
@@ -166,24 +202,30 @@ describe("PrunerScopeTab (Plex)", () => {
 
   it("shows apply-from-preview for Plex only when snapshot is missing-primary success with candidates", async () => {
     const runId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([
-      {
-        preview_run_id: runId,
-        server_instance_id: 9,
-        media_scope: "tv",
-        rule_family_id: RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-        pruner_job_id: 1,
-        candidate_count: 2,
-        truncated: false,
-        outcome: "success",
-        unsupported_detail: null,
-        error_message: null,
-        created_at: new Date().toISOString(),
-      },
-    ]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([
+        {
+          preview_run_id: runId,
+          server_instance_id: 9,
+          media_scope: "tv",
+          rule_family_id: RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+          pruner_job_id: 1,
+          candidate_count: 2,
+          truncated: false,
+          outcome: "success",
+          unsupported_detail: null,
+          error_message: null,
+          created_at: new Date().toISOString(),
+        },
+      ]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -204,7 +246,11 @@ describe("PrunerScopeTab (Plex)", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId(`pruner-apply-open-${runId}`)).toBeInTheDocument());
+      await waitFor(() =>
+        expect(
+          screen.getByTestId(`pruner-apply-open-${runId}`),
+        ).toBeInTheDocument(),
+      );
     } finally {
       spy.mockRestore();
       spyInst.mockRestore();
@@ -214,39 +260,45 @@ describe("PrunerScopeTab (Plex)", () => {
   it("Plex: never_played_stale_reported and watched_tv_reported preview rows stay unsupported (no apply)", async () => {
     const neverId = "bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee";
     const watchedId = "cccccccc-bbbb-cccc-dddd-eeeeeeeeeeee";
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([
-      {
-        preview_run_id: neverId,
-        server_instance_id: 9,
-        media_scope: "tv",
-        rule_family_id: "never_played_stale_reported",
-        pruner_job_id: 2,
-        candidate_count: 0,
-        truncated: false,
-        outcome: "unsupported",
-        unsupported_detail:
-          "Plex: never-played stale library candidacy is not implemented on MediaMop (Jellyfin/Emby only for this rule).",
-        error_message: null,
-        created_at: new Date().toISOString(),
-      },
-      {
-        preview_run_id: watchedId,
-        server_instance_id: 9,
-        media_scope: "tv",
-        rule_family_id: RULE_FAMILY_WATCHED_TV_REPORTED,
-        pruner_job_id: 3,
-        candidate_count: 0,
-        truncated: false,
-        outcome: "unsupported",
-        unsupported_detail:
-          "Plex: watched TV preview is not implemented on MediaMop in this release (Jellyfin/Emby only).",
-        error_message: null,
-        created_at: new Date().toISOString(),
-      },
-    ]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([
+        {
+          preview_run_id: neverId,
+          server_instance_id: 9,
+          media_scope: "tv",
+          rule_family_id: "never_played_stale_reported",
+          pruner_job_id: 2,
+          candidate_count: 0,
+          truncated: false,
+          outcome: "unsupported",
+          unsupported_detail:
+            "Plex: never-played stale library candidacy is not implemented on MediaMop (Jellyfin/Emby only for this rule).",
+          error_message: null,
+          created_at: new Date().toISOString(),
+        },
+        {
+          preview_run_id: watchedId,
+          server_instance_id: 9,
+          media_scope: "tv",
+          rule_family_id: RULE_FAMILY_WATCHED_TV_REPORTED,
+          pruner_job_id: 3,
+          candidate_count: 0,
+          truncated: false,
+          outcome: "unsupported",
+          unsupported_detail:
+            "Plex: watched TV preview is not implemented on MediaMop in this release (Jellyfin/Emby only).",
+          error_message: null,
+          created_at: new Date().toISOString(),
+        },
+      ]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -267,14 +319,30 @@ describe("PrunerScopeTab (Plex)", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByText(/Delete never-started TV or movies/i)).toBeInTheDocument());
-      await waitFor(() => expect(screen.getByText(/Delete watched TV episodes/i)).toBeInTheDocument());
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Delete never-started TV or movies/i),
+        ).toBeInTheDocument(),
+      );
+      await waitFor(() =>
+        expect(
+          screen.getByText(/Delete watched TV episodes/i),
+        ).toBeInTheDocument(),
+      );
       expect(
-        screen.getAllByText(/never-played stale library candidacy is not implemented/i).length,
+        screen.getAllByText(
+          /never-played stale library candidacy is not implemented/i,
+        ).length,
       ).toBeGreaterThanOrEqual(1);
-      expect(screen.getAllByText(/watched TV preview is not implemented/i).length).toBeGreaterThanOrEqual(1);
-      expect(screen.queryByTestId(`pruner-apply-open-${neverId}`)).not.toBeInTheDocument();
-      expect(screen.queryByTestId(`pruner-apply-open-${watchedId}`)).not.toBeInTheDocument();
+      expect(
+        screen.getAllByText(/watched TV preview is not implemented/i).length,
+      ).toBeGreaterThanOrEqual(1);
+      expect(
+        screen.queryByTestId(`pruner-apply-open-${neverId}`),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`pruner-apply-open-${watchedId}`),
+      ).not.toBeInTheDocument();
     } finally {
       spy.mockRestore();
       spyInst.mockRestore();
@@ -282,10 +350,16 @@ describe("PrunerScopeTab (Plex)", () => {
   });
 
   it("shows Plex missing-primary preview cap note for operators", async () => {
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -306,8 +380,13 @@ describe("PrunerScopeTab (Plex)", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-plex-preview-cap-note")).toBeInTheDocument());
-      const note = screen.getByTestId("pruner-plex-preview-cap-note").textContent ?? "";
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-plex-preview-cap-note"),
+        ).toBeInTheDocument(),
+      );
+      const note =
+        screen.getByTestId("pruner-plex-preview-cap-note").textContent ?? "";
       expect(note).toMatch(/per-tab item limit/i);
       expect(note).toMatch(/built-in safety cap/i);
     } finally {
@@ -317,10 +396,16 @@ describe("PrunerScopeTab (Plex)", () => {
   });
 
   it("does not render Jellyfin-only never-played panel for Plex", async () => {
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -341,8 +426,14 @@ describe("PrunerScopeTab (Plex)", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-plex-other-rules-note")).toBeInTheDocument());
-      expect(screen.queryByTestId("pruner-never-played-stale-panel")).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-plex-other-rules-note"),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.queryByTestId("pruner-never-played-stale-panel"),
+      ).not.toBeInTheDocument();
     } finally {
       spy.mockRestore();
       spyInst.mockRestore();
@@ -351,11 +442,19 @@ describe("PrunerScopeTab (Plex)", () => {
 
   it("saves low-rating ceiling using Plex audienceRating field only (not Jellyfin/Emby CommunityRating)", async () => {
     vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf-test");
-    const spyPatch = vi.spyOn(prunerApi, "patchPrunerScope").mockResolvedValue(plexInstance.scopes[1]!);
-    const spy = vi.spyOn(prunerApi, "fetchPrunerPreviewRuns").mockResolvedValue([]);
-    const spyInst = vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(plexInstance);
+    const spyPatch = vi
+      .spyOn(prunerApi, "patchPrunerScope")
+      .mockResolvedValue(plexInstance.scopes[1]!);
+    const spy = vi
+      .spyOn(prunerApi, "fetchPrunerPreviewRuns")
+      .mockResolvedValue([]);
+    const spyInst = vi
+      .spyOn(prunerApi, "fetchPrunerInstance")
+      .mockResolvedValue(plexInstance);
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 9], plexInstance);
 
@@ -364,7 +463,9 @@ describe("PrunerScopeTab (Plex)", () => {
           {
             path: "/instances/:instanceId",
             element: <PrunerInstanceShell />,
-            children: [{ path: "movies", element: <PrunerScopeTab scope="movies" /> }],
+            children: [
+              { path: "movies", element: <PrunerScopeTab scope="movies" /> },
+            ],
           },
         ],
         { initialEntries: ["/instances/9/movies"] },
@@ -376,13 +477,22 @@ describe("PrunerScopeTab (Plex)", () => {
         </QueryClientProvider>,
       );
 
-      await waitFor(() => expect(screen.getByTestId("pruner-watched-low-rating-panel")).toBeInTheDocument());
-      fireEvent.click(screen.getByRole("button", { name: /save low-rating rule/i }));
+      await waitFor(() =>
+        expect(
+          screen.getByTestId("pruner-watched-low-rating-panel"),
+        ).toBeInTheDocument(),
+      );
+      fireEvent.click(
+        screen.getByRole("button", { name: /save low-rating rule/i }),
+      );
       await waitFor(() => expect(spyPatch).toHaveBeenCalled());
       const body = spyPatch.mock.calls[0]![2] as Record<string, unknown>;
       expect(body.watched_movie_low_rating_max_plex_audience_rating).toBe(4);
       expect(
-        Object.prototype.hasOwnProperty.call(body, "watched_movie_low_rating_max_jellyfin_emby_community_rating"),
+        Object.prototype.hasOwnProperty.call(
+          body,
+          "watched_movie_low_rating_max_jellyfin_emby_community_rating",
+        ),
       ).toBe(false);
     } finally {
       spyPatch.mockRestore();

--- a/apps/web/src/pages/pruner/pruner-scope-tab-sections.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-sections.tsx
@@ -22,9 +22,16 @@ export function PrunerApplySection({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
-export function PrunerProviderSection({ scope, section, children }: ProviderSectionProps) {
+export function PrunerProviderSection({
+  scope,
+  section,
+  children,
+}: ProviderSectionProps) {
   return (
-    <section className="flex min-h-0 w-full min-w-0 flex-1 flex-col" data-testid={`pruner-provider-subsection-${section}-${scope}`}>
+    <section
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col"
+      data-testid={`pruner-provider-subsection-${section}-${scope}`}
+    >
       {children}
     </section>
   );

--- a/apps/web/src/pages/pruner/pruner-scope-tab-year-studio-collection.test.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab-year-studio-collection.test.tsx
@@ -53,7 +53,10 @@ const jellyfin: PrunerServerInstance = {
   last_connection_test_at: null,
   last_connection_test_ok: null,
   last_connection_test_detail: null,
-  scopes: [scopeBase({ media_scope: "tv" }), scopeBase({ media_scope: "movies" })],
+  scopes: [
+    scopeBase({ media_scope: "tv" }),
+    scopeBase({ media_scope: "movies" }),
+  ],
 };
 
 const plex: PrunerServerInstance = {
@@ -65,7 +68,10 @@ const plex: PrunerServerInstance = {
   last_connection_test_at: null,
   last_connection_test_ok: null,
   last_connection_test_detail: null,
-  scopes: [scopeBase({ media_scope: "tv" }), scopeBase({ media_scope: "movies" })],
+  scopes: [
+    scopeBase({ media_scope: "tv" }),
+    scopeBase({ media_scope: "movies" }),
+  ],
 };
 
 describe("PrunerScopeTab year / studio / collection preview filters", () => {
@@ -80,7 +86,9 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
       preview_include_studios: ["Acme"],
     });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 71], jellyfin);
 
@@ -102,13 +110,23 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-year-filters-panel")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-year-filters-panel"),
+        ).toBeInTheDocument();
       });
-      expect(screen.queryByTestId("pruner-collection-preview-panel")).toBeNull();
+      expect(
+        screen.queryByTestId("pruner-collection-preview-panel"),
+      ).toBeNull();
 
-      fireEvent.change(screen.getByRole("spinbutton", { name: /min year/i }), { target: { value: "2010" } });
-      fireEvent.change(screen.getByRole("spinbutton", { name: /max year/i }), { target: { value: "2020" } });
-      fireEvent.click(screen.getByRole("button", { name: /save year bounds/i }));
+      fireEvent.change(screen.getByRole("spinbutton", { name: /min year/i }), {
+        target: { value: "2010" },
+      });
+      fireEvent.change(screen.getByRole("spinbutton", { name: /max year/i }), {
+        target: { value: "2020" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /save year bounds/i }),
+      );
 
       await waitFor(() => {
         expect(spyPatch).toHaveBeenCalledWith(
@@ -122,8 +140,12 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
         );
       });
 
-      fireEvent.change(screen.getByPlaceholderText(/warner bros/i), { target: { value: "Acme" } });
-      fireEvent.click(screen.getByRole("button", { name: /save studio filters/i }));
+      fireEvent.change(screen.getByPlaceholderText(/warner bros/i), {
+        target: { value: "Acme" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /save studio filters/i }),
+      );
 
       await waitFor(() => {
         expect(spyPatch).toHaveBeenCalledWith(
@@ -149,7 +171,9 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
       preview_include_collections: ["MCU"],
     });
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 72], plex);
 
@@ -171,12 +195,20 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-collection-preview-panel")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-collection-preview-panel"),
+        ).toBeInTheDocument();
       });
-      expect(screen.getByText(/Comma-separated collection names/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Comma-separated collection names/i),
+      ).toBeInTheDocument();
 
-      fireEvent.change(screen.getByPlaceholderText(/marvel cinematic/i), { target: { value: "MCU" } });
-      fireEvent.click(screen.getByRole("button", { name: /save collection filters/i }));
+      fireEvent.change(screen.getByPlaceholderText(/marvel cinematic/i), {
+        target: { value: "MCU" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /save collection filters/i }),
+      );
 
       await waitFor(() => {
         expect(spyPatch).toHaveBeenCalledWith(
@@ -199,7 +231,9 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
     vi.spyOn(prunerApi, "fetchPrunerInstance").mockResolvedValue(jellyfin);
     const spyPatch = vi.spyOn(prunerApi, "patchPrunerScope");
     try {
-      const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       qc.setQueryData(qk.me, operator);
       qc.setQueryData(["pruner", "instances", 71], jellyfin);
 
@@ -221,14 +255,22 @@ describe("PrunerScopeTab year / studio / collection preview filters", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByTestId("pruner-year-filters-panel")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("pruner-year-filters-panel"),
+        ).toBeInTheDocument();
       });
 
-      fireEvent.change(screen.getByRole("spinbutton", { name: /min year/i }), { target: { value: "20.5" } });
-      fireEvent.click(screen.getByRole("button", { name: /save year bounds/i }));
+      fireEvent.change(screen.getByRole("spinbutton", { name: /min year/i }), {
+        target: { value: "20.5" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /save year bounds/i }),
+      );
 
       await waitFor(() => {
-        expect(screen.getByText(/whole number between 1900 and 2100/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/whole number between 1900 and 2100/i),
+        ).toBeInTheDocument();
       });
       expect(spyPatch).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/pages/pruner/pruner-scope-tab.tsx
+++ b/apps/web/src/pages/pruner/pruner-scope-tab.tsx
@@ -33,7 +33,10 @@ import {
   PRUNER_RUN_INTERVAL_MIN_MINUTES,
 } from "../../lib/ui/pruner-schedule-interval";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
-import { PrunerGenreMultiSelect, prunerGenresFromApi } from "./pruner-genre-multi-select";
+import {
+  PrunerGenreMultiSelect,
+  prunerGenresFromApi,
+} from "./pruner-genre-multi-select";
 import {
   PrunerPeopleRoleCheckboxes,
   normalizePeopleRolesFromApi,
@@ -51,9 +54,13 @@ function canApplyFromPreviewSnapshot(
   provider: string | undefined,
   row: { outcome: string; candidate_count: number; rule_family_id: string },
 ): boolean {
-  if (!provider || row.outcome !== "success" || row.candidate_count <= 0) return false;
+  if (!provider || row.outcome !== "success" || row.candidate_count <= 0)
+    return false;
   if (provider === "jellyfin" || provider === "emby") return true;
-  return provider === "plex" && row.rule_family_id === RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED;
+  return (
+    provider === "plex" &&
+    row.rule_family_id === RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED
+  );
 }
 
 export function PrunerScopeTab(props: {
@@ -76,7 +83,9 @@ export function PrunerScopeTab(props: {
   const [jsonPreview, setJsonPreview] = useState<string | null>(null);
   const [schedEnabled, setSchedEnabled] = useState(false);
   const [schedIntervalSec, setSchedIntervalSec] = useState(3600);
-  const [schedIntervalMinDraft, setSchedIntervalMinDraft] = useState<string | null>(null);
+  const [schedIntervalMinDraft, setSchedIntervalMinDraft] = useState<
+    string | null
+  >(null);
   const [schedHoursLimited, setSchedHoursLimited] = useState(false);
   const [schedDays, setSchedDays] = useState("");
   const [schedStart, setSchedStart] = useState("00:00");
@@ -96,7 +105,9 @@ export function PrunerScopeTab(props: {
   const [lowRatingMsg, setLowRatingMsg] = useState<string | null>(null);
   const [unwatchedStaleEnabled, setUnwatchedStaleEnabled] = useState(false);
   const [unwatchedStaleDays, setUnwatchedStaleDays] = useState(90);
-  const [unwatchedStaleMsg, setUnwatchedStaleMsg] = useState<string | null>(null);
+  const [unwatchedStaleMsg, setUnwatchedStaleMsg] = useState<string | null>(
+    null,
+  );
   const [genreSelection, setGenreSelection] = useState<string[]>([]);
   const [genreMsg, setGenreMsg] = useState<string | null>(null);
   const [peopleText, setPeopleText] = useState("");
@@ -110,12 +121,15 @@ export function PrunerScopeTab(props: {
   const [collectionText, setCollectionText] = useState("");
   const [collectionMsg, setCollectionMsg] = useState<string | null>(null);
   const [previewMaxItems, setPreviewMaxItems] = useState(500);
-  const [previewMaxItemsMsg, setPreviewMaxItemsMsg] = useState<string | null>(null);
+  const [previewMaxItemsMsg, setPreviewMaxItemsMsg] = useState<string | null>(
+    null,
+  );
   const [bundleMsg, setBundleMsg] = useState<string | null>(null);
   /** Provider Rules: single inputs (0 = off) mapped to never-played / low-rating / unwatched stale. */
   const [rulesTvOlderDaysStr, setRulesTvOlderDaysStr] = useState("0");
   const [rulesMoviesLowRatingStr, setRulesMoviesLowRatingStr] = useState("0");
-  const [rulesMoviesUnwatchedDaysStr, setRulesMoviesUnwatchedDaysStr] = useState("0");
+  const [rulesMoviesUnwatchedDaysStr, setRulesMoviesUnwatchedDaysStr] =
+    useState("0");
   const isProvider = props.variant === "provider";
   const provSub = props.providerSubSection;
   const canOperate = me.data?.role === "admin" || me.data?.role === "operator";
@@ -127,25 +141,47 @@ export function PrunerScopeTab(props: {
   const libraryTabPhrase = props.scope === "tv" ? "TV tab" : "Movies tab";
 
   function ruleFamilyColumnLabel(id: string): string {
-    if (id === RULE_FAMILY_WATCHED_TV_REPORTED) return "Delete watched TV episodes";
-    if (id === RULE_FAMILY_WATCHED_MOVIES_REPORTED) return "Delete watched movies";
-    if (id === RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED) return "Delete watched movies below your score";
-    if (id === RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED) return "Delete unwatched movies older than your age setting";
-    if (id === RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED) return "Delete never-started TV or movies older than your age setting";
-    if (id === RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED) return "Delete items missing a main poster or episode image";
+    if (id === RULE_FAMILY_WATCHED_TV_REPORTED)
+      return "Delete watched TV episodes";
+    if (id === RULE_FAMILY_WATCHED_MOVIES_REPORTED)
+      return "Delete watched movies";
+    if (id === RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED)
+      return "Delete watched movies below your score";
+    if (id === RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED)
+      return "Delete unwatched movies older than your age setting";
+    if (id === RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED)
+      return "Delete never-started TV or movies older than your age setting";
+    if (id === RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED)
+      return "Delete items missing a main poster or episode image";
     return "This cleanup type";
   }
 
-  const previewRunsQueryKey = ["pruner", "preview-runs", instanceId, props.scope] as const;
+  const previewRunsQueryKey = [
+    "pruner",
+    "preview-runs",
+    instanceId,
+    props.scope,
+  ] as const;
   const runsQuery = useQuery({
     queryKey: previewRunsQueryKey,
-    queryFn: () => fetchPrunerPreviewRuns(instanceId, { media_scope: props.scope, limit: 25 }),
+    queryFn: () =>
+      fetchPrunerPreviewRuns(instanceId, {
+        media_scope: props.scope,
+        limit: 25,
+      }),
     enabled: !isProvider && Boolean(instanceId),
   });
 
   const applyEligQuery = useQuery({
-    queryKey: ["pruner", "apply-eligibility", instanceId, props.scope, applyModalRunId] as const,
-    queryFn: () => fetchPrunerApplyEligibility(instanceId, props.scope, applyModalRunId!),
+    queryKey: [
+      "pruner",
+      "apply-eligibility",
+      instanceId,
+      props.scope,
+      applyModalRunId,
+    ] as const,
+    queryFn: () =>
+      fetchPrunerApplyEligibility(instanceId, props.scope, applyModalRunId!),
     enabled: Boolean(instanceId && applyModalRunId),
   });
 
@@ -180,16 +216,28 @@ export function PrunerScopeTab(props: {
     setGenreSelection(prunerGenresFromApi(scopeRow.preview_include_genres));
     setPeopleText((scopeRow.preview_include_people ?? []).join(", "));
     setPeopleRoles(
-      isPlex ? peopleRolesForPlexUiState(scopeRow.preview_include_people_roles) : normalizePeopleRolesFromApi(scopeRow.preview_include_people_roles),
+      isPlex
+        ? peopleRolesForPlexUiState(scopeRow.preview_include_people_roles)
+        : normalizePeopleRolesFromApi(scopeRow.preview_include_people_roles),
     );
-    setYearMinStr(scopeRow.preview_year_min != null ? String(scopeRow.preview_year_min) : "");
-    setYearMaxStr(scopeRow.preview_year_max != null ? String(scopeRow.preview_year_max) : "");
+    setYearMinStr(
+      scopeRow.preview_year_min != null
+        ? String(scopeRow.preview_year_min)
+        : "",
+    );
+    setYearMaxStr(
+      scopeRow.preview_year_max != null
+        ? String(scopeRow.preview_year_max)
+        : "",
+    );
     setStudioText((scopeRow.preview_include_studios ?? []).join(", "));
     setCollectionText((scopeRow.preview_include_collections ?? []).join(", "));
     setPreviewMaxItems(scopeRow.preview_max_items);
     if (props.scope === "tv") {
       setRulesTvOlderDaysStr(
-        !scopeRow.never_played_stale_reported_enabled ? "0" : String(scopeRow.never_played_min_age_days),
+        !scopeRow.never_played_stale_reported_enabled
+          ? "0"
+          : String(scopeRow.never_played_min_age_days),
       );
     }
     if (props.scope === "movies") {
@@ -203,7 +251,9 @@ export function PrunerScopeTab(props: {
             ),
       );
       setRulesMoviesUnwatchedDaysStr(
-        !scopeRow.unwatched_movie_stale_reported_enabled ? "0" : String(scopeRow.unwatched_movie_stale_min_age_days),
+        !scopeRow.unwatched_movie_stale_reported_enabled
+          ? "0"
+          : String(scopeRow.unwatched_movie_stale_min_age_days),
       );
     }
   }, [
@@ -244,7 +294,10 @@ export function PrunerScopeTab(props: {
       const csrf_token = await fetchCsrfToken();
       const resolvedSec =
         schedIntervalMinDraft !== null
-          ? finalizePrunerRunIntervalMinutesDraft(schedIntervalMinDraft, schedIntervalSec)
+          ? finalizePrunerRunIntervalMinutesDraft(
+              schedIntervalMinDraft,
+              schedIntervalSec,
+            )
           : schedIntervalSec;
       const iv = Math.max(60, Math.min(86400, resolvedSec));
       await patchPrunerScope(instanceId, props.scope, {
@@ -258,8 +311,12 @@ export function PrunerScopeTab(props: {
       });
       setSchedIntervalMinDraft(null);
       setSchedIntervalSec(iv);
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setSchedMsg(`Saved. Automatic scans use this server’s ${libraryTabPhrase} only.`);
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setSchedMsg(
+        `Saved. Automatic scans use this server’s ${libraryTabPhrase} only.`,
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -278,8 +335,12 @@ export function PrunerScopeTab(props: {
         preview_max_items: v,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setPreviewMaxItemsMsg("Saved how many items each scan may check for this library.");
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setPreviewMaxItemsMsg(
+        "Saved how many items each scan may check for this library.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -299,8 +360,12 @@ export function PrunerScopeTab(props: {
         never_played_min_age_days: d,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setStaleNeverMsg("Saved never-watched TV and movie age settings for this library.");
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setStaleNeverMsg(
+        "Saved never-watched TV and movie age settings for this library.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -319,7 +384,9 @@ export function PrunerScopeTab(props: {
         preview_include_genres: tokens,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setGenreMsg(
         tokens.length
           ? "Saved your genre picks for this library."
@@ -344,10 +411,14 @@ export function PrunerScopeTab(props: {
         .filter(Boolean);
       await patchPrunerScope(instanceId, props.scope, {
         preview_include_people: tokens,
-        preview_include_people_roles: isPlex ? peopleRolesForPlexPersist(peopleRoles) : [...peopleRoles],
+        preview_include_people_roles: isPlex
+          ? peopleRolesForPlexPersist(peopleRoles)
+          : [...peopleRoles],
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setPeopleMsg(
         tokens.length
           ? "Saved name filters for this library."
@@ -376,7 +447,9 @@ export function PrunerScopeTab(props: {
       const yMin = parseBound(yearMinStr);
       const yMax = parseBound(yearMaxStr);
       if (yMin === "bad" || yMax === "bad") {
-        setErr("Each year must be a whole number between 1900 and 2100, or left empty.");
+        setErr(
+          "Each year must be a whole number between 1900 and 2100, or left empty.",
+        );
         return;
       }
       if (yMin != null && yMax != null && yMin > yMax) {
@@ -388,7 +461,9 @@ export function PrunerScopeTab(props: {
         preview_year_max: yearMaxStr.trim() ? yMax : null,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setYearMsg("Saved release year limits for this library.");
     } catch (e) {
       setErr((e as Error).message);
@@ -411,7 +486,9 @@ export function PrunerScopeTab(props: {
         preview_include_studios: tokens,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setStudioMsg(
         tokens.length
           ? "Saved studio filters for this library."
@@ -438,7 +515,9 @@ export function PrunerScopeTab(props: {
         preview_include_collections: tokens,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setCollectionMsg(
         tokens.length
           ? "Saved collection filters for this library."
@@ -461,8 +540,12 @@ export function PrunerScopeTab(props: {
         watched_movies_reported_enabled: watchedMoviesEnabled,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setWatchedMoviesMsg("Saved watched-movie cleanup setting for this library.");
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setWatchedMoviesMsg(
+        "Saved watched-movie cleanup setting for this library.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -476,15 +559,22 @@ export function PrunerScopeTab(props: {
     setBusy(true);
     try {
       const csrf_token = await fetchCsrfToken();
-      const cap = Math.max(0, Math.min(10, Number.parseFloat(lowRatingMax) || 4));
+      const cap = Math.max(
+        0,
+        Math.min(10, Number.parseFloat(lowRatingMax) || 4),
+      );
       await patchPrunerScope(instanceId, props.scope, {
         watched_movie_low_rating_reported_enabled: lowRatingEnabled,
         ...(instance?.provider === "plex"
           ? { watched_movie_low_rating_max_plex_audience_rating: cap }
-          : { watched_movie_low_rating_max_jellyfin_emby_community_rating: cap }),
+          : {
+              watched_movie_low_rating_max_jellyfin_emby_community_rating: cap,
+            }),
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setLowRatingMsg(
         instance?.provider === "plex"
           ? "Saved low-score watched-movie setting (Plex audience rating)."
@@ -509,7 +599,9 @@ export function PrunerScopeTab(props: {
         unwatched_movie_stale_min_age_days: d,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setUnwatchedStaleMsg(
         instance?.provider === "plex"
           ? "Saved old unwatched movie setting (uses when Plex says the title was added)."
@@ -532,7 +624,9 @@ export function PrunerScopeTab(props: {
         watched_tv_reported_enabled: watchedTvEnabled,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setWatchedTvMsg("Saved watched-TV cleanup setting for this library.");
     } catch (e) {
       setErr((e as Error).message);
@@ -547,9 +641,13 @@ export function PrunerScopeTab(props: {
     setPreview(null);
     try {
       await postPrunerPreview(instanceId, props.scope);
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for broken posters and images started. The table below updates when results are ready.");
+      setPreview(
+        "Scan for broken posters and images started. The table below updates when results are ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -565,9 +663,13 @@ export function PrunerScopeTab(props: {
       await postPrunerPreview(instanceId, props.scope, {
         rule_family_id: RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for unwatched TV or movies older than your setting started. The table below updates when ready.");
+      setPreview(
+        "Scan for unwatched TV or movies older than your setting started. The table below updates when ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -583,9 +685,13 @@ export function PrunerScopeTab(props: {
       await postPrunerPreview(instanceId, props.scope, {
         rule_family_id: RULE_FAMILY_WATCHED_MOVIES_REPORTED,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for watched movies started. The table below updates when ready.");
+      setPreview(
+        "Scan for watched movies started. The table below updates when ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -601,9 +707,13 @@ export function PrunerScopeTab(props: {
       await postPrunerPreview(instanceId, props.scope, {
         rule_family_id: RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for low-score watched movies started. The table below updates when ready.");
+      setPreview(
+        "Scan for low-score watched movies started. The table below updates when ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -619,9 +729,13 @@ export function PrunerScopeTab(props: {
       await postPrunerPreview(instanceId, props.scope, {
         rule_family_id: RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for old unwatched movies started. The table below updates when ready.");
+      setPreview(
+        "Scan for old unwatched movies started. The table below updates when ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -637,9 +751,13 @@ export function PrunerScopeTab(props: {
       await postPrunerPreview(instanceId, props.scope, {
         rule_family_id: RULE_FAMILY_WATCHED_TV_REPORTED,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
-      setPreview("Scan for watched TV shows started. The table below updates when ready.");
+      setPreview(
+        "Scan for watched TV shows started. The table below updates when ready.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -663,7 +781,8 @@ export function PrunerScopeTab(props: {
     const elig = applyEligQuery.data;
     if (!elig) return;
     const opLabel =
-      elig.apply_operator_label || prunerApplyLabelForRuleFamily(elig.rule_family_id);
+      elig.apply_operator_label ||
+      prunerApplyLabelForRuleFamily(elig.rule_family_id);
     setErr(null);
     setBusy(true);
     try {
@@ -671,7 +790,9 @@ export function PrunerScopeTab(props: {
       await qc.invalidateQueries({ queryKey: previewRunsQueryKey });
       await qc.invalidateQueries({ queryKey: ["activity"] });
       closeApplyModal();
-      setPreview(`Deletion started (${opLabel}). Check Activity for removed, skipped, and failed counts.`);
+      setPreview(
+        `Deletion started (${opLabel}). Check Activity for removed, skipped, and failed counts.`,
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -717,7 +838,9 @@ export function PrunerScopeTab(props: {
         never_played_min_age_days: tvStaleDays,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setBundleMsg("Saved TV rules.");
     } catch (e) {
       setErr((e as Error).message);
@@ -744,12 +867,16 @@ export function PrunerScopeTab(props: {
         watched_movie_low_rating_reported_enabled: lowOn,
         ...(instance?.provider === "plex"
           ? { watched_movie_low_rating_max_plex_audience_rating: cap }
-          : { watched_movie_low_rating_max_jellyfin_emby_community_rating: cap }),
+          : {
+              watched_movie_low_rating_max_jellyfin_emby_community_rating: cap,
+            }),
         unwatched_movie_stale_reported_enabled: uwOn,
         unwatched_movie_stale_min_age_days: uwDays,
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
       setBundleMsg("Saved Movies rules.");
     } catch (e) {
       setErr((e as Error).message);
@@ -780,14 +907,19 @@ export function PrunerScopeTab(props: {
       const yMin = parseBound(yearMinStr);
       const yMax = parseBound(yearMaxStr);
       if (yMin === "bad" || yMax === "bad") {
-        setErr("Each year must be a whole number between 1900 and 2100, or left empty.");
+        setErr(
+          "Each year must be a whole number between 1900 and 2100, or left empty.",
+        );
         return;
       }
       if (yMin != null && yMax != null && yMin > yMax) {
         setErr("Minimum year must be less than or equal to maximum year.");
         return;
       }
-      const collectionsPreserve = isPlex && props.scope === "movies" ? (scopeRow?.preview_include_collections ?? []) : [];
+      const collectionsPreserve =
+        isPlex && props.scope === "movies"
+          ? (scopeRow?.preview_include_collections ?? [])
+          : [];
       const payload = {
         preview_include_genres: genreTokens,
         preview_include_people: peopleTokens,
@@ -800,8 +932,12 @@ export function PrunerScopeTab(props: {
         csrf_token,
       };
       await patchPrunerScope(instanceId, props.scope, payload);
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setBundleMsg(props.scope === "tv" ? "Saved TV filters." : "Saved Movies filters.");
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setBundleMsg(
+        props.scope === "tv" ? "Saved TV filters." : "Saved Movies filters.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -821,11 +957,17 @@ export function PrunerScopeTab(props: {
         .filter(Boolean);
       await patchPrunerScope(instanceId, props.scope, {
         preview_include_people: lines,
-        preview_include_people_roles: isPlex ? peopleRolesForPlexPersist(peopleRoles) : [...peopleRoles],
+        preview_include_people_roles: isPlex
+          ? peopleRolesForPlexPersist(peopleRoles)
+          : [...peopleRoles],
         csrf_token,
       });
-      await qc.invalidateQueries({ queryKey: ["pruner", "instances", instanceId] });
-      setBundleMsg(props.scope === "tv" ? "Saved TV people." : "Saved Movies people.");
+      await qc.invalidateQueries({
+        queryKey: ["pruner", "instances", instanceId],
+      });
+      setBundleMsg(
+        props.scope === "tv" ? "Saved TV people." : "Saved Movies people.",
+      );
     } catch (e) {
       setErr((e as Error).message);
     } finally {
@@ -837,14 +979,25 @@ export function PrunerScopeTab(props: {
     if (props.scope === "tv") {
       if (isPlex) {
         return (
-          <div className="mm-bubble-stack" data-testid="pruner-provider-plex-tv-unsupported-rules">
+          <div
+            className="mm-bubble-stack"
+            data-testid="pruner-provider-plex-tv-unsupported-rules"
+          >
             <div className="space-y-1.5">
-              <p className="text-sm font-medium text-[var(--mm-text1)]">Watched TV removal</p>
-              <p className="text-xs leading-relaxed text-[var(--mm-text3)]">Not supported for Plex.</p>
+              <p className="text-sm font-medium text-[var(--mm-text1)]">
+                Watched TV removal
+              </p>
+              <p className="text-xs leading-relaxed text-[var(--mm-text3)]">
+                Not supported for Plex.
+              </p>
             </div>
             <div className="space-y-1.5">
-              <p className="text-sm font-medium text-[var(--mm-text1)]">Unwatched TV older than N days</p>
-              <p className="text-xs leading-relaxed text-[var(--mm-text3)]">Not supported for Plex.</p>
+              <p className="text-sm font-medium text-[var(--mm-text1)]">
+                Unwatched TV older than N days
+              </p>
+              <p className="text-xs leading-relaxed text-[var(--mm-text3)]">
+                Not supported for Plex.
+              </p>
             </div>
           </div>
         );
@@ -862,7 +1015,10 @@ export function PrunerScopeTab(props: {
               />
             ) : (
               <p className="text-xs text-[var(--mm-text2)]">
-                Watched TV removal: <strong>{scopeRow?.watched_tv_reported_enabled ? "On" : "Off"}</strong>
+                Watched TV removal:{" "}
+                <strong>
+                  {scopeRow?.watched_tv_reported_enabled ? "On" : "Off"}
+                </strong>
               </p>
             )}
             <p className="mt-2 text-xs leading-relaxed text-[var(--mm-text3)]">
@@ -870,7 +1026,9 @@ export function PrunerScopeTab(props: {
             </p>
           </div>
           <div data-testid="pruner-never-played-stale-panel">
-            <p className="text-sm font-medium text-[var(--mm-text1)]">Unwatched TV older than N days</p>
+            <p className="text-sm font-medium text-[var(--mm-text1)]">
+              Unwatched TV older than N days
+            </p>
             {showInteractiveControls ? (
               <div className="mt-2 flex flex-wrap items-center gap-2">
                 <input
@@ -888,7 +1046,9 @@ export function PrunerScopeTab(props: {
               <p className="mt-2 text-xs text-[var(--mm-text2)]">
                 Days:{" "}
                 <strong>
-                  {!scopeRow?.never_played_stale_reported_enabled ? "0 (off)" : scopeRow.never_played_min_age_days}
+                  {!scopeRow?.never_played_stale_reported_enabled
+                    ? "0 (off)"
+                    : scopeRow.never_played_min_age_days}
                 </strong>
               </p>
             )}
@@ -912,17 +1072,26 @@ export function PrunerScopeTab(props: {
             />
           ) : (
             <p className="text-xs text-[var(--mm-text2)]">
-              Watched movies removal: <strong>{scopeRow?.watched_movies_reported_enabled ? "On" : "Off"}</strong>
+              Watched movies removal:{" "}
+              <strong>
+                {scopeRow?.watched_movies_reported_enabled ? "On" : "Off"}
+              </strong>
             </p>
           )}
           <p className="mt-2 text-xs leading-relaxed text-[var(--mm-text3)]">
-            {isPlex ? "Uses Plex watched state from allLeaves." : "Uses provider watched state for movie items."}
+            {isPlex
+              ? "Uses Plex watched state from allLeaves."
+              : "Uses provider watched state for movie items."}
           </p>
         </div>
         <div data-testid="pruner-watched-low-rating-panel">
-          <p className="text-sm font-medium text-[var(--mm-text1)]">Low-rating watched movies</p>
+          <p className="text-sm font-medium text-[var(--mm-text1)]">
+            Low-rating watched movies
+          </p>
           <p className="mt-1 text-xs text-[var(--mm-text3)]">
-            {isPlex ? "Plex audienceRating max (0–10)" : "Jellyfin/Emby CommunityRating max (0–10)"}
+            {isPlex
+              ? "Plex audienceRating max (0–10)"
+              : "Jellyfin/Emby CommunityRating max (0–10)"}
           </p>
           {showInteractiveControls ? (
             <input
@@ -947,10 +1116,14 @@ export function PrunerScopeTab(props: {
               </strong>
             </p>
           )}
-          <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">Set 0 to disable.</p>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+            Set 0 to disable.
+          </p>
         </div>
         <div data-testid="pruner-unwatched-stale-panel">
-          <p className="text-sm font-medium text-[var(--mm-text1)]">Unwatched movies older than N days</p>
+          <p className="text-sm font-medium text-[var(--mm-text1)]">
+            Unwatched movies older than N days
+          </p>
           {showInteractiveControls ? (
             <div className="mt-2 flex flex-wrap items-center gap-2">
               <input
@@ -968,15 +1141,24 @@ export function PrunerScopeTab(props: {
             <p className="mt-2 text-xs text-[var(--mm-text2)]">
               Days:{" "}
               <strong>
-                {!scopeRow?.unwatched_movie_stale_reported_enabled ? "0 (off)" : scopeRow.unwatched_movie_stale_min_age_days}
+                {!scopeRow?.unwatched_movie_stale_reported_enabled
+                  ? "0 (off)"
+                  : scopeRow.unwatched_movie_stale_min_age_days}
               </strong>
             </p>
           )}
-          <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">Set 0 to disable.</p>
+          <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+            Set 0 to disable.
+          </p>
         </div>
         {isPlex ? (
-          <p className="text-xs text-[var(--mm-text3)]" data-testid="pruner-plex-other-rules-note" role="status">
-            Plex: watched TV and never-played stale are unsupported on the TV scope.
+          <p
+            className="text-xs text-[var(--mm-text3)]"
+            data-testid="pruner-plex-other-rules-note"
+            role="status"
+          >
+            Plex: watched TV and never-played stale are unsupported on the TV
+            scope.
           </p>
         ) : null}
       </div>
@@ -987,7 +1169,11 @@ export function PrunerScopeTab(props: {
     return (
       <div className="mm-bubble-stack">
         {isPlex && props.scope === "tv" ? (
-          <p className="text-xs leading-relaxed text-amber-100/90" data-testid="pruner-plex-tv-filters-scope-note" role="status">
+          <p
+            className="text-xs leading-relaxed text-amber-100/90"
+            data-testid="pruner-plex-tv-filters-scope-note"
+            role="status"
+          >
             On Plex, filters apply to the missing primary art rule only.
           </p>
         ) : null}
@@ -1006,10 +1192,14 @@ export function PrunerScopeTab(props: {
               {(scopeRow?.preview_include_genres ?? []).join(", ") || "—"}
             </p>
           )}
-          <p className="text-xs text-[var(--mm-text3)]">Leave none selected to include every genre.</p>
+          <p className="text-xs text-[var(--mm-text3)]">
+            Leave none selected to include every genre.
+          </p>
         </div>
         <div className="space-y-2" data-testid="pruner-year-filters-panel">
-          <p className="text-sm font-medium text-[var(--mm-text1)]">Year range</p>
+          <p className="text-sm font-medium text-[var(--mm-text1)]">
+            Year range
+          </p>
           {showInteractiveControls ? (
             <div className="flex flex-wrap items-end gap-3">
               <label className="text-sm text-[var(--mm-text2)]">
@@ -1041,10 +1231,13 @@ export function PrunerScopeTab(props: {
             </div>
           ) : (
             <p className="text-xs text-[var(--mm-text2)]">
-              {scopeRow?.preview_year_min ?? "—"} to {scopeRow?.preview_year_max ?? "—"}
+              {scopeRow?.preview_year_min ?? "—"} to{" "}
+              {scopeRow?.preview_year_max ?? "—"}
             </p>
           )}
-          <p className="text-xs text-[var(--mm-text3)]">Leave blank for open-ended. Range 1900–2100.</p>
+          <p className="text-xs text-[var(--mm-text3)]">
+            Leave blank for open-ended. Range 1900–2100.
+          </p>
         </div>
         <div className="space-y-2" data-testid="pruner-studio-preview-panel">
           <p className="text-sm font-medium text-[var(--mm-text1)]">Studio</p>
@@ -1062,7 +1255,9 @@ export function PrunerScopeTab(props: {
               {(scopeRow?.preview_include_studios ?? []).join(", ") || "—"}
             </p>
           )}
-          <p className="text-xs text-[var(--mm-text3)]">Leave blank to include all studios.</p>
+          <p className="text-xs text-[var(--mm-text3)]">
+            Leave blank to include all studios.
+          </p>
         </div>
       </div>
     );
@@ -1071,7 +1266,10 @@ export function PrunerScopeTab(props: {
   function renderProviderPeopleControls(): ReactNode {
     return (
       <div className="space-y-3">
-        <label className="block text-sm font-medium text-[var(--mm-text1)]" htmlFor={`pruner-people-names-${props.scope}-${instanceId}`}>
+        <label
+          className="block text-sm font-medium text-[var(--mm-text1)]"
+          htmlFor={`pruner-people-names-${props.scope}-${instanceId}`}
+        >
           Names
         </label>
         {showInteractiveControls ? (
@@ -1089,7 +1287,9 @@ export function PrunerScopeTab(props: {
             {(scopeRow?.preview_include_people ?? []).join("\n") || "—"}
           </p>
         )}
-        <p className="text-xs text-[var(--mm-text3)]">Leave blank to use no name filter.</p>
+        <p className="text-xs text-[var(--mm-text3)]">
+          Leave blank to use no name filter.
+        </p>
         {showInteractiveControls ? (
           <PrunerPeopleRoleCheckboxes
             value={peopleRoles}
@@ -1113,24 +1313,39 @@ export function PrunerScopeTab(props: {
   }
 
   if (isProvider && provSub === "rules") {
-    const saveLabel = props.scope === "tv" ? "Save TV rules" : "Save Movies rules";
-    const onSave = props.scope === "tv" ? saveProviderTvRulesBundle : saveProviderMoviesRulesBundle;
-    const saveDisabled = busy || !showInteractiveControls || (isPlex && props.scope === "tv");
+    const saveLabel =
+      props.scope === "tv" ? "Save TV rules" : "Save Movies rules";
+    const onSave =
+      props.scope === "tv"
+        ? saveProviderTvRulesBundle
+        : saveProviderMoviesRulesBundle;
+    const saveDisabled =
+      busy || !showInteractiveControls || (isPlex && props.scope === "tv");
     return (
       <PrunerProviderSection scope={props.scope} section="rules">
-        <fieldset disabled={Boolean(props.disabledMode)} className="flex min-h-0 flex-1 flex-col">
-          <div className="mm-card-action-body min-h-0 flex-1">{renderProviderRulesControls()}</div>
+        <fieldset
+          disabled={Boolean(props.disabledMode)}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <div className="mm-card-action-body min-h-0 flex-1">
+            {renderProviderRulesControls()}
+          </div>
           {showInteractiveControls ? (
             <div className="mm-card-action-footer">
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: "primary", disabled: saveDisabled })}
+                className={mmActionButtonClass({
+                  variant: "primary",
+                  disabled: saveDisabled,
+                })}
                 disabled={saveDisabled}
                 onClick={() => void onSave()}
               >
                 {busy ? "Saving…" : saveLabel}
               </button>
-              {bundleMsg ? <p className="text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="text-sm text-red-600" role="alert">
                   {err}
@@ -1139,7 +1354,9 @@ export function PrunerScopeTab(props: {
             </div>
           ) : (
             <>
-              {bundleMsg ? <p className="mt-3 text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="mt-3 text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="mt-2 text-sm text-red-600" role="alert">
                   {err}
@@ -1153,22 +1370,33 @@ export function PrunerScopeTab(props: {
   }
 
   if (isProvider && provSub === "filters") {
-    const saveLabel = props.scope === "tv" ? "Save TV filters" : "Save Movies filters";
+    const saveLabel =
+      props.scope === "tv" ? "Save TV filters" : "Save Movies filters";
     return (
       <PrunerProviderSection scope={props.scope} section="filters">
-        <fieldset disabled={Boolean(props.disabledMode)} className="flex min-h-0 flex-1 flex-col">
-          <div className="mm-card-action-body min-h-0 flex-1">{renderProviderFiltersControls()}</div>
+        <fieldset
+          disabled={Boolean(props.disabledMode)}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <div className="mm-card-action-body min-h-0 flex-1">
+            {renderProviderFiltersControls()}
+          </div>
           {showInteractiveControls ? (
             <div className="mm-card-action-footer">
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: "primary", disabled: busy })}
+                className={mmActionButtonClass({
+                  variant: "primary",
+                  disabled: busy,
+                })}
                 disabled={busy}
                 onClick={() => void saveProviderFiltersBundle()}
               >
                 {busy ? "Saving…" : saveLabel}
               </button>
-              {bundleMsg ? <p className="text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="text-sm text-red-600" role="alert">
                   {err}
@@ -1177,7 +1405,9 @@ export function PrunerScopeTab(props: {
             </div>
           ) : (
             <>
-              {bundleMsg ? <p className="mt-3 text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="mt-3 text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="mt-2 text-sm text-red-600" role="alert">
                   {err}
@@ -1191,22 +1421,33 @@ export function PrunerScopeTab(props: {
   }
 
   if (isProvider && provSub === "people") {
-    const saveLabel = props.scope === "tv" ? "Save TV people" : "Save Movies people";
+    const saveLabel =
+      props.scope === "tv" ? "Save TV people" : "Save Movies people";
     return (
       <PrunerProviderSection scope={props.scope} section="people">
-        <fieldset disabled={Boolean(props.disabledMode)} className="flex min-h-0 flex-1 flex-col">
-          <div className="mm-card-action-body min-h-0 flex-1">{renderProviderPeopleControls()}</div>
+        <fieldset
+          disabled={Boolean(props.disabledMode)}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <div className="mm-card-action-body min-h-0 flex-1">
+            {renderProviderPeopleControls()}
+          </div>
           {showInteractiveControls ? (
             <div className="mm-card-action-footer">
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: "primary", disabled: busy })}
+                className={mmActionButtonClass({
+                  variant: "primary",
+                  disabled: busy,
+                })}
                 disabled={busy}
                 onClick={() => void saveProviderPeopleBundle()}
               >
                 {busy ? "Saving…" : saveLabel}
               </button>
-              {bundleMsg ? <p className="text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="text-sm text-red-600" role="alert">
                   {err}
@@ -1215,7 +1456,9 @@ export function PrunerScopeTab(props: {
             </div>
           ) : (
             <>
-              {bundleMsg ? <p className="mt-3 text-sm text-green-600">{bundleMsg}</p> : null}
+              {bundleMsg ? (
+                <p className="mt-3 text-sm text-green-600">{bundleMsg}</p>
+              ) : null}
               {err ? (
                 <p className="mt-2 text-sm text-red-600" role="alert">
                   {err}
@@ -1230,540 +1473,701 @@ export function PrunerScopeTab(props: {
 
   if (isProvider && !provSub) {
     return (
-        <p className="text-sm text-red-600" role="alert" data-testid="pruner-provider-subsection-missing">
-        Something is misconfigured. Try reloading the page or opening the provider tab again.
+      <p
+        className="text-sm text-red-600"
+        role="alert"
+        data-testid="pruner-provider-subsection-missing"
+      >
+        Something is misconfigured. Try reloading the page or opening the
+        provider tab again.
       </p>
     );
   }
 
   return (
     <section
-      className={isProvider ? "mm-bubble-stack w-full min-w-0" : "mm-bubble-stack max-w-3xl"}
+      className={
+        isProvider
+          ? "mm-bubble-stack w-full min-w-0"
+          : "mm-bubble-stack max-w-3xl"
+      }
       aria-labelledby="pruner-scope-heading"
     >
-      <fieldset disabled={Boolean(props.disabledMode)} className="mm-bubble-stack">
-      {!isProvider ? (
-        <h2 id="pruner-scope-heading" className="text-base font-semibold text-[var(--mm-text)]">
-          {label}
-        </h2>
-      ) : (
-        <h2 id="pruner-scope-heading" className="sr-only">
-          {label}
-        </h2>
-      )}
-      {props.disabledMode && !isProvider ? (
-        <p className="rounded-md border border-dashed border-[var(--mm-border)] bg-[var(--mm-surface2)]/35 px-3 py-2 text-xs text-[var(--mm-text2)]">
-          Save this server on the Connection tab first to turn on these controls.
-        </p>
-      ) : null}
-      <div
-        className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-        data-testid="pruner-run-limits-panel"
+      <fieldset
+        disabled={Boolean(props.disabledMode)}
+        className="mm-bubble-stack"
       >
-        <p className="text-sm font-semibold text-[var(--mm-text)]">How many items each scan may check</p>
-        <p className="text-xs text-[var(--mm-text2)]" data-testid="pruner-delete-cap-note">
-          This limit only affects how many rows MediaMop lists for you to review. Deleting still uses exactly the list you
-          confirmed, not a fresh scan.
-        </p>
-        {showInteractiveControls ? (
-          <div className="flex flex-wrap items-center gap-2">
-            <label className="text-xs text-[var(--mm-text2)]">
-              Max items per scan (1–5000)
-              <input
-                type="number"
-                min={1}
-                max={5000}
-                value={previewMaxItems}
-                disabled={busy}
-                onChange={(e) => setPreviewMaxItems(Math.max(1, Math.min(5000, Number(e.target.value) || 500)))}
-                className="ml-2 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-              />
-            </label>
-            <button
-              type="button"
-              className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-              disabled={busy}
-              onClick={() => void savePreviewMaxItemsSettings()}
-            >
-              Save run limits
-            </button>
-            {previewMaxItemsMsg ? <p className="text-xs text-green-600">{previewMaxItemsMsg}</p> : null}
-          </div>
+        {!isProvider ? (
+          <h2
+            id="pruner-scope-heading"
+            className="text-base font-semibold text-[var(--mm-text)]"
+          >
+            {label}
+          </h2>
         ) : (
-          <p className="text-xs text-[var(--mm-text2)]">
-            Max items per scan: <strong>{scopeRow?.preview_max_items ?? "—"}</strong>. Sign in as an operator to edit.
-          </p>
+          <h2 id="pruner-scope-heading" className="sr-only">
+            {label}
+          </h2>
         )}
-      </div>
-      <div
-        className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)]/40 px-4 py-3 text-xs text-[var(--mm-text2)] sm:text-sm"
-        data-testid="pruner-scope-trust-banner"
-      >
-        <p>Each scan saves a fixed list you can review. Deleting uses only that saved list, not a new pass over the library.</p>
-      </div>
-      {!isProvider && !isPlex ? (
-        <p className="text-sm text-[var(--mm-text2)]">
-          {props.scope === "tv"
-            ? "Scans can list episodes missing a main image, or episodes never played for your MediaMop user that are older than the age you set. Each cleanup type has its own button above."
-            : "Scans can list movies missing a main poster, movies marked watched for your MediaMop user, or movies never watched and older than the age you set. Each cleanup type has its own button above."}
-        </p>
-      ) : !isProvider ? (
-        <p className="text-sm text-[var(--mm-text2)]">
-          On Plex, scans read the same on-server details as Jellyfin and Emby: broken posters look for missing episode or
-          movie art. Movie scans can also find watched titles, low audience scores, and old unwatched titles. Deleting
-          only touches the exact titles from the list you reviewed; items already gone are counted as skipped. Whether
-          Plex removes files or only metadata depends on your Plex server.
-        </p>
-      ) : null}
-      {isProvider ? (
-        <p className="text-xs text-[var(--mm-text2)]">
-          Run a scan, review the list or raw details, then delete from that list if you choose.
-        </p>
-      ) : null}
-      {isPlex && scopeRow && !isProvider ? (
-        <p className="text-xs text-[var(--mm-text2)]" data-testid="pruner-plex-preview-cap-note">
-          Plex stops each scan at the smaller of your per-tab item limit and a built-in safety cap. If a scan says the
-          list was shortened, there were more matches than MediaMop showed this time.
-        </p>
-      ) : null}
-      {isPlex && props.scope === "tv" && isProvider ? (
-        <div className="space-y-2" data-testid="pruner-provider-plex-tv-unsupported-rules">
-          <div
-            className="space-y-2 rounded-md border border-amber-600/40 bg-amber-950/20 px-4 py-3 text-sm text-[var(--mm-text)]"
-            data-testid="pruner-plex-tv-watched-unsupported"
-          >
-            <p className="text-sm font-semibold text-amber-100">Watched TV removal</p>
-            <label className="flex cursor-not-allowed items-center gap-2 text-sm text-[var(--mm-text2)]">
-              <input type="checkbox" disabled checked={false} readOnly className="opacity-60" />
-              Not supported for Plex.
-            </label>
-          </div>
-          <div
-            className="space-y-2 rounded-md border border-amber-600/40 bg-amber-950/20 px-4 py-3 text-sm text-[var(--mm-text)]"
-            data-testid="pruner-plex-tv-never-played-unsupported"
-          >
-            <p className="text-sm font-semibold text-amber-100">Never-played TV older than N days</p>
-            <label className="flex cursor-not-allowed items-center gap-2 text-sm text-[var(--mm-text2)]">
-              <input type="checkbox" disabled checked={false} readOnly className="opacity-60" />
-              Not supported for Plex.
-            </label>
-            <label className="block text-xs text-[var(--mm-text2)]">
-              Minimum age (days)
-              <input
-                type="number"
-                disabled
-                readOnly
-                className="ml-2 mt-1 w-24 cursor-not-allowed rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm opacity-60"
-                value={90}
-              />
-            </label>
-          </div>
-        </div>
-      ) : null}
-      <div>
-        <h3 className="text-base font-semibold text-[var(--mm-text)]" data-testid="pruner-filters-section-heading">
-          Optional filters for scans
-        </h3>
-        <p className="text-xs text-[var(--mm-text2)]">
-          Filters affect scan results on this {libraryTabPhrase} only.
-        </p>
-        {isPlex && props.scope === "tv" && isProvider ? (
-          <p className="mt-1 text-xs text-amber-100/90" data-testid="pruner-plex-tv-filters-scope-note" role="status">
-            On Plex TV, genre, people, year, and studio filters only affect scans for broken posters and images.
+        {props.disabledMode && !isProvider ? (
+          <p className="rounded-md border border-dashed border-[var(--mm-border)] bg-[var(--mm-surface2)]/35 px-3 py-2 text-xs text-[var(--mm-text2)]">
+            Save this server on the Connection tab first to turn on these
+            controls.
           </p>
         ) : null}
-      </div>
-      {scopeRow ? (
-        <div className="space-y-2 text-sm text-[var(--mm-text)]" data-testid="pruner-genre-filters-panel">
-          <p className="text-sm font-semibold text-[var(--mm-text)]">
-            Optional genres (this {libraryTabPhrase} only)
-          </p>
-          <p className="text-xs text-[var(--mm-text2)]">Pick from the list below; leave none selected to include every genre.</p>
-          {isPlex && !isProvider ? (
-            <p
-              className="text-xs text-amber-100/90"
-              data-testid="pruner-plex-genre-empty-preview-note"
-            >
-              If a scan finishes with <strong>nothing listed</strong> while genres are selected, nothing in this pass
-              matched both the rule and those genres — it does not prove your library is already clean.
-            </p>
-          ) : null}
-          {showInteractiveControls ? (
-            <div className="space-y-2">
-              <PrunerGenreMultiSelect
-                value={genreSelection}
-                onChange={setGenreSelection}
-                disabled={busy}
-                testId={`pruner-genre-multiselect-${instanceId}-${props.scope}`}
-                filterHelperText=""
-              />
-              <button
-                type="button"
-                className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void saveGenreFilters()}
-              >
-                Save genre filters
-              </button>
-              {genreMsg ? <p className="text-xs text-green-600">{genreMsg}</p> : null}
-            </div>
-          ) : (
-            <p className="text-xs text-[var(--mm-text2)]">
-              Current filters:{" "}
-              <strong>{(scopeRow.preview_include_genres ?? []).length ? scopeRow.preview_include_genres.join(", ") : "none"}</strong>
-              . Sign in as an operator to edit.
-            </p>
-          )}
-        </div>
-      ) : null}
-      {scopeRow ? (
-        <div className="space-y-2 text-sm text-[var(--mm-text)]" data-testid="pruner-people-filters-panel">
-          <p className="text-sm font-semibold text-[var(--mm-text)]">
-            Optional cast and crew names (this {libraryTabPhrase} only)
-          </p>
-          <p className="text-xs text-[var(--mm-text2)]">Comma-separated full names.</p>
-          {isPlex && props.scope === "tv" && isProvider ? null : isPlex && !isProvider ? (
-            <p className="text-xs text-[var(--mm-text2)]" data-testid="pruner-people-plex-note">
-              Plex: names apply to broken-poster scans plus the movie scans above. They come from cast, writer, and
-              director lines on each title.
-            </p>
-          ) : !isProvider ? (
-            <p className="text-xs text-[var(--mm-text2)]" data-testid="pruner-people-jf-emby-note">
-              Jellyfin / Emby: names come from each item’s People list on the server and apply to every scan for this library.
-            </p>
-          ) : null}
-          {showInteractiveControls ? (
-            <div className="space-y-3">
-              <textarea
-                rows={5}
-                className="mm-input min-h-[7rem] w-full resize-y font-sans text-sm"
-                placeholder="e.g. Alex Carter, Jordan Lee (comma or one per line)"
-                value={peopleText}
-                disabled={busy}
-                onChange={(e) => setPeopleText(e.target.value)}
-              />
-              <p className="text-xs text-[var(--mm-text3)]">Leave blank to use no name filter.</p>
-              <PrunerPeopleRoleCheckboxes
-                value={peopleRoles}
-                onChange={setPeopleRoles}
-                disabled={busy}
-                variant={isPlex ? "plex" : "emby-jellyfin"}
-                testId={`pruner-people-filters-roles-${instanceId}-${props.scope}`}
-              />
-              <button
-                type="button"
-                className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void savePeopleFilters()}
-              >
-                Save people filters
-              </button>
-              {peopleMsg ? <p className="text-xs text-green-600">{peopleMsg}</p> : null}
-            </div>
-          ) : (
-            <p className="text-xs text-[var(--mm-text2)]">
-              Current people filters:{" "}
-              <strong>
-                {(scopeRow.preview_include_people ?? []).length
-                  ? scopeRow.preview_include_people.join(", ")
-                  : "none"}
-              </strong>
-              . Sign in as an operator to edit.
-            </p>
-          )}
-        </div>
-      ) : null}
-      {scopeRow ? (
         <div
           className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-          data-testid="pruner-year-filters-panel"
+          data-testid="pruner-run-limits-panel"
         >
-          <p className="text-sm font-semibold text-[var(--mm-text)]">Optional release years (this {libraryTabPhrase} only)</p>
-          <p className="text-xs text-[var(--mm-text2)]">Inclusive 1900-2100. Blank means open-ended.</p>
+          <p className="text-sm font-semibold text-[var(--mm-text)]">
+            How many items each scan may check
+          </p>
+          <p
+            className="text-xs text-[var(--mm-text2)]"
+            data-testid="pruner-delete-cap-note"
+          >
+            This limit only affects how many rows MediaMop lists for you to
+            review. Deleting still uses exactly the list you confirmed, not a
+            fresh scan.
+          </p>
           {showInteractiveControls ? (
-            <div className="flex flex-wrap items-end gap-2">
+            <div className="flex flex-wrap items-center gap-2">
               <label className="text-xs text-[var(--mm-text2)]">
-                Min year
+                Max items per scan (1–5000)
                 <input
                   type="number"
-                  min={1900}
-                  max={2100}
-                  className="ml-1 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-                  value={yearMinStr}
+                  min={1}
+                  max={5000}
+                  value={previewMaxItems}
                   disabled={busy}
-                  onChange={(e) => setYearMinStr(e.target.value)}
-                />
-              </label>
-              <label className="text-xs text-[var(--mm-text2)]">
-                Max year
-                <input
-                  type="number"
-                  min={1900}
-                  max={2100}
-                  className="ml-1 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-                  value={yearMaxStr}
-                  disabled={busy}
-                  onChange={(e) => setYearMaxStr(e.target.value)}
+                  onChange={(e) =>
+                    setPreviewMaxItems(
+                      Math.max(
+                        1,
+                        Math.min(5000, Number(e.target.value) || 500),
+                      ),
+                    )
+                  }
+                  className="ml-2 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
                 />
               </label>
               <button
                 type="button"
                 className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
                 disabled={busy}
-                onClick={() => void savePreviewYearBounds()}
+                onClick={() => void savePreviewMaxItemsSettings()}
               >
-                Save year bounds
+                Save run limits
               </button>
-              {yearMsg ? <p className="w-full text-xs text-green-600">{yearMsg}</p> : null}
+              {previewMaxItemsMsg ? (
+                <p className="text-xs text-green-600">{previewMaxItemsMsg}</p>
+              ) : null}
             </div>
           ) : (
             <p className="text-xs text-[var(--mm-text2)]">
-              Current bounds:{" "}
-              <strong>
-                {scopeRow.preview_year_min ?? "—"} to {scopeRow.preview_year_max ?? "—"}
-              </strong>
-              . Sign in as an operator to edit.
+              Max items per scan:{" "}
+              <strong>{scopeRow?.preview_max_items ?? "—"}</strong>. Sign in as
+              an operator to edit.
             </p>
           )}
         </div>
-      ) : null}
-      {scopeRow ? (
         <div
-          className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-          data-testid="pruner-studio-preview-panel"
+          className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)]/40 px-4 py-3 text-xs text-[var(--mm-text2)] sm:text-sm"
+          data-testid="pruner-scope-trust-banner"
         >
-          <p className="text-sm font-semibold text-[var(--mm-text)]">Optional studios (this {libraryTabPhrase} only)</p>
-          <p className="text-xs text-[var(--mm-text2)]">Comma-separated studio names.</p>
-          {showInteractiveControls ? (
-            <div className="space-y-2">
-              <input
-                type="text"
-                className="w-full rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-                placeholder="e.g. Warner Bros., BBC"
-                value={studioText}
-                disabled={busy}
-                onChange={(e) => setStudioText(e.target.value)}
-              />
-              <button
-                type="button"
-                className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void saveStudioPreviewFilters()}
-              >
-                Save studio filters
-              </button>
-              {studioMsg ? <p className="text-xs text-green-600">{studioMsg}</p> : null}
-            </div>
-          ) : (
-            <p className="text-xs text-[var(--mm-text2)]">
-              Current studio filters:{" "}
-              <strong>
-                {(scopeRow.preview_include_studios ?? []).length
-                  ? scopeRow.preview_include_studios.join(", ")
-                  : "none"}
-              </strong>
-              .
-            </p>
-          )}
-        </div>
-      ) : null}
-      {scopeRow && isPlex ? (
-        <div
-          className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-          data-testid="pruner-collection-preview-panel"
-        >
-          <p className="text-sm font-semibold text-[var(--mm-text)]">Optional Plex movie collections</p>
-          <p className="text-xs text-[var(--mm-text2)]">Comma-separated collection names.</p>
-          {showInteractiveControls ? (
-            <div className="space-y-2">
-              <input
-                type="text"
-                className="w-full rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-                placeholder="e.g. Marvel Cinematic Universe"
-                value={collectionText}
-                disabled={busy}
-                onChange={(e) => setCollectionText(e.target.value)}
-              />
-              <button
-                type="button"
-                className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-                disabled={busy}
-                onClick={() => void saveCollectionPreviewFilters()}
-              >
-                Save collection filters
-              </button>
-              {collectionMsg ? <p className="text-xs text-green-600">{collectionMsg}</p> : null}
-            </div>
-          ) : (
-            <p className="text-xs text-[var(--mm-text2)]">
-              Current collection filters:{" "}
-              <strong>
-                {(scopeRow.preview_include_collections ?? []).length
-                  ? scopeRow.preview_include_collections.join(", ")
-                  : "none"}
-              </strong>
-              .
-            </p>
-          )}
-        </div>
-      ) : null}
-      {isPlex ? (
-        <div
-          className="rounded-md border border-amber-600/40 bg-amber-950/20 px-3 py-2 text-xs text-[var(--mm-text)]"
-          role="status"
-          data-testid="pruner-plex-other-rules-note"
-        >
-          <p className="font-medium text-amber-100">
-            {props.scope === "movies"
-              ? "Plex does not support watched-TV or never-started cleanup on the Movies tab."
-              : "Plex does not support watched-TV or never-started TV cleanup on the TV tab."}
+          <p>
+            Each scan saves a fixed list you can review. Deleting uses only that
+            saved list, not a new pass over the library.
           </p>
         </div>
-      ) : null}
-      {!isPlex ? (
-        <Fragment>
-        <div
-          className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-          data-testid="pruner-never-played-stale-panel"
-        >
-          <p className="text-sm font-semibold text-[var(--mm-text)]">
+        {!isProvider && !isPlex ? (
+          <p className="text-sm text-[var(--mm-text2)]">
             {props.scope === "tv"
-              ? "Delete TV shows not watched in the last N days — Jellyfin / Emby"
-              : "Delete TV or movies never started and older than N days — Jellyfin / Emby"}
+              ? "Scans can list episodes missing a main image, or episodes never played for your MediaMop user that are older than the age you set. Each cleanup type has its own button above."
+              : "Scans can list movies missing a main poster, movies marked watched for your MediaMop user, or movies never watched and older than the age you set. Each cleanup type has its own button above."}
           </p>
-          <p className="text-xs text-[var(--mm-text2)]">Only titles with no play time and older than this age.</p>
-          {showInteractiveControls ? (
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm">
+        ) : !isProvider ? (
+          <p className="text-sm text-[var(--mm-text2)]">
+            On Plex, scans read the same on-server details as Jellyfin and Emby:
+            broken posters look for missing episode or movie art. Movie scans
+            can also find watched titles, low audience scores, and old unwatched
+            titles. Deleting only touches the exact titles from the list you
+            reviewed; items already gone are counted as skipped. Whether Plex
+            removes files or only metadata depends on your Plex server.
+          </p>
+        ) : null}
+        {isProvider ? (
+          <p className="text-xs text-[var(--mm-text2)]">
+            Run a scan, review the list or raw details, then delete from that
+            list if you choose.
+          </p>
+        ) : null}
+        {isPlex && scopeRow && !isProvider ? (
+          <p
+            className="text-xs text-[var(--mm-text2)]"
+            data-testid="pruner-plex-preview-cap-note"
+          >
+            Plex stops each scan at the smaller of your per-tab item limit and a
+            built-in safety cap. If a scan says the list was shortened, there
+            were more matches than MediaMop showed this time.
+          </p>
+        ) : null}
+        {isPlex && props.scope === "tv" && isProvider ? (
+          <div
+            className="space-y-2"
+            data-testid="pruner-provider-plex-tv-unsupported-rules"
+          >
+            <div
+              className="space-y-2 rounded-md border border-amber-600/40 bg-amber-950/20 px-4 py-3 text-sm text-[var(--mm-text)]"
+              data-testid="pruner-plex-tv-watched-unsupported"
+            >
+              <p className="text-sm font-semibold text-amber-100">
+                Watched TV removal
+              </p>
+              <label className="flex cursor-not-allowed items-center gap-2 text-sm text-[var(--mm-text2)]">
                 <input
                   type="checkbox"
-                  checked={staleNeverEnabled}
-                  disabled={busy}
-                  onChange={(e) => setStaleNeverEnabled(e.target.checked)}
+                  disabled
+                  checked={false}
+                  readOnly
+                  className="opacity-60"
                 />
-                {props.scope === "tv"
-                  ? "Turn on never-watched TV older than this age"
-                  : "Turn on never-watched TV or movies older than this age"}
+                Not supported for Plex.
               </label>
-              <div className="flex flex-wrap items-center gap-2">
-                <label className="text-sm text-[var(--mm-text2)]">
-                  Minimum age (days, 7–3650):{" "}
-                  <input
-                    type="number"
-                    min={7}
-                    max={3650}
-                    className="w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
-                    value={staleNeverDays}
-                    disabled={busy}
-                    onChange={(e) => setStaleNeverDays(parseInt(e.target.value, 10) || 90)}
-                  />
-                </label>
-                <button
-                  type="button"
-                  className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-                  disabled={busy}
-                  onClick={() => void saveStaleNeverSettings()}
-                >
-                  Save never-watched age rule
-                </button>
-              </div>
-              {staleNeverMsg ? <p className="text-xs text-green-600">{staleNeverMsg}</p> : null}
-              <button
-                type="button"
-                className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
-                disabled={busy || !staleNeverEnabled}
-                title={!staleNeverEnabled ? "Turn the rule on and save before running this scan." : undefined}
-                onClick={() => void runStaleNeverPreview()}
-              >
-                {props.scope === "tv"
-                  ? "Scan for unwatched TV shows older than your setting"
-                  : "Scan for unwatched TV or movies older than your setting"}
-              </button>
             </div>
-          ) : (
-            <p className="text-xs text-[var(--mm-text2)]">
-              Rule is <strong>{scopeRow?.never_played_stale_reported_enabled ? "on" : "off"}</strong>
-              {scopeRow ? (
-                <>
-                  {" "}
-                  (minimum age {scopeRow.never_played_min_age_days} days). Sign in as an operator to change it.
-                </>
-              ) : null}
-            </p>
-          )}
-        </div>
-        {props.scope === "tv" ? (
-          <div
-            className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
-            data-testid="pruner-watched-tv-panel"
+            <div
+              className="space-y-2 rounded-md border border-amber-600/40 bg-amber-950/20 px-4 py-3 text-sm text-[var(--mm-text)]"
+              data-testid="pruner-plex-tv-never-played-unsupported"
+            >
+              <p className="text-sm font-semibold text-amber-100">
+                Never-played TV older than N days
+              </p>
+              <label className="flex cursor-not-allowed items-center gap-2 text-sm text-[var(--mm-text2)]">
+                <input
+                  type="checkbox"
+                  disabled
+                  checked={false}
+                  readOnly
+                  className="opacity-60"
+                />
+                Not supported for Plex.
+              </label>
+              <label className="block text-xs text-[var(--mm-text2)]">
+                Minimum age (days)
+                <input
+                  type="number"
+                  disabled
+                  readOnly
+                  className="ml-2 mt-1 w-24 cursor-not-allowed rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm opacity-60"
+                  value={90}
+                />
+              </label>
+            </div>
+          </div>
+        ) : null}
+        <div>
+          <h3
+            className="text-base font-semibold text-[var(--mm-text)]"
+            data-testid="pruner-filters-section-heading"
           >
-            <p className="text-sm font-semibold text-[var(--mm-text)]">Delete watched TV episodes — Jellyfin / Emby</p>
-            <p className="text-xs text-[var(--mm-text2)]">Uses the watched flag for your MediaMop user on this server.</p>
+            Optional filters for scans
+          </h3>
+          <p className="text-xs text-[var(--mm-text2)]">
+            Filters affect scan results on this {libraryTabPhrase} only.
+          </p>
+          {isPlex && props.scope === "tv" && isProvider ? (
+            <p
+              className="mt-1 text-xs text-amber-100/90"
+              data-testid="pruner-plex-tv-filters-scope-note"
+              role="status"
+            >
+              On Plex TV, genre, people, year, and studio filters only affect
+              scans for broken posters and images.
+            </p>
+          ) : null}
+        </div>
+        {scopeRow ? (
+          <div
+            className="space-y-2 text-sm text-[var(--mm-text)]"
+            data-testid="pruner-genre-filters-panel"
+          >
+            <p className="text-sm font-semibold text-[var(--mm-text)]">
+              Optional genres (this {libraryTabPhrase} only)
+            </p>
+            <p className="text-xs text-[var(--mm-text2)]">
+              Pick from the list below; leave none selected to include every
+              genre.
+            </p>
+            {isPlex && !isProvider ? (
+              <p
+                className="text-xs text-amber-100/90"
+                data-testid="pruner-plex-genre-empty-preview-note"
+              >
+                If a scan finishes with <strong>nothing listed</strong> while
+                genres are selected, nothing in this pass matched both the rule
+                and those genres — it does not prove your library is already
+                clean.
+              </p>
+            ) : null}
             {showInteractiveControls ? (
               <div className="space-y-2">
-                <label className="flex items-center gap-2 text-sm">
-                  <input
-                    type="checkbox"
-                    checked={watchedTvEnabled}
-                    disabled={busy}
-                    onChange={(e) => setWatchedTvEnabled(e.target.checked)}
-                  />
-                  Turn on watched-TV cleanup
-                </label>
+                <PrunerGenreMultiSelect
+                  value={genreSelection}
+                  onChange={setGenreSelection}
+                  disabled={busy}
+                  testId={`pruner-genre-multiselect-${instanceId}-${props.scope}`}
+                  filterHelperText=""
+                />
                 <button
                   type="button"
                   className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
                   disabled={busy}
-                  onClick={() => void saveWatchedTvSettings()}
+                  onClick={() => void saveGenreFilters()}
                 >
-                  Save watched TV rule
+                  Save genre filters
                 </button>
-                {watchedTvMsg ? <p className="text-xs text-green-600">{watchedTvMsg}</p> : null}
-                <button
-                  type="button"
-                  className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
-                  disabled={busy || !watchedTvEnabled}
-                  title={!watchedTvEnabled ? "Turn the rule on and save before running this scan." : undefined}
-                  onClick={() => void runWatchedTvPreview()}
-                >
-                  Scan for watched TV shows
-                </button>
+                {genreMsg ? (
+                  <p className="text-xs text-green-600">{genreMsg}</p>
+                ) : null}
               </div>
             ) : (
               <p className="text-xs text-[var(--mm-text2)]">
-                Watched TV rule is <strong>{scopeRow?.watched_tv_reported_enabled ? "on" : "off"}</strong> for this{" "}
-                {libraryTabPhrase}.
-                Sign in as an operator to change it.
+                Current filters:{" "}
+                <strong>
+                  {(scopeRow.preview_include_genres ?? []).length
+                    ? scopeRow.preview_include_genres.join(", ")
+                    : "none"}
+                </strong>
+                . Sign in as an operator to edit.
               </p>
             )}
           </div>
         ) : null}
-        </Fragment>
-      ) : null}
-      {!isPlex ? null : props.scope === "movies" && !isProvider ? (
-        <p className="text-xs text-[var(--mm-text2)]">
-          On Plex, watched movies, low-score movies, and old unwatched movies all use the same on-server details MediaMop
-          already reads for other scans — watched means the server shows you played it; low score uses Plex audience
-          rating; old unwatched uses when Plex says the title was added to the library.
-        </p>
-      ) : null}
-      <div>
-        <h3 className="text-base font-semibold text-[var(--mm-text)]" data-testid="pruner-rules-section-heading">
-          Cleanup rules
-        </h3>
-        <p className="text-xs text-[var(--mm-text2)]">Turn a rule on, save, then run its scan when you are ready.</p>
-      </div>
-      {props.scope === "movies" ? (
+        {scopeRow ? (
+          <div
+            className="space-y-2 text-sm text-[var(--mm-text)]"
+            data-testid="pruner-people-filters-panel"
+          >
+            <p className="text-sm font-semibold text-[var(--mm-text)]">
+              Optional cast and crew names (this {libraryTabPhrase} only)
+            </p>
+            <p className="text-xs text-[var(--mm-text2)]">
+              Comma-separated full names.
+            </p>
+            {isPlex && props.scope === "tv" && isProvider ? null : isPlex &&
+              !isProvider ? (
+              <p
+                className="text-xs text-[var(--mm-text2)]"
+                data-testid="pruner-people-plex-note"
+              >
+                Plex: names apply to broken-poster scans plus the movie scans
+                above. They come from cast, writer, and director lines on each
+                title.
+              </p>
+            ) : !isProvider ? (
+              <p
+                className="text-xs text-[var(--mm-text2)]"
+                data-testid="pruner-people-jf-emby-note"
+              >
+                Jellyfin / Emby: names come from each item’s People list on the
+                server and apply to every scan for this library.
+              </p>
+            ) : null}
+            {showInteractiveControls ? (
+              <div className="space-y-3">
+                <textarea
+                  rows={5}
+                  className="mm-input min-h-[7rem] w-full resize-y font-sans text-sm"
+                  placeholder="e.g. Alex Carter, Jordan Lee (comma or one per line)"
+                  value={peopleText}
+                  disabled={busy}
+                  onChange={(e) => setPeopleText(e.target.value)}
+                />
+                <p className="text-xs text-[var(--mm-text3)]">
+                  Leave blank to use no name filter.
+                </p>
+                <PrunerPeopleRoleCheckboxes
+                  value={peopleRoles}
+                  onChange={setPeopleRoles}
+                  disabled={busy}
+                  variant={isPlex ? "plex" : "emby-jellyfin"}
+                  testId={`pruner-people-filters-roles-${instanceId}-${props.scope}`}
+                />
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                  disabled={busy}
+                  onClick={() => void savePeopleFilters()}
+                >
+                  Save people filters
+                </button>
+                {peopleMsg ? (
+                  <p className="text-xs text-green-600">{peopleMsg}</p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-xs text-[var(--mm-text2)]">
+                Current people filters:{" "}
+                <strong>
+                  {(scopeRow.preview_include_people ?? []).length
+                    ? scopeRow.preview_include_people.join(", ")
+                    : "none"}
+                </strong>
+                . Sign in as an operator to edit.
+              </p>
+            )}
+          </div>
+        ) : null}
+        {scopeRow ? (
+          <div
+            className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
+            data-testid="pruner-year-filters-panel"
+          >
+            <p className="text-sm font-semibold text-[var(--mm-text)]">
+              Optional release years (this {libraryTabPhrase} only)
+            </p>
+            <p className="text-xs text-[var(--mm-text2)]">
+              Inclusive 1900-2100. Blank means open-ended.
+            </p>
+            {showInteractiveControls ? (
+              <div className="flex flex-wrap items-end gap-2">
+                <label className="text-xs text-[var(--mm-text2)]">
+                  Min year
+                  <input
+                    type="number"
+                    min={1900}
+                    max={2100}
+                    className="ml-1 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
+                    value={yearMinStr}
+                    disabled={busy}
+                    onChange={(e) => setYearMinStr(e.target.value)}
+                  />
+                </label>
+                <label className="text-xs text-[var(--mm-text2)]">
+                  Max year
+                  <input
+                    type="number"
+                    min={1900}
+                    max={2100}
+                    className="ml-1 w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
+                    value={yearMaxStr}
+                    disabled={busy}
+                    onChange={(e) => setYearMaxStr(e.target.value)}
+                  />
+                </label>
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                  disabled={busy}
+                  onClick={() => void savePreviewYearBounds()}
+                >
+                  Save year bounds
+                </button>
+                {yearMsg ? (
+                  <p className="w-full text-xs text-green-600">{yearMsg}</p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-xs text-[var(--mm-text2)]">
+                Current bounds:{" "}
+                <strong>
+                  {scopeRow.preview_year_min ?? "—"} to{" "}
+                  {scopeRow.preview_year_max ?? "—"}
+                </strong>
+                . Sign in as an operator to edit.
+              </p>
+            )}
+          </div>
+        ) : null}
+        {scopeRow ? (
+          <div
+            className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
+            data-testid="pruner-studio-preview-panel"
+          >
+            <p className="text-sm font-semibold text-[var(--mm-text)]">
+              Optional studios (this {libraryTabPhrase} only)
+            </p>
+            <p className="text-xs text-[var(--mm-text2)]">
+              Comma-separated studio names.
+            </p>
+            {showInteractiveControls ? (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  className="w-full rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
+                  placeholder="e.g. Warner Bros., BBC"
+                  value={studioText}
+                  disabled={busy}
+                  onChange={(e) => setStudioText(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                  disabled={busy}
+                  onClick={() => void saveStudioPreviewFilters()}
+                >
+                  Save studio filters
+                </button>
+                {studioMsg ? (
+                  <p className="text-xs text-green-600">{studioMsg}</p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-xs text-[var(--mm-text2)]">
+                Current studio filters:{" "}
+                <strong>
+                  {(scopeRow.preview_include_studios ?? []).length
+                    ? scopeRow.preview_include_studios.join(", ")
+                    : "none"}
+                </strong>
+                .
+              </p>
+            )}
+          </div>
+        ) : null}
+        {scopeRow && isPlex ? (
+          <div
+            className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
+            data-testid="pruner-collection-preview-panel"
+          >
+            <p className="text-sm font-semibold text-[var(--mm-text)]">
+              Optional Plex movie collections
+            </p>
+            <p className="text-xs text-[var(--mm-text2)]">
+              Comma-separated collection names.
+            </p>
+            {showInteractiveControls ? (
+              <div className="space-y-2">
+                <input
+                  type="text"
+                  className="w-full rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
+                  placeholder="e.g. Marvel Cinematic Universe"
+                  value={collectionText}
+                  disabled={busy}
+                  onChange={(e) => setCollectionText(e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                  disabled={busy}
+                  onClick={() => void saveCollectionPreviewFilters()}
+                >
+                  Save collection filters
+                </button>
+                {collectionMsg ? (
+                  <p className="text-xs text-green-600">{collectionMsg}</p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-xs text-[var(--mm-text2)]">
+                Current collection filters:{" "}
+                <strong>
+                  {(scopeRow.preview_include_collections ?? []).length
+                    ? scopeRow.preview_include_collections.join(", ")
+                    : "none"}
+                </strong>
+                .
+              </p>
+            )}
+          </div>
+        ) : null}
+        {isPlex ? (
+          <div
+            className="rounded-md border border-amber-600/40 bg-amber-950/20 px-3 py-2 text-xs text-[var(--mm-text)]"
+            role="status"
+            data-testid="pruner-plex-other-rules-note"
+          >
+            <p className="font-medium text-amber-100">
+              {props.scope === "movies"
+                ? "Plex does not support watched-TV or never-started cleanup on the Movies tab."
+                : "Plex does not support watched-TV or never-started TV cleanup on the TV tab."}
+            </p>
+          </div>
+        ) : null}
+        {!isPlex ? (
+          <Fragment>
+            <div
+              className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
+              data-testid="pruner-never-played-stale-panel"
+            >
+              <p className="text-sm font-semibold text-[var(--mm-text)]">
+                {props.scope === "tv"
+                  ? "Delete TV shows not watched in the last N days — Jellyfin / Emby"
+                  : "Delete TV or movies never started and older than N days — Jellyfin / Emby"}
+              </p>
+              <p className="text-xs text-[var(--mm-text2)]">
+                Only titles with no play time and older than this age.
+              </p>
+              {showInteractiveControls ? (
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={staleNeverEnabled}
+                      disabled={busy}
+                      onChange={(e) => setStaleNeverEnabled(e.target.checked)}
+                    />
+                    {props.scope === "tv"
+                      ? "Turn on never-watched TV older than this age"
+                      : "Turn on never-watched TV or movies older than this age"}
+                  </label>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <label className="text-sm text-[var(--mm-text2)]">
+                      Minimum age (days, 7–3650):{" "}
+                      <input
+                        type="number"
+                        min={7}
+                        max={3650}
+                        className="w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
+                        value={staleNeverDays}
+                        disabled={busy}
+                        onChange={(e) =>
+                          setStaleNeverDays(parseInt(e.target.value, 10) || 90)
+                        }
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                      disabled={busy}
+                      onClick={() => void saveStaleNeverSettings()}
+                    >
+                      Save never-watched age rule
+                    </button>
+                  </div>
+                  {staleNeverMsg ? (
+                    <p className="text-xs text-green-600">{staleNeverMsg}</p>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
+                    disabled={busy || !staleNeverEnabled}
+                    title={
+                      !staleNeverEnabled
+                        ? "Turn the rule on and save before running this scan."
+                        : undefined
+                    }
+                    onClick={() => void runStaleNeverPreview()}
+                  >
+                    {props.scope === "tv"
+                      ? "Scan for unwatched TV shows older than your setting"
+                      : "Scan for unwatched TV or movies older than your setting"}
+                  </button>
+                </div>
+              ) : (
+                <p className="text-xs text-[var(--mm-text2)]">
+                  Rule is{" "}
+                  <strong>
+                    {scopeRow?.never_played_stale_reported_enabled
+                      ? "on"
+                      : "off"}
+                  </strong>
+                  {scopeRow ? (
+                    <>
+                      {" "}
+                      (minimum age {scopeRow.never_played_min_age_days} days).
+                      Sign in as an operator to change it.
+                    </>
+                  ) : null}
+                </p>
+              )}
+            </div>
+            {props.scope === "tv" ? (
+              <div
+                className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
+                data-testid="pruner-watched-tv-panel"
+              >
+                <p className="text-sm font-semibold text-[var(--mm-text)]">
+                  Delete watched TV episodes — Jellyfin / Emby
+                </p>
+                <p className="text-xs text-[var(--mm-text2)]">
+                  Uses the watched flag for your MediaMop user on this server.
+                </p>
+                {showInteractiveControls ? (
+                  <div className="space-y-2">
+                    <label className="flex items-center gap-2 text-sm">
+                      <input
+                        type="checkbox"
+                        checked={watchedTvEnabled}
+                        disabled={busy}
+                        onChange={(e) => setWatchedTvEnabled(e.target.checked)}
+                      />
+                      Turn on watched-TV cleanup
+                    </label>
+                    <button
+                      type="button"
+                      className="rounded-md border border-[var(--mm-border)] px-3 py-1 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+                      disabled={busy}
+                      onClick={() => void saveWatchedTvSettings()}
+                    >
+                      Save watched TV rule
+                    </button>
+                    {watchedTvMsg ? (
+                      <p className="text-xs text-green-600">{watchedTvMsg}</p>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
+                      disabled={busy || !watchedTvEnabled}
+                      title={
+                        !watchedTvEnabled
+                          ? "Turn the rule on and save before running this scan."
+                          : undefined
+                      }
+                      onClick={() => void runWatchedTvPreview()}
+                    >
+                      Scan for watched TV shows
+                    </button>
+                  </div>
+                ) : (
+                  <p className="text-xs text-[var(--mm-text2)]">
+                    Watched TV rule is{" "}
+                    <strong>
+                      {scopeRow?.watched_tv_reported_enabled ? "on" : "off"}
+                    </strong>{" "}
+                    for this {libraryTabPhrase}. Sign in as an operator to
+                    change it.
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </Fragment>
+        ) : null}
+        {!isPlex ? null : props.scope === "movies" && !isProvider ? (
+          <p className="text-xs text-[var(--mm-text2)]">
+            On Plex, watched movies, low-score movies, and old unwatched movies
+            all use the same on-server details MediaMop already reads for other
+            scans — watched means the server shows you played it; low score uses
+            Plex audience rating; old unwatched uses when Plex says the title
+            was added to the library.
+          </p>
+        ) : null}
+        <div>
+          <h3
+            className="text-base font-semibold text-[var(--mm-text)]"
+            data-testid="pruner-rules-section-heading"
+          >
+            Cleanup rules
+          </h3>
+          <p className="text-xs text-[var(--mm-text2)]">
+            Turn a rule on, save, then run its scan when you are ready.
+          </p>
+        </div>
+        {props.scope === "movies" ? (
           <>
             <div
               className="space-y-2 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text)]"
               data-testid="pruner-watched-movies-panel"
             >
               <p className="text-sm font-semibold text-[var(--mm-text)]">
-                {isPlex ? "Delete watched movies — Plex" : "Delete watched movies — Jellyfin / Emby"}
+                {isPlex
+                  ? "Delete watched movies — Plex"
+                  : "Delete watched movies — Jellyfin / Emby"}
               </p>
               <p className="text-xs text-[var(--mm-text2)]">
-                {isPlex ? "Uses Plex watched flags for your MediaMop user." : "Uses the server watched flag for each movie."}
+                {isPlex
+                  ? "Uses Plex watched flags for your MediaMop user."
+                  : "Uses the server watched flag for each movie."}
               </p>
               {showInteractiveControls ? (
                 <div className="space-y-2">
@@ -1772,7 +2176,9 @@ export function PrunerScopeTab(props: {
                       type="checkbox"
                       checked={watchedMoviesEnabled}
                       disabled={busy}
-                      onChange={(e) => setWatchedMoviesEnabled(e.target.checked)}
+                      onChange={(e) =>
+                        setWatchedMoviesEnabled(e.target.checked)
+                      }
                     />
                     Turn on watched-movie cleanup
                   </label>
@@ -1784,13 +2190,17 @@ export function PrunerScopeTab(props: {
                   >
                     Save watched movies rule
                   </button>
-                  {watchedMoviesMsg ? <p className="text-xs text-green-600">{watchedMoviesMsg}</p> : null}
+                  {watchedMoviesMsg ? (
+                    <p className="text-xs text-green-600">{watchedMoviesMsg}</p>
+                  ) : null}
                   <button
                     type="button"
                     className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
                     disabled={busy || !watchedMoviesEnabled}
                     title={
-                      !watchedMoviesEnabled ? "Turn the rule on and save before running this scan." : undefined
+                      !watchedMoviesEnabled
+                        ? "Turn the rule on and save before running this scan."
+                        : undefined
                     }
                     onClick={() => void runWatchedMoviesPreview()}
                   >
@@ -1799,8 +2209,11 @@ export function PrunerScopeTab(props: {
                 </div>
               ) : (
                 <p className="text-xs text-[var(--mm-text2)]">
-                  Watched movies rule is <strong>{scopeRow?.watched_movies_reported_enabled ? "on" : "off"}</strong> for
-                  this library. Sign in as an operator to change it.
+                  Watched movies rule is{" "}
+                  <strong>
+                    {scopeRow?.watched_movies_reported_enabled ? "on" : "off"}
+                  </strong>{" "}
+                  for this library. Sign in as an operator to change it.
                 </p>
               )}
             </div>
@@ -1809,10 +2222,14 @@ export function PrunerScopeTab(props: {
               data-testid="pruner-watched-low-rating-panel"
             >
               <p className="text-sm font-semibold text-[var(--mm-text)]">
-                {isPlex ? "Delete low-score watched movies — Plex" : "Delete low-score watched movies — Jellyfin / Emby"}
+                {isPlex
+                  ? "Delete low-score watched movies — Plex"
+                  : "Delete low-score watched movies — Jellyfin / Emby"}
               </p>
               <p className="text-xs text-[var(--mm-text2)]">
-                {isPlex ? "Uses Plex audience rating." : "Uses your server’s community rating."}
+                {isPlex
+                  ? "Uses Plex audience rating."
+                  : "Uses your server’s community rating."}
               </p>
               {showInteractiveControls ? (
                 <div className="space-y-2">
@@ -1848,13 +2265,17 @@ export function PrunerScopeTab(props: {
                   >
                     Save low-rating rule
                   </button>
-                  {lowRatingMsg ? <p className="text-xs text-green-600">{lowRatingMsg}</p> : null}
+                  {lowRatingMsg ? (
+                    <p className="text-xs text-green-600">{lowRatingMsg}</p>
+                  ) : null}
                   <button
                     type="button"
                     className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
                     disabled={busy || !lowRatingEnabled}
                     title={
-                      !lowRatingEnabled ? "Turn the rule on and save before running this scan." : undefined
+                      !lowRatingEnabled
+                        ? "Turn the rule on and save before running this scan."
+                        : undefined
                     }
                     onClick={() => void runLowRatingMoviesPreview()}
                   >
@@ -1863,7 +2284,12 @@ export function PrunerScopeTab(props: {
                 </div>
               ) : (
                 <p className="text-xs text-[var(--mm-text2)]">
-                  Low-score rule is <strong>{scopeRow?.watched_movie_low_rating_reported_enabled ? "on" : "off"}</strong>
+                  Low-score rule is{" "}
+                  <strong>
+                    {scopeRow?.watched_movie_low_rating_reported_enabled
+                      ? "on"
+                      : "off"}
+                  </strong>
                   {scopeRow?.watched_movie_low_rating_reported_enabled ? (
                     <>
                       {" "}
@@ -1883,10 +2309,14 @@ export function PrunerScopeTab(props: {
               data-testid="pruner-unwatched-stale-panel"
             >
               <p className="text-sm font-semibold text-[var(--mm-text)]">
-                {isPlex ? "Delete old unwatched movies — Plex" : "Delete old unwatched movies — Jellyfin / Emby"}
+                {isPlex
+                  ? "Delete old unwatched movies — Plex"
+                  : "Delete old unwatched movies — Jellyfin / Emby"}
               </p>
               <p className="text-xs text-[var(--mm-text2)]">
-                {isPlex ? "Never watched, using when Plex added the title." : "Never watched, using when the server created the title."}
+                {isPlex
+                  ? "Never watched, using when Plex added the title."
+                  : "Never watched, using when the server created the title."}
               </p>
               {showInteractiveControls ? (
                 <div className="space-y-2">
@@ -1895,7 +2325,9 @@ export function PrunerScopeTab(props: {
                       type="checkbox"
                       checked={unwatchedStaleEnabled}
                       disabled={busy}
-                      onChange={(e) => setUnwatchedStaleEnabled(e.target.checked)}
+                      onChange={(e) =>
+                        setUnwatchedStaleEnabled(e.target.checked)
+                      }
                     />
                     Turn on old unwatched movie cleanup
                   </label>
@@ -1908,7 +2340,11 @@ export function PrunerScopeTab(props: {
                       className="w-24 rounded border border-[var(--mm-border)] bg-[var(--mm-surface2)] px-2 py-1 text-sm text-[var(--mm-text)]"
                       value={unwatchedStaleDays}
                       disabled={busy}
-                      onChange={(e) => setUnwatchedStaleDays(parseInt(e.target.value, 10) || 90)}
+                      onChange={(e) =>
+                        setUnwatchedStaleDays(
+                          parseInt(e.target.value, 10) || 90,
+                        )
+                      }
                     />
                   </label>
                   <button
@@ -1919,13 +2355,19 @@ export function PrunerScopeTab(props: {
                   >
                     Save unwatched stale rule
                   </button>
-                  {unwatchedStaleMsg ? <p className="text-xs text-green-600">{unwatchedStaleMsg}</p> : null}
+                  {unwatchedStaleMsg ? (
+                    <p className="text-xs text-green-600">
+                      {unwatchedStaleMsg}
+                    </p>
+                  ) : null}
                   <button
                     type="button"
                     className="rounded-md bg-[var(--mm-surface2)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] ring-1 ring-[var(--mm-border)] disabled:opacity-50"
                     disabled={busy || !unwatchedStaleEnabled}
                     title={
-                      !unwatchedStaleEnabled ? "Turn the rule on and save before running this scan." : undefined
+                      !unwatchedStaleEnabled
+                        ? "Turn the rule on and save before running this scan."
+                        : undefined
                     }
                     onClick={() => void runUnwatchedStaleMoviesPreview()}
                   >
@@ -1934,373 +2376,477 @@ export function PrunerScopeTab(props: {
                 </div>
               ) : (
                 <p className="text-xs text-[var(--mm-text2)]">
-                  Unwatched stale rule is <strong>{scopeRow?.unwatched_movie_stale_reported_enabled ? "on" : "off"}</strong>{" "}
-                  (min age {scopeRow?.unwatched_movie_stale_min_age_days} days). Sign in as an operator to change it.
+                  Unwatched stale rule is{" "}
+                  <strong>
+                    {scopeRow?.unwatched_movie_stale_reported_enabled
+                      ? "on"
+                      : "off"}
+                  </strong>{" "}
+                  (min age {scopeRow?.unwatched_movie_stale_min_age_days} days).
+                  Sign in as an operator to change it.
                 </p>
               )}
             </div>
           </>
         ) : null}
-      {!isProvider && scopeRow ? (
-        <div
-          className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text2)]"
-          data-testid="pruner-scope-latest-preview-summary"
-        >
-          <h3 className="text-sm font-semibold text-[var(--mm-text)]">Latest automatic scan (this {libraryTabPhrase})</h3>
-          <p className="mt-1 text-xs text-[var(--mm-text2)]">
-            Quick readout from the last finished scan — use the history table for older runs.
-          </p>
-          <dl className="mt-2 space-y-1 text-xs sm:text-sm">
-            <div>
-              <dt className="inline text-[var(--mm-text3)]">When</dt>{" "}
-              <dd className="inline font-medium text-[var(--mm-text1)]">
-                {formatPrunerDateTime(scopeRow.last_preview_at)}
-              </dd>
-            </div>
-            <div>
-              <dt className="inline text-[var(--mm-text3)]">Outcome</dt>{" "}
-              <dd className="inline font-medium text-[var(--mm-text1)]">{scopeRow.last_preview_outcome ?? "—"}</dd>
-            </div>
-            <div>
-              <dt className="inline text-[var(--mm-text3)]">Items matched</dt>{" "}
-              <dd className="inline font-medium text-[var(--mm-text1)]">{scopeRow.last_preview_candidate_count ?? "—"}</dd>
-            </div>
-            <div>
-              <dt className="inline text-[var(--mm-text3)]">Problem detail</dt>{" "}
-              <dd className="inline text-[var(--mm-text1)]">{scopeRow.last_preview_error ?? "—"}</dd>
-            </div>
-          </dl>
+        {!isProvider && scopeRow ? (
+          <div
+            className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3 text-sm text-[var(--mm-text2)]"
+            data-testid="pruner-scope-latest-preview-summary"
+          >
+            <h3 className="text-sm font-semibold text-[var(--mm-text)]">
+              Latest automatic scan (this {libraryTabPhrase})
+            </h3>
+            <p className="mt-1 text-xs text-[var(--mm-text2)]">
+              Quick readout from the last finished scan — use the history table
+              for older runs.
+            </p>
+            <dl className="mt-2 space-y-1 text-xs sm:text-sm">
+              <div>
+                <dt className="inline text-[var(--mm-text3)]">When</dt>{" "}
+                <dd className="inline font-medium text-[var(--mm-text1)]">
+                  {formatPrunerDateTime(scopeRow.last_preview_at)}
+                </dd>
+              </div>
+              <div>
+                <dt className="inline text-[var(--mm-text3)]">Outcome</dt>{" "}
+                <dd className="inline font-medium text-[var(--mm-text1)]">
+                  {scopeRow.last_preview_outcome ?? "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="inline text-[var(--mm-text3)]">Items matched</dt>{" "}
+                <dd className="inline font-medium text-[var(--mm-text1)]">
+                  {scopeRow.last_preview_candidate_count ?? "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="inline text-[var(--mm-text3)]">
+                  Problem detail
+                </dt>{" "}
+                <dd className="inline text-[var(--mm-text1)]">
+                  {scopeRow.last_preview_error ?? "—"}
+                </dd>
+              </div>
+            </dl>
+          </div>
+        ) : null}
+        <div>
+          <h3
+            className="text-base font-semibold text-[var(--mm-text)]"
+            data-testid="pruner-actions-history-heading"
+          >
+            {isProvider ? "Scan actions" : "Scan and delete actions"}
+          </h3>
+          {isProvider ? null : (
+            <p className="text-xs text-[var(--mm-text2)]">
+              Run scans, review the table, then delete from one chosen list if
+              you want. The table explains empty results and types your server
+              does not support.
+            </p>
+          )}
         </div>
-      ) : null}
-      <div>
-        <h3 className="text-base font-semibold text-[var(--mm-text)]" data-testid="pruner-actions-history-heading">
-          {isProvider ? "Scan actions" : "Scan and delete actions"}
-        </h3>
-        {isProvider ? null : (
-          <p className="text-xs text-[var(--mm-text2)]">
-            Run scans, review the table, then delete from one chosen list if you want. The table explains empty results and
-            types your server does not support.
-          </p>
-        )}
-      </div>
-      {showInteractiveControls ? (
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="rounded-md bg-[var(--mm-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-            disabled={busy}
-            onClick={() => void runPreview()}
-          >
-            Scan for broken posters
-          </button>
-          <button
-            type="button"
-            className="rounded-md border border-[var(--mm-border)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
-            disabled={busy || !scopeRow?.last_preview_run_uuid}
-            onClick={() => void loadJsonFor(scopeRow?.last_preview_run_uuid)}
-          >
-            View last scan results
-          </button>
-          {isProvider && scopeRow?.last_preview_run_uuid ? (
+        {showInteractiveControls ? (
+          <div className="flex flex-wrap gap-2">
             <button
               type="button"
-              className="rounded-md border border-red-900/50 bg-red-950/30 px-3 py-1.5 text-sm font-medium text-red-100 disabled:opacity-50"
+              className="rounded-md bg-[var(--mm-accent)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
               disabled={busy}
-              onClick={() => openApplyModal(scopeRow.last_preview_run_uuid!)}
+              onClick={() => void runPreview()}
             >
-              Delete from last scan
+              Scan for broken posters
             </button>
-          ) : null}
-        </div>
-      ) : (
-        <p className="text-sm text-[var(--mm-text2)]">Sign in as an operator to run scans.</p>
-      )}
-      <div className="mm-card mm-dash-card flex min-h-0 flex-col p-6" data-testid="pruner-scope-scheduled-preview">
-        <div className="mm-card-action-body flex-1 min-h-0">
-          <div>
-            <h3 className="text-base font-semibold text-[var(--mm-text1)]">
-              Automatic scans ({props.scope === "tv" ? "TV shows" : "Movies"})
-            </h3>
-            <p className="mt-1 text-sm text-[var(--mm-text2)]">
-              The schedule runs your saved criteria automatically and records a review snapshot. Deleting only happens when
-              automatic apply is enabled for this library and uses that saved snapshot.
+            <button
+              type="button"
+              className="rounded-md border border-[var(--mm-border)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)] disabled:opacity-50"
+              disabled={busy || !scopeRow?.last_preview_run_uuid}
+              onClick={() => void loadJsonFor(scopeRow?.last_preview_run_uuid)}
+            >
+              View last scan results
+            </button>
+            {isProvider && scopeRow?.last_preview_run_uuid ? (
+              <button
+                type="button"
+                className="rounded-md border border-red-900/50 bg-red-950/30 px-3 py-1.5 text-sm font-medium text-red-100 disabled:opacity-50"
+                disabled={busy}
+                onClick={() => openApplyModal(scopeRow.last_preview_run_uuid!)}
+              >
+                Delete from last scan
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-sm text-[var(--mm-text2)]">
+            Sign in as an operator to run scans.
+          </p>
+        )}
+        <div
+          className="mm-card mm-dash-card flex min-h-0 flex-col p-6"
+          data-testid="pruner-scope-scheduled-preview"
+        >
+          <div className="mm-card-action-body flex-1 min-h-0">
+            <div>
+              <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+                Automatic scans ({props.scope === "tv" ? "TV shows" : "Movies"})
+              </h3>
+              <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                The schedule runs your saved criteria automatically and records
+                a review snapshot. Deleting only happens when automatic apply is
+                enabled for this library and uses that saved snapshot.
+              </p>
+            </div>
+            {showInteractiveControls ? (
+              <>
+                <MmOnOffSwitch
+                  id={`pruner-scope-${instanceId}-${props.scope}-timed`}
+                  label="Enable timed scans"
+                  enabled={schedEnabled}
+                  disabled={busy}
+                  onChange={setSchedEnabled}
+                />
+                <div>
+                  <span className="text-sm font-medium text-[var(--mm-text1)]">
+                    Run interval (minutes)
+                  </span>
+                  <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                    How often this search runs automatically.
+                  </p>
+                  <input
+                    type="number"
+                    min={PRUNER_RUN_INTERVAL_MIN_MINUTES}
+                    max={PRUNER_RUN_INTERVAL_MAX_MINUTES}
+                    className="mm-input mt-2 w-full"
+                    value={
+                      schedIntervalMinDraft !== null
+                        ? schedIntervalMinDraft
+                        : committedPrunerRunIntervalMinutes(schedIntervalSec)
+                    }
+                    onFocus={() =>
+                      setSchedIntervalMinDraft(
+                        committedPrunerRunIntervalMinutes(schedIntervalSec),
+                      )
+                    }
+                    onChange={(e) => setSchedIntervalMinDraft(e.target.value)}
+                    onBlur={() => setSchedIntervalMinDraft(null)}
+                    disabled={busy}
+                    aria-label="Run interval in minutes"
+                  />
+                </div>
+                <div className="space-y-3">
+                  <div>
+                    <span className="text-sm font-medium text-[var(--mm-text1)]">
+                      Schedule window
+                    </span>
+                    <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                      {MM_SCHEDULE_TIME_WINDOW_HELPER}
+                    </p>
+                  </div>
+                  <div className="space-y-4">
+                    <MmOnOffSwitch
+                      id={`pruner-scope-${instanceId}-${props.scope}-hours`}
+                      label="Limit to these hours"
+                      enabled={schedHoursLimited}
+                      disabled={busy}
+                      onChange={setSchedHoursLimited}
+                    />
+                    <div className="space-y-2">
+                      <span className="text-sm font-medium text-[var(--mm-text1)]">
+                        Days
+                      </span>
+                      <MmScheduleDayChips
+                        scheduleDaysCsv={schedDays}
+                        disabled={busy}
+                        onChangeCsv={setSchedDays}
+                      />
+                    </div>
+                    <MmScheduleTimeFields
+                      idPrefix={`pruner-scope-${instanceId}-${props.scope}`}
+                      start={schedStart}
+                      end={schedEnd}
+                      disabled={busy}
+                      onStart={setSchedStart}
+                      onEnd={setSchedEnd}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : (
+              <p className="text-sm text-[var(--mm-text2)]">
+                Timed scans are{" "}
+                <strong>
+                  {scopeRow?.scheduled_preview_enabled ? "on" : "off"}
+                </strong>
+                {scopeRow ? (
+                  <>
+                    {" "}
+                    (every{" "}
+                    {Math.round(
+                      scopeRow.scheduled_preview_interval_seconds / 60,
+                    )}{" "}
+                    minutes). Sign in as an operator to change it.
+                  </>
+                ) : null}
+              </p>
+            )}
+            <p className="text-xs text-[var(--mm-text3)]">
+              Last automatic scan:{" "}
+              <span className="font-medium text-[var(--mm-text1)]">
+                {scopeRow?.last_scheduled_preview_enqueued_at
+                  ? fmt(scopeRow.last_scheduled_preview_enqueued_at)
+                  : "Never run"}
+              </span>
             </p>
           </div>
           {showInteractiveControls ? (
-            <>
-              <MmOnOffSwitch
-                id={`pruner-scope-${instanceId}-${props.scope}-timed`}
-                label="Enable timed scans"
-                enabled={schedEnabled}
+            <div className="mm-card-action-footer">
+              <button
+                type="button"
+                className={`${mmActionButtonClass({ variant: "primary", disabled: busy })} w-full`}
                 disabled={busy}
-                onChange={setSchedEnabled}
-              />
-              <div>
-                <span className="text-sm font-medium text-[var(--mm-text1)]">Run interval (minutes)</span>
-                <p className="mt-1 text-xs text-[var(--mm-text3)]">How often this search runs automatically.</p>
-                <input
-                  type="number"
-                  min={PRUNER_RUN_INTERVAL_MIN_MINUTES}
-                  max={PRUNER_RUN_INTERVAL_MAX_MINUTES}
-                  className="mm-input mt-2 w-full"
-                  value={
-                    schedIntervalMinDraft !== null
-                      ? schedIntervalMinDraft
-                      : committedPrunerRunIntervalMinutes(schedIntervalSec)
-                  }
-                  onFocus={() => setSchedIntervalMinDraft(committedPrunerRunIntervalMinutes(schedIntervalSec))}
-                  onChange={(e) => setSchedIntervalMinDraft(e.target.value)}
-                  onBlur={() => setSchedIntervalMinDraft(null)}
-                  disabled={busy}
-                  aria-label="Run interval in minutes"
-                />
-              </div>
-              <div className="space-y-3">
-                <div>
-                  <span className="text-sm font-medium text-[var(--mm-text1)]">Schedule window</span>
-                  <p className="mt-1 text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_TIME_WINDOW_HELPER}</p>
-                </div>
-                <div className="space-y-4">
-                  <MmOnOffSwitch
-                    id={`pruner-scope-${instanceId}-${props.scope}-hours`}
-                    label="Limit to these hours"
-                    enabled={schedHoursLimited}
-                    disabled={busy}
-                    onChange={setSchedHoursLimited}
-                  />
-                  <div className="space-y-2">
-                    <span className="text-sm font-medium text-[var(--mm-text1)]">Days</span>
-                    <MmScheduleDayChips scheduleDaysCsv={schedDays} disabled={busy} onChangeCsv={setSchedDays} />
-                  </div>
-                  <MmScheduleTimeFields
-                    idPrefix={`pruner-scope-${instanceId}-${props.scope}`}
-                    start={schedStart}
-                    end={schedEnd}
-                    disabled={busy}
-                    onStart={setSchedStart}
-                    onEnd={setSchedEnd}
-                  />
-                </div>
-              </div>
-            </>
-          ) : (
-            <p className="text-sm text-[var(--mm-text2)]">
-              Timed scans are <strong>{scopeRow?.scheduled_preview_enabled ? "on" : "off"}</strong>
-              {scopeRow ? (
-                <>
-                  {" "}
-                  (every {Math.round(scopeRow.scheduled_preview_interval_seconds / 60)} minutes). Sign in
-                  as an operator to change it.
-                </>
+                onClick={() => void saveSchedule()}
+              >
+                {props.scope === "tv"
+                  ? "Save TV schedule window"
+                  : "Save Movies schedule window"}
+              </button>
+              {schedMsg ? (
+                <p className="text-xs text-green-600">{schedMsg}</p>
               ) : null}
-            </p>
-          )}
-          <p className="text-xs text-[var(--mm-text3)]">
-            Last automatic scan:{" "}
-            <span className="font-medium text-[var(--mm-text1)]">
-              {scopeRow?.last_scheduled_preview_enqueued_at ? fmt(scopeRow.last_scheduled_preview_enqueued_at) : "Never run"}
-            </span>
-          </p>
+            </div>
+          ) : null}
         </div>
-        {showInteractiveControls ? (
-          <div className="mm-card-action-footer">
-            <button
-              type="button"
-              className={`${mmActionButtonClass({ variant: "primary", disabled: busy })} w-full`}
-              disabled={busy}
-              onClick={() => void saveSchedule()}
-            >
-              {props.scope === "tv" ? "Save TV schedule window" : "Save Movies schedule window"}
-            </button>
-            {schedMsg ? <p className="text-xs text-green-600">{schedMsg}</p> : null}
-          </div>
-        ) : null}
-      </div>
-      {!isProvider ? (
-      <div className="space-y-2" data-testid="pruner-preview-runs-history">
-        <h3 className="text-sm font-semibold text-[var(--mm-text)]">
-          Recent scans ({props.scope === "tv" ? "TV shows" : "Movies"})
-        </h3>
-        {runsQuery.isLoading ? (
-          <p className="text-sm text-[var(--mm-text2)]">Loading history…</p>
-        ) : runsQuery.isError ? (
-          <p className="text-sm text-red-600" role="alert">
-            {(runsQuery.error as Error).message}
-          </p>
-        ) : runsQuery.data?.length ? (
-          <div className="overflow-x-auto rounded-md border border-[var(--mm-border)]">
-            <table className="w-full min-w-[30rem] border-collapse text-left text-sm text-[var(--mm-text)]">
-              <thead className="border-b border-[var(--mm-border)] bg-[var(--mm-surface2)] text-xs uppercase text-[var(--mm-text2)]">
-                <tr>
-                  <th className="px-2 py-2">#</th>
-                  <th className="px-2 py-2">Cleanup type</th>
-                  <th className="px-2 py-2">When</th>
-                  <th className="px-2 py-2">Result</th>
-                  <th className="px-2 py-2">What it means</th>
-                  <th className="px-2 py-2">Items</th>
-                  <th className="px-2 py-2"> </th>
-                </tr>
-              </thead>
-              <tbody>
-                {runsQuery.data.map((row, idx) => (
-                  <tr key={row.preview_run_id} className="border-b border-[var(--mm-border)] align-top">
-                    <td className="px-2 py-2 text-xs text-[var(--mm-text2)]">{idx + 1}</td>
-                    <td className="px-2 py-2 text-xs text-[var(--mm-text2)]">{ruleFamilyColumnLabel(row.rule_family_id)}</td>
-                    <td className="whitespace-nowrap px-2 py-2 text-xs text-[var(--mm-text2)]">{fmt(row.created_at)}</td>
-                    <td className="max-w-[14rem] break-words px-2 py-2 text-xs">
-                      <span className="font-medium">{row.outcome}</span>
-                      {row.unsupported_detail ? (
-                        <div className="mt-1 text-[var(--mm-text2)]">{row.unsupported_detail}</div>
-                      ) : null}
-                      {row.error_message ? (
-                        <div className="mt-1 text-red-600">{row.error_message}</div>
-                      ) : null}
-                    </td>
-                    <td
-                      className="px-2 py-2 align-top text-[0.7rem] leading-snug text-[var(--mm-text2)]"
-                      data-testid={`pruner-preview-run-caption-${row.preview_run_id}`}
-                    >
-                      {previewRunRowCaption(row)}
-                    </td>
-                    <td className="whitespace-nowrap px-2 py-2 text-xs">
-                      {row.candidate_count}
-                      {row.truncated ? " (list stopped at limit)" : ""}
-                    </td>
-                    <td className="px-2 py-2 space-y-1">
-                      <button
-                        type="button"
-                        className="rounded border border-[var(--mm-border)] px-2 py-1 text-xs font-medium text-[var(--mm-text)] disabled:opacity-50"
-                        disabled={busy}
-                        onClick={() => void loadJsonFor(row.preview_run_id)}
+        {!isProvider ? (
+          <div className="space-y-2" data-testid="pruner-preview-runs-history">
+            <h3 className="text-sm font-semibold text-[var(--mm-text)]">
+              Recent scans ({props.scope === "tv" ? "TV shows" : "Movies"})
+            </h3>
+            {runsQuery.isLoading ? (
+              <p className="text-sm text-[var(--mm-text2)]">Loading history…</p>
+            ) : runsQuery.isError ? (
+              <p className="text-sm text-red-600" role="alert">
+                {(runsQuery.error as Error).message}
+              </p>
+            ) : runsQuery.data?.length ? (
+              <div className="overflow-x-auto rounded-md border border-[var(--mm-border)]">
+                <table className="w-full min-w-[30rem] border-collapse text-left text-sm text-[var(--mm-text)]">
+                  <thead className="border-b border-[var(--mm-border)] bg-[var(--mm-surface2)] text-xs uppercase text-[var(--mm-text2)]">
+                    <tr>
+                      <th className="px-2 py-2">#</th>
+                      <th className="px-2 py-2">Cleanup type</th>
+                      <th className="px-2 py-2">When</th>
+                      <th className="px-2 py-2">Result</th>
+                      <th className="px-2 py-2">What it means</th>
+                      <th className="px-2 py-2">Items</th>
+                      <th className="px-2 py-2"> </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {runsQuery.data.map((row, idx) => (
+                      <tr
+                        key={row.preview_run_id}
+                        className="border-b border-[var(--mm-border)] align-top"
                       >
-                        Raw
-                      </button>
-                      {canOperate && canApplyFromPreviewSnapshot(instance?.provider, row) ? (
-                        <div>
+                        <td className="px-2 py-2 text-xs text-[var(--mm-text2)]">
+                          {idx + 1}
+                        </td>
+                        <td className="px-2 py-2 text-xs text-[var(--mm-text2)]">
+                          {ruleFamilyColumnLabel(row.rule_family_id)}
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-2 text-xs text-[var(--mm-text2)]">
+                          {fmt(row.created_at)}
+                        </td>
+                        <td className="max-w-[14rem] break-words px-2 py-2 text-xs">
+                          <span className="font-medium">{row.outcome}</span>
+                          {row.unsupported_detail ? (
+                            <div className="mt-1 text-[var(--mm-text2)]">
+                              {row.unsupported_detail}
+                            </div>
+                          ) : null}
+                          {row.error_message ? (
+                            <div className="mt-1 text-red-600">
+                              {row.error_message}
+                            </div>
+                          ) : null}
+                        </td>
+                        <td
+                          className="px-2 py-2 align-top text-[0.7rem] leading-snug text-[var(--mm-text2)]"
+                          data-testid={`pruner-preview-run-caption-${row.preview_run_id}`}
+                        >
+                          {previewRunRowCaption(row)}
+                        </td>
+                        <td className="whitespace-nowrap px-2 py-2 text-xs">
+                          {row.candidate_count}
+                          {row.truncated ? " (list stopped at limit)" : ""}
+                        </td>
+                        <td className="px-2 py-2 space-y-1">
                           <button
                             type="button"
-                            className="mt-1 block w-full rounded border border-red-900/50 bg-red-950/30 px-2 py-1 text-left text-xs font-medium text-red-100 disabled:opacity-50"
-                            data-testid={`pruner-apply-open-${row.preview_run_id}`}
+                            className="rounded border border-[var(--mm-border)] px-2 py-1 text-xs font-medium text-[var(--mm-text)] disabled:opacity-50"
                             disabled={busy}
-                            onClick={() => openApplyModal(row.preview_run_id)}
+                            onClick={() => void loadJsonFor(row.preview_run_id)}
                           >
-                            {prunerApplyLabelForRuleFamily(row.rule_family_id)}
+                            Raw
                           </button>
-                        </div>
-                      ) : null}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
+                          {canOperate &&
+                          canApplyFromPreviewSnapshot(
+                            instance?.provider,
+                            row,
+                          ) ? (
+                            <div>
+                              <button
+                                type="button"
+                                className="mt-1 block w-full rounded border border-red-900/50 bg-red-950/30 px-2 py-1 text-left text-xs font-medium text-red-100 disabled:opacity-50"
+                                data-testid={`pruner-apply-open-${row.preview_run_id}`}
+                                disabled={busy}
+                                onClick={() =>
+                                  openApplyModal(row.preview_run_id)
+                                }
+                              >
+                                {prunerApplyLabelForRuleFamily(
+                                  row.rule_family_id,
+                                )}
+                              </button>
+                            </div>
+                          ) : null}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : (
+              <p
+                className="text-sm text-[var(--mm-text2)]"
+                data-testid="pruner-preview-runs-empty"
+              >
+                No scans yet for this library. Run a scan from a rule panel
+                above; when it finishes, rows appear here with the result, how
+                many items matched, and a short explanation (including rules
+                Plex does not support).
+              </p>
+            )}
           </div>
-        ) : (
-          <p className="text-sm text-[var(--mm-text2)]" data-testid="pruner-preview-runs-empty">
-            No scans yet for this library. Run a scan from a rule panel above; when it finishes, rows appear here with the
-            result, how many items matched, and a short explanation (including rules Plex does not support).
-          </p>
-        )}
-      </div>
-      ) : null}
-      {applyModalRunId ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="pruner-apply-modal-title"
-          data-testid="pruner-apply-modal"
-        >
-          <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-4 shadow-xl">
-            <h3 id="pruner-apply-modal-title" className="text-base font-semibold text-[var(--mm-text)]">
-              {applySnapshotOperatorLabel ?? "Delete from last scan"}
-            </h3>
-            <p className="mt-2 text-sm text-[var(--mm-text2)]">
-              This deletes <strong>only</strong> the titles from the saved list you opened — MediaMop does not run a new
-              scan or add titles. Items already removed on the server are usually counted as skipped; full counts appear
-              in Activity when the job finishes.
-            </p>
-            {applyEligQuery.isLoading ? (
-              <p className="mt-3 text-sm text-[var(--mm-text2)]">Checking whether deletion is allowed…</p>
-            ) : applyEligQuery.isError ? (
-              <p className="mt-3 text-sm text-red-600" role="alert">
-                {(applyEligQuery.error as Error).message}
-              </p>
-            ) : applyEligQuery.data ? (
-              <ul className="mt-3 list-inside list-disc space-y-1 text-sm text-[var(--mm-text)]">
-                <li>
-                  Server: <strong>{applyEligQuery.data.display_name}</strong> ({applyEligQuery.data.provider})
-                </li>
-                <li>
-                  Library type: <strong>{applyEligQuery.data.media_scope === "tv" ? "TV shows" : "Movies"}</strong>
-                </li>
-                <li>
-                  Scan time:{" "}
-                  {applyEligQuery.data.preview_created_at ? fmt(applyEligQuery.data.preview_created_at) : "—"}
-                </li>
-                <li>
-                  Items in this list: <strong>{applyEligQuery.data.candidate_count}</strong>
-                </li>
-              </ul>
-            ) : null}
-            {applyEligQuery.data && !applyEligQuery.data.eligible ? (
-              <p className="mt-3 text-sm text-amber-700" role="status">
-                {applyEligQuery.data.reasons.length
-                  ? applyEligQuery.data.reasons.join(" ")
-                  : "These items cannot be deleted right now."}
-              </p>
-            ) : null}
-            {applyEligQuery.data?.eligible ? (
-              <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm text-[var(--mm-text)]">
-                <input
-                  type="checkbox"
-                  className="mt-1"
-                  checked={applySnapshotConfirmed}
-                  onChange={(e) => setApplySnapshotConfirmed(e.target.checked)}
-                />
-                <span>
-                  I confirm <strong>{applySnapshotOperatorLabel}</strong> for this saved list of up to{" "}
-                  {applyEligQuery.data.candidate_count} titles.
-                </span>
-              </label>
-            ) : null}
-            <div className="mt-4 flex flex-wrap justify-end gap-2">
-              <button
-                type="button"
-                className="rounded-md border border-[var(--mm-border)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)]"
-                onClick={() => closeApplyModal()}
+        ) : null}
+        {applyModalRunId ? (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pruner-apply-modal-title"
+            data-testid="pruner-apply-modal"
+          >
+            <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-4 shadow-xl">
+              <h3
+                id="pruner-apply-modal-title"
+                className="text-base font-semibold text-[var(--mm-text)]"
               >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="rounded-md bg-red-800 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
-                data-testid="pruner-apply-confirm"
-                disabled={
-                  busy ||
-                  !applyEligQuery.data?.eligible ||
-                  !applySnapshotConfirmed ||
-                  applyEligQuery.isLoading ||
-                  applyEligQuery.isError
-                }
-                onClick={() => void confirmApplyFromSnapshot()}
-              >
-                {applySnapshotOperatorLabel ?? "Confirm delete"}
-              </button>
+                {applySnapshotOperatorLabel ?? "Delete from last scan"}
+              </h3>
+              <p className="mt-2 text-sm text-[var(--mm-text2)]">
+                This deletes <strong>only</strong> the titles from the saved
+                list you opened — MediaMop does not run a new scan or add
+                titles. Items already removed on the server are usually counted
+                as skipped; full counts appear in Activity when the job
+                finishes.
+              </p>
+              {applyEligQuery.isLoading ? (
+                <p className="mt-3 text-sm text-[var(--mm-text2)]">
+                  Checking whether deletion is allowed…
+                </p>
+              ) : applyEligQuery.isError ? (
+                <p className="mt-3 text-sm text-red-600" role="alert">
+                  {(applyEligQuery.error as Error).message}
+                </p>
+              ) : applyEligQuery.data ? (
+                <ul className="mt-3 list-inside list-disc space-y-1 text-sm text-[var(--mm-text)]">
+                  <li>
+                    Server: <strong>{applyEligQuery.data.display_name}</strong>{" "}
+                    ({applyEligQuery.data.provider})
+                  </li>
+                  <li>
+                    Library type:{" "}
+                    <strong>
+                      {applyEligQuery.data.media_scope === "tv"
+                        ? "TV shows"
+                        : "Movies"}
+                    </strong>
+                  </li>
+                  <li>
+                    Scan time:{" "}
+                    {applyEligQuery.data.preview_created_at
+                      ? fmt(applyEligQuery.data.preview_created_at)
+                      : "—"}
+                  </li>
+                  <li>
+                    Items in this list:{" "}
+                    <strong>{applyEligQuery.data.candidate_count}</strong>
+                  </li>
+                </ul>
+              ) : null}
+              {applyEligQuery.data && !applyEligQuery.data.eligible ? (
+                <p className="mt-3 text-sm text-amber-700" role="status">
+                  {applyEligQuery.data.reasons.length
+                    ? applyEligQuery.data.reasons.join(" ")
+                    : "These items cannot be deleted right now."}
+                </p>
+              ) : null}
+              {applyEligQuery.data?.eligible ? (
+                <label className="mt-4 flex cursor-pointer items-start gap-2 text-sm text-[var(--mm-text)]">
+                  <input
+                    type="checkbox"
+                    className="mt-1"
+                    checked={applySnapshotConfirmed}
+                    onChange={(e) =>
+                      setApplySnapshotConfirmed(e.target.checked)
+                    }
+                  />
+                  <span>
+                    I confirm <strong>{applySnapshotOperatorLabel}</strong> for
+                    this saved list of up to{" "}
+                    {applyEligQuery.data.candidate_count} titles.
+                  </span>
+                </label>
+              ) : null}
+              <div className="mt-4 flex flex-wrap justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-[var(--mm-border)] px-3 py-1.5 text-sm font-medium text-[var(--mm-text)]"
+                  onClick={() => closeApplyModal()}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-800 px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+                  data-testid="pruner-apply-confirm"
+                  disabled={
+                    busy ||
+                    !applyEligQuery.data?.eligible ||
+                    !applySnapshotConfirmed ||
+                    applyEligQuery.isLoading ||
+                    applyEligQuery.isError
+                  }
+                  onClick={() => void confirmApplyFromSnapshot()}
+                >
+                  {applySnapshotOperatorLabel ?? "Confirm delete"}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
-      {err ? (
-        <p className="text-sm text-red-600" role="alert">
-          {err}
-        </p>
-      ) : null}
-      {preview ? <p className="text-sm text-[var(--mm-text)]">{preview}</p> : null}
-      {jsonPreview ? (
-        <pre className="max-h-96 overflow-auto rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)] p-3 text-xs">
-          {jsonPreview}
-        </pre>
-      ) : null}
+        ) : null}
+        {err ? (
+          <p className="text-sm text-red-600" role="alert">
+            {err}
+          </p>
+        ) : null}
+        {preview ? (
+          <p className="text-sm text-[var(--mm-text)]">{preview}</p>
+        ) : null}
+        {jsonPreview ? (
+          <pre className="max-h-96 overflow-auto rounded-md border border-[var(--mm-border)] bg-[var(--mm-surface2)] p-3 text-xs">
+            {jsonPreview}
+          </pre>
+        ) : null}
       </fieldset>
     </section>
   );

--- a/apps/web/src/pages/pruner/pruner-studio-multi-select.tsx
+++ b/apps/web/src/pages/pruner/pruner-studio-multi-select.tsx
@@ -13,7 +13,10 @@ function studioTriggerSummary(values: string[]): string {
   return `${values.length} studios selected`;
 }
 
-function mergeOptionsFromLibrary(libraryStudios: readonly string[], selected: readonly string[]): MmListboxOption[] {
+function mergeOptionsFromLibrary(
+  libraryStudios: readonly string[],
+  selected: readonly string[],
+): MmListboxOption[] {
   const byFold = new Map<string, string>();
   for (const s of libraryStudios) {
     const t = s.trim();
@@ -27,7 +30,9 @@ function mergeOptionsFromLibrary(libraryStudios: readonly string[], selected: re
     const k = t.toLowerCase();
     if (!byFold.has(k)) byFold.set(k, t);
   }
-  const labels = [...byFold.values()].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+  const labels = [...byFold.values()].sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: "base" }),
+  );
   return labels.map((label) => ({ value: label, label }));
 }
 
@@ -55,7 +60,9 @@ export function PrunerStudioMultiSelect({
   const baseTestId = testId ?? "pruner-studio-multiselect";
 
   const helperBelow = (
-    <p className="text-xs text-[var(--mm-text3)]">Select studios to activate this rule.</p>
+    <p className="text-xs text-[var(--mm-text3)]">
+      Select studios to activate this rule.
+    </p>
   );
 
   if (loading) {
@@ -82,10 +89,17 @@ export function PrunerStudioMultiSelect({
         <span className="sr-only" data-testid={`${baseTestId}-summary`}>
           {summary}
         </span>
-        <select className="mm-input w-full cursor-not-allowed opacity-70" disabled value="__none__" data-testid={`${baseTestId}-empty`}>
+        <select
+          className="mm-input w-full cursor-not-allowed opacity-70"
+          disabled
+          value="__none__"
+          data-testid={`${baseTestId}-empty`}
+        >
           <option value="__none__">No studios found</option>
         </select>
-        <p className="text-xs text-[var(--mm-text3)]">No studios found in your library for this scope.</p>
+        <p className="text-xs text-[var(--mm-text3)]">
+          No studios found in your library for this scope.
+        </p>
         {helperBelow}
       </div>
     );

--- a/apps/web/src/pages/pruner/pruner-ui-utils.ts
+++ b/apps/web/src/pages/pruner/pruner-ui-utils.ts
@@ -30,7 +30,9 @@ export function previewRunRowCaption(row: PrunerPreviewRunSummary): string {
 }
 
 /** Maps internal job kind strings to short operator-facing labels (never shows raw API identifiers). */
-export function prunerJobKindOperatorLabel(jobKind: string | null | undefined): string {
+export function prunerJobKindOperatorLabel(
+  jobKind: string | null | undefined,
+): string {
   if (!jobKind?.trim()) return "—";
   const k = jobKind.toLowerCase();
   if (k.includes("apply")) return "Delete run";
@@ -44,7 +46,10 @@ export type PrunerScopeMedia = "tv" | "movies";
 /** Rule families that have no honest preview on Plex for the given scope (operator-facing). */
 export function plexUnsupportedRuleFamilies(scope: PrunerScopeMedia): string[] {
   if (scope === "tv") {
-    return ["TV shows never started, older than your age setting", "Watched TV episodes"];
+    return [
+      "TV shows never started, older than your age setting",
+      "Watched TV episodes",
+    ];
   }
   return [];
 }

--- a/apps/web/src/pages/refiner/refiner-jobs-inspection-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-jobs-inspection-section.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useId, useState } from "react";
 import { Link } from "react-router-dom";
 import { MmJobsPagination } from "../../components/overview/mm-overview-cards";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useMeQuery } from "../../lib/auth/queries";
 import type { RefinerJobsInspectionFilter } from "../../lib/refiner/jobs-inspection/queries";
 import {
@@ -23,7 +26,10 @@ function statusLabel(status: string): string {
   return status;
 }
 
-const REFINER_JOBS_INSPECTION_FILTER_OPTIONS: { value: RefinerJobsInspectionFilter; label: string }[] = [
+const REFINER_JOBS_INSPECTION_FILTER_OPTIONS: {
+  value: RefinerJobsInspectionFilter;
+  label: string;
+}[] = [
   { value: "recent", label: "Recent (all statuses, newest first)" },
   { value: "pending", label: "Pending only" },
   { value: "leased", label: "Leased only" },
@@ -67,15 +73,23 @@ export function RefinerJobsInspectionSection() {
       data-testid="refiner-jobs-inspection-section"
     >
       <header className="border-b border-[var(--mm-border)] bg-black/10 px-4 py-3.5 sm:px-5 sm:py-4">
-        <h2 id="refiner-jobs-inspection-heading" className="text-lg font-semibold tracking-tight text-[var(--mm-text)]">
+        <h2
+          id="refiner-jobs-inspection-heading"
+          className="text-lg font-semibold tracking-tight text-[var(--mm-text)]"
+        >
           Jobs
         </h2>
-        <p className="mt-1 text-sm text-[var(--mm-text2)]">Pending, running, and recent Refiner work.</p>
+        <p className="mt-1 text-sm text-[var(--mm-text2)]">
+          Pending, running, and recent Refiner work.
+        </p>
       </header>
       <div className="space-y-4 px-4 py-4 sm:px-5 sm:py-5">
         <div className="flex flex-col gap-3 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3.5 py-3.5 sm:flex-row sm:items-end sm:justify-between sm:px-5 sm:py-4">
           <label className="block min-w-0 flex-1">
-            <span id={filterLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+            <span
+              id={filterLabelId}
+              className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+            >
               Show jobs
             </span>
             <MmListboxPicker
@@ -89,9 +103,15 @@ export function RefinerJobsInspectionSection() {
             />
           </label>
         </div>
-        {q.isPending || me.isPending ? <p className="text-sm text-[var(--mm-text2)]">Loading jobs…</p> : null}
+        {q.isPending || me.isPending ? (
+          <p className="text-sm text-[var(--mm-text2)]">Loading jobs…</p>
+        ) : null}
         {q.isError ? (
-          <p className="text-sm text-red-600" role="alert" data-testid="refiner-jobs-inspection-error">
+          <p
+            className="text-sm text-red-600"
+            role="alert"
+            data-testid="refiner-jobs-inspection-error"
+          >
             {isLikelyNetworkFailure(q.error)
               ? "Could not reach the MediaMop API. Check that the backend is running."
               : isHttpErrorFromApi(q.error)
@@ -103,8 +123,14 @@ export function RefinerJobsInspectionSection() {
         ) : null}
 
         {cancel.isError ? (
-          <p className="text-sm text-red-300" role="alert" data-testid="refiner-jobs-inspection-cancel-error">
-            {cancel.error instanceof Error ? cancel.error.message : "Cancel failed."}
+          <p
+            className="text-sm text-red-300"
+            role="alert"
+            data-testid="refiner-jobs-inspection-cancel-error"
+          >
+            {cancel.error instanceof Error
+              ? cancel.error.message
+              : "Cancel failed."}
           </p>
         ) : null}
 
@@ -113,9 +139,14 @@ export function RefinerJobsInspectionSection() {
             className="space-y-1 rounded border border-[var(--mm-border)] bg-black/10 px-5 py-10 text-center"
             data-testid="refiner-jobs-inspection-empty"
           >
-            <p className="text-sm font-medium text-[var(--mm-text)]">No jobs match this view</p>
+            <p className="text-sm font-medium text-[var(--mm-text)]">
+              No jobs match this view
+            </p>
             <p className="text-xs text-[var(--mm-text2)]">
-              Nothing matches this filter yet. Try <strong className="text-[var(--mm-text2)]">Recent (all statuses)</strong>{" "}
+              Nothing matches this filter yet. Try{" "}
+              <strong className="text-[var(--mm-text2)]">
+                Recent (all statuses)
+              </strong>{" "}
               for the latest rows.
             </p>
           </div>
@@ -124,24 +155,41 @@ export function RefinerJobsInspectionSection() {
         {!q.isPending && !q.isError && jobs.length > 0 ? (
           <>
             <div className="w-full min-w-0 overflow-x-auto rounded border border-[var(--mm-border)]">
-            <table className="w-full min-w-[34rem] text-left text-sm">
-              <thead className="bg-black/20 text-[var(--mm-text2)]">
-                <tr>
-                  <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">Id</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Status</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Kind</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Updated</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Lease</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Dedupe</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium" />
-                </tr>
-              </thead>
-              <tbody>
-                {pagedRows.map((j) => (
-                  <RefinerJobRow key={j.id} job={j} canCancel={canCancel} cancelMutation={cancel} />
-                ))}
-              </tbody>
-            </table>
+              <table className="w-full min-w-[34rem] text-left text-sm">
+                <thead className="bg-black/20 text-[var(--mm-text2)]">
+                  <tr>
+                    <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">
+                      Id
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Status
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Kind
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Updated
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Lease
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Dedupe
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {pagedRows.map((j) => (
+                    <RefinerJobRow
+                      key={j.id}
+                      job={j}
+                      canCancel={canCancel}
+                      cancelMutation={cancel}
+                    />
+                  ))}
+                </tbody>
+              </table>
             </div>
             <MmJobsPagination
               page={page}
@@ -156,7 +204,10 @@ export function RefinerJobsInspectionSection() {
 
         <p className="text-xs text-[var(--mm-text2)]">
           Full detail on Refiner outcomes is in the{" "}
-          <Link to="/app/activity" className="text-[var(--mm-accent)] underline">
+          <Link
+            to="/app/activity"
+            className="text-[var(--mm-accent)] underline"
+          >
             Activity log
           </Link>
           .
@@ -177,13 +228,20 @@ function RefinerJobRow({
 }) {
   const showCancel = canCancel && job.status === "pending";
   return (
-    <tr className="border-t border-[var(--mm-border)] align-top text-[var(--mm-text)]" data-testid="refiner-jobs-row">
+    <tr
+      className="border-t border-[var(--mm-border)] align-top text-[var(--mm-text)]"
+      data-testid="refiner-jobs-row"
+    >
       <td className="sticky left-0 z-[1] whitespace-nowrap bg-[var(--mm-card-bg)] px-3 py-2 font-mono text-xs text-[var(--mm-text1)]">
         #{job.id}
       </td>
       <td className="whitespace-nowrap px-3 py-2">{statusLabel(job.status)}</td>
-      <td className="max-w-[16rem] break-words px-3 py-2 font-mono text-[0.8rem] text-[var(--mm-text2)]">{job.job_kind}</td>
-      <td className="whitespace-nowrap px-3 py-2 text-xs text-[var(--mm-text2)]">{job.updated_at}</td>
+      <td className="max-w-[16rem] break-words px-3 py-2 font-mono text-[0.8rem] text-[var(--mm-text2)]">
+        {job.job_kind}
+      </td>
+      <td className="whitespace-nowrap px-3 py-2 text-xs text-[var(--mm-text2)]">
+        {job.updated_at}
+      </td>
       <td className="max-w-[16rem] break-words px-3 py-2 text-[var(--mm-text2)]">
         {job.lease_owner ? (
           <span title={job.lease_expires_at ?? ""}>
@@ -195,7 +253,11 @@ function RefinerJobRow({
         )}
       </td>
       <td className="max-w-[14rem] break-words px-3 py-2 font-mono text-[0.75rem] text-[var(--mm-text3)]">
-        <span title={job.dedupe_key}>{job.dedupe_key.length > 48 ? `${job.dedupe_key.slice(0, 48)}…` : job.dedupe_key}</span>
+        <span title={job.dedupe_key}>
+          {job.dedupe_key.length > 48
+            ? `${job.dedupe_key.slice(0, 48)}…`
+            : job.dedupe_key}
+        </span>
       </td>
       <td className="px-3 py-2 text-right">
         {showCancel ? (

--- a/apps/web/src/pages/refiner/refiner-overview-tab.tsx
+++ b/apps/web/src/pages/refiner/refiner-overview-tab.tsx
@@ -9,7 +9,10 @@ import {
   MmStatTileRow,
 } from "../../components/overview/mm-overview-cards";
 import { PageLoading } from "../../components/shared/page-loading";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useRefinerJobsInspectionQuery } from "../../lib/refiner/jobs-inspection/queries";
 import {
   useRefinerOperatorSettingsQuery,
@@ -21,9 +24,15 @@ import { refinerStreamLanguageLabel } from "../../lib/refiner/stream-language-op
 import type { RefinerRemuxRulesScopeSettings } from "../../lib/refiner/types";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
-export type RefinerOverviewOpenTab = "libraries" | "audio-subtitles" | "jobs" | "schedules";
+export type RefinerOverviewOpenTab =
+  | "libraries"
+  | "audio-subtitles"
+  | "jobs"
+  | "schedules";
 
-function remuxDefaultsGlanceBody(rem: RefinerRemuxRulesScopeSettings): ReactNode {
+function remuxDefaultsGlanceBody(
+  rem: RefinerRemuxRulesScopeSettings,
+): ReactNode {
   const pri = refinerStreamLanguageLabel(rem.primary_audio_lang);
   const sec = (rem.secondary_audio_lang ?? "").trim()
     ? refinerStreamLanguageLabel(rem.secondary_audio_lang)
@@ -64,7 +73,10 @@ function remuxDefaultsGlanceBody(rem: RefinerRemuxRulesScopeSettings): ReactNode
   );
 }
 
-function buildNeedsAttention(args: { failedCount: number; watchedSet: boolean }): { text: string; target?: RefinerOverviewOpenTab }[] {
+function buildNeedsAttention(args: {
+  failedCount: number;
+  watchedSet: boolean;
+}): { text: string; target?: RefinerOverviewOpenTab }[] {
   const items: { text: string; target?: RefinerOverviewOpenTab }[] = [];
   if (args.failedCount > 0) {
     items.push({
@@ -101,7 +113,12 @@ function tabActionLabel(id: RefinerOverviewOpenTab): string {
   }
 }
 
-const NEEDS_ATTENTION_ORDER: RefinerOverviewOpenTab[] = ["libraries", "audio-subtitles", "schedules", "jobs"];
+const NEEDS_ATTENTION_ORDER: RefinerOverviewOpenTab[] = [
+  "libraries",
+  "audio-subtitles",
+  "schedules",
+  "jobs",
+];
 
 function RefinerOverviewNeedsAttention({
   items,
@@ -110,7 +127,9 @@ function RefinerOverviewNeedsAttention({
   items: { text: string; target?: RefinerOverviewOpenTab }[];
   onOpenTab?: (t: RefinerOverviewOpenTab) => void;
 }) {
-  const actionTargets = NEEDS_ATTENTION_ORDER.filter((t) => items.some((row) => row.target === t));
+  const actionTargets = NEEDS_ATTENTION_ORDER.filter((t) =>
+    items.some((row) => row.target === t),
+  );
 
   return (
     <MmOverviewSection
@@ -170,7 +189,11 @@ export function RefinerOverviewTab({
   const leased = useRefinerJobsInspectionQuery("leased");
   const failed = useRefinerJobsInspectionQuery("failed");
 
-  const blocking = pathSettings.isError ? pathSettings.error : operatorSettings.isError ? operatorSettings.error : null;
+  const blocking = pathSettings.isError
+    ? pathSettings.error
+    : operatorSettings.isError
+      ? operatorSettings.error
+      : null;
 
   if (blocking) {
     return <RefinerOverviewLoadError err={blocking} />;
@@ -187,9 +210,15 @@ export function RefinerOverviewTab({
   const watchedSet =
     Boolean((pathSettings.data.refiner_watched_folder ?? "").trim()) ||
     Boolean((pathSettings.data.refiner_tv_watched_folder ?? "").trim());
-  const outputSet = Boolean((pathSettings.data.refiner_output_folder ?? "").trim());
-  const tvWatchedSet = Boolean((pathSettings.data.refiner_tv_watched_folder ?? "").trim());
-  const tvOutputSet = Boolean((pathSettings.data.refiner_tv_output_folder ?? "").trim());
+  const outputSet = Boolean(
+    (pathSettings.data.refiner_output_folder ?? "").trim(),
+  );
+  const tvWatchedSet = Boolean(
+    (pathSettings.data.refiner_tv_watched_folder ?? "").trim(),
+  );
+  const tvOutputSet = Boolean(
+    (pathSettings.data.refiner_tv_output_folder ?? "").trim(),
+  );
 
   const pendingN = pending.data?.jobs.length ?? 0;
   const leasedN = leased.data?.jobs.length ?? 0;
@@ -197,17 +226,24 @@ export function RefinerOverviewTab({
   const failedReady = !failed.isPending && !failed.isError;
 
   const workerBody = (
-      <div className="space-y-3 lg:space-y-3.5">
-        <p className="font-medium text-[var(--mm-text1)]">
-          Up to {operatorSettings.data.max_concurrent_files} file
-          {operatorSettings.data.max_concurrent_files === 1 ? "" : "s"} at once
-        </p>
-        <div className="space-y-2 text-xs leading-relaxed text-[var(--mm-text3)] lg:space-y-2.5 lg:text-sm">
+    <div className="space-y-3 lg:space-y-3.5">
+      <p className="font-medium text-[var(--mm-text1)]">
+        Up to {operatorSettings.data.max_concurrent_files} file
+        {operatorSettings.data.max_concurrent_files === 1 ? "" : "s"} at once
+      </p>
+      <div className="space-y-2 text-xs leading-relaxed text-[var(--mm-text3)] lg:space-y-2.5 lg:text-sm">
         <p>
-          <span className="font-medium text-[var(--mm-text2)]">Folder checks:</span> TV every{" "}
-          {pathSettings.data.tv_watched_folder_check_interval_seconds}s · Movies every{" "}
-          {pathSettings.data.movie_watched_folder_check_interval_seconds}s (under Libraries). Files must sit unchanged at
-          least {operatorSettings.data.min_file_age_seconds}s before watched-folder scans enqueue them. The same minimum also applies when TV season cleanup checks episodes Refiner never finished and Sonarr is not tracking in its queue.
+          <span className="font-medium text-[var(--mm-text2)]">
+            Folder checks:
+          </span>{" "}
+          TV every {pathSettings.data.tv_watched_folder_check_interval_seconds}s
+          · Movies every{" "}
+          {pathSettings.data.movie_watched_folder_check_interval_seconds}s
+          (under Libraries). Files must sit unchanged at least{" "}
+          {operatorSettings.data.min_file_age_seconds}s before watched-folder
+          scans enqueue them. The same minimum also applies when TV season
+          cleanup checks episodes Refiner never finished and Sonarr is not
+          tracking in its queue.
         </p>
       </div>
     </div>
@@ -216,27 +252,39 @@ export function RefinerOverviewTab({
   const foldersBody = (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-x-6">
       <div className="min-w-0 space-y-2">
-        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)]">TV</p>
-        <p>
-          <span className="text-[var(--mm-text3)]">Watched · </span>
-          <span className="font-medium text-[var(--mm-text1)]">{tvWatchedSet ? "Set" : "Not set"}</span>
+        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+          TV
         </p>
-        <p>
-          <span className="text-[var(--mm-text3)]">Output · </span>
-          <span className="font-medium text-[var(--mm-text1)]">{tvOutputSet ? "Set" : "Not set"}</span>
-        </p>
-      </div>
-      <div className="min-w-0 space-y-2">
-        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Movies</p>
         <p>
           <span className="text-[var(--mm-text3)]">Watched · </span>
           <span className="font-medium text-[var(--mm-text1)]">
-            {(pathSettings.data.refiner_watched_folder ?? "").trim() ? "Set" : "Not set"}
+            {tvWatchedSet ? "Set" : "Not set"}
           </span>
         </p>
         <p>
           <span className="text-[var(--mm-text3)]">Output · </span>
-          <span className="font-medium text-[var(--mm-text1)]">{outputSet ? "Set" : "Not set"}</span>
+          <span className="font-medium text-[var(--mm-text1)]">
+            {tvOutputSet ? "Set" : "Not set"}
+          </span>
+        </p>
+      </div>
+      <div className="min-w-0 space-y-2">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+          Movies
+        </p>
+        <p>
+          <span className="text-[var(--mm-text3)]">Watched · </span>
+          <span className="font-medium text-[var(--mm-text1)]">
+            {(pathSettings.data.refiner_watched_folder ?? "").trim()
+              ? "Set"
+              : "Not set"}
+          </span>
+        </p>
+        <p>
+          <span className="text-[var(--mm-text3)]">Output · </span>
+          <span className="font-medium text-[var(--mm-text1)]">
+            {outputSet ? "Set" : "Not set"}
+          </span>
         </p>
       </div>
     </div>
@@ -246,11 +294,15 @@ export function RefinerOverviewTab({
     <div className="space-y-1.5">
       <p>
         <span className="text-[var(--mm-text3)]">Waiting:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{pendingN === 0 ? "None" : `${pendingN} job(s)`}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {pendingN === 0 ? "None" : `${pendingN} job(s)`}
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">Running:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{leasedN === 0 ? "None" : `${leasedN} job(s)`}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {leasedN === 0 ? "None" : `${leasedN} job(s)`}
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">Failed list:</span>{" "}
@@ -267,41 +319,50 @@ export function RefinerOverviewTab({
     </div>
   );
 
-
-  const remuxBody =
-    remuxRules.isPending ? (
-      <p className="text-[var(--mm-text3)]">Loading…</p>
-    ) : remuxRules.isError ? (
-      <p className="text-[var(--mm-text3)]">Could not load defaults.</p>
-    ) : remuxRules.data ? (
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-x-5 lg:gap-x-6 lg:gap-y-1">
-        <div className="min-w-0 space-y-2 lg:space-y-2.5">
-          <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)] lg:text-xs">TV</p>
-          {remuxDefaultsGlanceBody(remuxRules.data.tv)}
-        </div>
-        <div className="min-w-0 space-y-2 lg:space-y-2.5">
-          <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)] lg:text-xs">
-            Movies
-          </p>
-          {remuxDefaultsGlanceBody(remuxRules.data.movie)}
-        </div>
+  const remuxBody = remuxRules.isPending ? (
+    <p className="text-[var(--mm-text3)]">Loading…</p>
+  ) : remuxRules.isError ? (
+    <p className="text-[var(--mm-text3)]">Could not load defaults.</p>
+  ) : remuxRules.data ? (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-x-5 lg:gap-x-6 lg:gap-y-1">
+      <div className="min-w-0 space-y-2 lg:space-y-2.5">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)] lg:text-xs">
+          TV
+        </p>
+        {remuxDefaultsGlanceBody(remuxRules.data.tv)}
       </div>
-    ) : (
-      <p className="text-[var(--mm-text3)]">—</p>
-    );
+      <div className="min-w-0 space-y-2 lg:space-y-2.5">
+        <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text3)] lg:text-xs">
+          Movies
+        </p>
+        {remuxDefaultsGlanceBody(remuxRules.data.movie)}
+      </div>
+    </div>
+  ) : (
+    <p className="text-[var(--mm-text3)]">—</p>
+  );
   const statsBody =
     overviewStats.isPending || overviewStats.isError || !overviewStats.data ? (
       <p className="text-[var(--mm-text3)]">Loading…</p>
     ) : (
       <div>
         <MmStatTileRow>
-          <MmStatTile label="Completed jobs" value={overviewStats.data.files_processed} />
-          <MmStatTile label="Failed jobs" value={overviewStats.data.files_failed} />
-          <MmStatTile label="Success" value={`${overviewStats.data.success_rate_percent}%`} />
+          <MmStatTile
+            label="Completed jobs"
+            value={overviewStats.data.files_processed}
+          />
+          <MmStatTile
+            label="Failed jobs"
+            value={overviewStats.data.files_failed}
+          />
+          <MmStatTile
+            label="Success"
+            value={`${overviewStats.data.success_rate_percent}%`}
+          />
         </MmStatTileRow>
         <MmStatCaption>
-          Counts completed and terminal-failed remux jobs in the overview window. Success rate = completed / (completed +
-          failed).
+          Counts completed and terminal-failed remux jobs in the overview
+          window. Success rate = completed / (completed + failed).
         </MmStatCaption>
       </div>
     );
@@ -312,7 +373,10 @@ export function RefinerOverviewTab({
   });
 
   return (
-    <div data-testid="refiner-overview-panel" className="mm-bubble-stack w-full min-w-0">
+    <div
+      data-testid="refiner-overview-panel"
+      className="mm-bubble-stack w-full min-w-0"
+    >
       <MmOverviewSection
         headingId="refiner-overview-at-a-glance-heading"
         heading="At a glance"
@@ -327,8 +391,18 @@ export function RefinerOverviewTab({
             data-testid="refiner-overview-last-30-days"
             gridClassName="lg:col-span-4"
           />
-          <MmAtGlanceCard glanceOrder="2" title="Libraries" body={foldersBody} gridClassName="lg:col-span-4" />
-          <MmAtGlanceCard glanceOrder="3" title="Job queue" body={queueBody} gridClassName="lg:col-span-4" />
+          <MmAtGlanceCard
+            glanceOrder="2"
+            title="Libraries"
+            body={foldersBody}
+            gridClassName="lg:col-span-4"
+          />
+          <MmAtGlanceCard
+            glanceOrder="3"
+            title="Job queue"
+            body={queueBody}
+            gridClassName="lg:col-span-4"
+          />
           <MmAtGlanceCard
             glanceOrder="4"
             title="Throughput & safety"
@@ -337,7 +411,11 @@ export function RefinerOverviewTab({
             size="large"
             footer={
               onOpenTab ? (
-                <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onOpenTab("schedules")}>
+                <button
+                  type="button"
+                  className={mmActionButtonClass({ variant: "secondary" })}
+                  onClick={() => onOpenTab("schedules")}
+                >
                   Open Schedules
                 </button>
               ) : undefined
@@ -365,7 +443,10 @@ export function RefinerOverviewTab({
         </MmAtGlanceGrid>
       </MmOverviewSection>
 
-      <RefinerOverviewNeedsAttention items={attentionItems} onOpenTab={onOpenTab} />
+      <RefinerOverviewNeedsAttention
+        items={attentionItems}
+        onOpenTab={onOpenTab}
+      />
 
       <MmOverviewSection
         headingId="refiner-overview-next-heading"
@@ -374,12 +455,18 @@ export function RefinerOverviewTab({
       >
         <div className="mm-bubble-stack">
           <p className="leading-relaxed">
-            Finished work is summarized on Activity. Use Libraries for paths, folder timers, and minimum file age. Use Schedules for optional hour
-            limits and to run library scans on demand. Use Audio & subtitles for defaults, and Jobs for the queue on this server.
+            Finished work is summarized on Activity. Use Libraries for paths,
+            folder timers, and minimum file age. Use Schedules for optional hour
+            limits and to run library scans on demand. Use Audio & subtitles for
+            defaults, and Jobs for the queue on this server.
           </p>
           {onOpenTab ? (
             <div className="flex flex-wrap gap-2.5 border-t border-[var(--mm-border)] pt-4">
-              <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onOpenTab("libraries")}>
+              <button
+                type="button"
+                className={mmActionButtonClass({ variant: "secondary" })}
+                onClick={() => onOpenTab("libraries")}
+              >
                 Libraries
               </button>
               <button
@@ -389,10 +476,18 @@ export function RefinerOverviewTab({
               >
                 Audio & subtitles
               </button>
-              <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onOpenTab("schedules")}>
+              <button
+                type="button"
+                className={mmActionButtonClass({ variant: "secondary" })}
+                onClick={() => onOpenTab("schedules")}
+              >
                 Schedules
               </button>
-              <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onOpenTab("jobs")}>
+              <button
+                type="button"
+                className={mmActionButtonClass({ variant: "secondary" })}
+                onClick={() => onOpenTab("jobs")}
+              >
                 Jobs
               </button>
             </div>

--- a/apps/web/src/pages/refiner/refiner-page.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.test.tsx
@@ -12,7 +12,10 @@ import {
   refinerPathSettingsQueryKey,
   refinerRemuxRulesSettingsQueryKey,
 } from "../../lib/refiner/queries";
-import type { RefinerPathSettingsOut, RefinerRemuxRulesSettingsOut } from "../../lib/refiner/types";
+import type {
+  RefinerPathSettingsOut,
+  RefinerRemuxRulesSettingsOut,
+} from "../../lib/refiner/types";
 import { RefinerPage } from "./refiner-page";
 
 const operatorMe: UserPublic = { id: 1, username: "alice", role: "operator" };
@@ -23,14 +26,18 @@ const minimalRefinerPathSettings: RefinerPathSettingsOut = {
   refiner_watched_folder_exists: false,
   refiner_work_folder: null,
   refiner_output_folder: "",
-  resolved_default_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
-  effective_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
+  resolved_default_work_folder:
+    "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
+  effective_work_folder:
+    "C:\\ProgramData\\MediaMop\\refiner\\refiner-movie-work",
   refiner_tv_watched_folder: null,
   refiner_tv_watched_folder_exists: false,
   refiner_tv_work_folder: null,
   refiner_tv_output_folder: null,
-  resolved_default_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
-  effective_tv_work_folder: "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
+  resolved_default_tv_work_folder:
+    "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
+  effective_tv_work_folder:
+    "C:\\ProgramData\\MediaMop\\refiner\\refiner-tv-work",
   movie_watched_folder_check_interval_seconds: 300,
   tv_watched_folder_check_interval_seconds: 300,
   updated_at: "2026-04-11T00:00:00Z",
@@ -99,7 +106,10 @@ function seedRefinerQueries(qc: QueryClient) {
     updated_at: "2026-04-11T00:00:00Z",
   });
   qc.setQueryData(refinerRemuxRulesSettingsQueryKey, minimalRefinerRemuxRules);
-  qc.setQueryData(refinerJobsInspectionQueryKey("recent"), { jobs: [], default_recent_slice: true });
+  qc.setQueryData(refinerJobsInspectionQueryKey("recent"), {
+    jobs: [],
+    default_recent_slice: true,
+  });
   qc.setQueryData(refinerJobsInspectionQueryKey("pending"), { jobs: [] });
   qc.setQueryData(refinerJobsInspectionQueryKey("leased"), { jobs: [] });
   qc.setQueryData(refinerJobsInspectionQueryKey("failed"), { jobs: [] });
@@ -125,11 +135,15 @@ describe("RefinerPage", () => {
   it("Overview is the default tab, stays Refiner-scoped, and links Activity without leaking env keys", () => {
     renderRefinerPage();
     expect(screen.getByTestId("refiner-overview-panel")).toBeInTheDocument();
-    const overview = screen.getByTestId("refiner-overview-panel").textContent ?? "";
+    const overview =
+      screen.getByTestId("refiner-overview-panel").textContent ?? "";
     expect(overview).toMatch(/At a glance/i);
     expect(overview).not.toMatch(/MEDIAMOP_/i);
     expect(overview).not.toMatch(/refiner_jobs/i);
-    expect(screen.getByRole("link", { name: "Activity" })).toHaveAttribute("href", "/app/activity");
+    expect(screen.getByRole("link", { name: "Activity" })).toHaveAttribute(
+      "href",
+      "/app/activity",
+    );
   });
 
   it("Overview surfaces saved audio/subtitle defaults at a glance", () => {
@@ -159,7 +173,9 @@ describe("RefinerPage", () => {
     openTab("Jobs");
     const block = screen.getByTestId("refiner-jobs-inspection-section");
     expect(block.textContent).toMatch(/Activity/i);
-    expect(block.textContent).toMatch(/Pending, running, and recent Refiner work/i);
+    expect(block.textContent).toMatch(
+      /Pending, running, and recent Refiner work/i,
+    );
   });
 
   it("Libraries tab shows processing settings controls", () => {
@@ -208,8 +224,12 @@ describe("RefinerPage", () => {
   it("Schedules includes independent TV and Movies scan-now actions", () => {
     renderRefinerPage();
     openTab("Schedules");
-    expect(screen.getByRole("button", { name: "Scan TV now" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Scan Movies now" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Scan TV now" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Scan Movies now" }),
+    ).toBeInTheDocument();
   });
 
   it("Schedules tab has no master scheduled-processing toggle (folder poll is under Libraries)", () => {
@@ -221,6 +241,8 @@ describe("RefinerPage", () => {
   it("Schedules tab has no suite timezone preamble banner", () => {
     renderRefinerPage();
     openTab("Schedules");
-    expect(screen.queryByText("Suite time zone for schedule windows")).toBeNull();
+    expect(
+      screen.queryByText("Suite time zone for schedule windows"),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/pages/refiner/refiner-page.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.tsx
@@ -3,19 +3,34 @@ import { Link } from "react-router-dom";
 import { mmSectionTabClass } from "../../lib/ui/mm-control-roles";
 import { RefinerProcessSettingsSection } from "./refiner-process-settings-section";
 import { RefinerJobsInspectionSection } from "./refiner-jobs-inspection-section";
-import { RefinerOverviewTab, type RefinerOverviewOpenTab } from "./refiner-overview-tab";
+import {
+  RefinerOverviewTab,
+  type RefinerOverviewOpenTab,
+} from "./refiner-overview-tab";
 import { RefinerPathSettingsSection } from "./refiner-path-settings-section";
 import { RefinerSchedulesSection } from "./refiner-schedules-section";
 import { RefinerRemuxSection } from "./refiner-remux-section";
-import { mmModuleTabBlurbBandClass, mmModuleTabBlurbTextClass } from "../../lib/ui/mm-module-tab-blurb";
+import {
+  mmModuleTabBlurbBandClass,
+  mmModuleTabBlurbTextClass,
+} from "../../lib/ui/mm-module-tab-blurb";
 
-type RefinerPageTabId = "overview" | "libraries" | "audio-subtitles" | "jobs" | "schedules";
+type RefinerPageTabId =
+  | "overview"
+  | "libraries"
+  | "audio-subtitles"
+  | "jobs"
+  | "schedules";
 
 const REFINER_TAB_BLURBS: Record<RefinerPageTabId, string> = {
-  overview: "Review remux throughput, recent outcomes, and overall Refiner status.",
-  libraries: "Set TV and Movies watched, work, and output folders, plus per-library scan controls.",
-  "audio-subtitles": "Choose default audio and subtitle remux rules separately for TV and Movies.",
-  schedules: "Set optional schedule windows and run manual watched-folder scans when needed.",
+  overview:
+    "Review remux throughput, recent outcomes, and overall Refiner status.",
+  libraries:
+    "Set TV and Movies watched, work, and output folders, plus per-library scan controls.",
+  "audio-subtitles":
+    "Choose default audio and subtitle remux rules separately for TV and Movies.",
+  schedules:
+    "Set optional schedule windows and run manual watched-folder scans when needed.",
   jobs: "View queued, running, and recent Refiner jobs for troubleshooting and progress.",
 };
 
@@ -46,9 +61,10 @@ export function RefinerPage() {
         <p className="mm-page__eyebrow">MediaMop</p>
         <h1 className="mm-page__title">Refiner</h1>
         <p className="mm-page__subtitle">
-          Refiner remuxes <strong className="text-[var(--mm-text)]">TV</strong> and{" "}
-          <strong className="text-[var(--mm-text)]">Movies</strong> into the audio and subtitle layout you want. Each library
-          stays on its own. When jobs finish, details are on{" "}
+          Refiner remuxes <strong className="text-[var(--mm-text)]">TV</strong>{" "}
+          and <strong className="text-[var(--mm-text)]">Movies</strong> into the
+          audio and subtitle layout you want. Each library stays on its own.
+          When jobs finish, details are on{" "}
           <Link
             className="font-semibold text-[var(--mm-text)] underline-offset-2 hover:underline"
             to="/app/activity"
@@ -78,12 +94,23 @@ export function RefinerPage() {
         ))}
       </nav>
 
-      <div className="mm-bubble-stack" role="tabpanel" aria-label={tabs.find((t) => t.id === tab)?.label}>
+      <div
+        className="mm-bubble-stack"
+        role="tabpanel"
+        aria-label={tabs.find((t) => t.id === tab)?.label}
+      >
         <div className="mm-bubble-stack w-full min-w-0">
-          <div className={mmModuleTabBlurbBandClass} data-testid="refiner-tab-blurb">
-            <p className={mmModuleTabBlurbTextClass}>{REFINER_TAB_BLURBS[tab]}</p>
+          <div
+            className={mmModuleTabBlurbBandClass}
+            data-testid="refiner-tab-blurb"
+          >
+            <p className={mmModuleTabBlurbTextClass}>
+              {REFINER_TAB_BLURBS[tab]}
+            </p>
           </div>
-          {tab === "overview" ? <RefinerOverviewTab onOpenTab={openFromOverview} /> : null}
+          {tab === "overview" ? (
+            <RefinerOverviewTab onOpenTab={openFromOverview} />
+          ) : null}
 
           {tab === "libraries" ? (
             <div className="mm-bubble-stack flex w-full min-w-0 flex-col">

--- a/apps/web/src/pages/refiner/refiner-path-settings-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-path-settings-section.tsx
@@ -1,16 +1,32 @@
 import { useEffect, useId, useState } from "react";
 import { PageLoading } from "../../components/shared/page-loading";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
-import { MmListboxPicker, type MmListboxOption } from "../../components/ui/mm-listbox-picker";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
+import {
+  MmListboxPicker,
+  type MmListboxOption,
+} from "../../components/ui/mm-listbox-picker";
 import { ServerFolderPickerButton } from "../../components/ui/server-folder-picker-button";
 import { useMeQuery } from "../../lib/auth/queries";
-import { useRefinerPathSettingsQuery, useRefinerPathSettingsSaveMutation } from "../../lib/refiner/queries";
-import { mmActionButtonClass, mmEditableTextFieldClass, mmTechnicalMonoSmallClass } from "../../lib/ui/mm-control-roles";
+import {
+  useRefinerPathSettingsQuery,
+  useRefinerPathSettingsSaveMutation,
+} from "../../lib/refiner/queries";
+import {
+  mmActionButtonClass,
+  mmEditableTextFieldClass,
+  mmTechnicalMonoSmallClass,
+} from "../../lib/ui/mm-control-roles";
 
-const WATCHED_FOLDER_INTERVAL_OPTIONS: MmListboxOption[] = Array.from({ length: 30 }, (_, i) => {
-  const seconds = 10 + i * 10;
-  return { value: String(seconds), label: `${seconds} seconds` };
-});
+const WATCHED_FOLDER_INTERVAL_OPTIONS: MmListboxOption[] = Array.from(
+  { length: 30 },
+  (_, i) => {
+    const seconds = 10 + i * 10;
+    return { value: String(seconds), label: `${seconds} seconds` };
+  },
+);
 
 function canEditRefinerPaths(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
@@ -30,7 +46,8 @@ export function RefinerPathSettingsSection() {
   const [tvWatched, setTvWatched] = useState("");
   const [tvWork, setTvWork] = useState("");
   const [tvOutput, setTvOutput] = useState("");
-  const [movieWatchedFolderInterval, setMovieWatchedFolderInterval] = useState("300");
+  const [movieWatchedFolderInterval, setMovieWatchedFolderInterval] =
+    useState("300");
   const [tvWatchedFolderInterval, setTvWatchedFolderInterval] = useState("300");
 
   useEffect(() => {
@@ -43,8 +60,12 @@ export function RefinerPathSettingsSection() {
     setTvWatched(q.data.refiner_tv_watched_folder ?? "");
     setTvWork(q.data.refiner_tv_work_folder ?? "");
     setTvOutput(q.data.refiner_tv_output_folder ?? "");
-    setMovieWatchedFolderInterval(String(q.data.movie_watched_folder_check_interval_seconds));
-    setTvWatchedFolderInterval(String(q.data.tv_watched_folder_check_interval_seconds));
+    setMovieWatchedFolderInterval(
+      String(q.data.movie_watched_folder_check_interval_seconds),
+    );
+    setTvWatchedFolderInterval(
+      String(q.data.tv_watched_folder_check_interval_seconds),
+    );
   }, [q.data]);
 
   const editable = canEditRefinerPaths(me.data?.role);
@@ -54,13 +75,15 @@ export function RefinerPathSettingsSection() {
     (watched !== (q.data.refiner_watched_folder ?? "") ||
       work !== (q.data.refiner_work_folder ?? "") ||
       output !== (q.data.refiner_output_folder ?? "") ||
-      movieWatchedFolderInterval !== String(q.data.movie_watched_folder_check_interval_seconds));
+      movieWatchedFolderInterval !==
+        String(q.data.movie_watched_folder_check_interval_seconds));
   const tvDirty =
     q.data !== undefined &&
     (tvWatched !== (q.data.refiner_tv_watched_folder ?? "") ||
       tvWork !== (q.data.refiner_tv_work_folder ?? "") ||
       tvOutput !== (q.data.refiner_tv_output_folder ?? "") ||
-      tvWatchedFolderInterval !== String(q.data.tv_watched_folder_check_interval_seconds));
+      tvWatchedFolderInterval !==
+        String(q.data.tv_watched_folder_check_interval_seconds));
   const tvNeedsOutput = tvWatched.trim().length > 0;
   const tvOutputMissing = tvNeedsOutput && tvOutput.trim().length === 0;
   const movieNeedsOutput = watched.trim().length > 0;
@@ -93,8 +116,12 @@ export function RefinerPathSettingsSection() {
   }
 
   const d = q.data;
-  const effectiveMovieWorkPreview = work.trim() ? work.trim() : d.effective_work_folder;
-  const effectiveTvWorkPreview = tvWork.trim() ? tvWork.trim() : d.effective_tv_work_folder;
+  const effectiveMovieWorkPreview = work.trim()
+    ? work.trim()
+    : d.effective_work_folder;
+  const effectiveTvWorkPreview = tvWork.trim()
+    ? tvWork.trim()
+    : d.effective_tv_work_folder;
 
   function renderFolderInput({
     label,
@@ -111,7 +138,9 @@ export function RefinerPathSettingsSection() {
   }) {
     return (
       <label className="block">
-        <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">{label}</span>
+        <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+          {label}
+        </span>
         <div className="mt-1 flex flex-col gap-2 sm:flex-row">
           <input
             className={mmEditableTextFieldClass}
@@ -121,186 +150,270 @@ export function RefinerPathSettingsSection() {
             placeholder=""
             required={required}
           />
-          <ServerFolderPickerButton title={title} value={value} disabled={!editable || save.isPending} onSelect={setter} />
+          <ServerFolderPickerButton
+            title={title}
+            value={value}
+            disabled={!editable || save.isPending}
+            onSelect={setter}
+          />
         </div>
       </label>
     );
   }
 
   return (
-    <div className="mm-bubble-stack w-full min-w-0" data-testid="refiner-path-settings">
+    <div
+      className="mm-bubble-stack w-full min-w-0"
+      data-testid="refiner-path-settings"
+    >
       <section
         className="mm-card mm-dash-card mm-module-surface w-full min-w-0 p-6 text-sm leading-relaxed text-[var(--mm-text2)] sm:p-7"
         aria-labelledby="refiner-path-settings-heading"
       >
-      <h2 id="refiner-path-settings-heading" className="text-base font-semibold text-[var(--mm-text)]">
-        Saved folders
-      </h2>
-      <p className="mt-2 max-w-3xl text-[var(--mm-text3)]">
-        TV and Movies each use their own watched, work, and output folders. Paths do not cross between the two libraries.
-      </p>
-      <p className="mt-1 max-w-3xl text-xs text-[var(--mm-text3)]">
-        TV needs a saved output folder whenever a TV watched folder is set. The Movies library needs a saved output folder.
-        TV and Movies folder trees must not overlap.
-      </p>
-
-      <details className="group mt-5 rounded-md border border-[var(--mm-border)] bg-black/10 px-4 py-3 text-xs text-[var(--mm-text3)]">
-        <summary className="cursor-pointer list-none font-medium text-[var(--mm-text2)] marker:hidden [&::-webkit-details-marker]:hidden">
-          <span className="underline-offset-2 group-open:underline">What happens to your files</span>
-        </summary>
-        <p className="mt-3 border-t border-[var(--mm-border)] pt-3">
-          Applies to per-file passes from the saved watched folder for{" "}
-          <strong className="text-[var(--mm-text2)]">TV</strong> or{" "}
-          <strong className="text-[var(--mm-text2)]">Movies</strong> (including when a folder scan queues that work). Other
-          Refiner jobs follow different rules.
+        <h2
+          id="refiner-path-settings-heading"
+          className="text-base font-semibold text-[var(--mm-text)]"
+        >
+          Saved folders
+        </h2>
+        <p className="mt-2 max-w-3xl text-[var(--mm-text3)]">
+          TV and Movies each use their own watched, work, and output folders.
+          Paths do not cross between the two libraries.
         </p>
-        <div className="mt-3 space-y-2.5">
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">Watched folder.</span> Refiner walks it recursively. It
-            only treats{" "}
-            <span className={mmTechnicalMonoSmallClass}>.mkv</span>, <span className={mmTechnicalMonoSmallClass}>.mp4</span>,{" "}
-            <span className={mmTechnicalMonoSmallClass}>.m4v</span>, <span className={mmTechnicalMonoSmallClass}>.webm</span>, and{" "}
-            <span className={mmTechnicalMonoSmallClass}>.avi</span> as media. Subtitles, <span className={mmTechnicalMonoSmallClass}>.nfo</span>,{" "}
-            <span className={mmTechnicalMonoSmallClass}>.par2</span>, and other files are not treated as media candidates
-            for this step. Whole-folder cleanup rules below can still remove them when a season or release folder is
-            removed.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">Work / temp.</span> When Refiner runs ffmpeg, it writes
-            a temp file here, checks it, then moves it into your output folder. The default work folder is created if it
-            is missing; a custom work folder must already exist. If ffmpeg or the check right after fails, Refiner
-            removes that temp file when it can. Separately, Refiner can also run periodic cleanup of its own stale temp
-            files under each scope&apos;s work folder — that is different from this one-file flow; schedule timers and
-            manual scan controls are under <strong className="text-[var(--mm-text2)]">Schedules</strong>. If the move into
-            output fails later, a temp file can be left behind.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">Output.</span> Finished files use the same folder
-            layout under output as under the watched folder. If something is already there, Refiner deletes it, then
-            moves the new file in. If the move fails after that delete, you can lose the old file there without the new
-            one in place. Refiner does not keep older copies or sweep stale outputs.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">Output library cleanup.</span> After a successful{" "}
-            remux, Refiner may optionally remove the whole output
-            folder that held the file — per title for Movies, per season for TV — only when library checks and other safety
-            gates pass.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">TV after a successful live pass.</span> When every
-            episode media file directly in the same season folder passes Refiner's safety checks (including Sonarr
-            queue status, whether another TV remux job is already running, finished output checks for files Refiner already
-            processed, and minimum file age for files Refiner never touched), Refiner may remove the whole season folder
-            under your TV watched folder — that removes episodes, subtitles, artwork, and subfolders together. If any
-            check fails, nothing in that season folder is removed. Refiner never removes your TV watched folder itself.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">Movies after a successful live pass.</span> Refiner may
-            remove the entire movie release folder under your Movies watched folder — the folder that holds the file that
-            was processed — but only when the output file at the expected path was found and verified. If output cannot be
-            verified, folder removal is skipped (including when no remux was needed and there is no output file at that path
-            yet). This whole-folder step is Movies-only.
-          </p>
-          <p>
-            <span className="font-semibold text-[var(--mm-text2)]">If a pass fails.</span> Refiner does not delete the
-            source. Output is usually unchanged, unless an existing destination was already removed and the move then
-            failed. Temp files are removed when ffmpeg or the post-ffmpeg check fails; that is not true for every failure
-            that happens after that. Separately from this one-file flow, Refiner can run periodic failed-job cleanup for
-            terminal failed remux jobs after a per-scope grace period. That later sweep may remove failed source/output
-            leftovers and matching Refiner temp files only when safety gates pass. If Radarr/Sonarr is unavailable or still
-            shows the file/season in queue, Refiner skips cleanup.
-          </p>
-        </div>
-      </details>
+        <p className="mt-1 max-w-3xl text-xs text-[var(--mm-text3)]">
+          TV needs a saved output folder whenever a TV watched folder is set.
+          The Movies library needs a saved output folder. TV and Movies folder
+          trees must not overlap.
+        </p>
 
-      {!editable ? (
-        <p className="mt-4 text-xs text-[var(--mm-text3)]">Operators and admins can edit these paths.</p>
-      ) : null}
+        <details className="group mt-5 rounded-md border border-[var(--mm-border)] bg-black/10 px-4 py-3 text-xs text-[var(--mm-text3)]">
+          <summary className="cursor-pointer list-none font-medium text-[var(--mm-text2)] marker:hidden [&::-webkit-details-marker]:hidden">
+            <span className="underline-offset-2 group-open:underline">
+              What happens to your files
+            </span>
+          </summary>
+          <p className="mt-3 border-t border-[var(--mm-border)] pt-3">
+            Applies to per-file passes from the saved watched folder for{" "}
+            <strong className="text-[var(--mm-text2)]">TV</strong> or{" "}
+            <strong className="text-[var(--mm-text2)]">Movies</strong>{" "}
+            (including when a folder scan queues that work). Other Refiner jobs
+            follow different rules.
+          </p>
+          <div className="mt-3 space-y-2.5">
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                Watched folder.
+              </span>{" "}
+              Refiner walks it recursively. It only treats{" "}
+              <span className={mmTechnicalMonoSmallClass}>.mkv</span>,{" "}
+              <span className={mmTechnicalMonoSmallClass}>.mp4</span>,{" "}
+              <span className={mmTechnicalMonoSmallClass}>.m4v</span>,{" "}
+              <span className={mmTechnicalMonoSmallClass}>.webm</span>, and{" "}
+              <span className={mmTechnicalMonoSmallClass}>.avi</span> as media.
+              Subtitles, <span className={mmTechnicalMonoSmallClass}>.nfo</span>
+              , <span className={mmTechnicalMonoSmallClass}>.par2</span>, and
+              other files are not treated as media candidates for this step.
+              Whole-folder cleanup rules below can still remove them when a
+              season or release folder is removed.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                Work / temp.
+              </span>{" "}
+              When Refiner runs ffmpeg, it writes a temp file here, checks it,
+              then moves it into your output folder. The default work folder is
+              created if it is missing; a custom work folder must already exist.
+              If ffmpeg or the check right after fails, Refiner removes that
+              temp file when it can. Separately, Refiner can also run periodic
+              cleanup of its own stale temp files under each scope&apos;s work
+              folder — that is different from this one-file flow; schedule
+              timers and manual scan controls are under{" "}
+              <strong className="text-[var(--mm-text2)]">Schedules</strong>. If
+              the move into output fails later, a temp file can be left behind.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                Output.
+              </span>{" "}
+              Finished files use the same folder layout under output as under
+              the watched folder. If something is already there, Refiner deletes
+              it, then moves the new file in. If the move fails after that
+              delete, you can lose the old file there without the new one in
+              place. Refiner does not keep older copies or sweep stale outputs.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                Output library cleanup.
+              </span>{" "}
+              After a successful remux, Refiner may optionally remove the whole
+              output folder that held the file — per title for Movies, per
+              season for TV — only when library checks and other safety gates
+              pass.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                TV after a successful live pass.
+              </span>{" "}
+              When every episode media file directly in the same season folder
+              passes Refiner&apos;s safety checks (including Sonarr queue
+              status, whether another TV remux job is already running, finished
+              output checks for files Refiner already processed, and minimum
+              file age for files Refiner never touched), Refiner may remove the
+              whole season folder under your TV watched folder — that removes
+              episodes, subtitles, artwork, and subfolders together. If any
+              check fails, nothing in that season folder is removed. Refiner
+              never removes your TV watched folder itself.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                Movies after a successful live pass.
+              </span>{" "}
+              Refiner may remove the entire movie release folder under your
+              Movies watched folder — the folder that holds the file that was
+              processed — but only when the output file at the expected path was
+              found and verified. If output cannot be verified, folder removal
+              is skipped (including when no remux was needed and there is no
+              output file at that path yet). This whole-folder step is
+              Movies-only.
+            </p>
+            <p>
+              <span className="font-semibold text-[var(--mm-text2)]">
+                If a pass fails.
+              </span>{" "}
+              Refiner does not delete the source. Output is usually unchanged,
+              unless an existing destination was already removed and the move
+              then failed. Temp files are removed when ffmpeg or the post-ffmpeg
+              check fails; that is not true for every failure that happens after
+              that. Separately from this one-file flow, Refiner can run periodic
+              failed-job cleanup for terminal failed remux jobs after a
+              per-scope grace period. That later sweep may remove failed
+              source/output leftovers and matching Refiner temp files only when
+              safety gates pass. If Radarr/Sonarr is unavailable or still shows
+              the file/season in queue, Refiner skips cleanup.
+            </p>
+          </div>
+        </details>
+
+        {!editable ? (
+          <p className="mt-4 text-xs text-[var(--mm-text3)]">
+            Operators and admins can edit these paths.
+          </p>
+        ) : null}
       </section>
 
       <div className="mm-dash-grid">
         <div className="mm-card mm-dash-card flex flex-col p-5 sm:p-6">
           <div className="border-b border-[var(--mm-border)] pb-4">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">Library</p>
-            <h3 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">TV</h3>
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">
+              Library
+            </p>
+            <h3 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+              TV
+            </h3>
           </div>
           <p className="mt-4 text-xs leading-relaxed text-[var(--mm-text3)]">
-            If work is blank, Refiner uses: <span className={mmTechnicalMonoSmallClass}>{d.resolved_default_tv_work_folder}</span>
+            If work is blank, Refiner uses:{" "}
+            <span className={mmTechnicalMonoSmallClass}>
+              {d.resolved_default_tv_work_folder}
+            </span>
           </p>
           <div className="mt-6 flex min-h-0 flex-1 flex-col">
             <div className="mm-card-action-body flex-1 min-h-0">
-            <div>
-              {renderFolderInput({
-                label: "Watched folder",
-                value: tvWatched,
-                setter: setTvWatched,
-                title: "Choose TV watched folder",
-              })}
-              {tvWatched.trim() && !d.refiner_tv_watched_folder_exists ? (
-                <span className="mt-1 block text-xs text-amber-200/90">
-                  This folder is not on disk yet. Save is allowed. Refiner will warn at runtime until it exists.
+              <div>
+                {renderFolderInput({
+                  label: "Watched folder",
+                  value: tvWatched,
+                  setter: setTvWatched,
+                  title: "Choose TV watched folder",
+                })}
+                {tvWatched.trim() && !d.refiner_tv_watched_folder_exists ? (
+                  <span className="mt-1 block text-xs text-amber-200/90">
+                    This folder is not on disk yet. Save is allowed. Refiner
+                    will warn at runtime until it exists.
+                  </span>
+                ) : null}
+              </div>
+              <div>
+                {renderFolderInput({
+                  label: "Work / temp folder",
+                  value: tvWork,
+                  setter: setTvWork,
+                  title: "Choose TV work folder",
+                })}
+                <span className="mt-1 block text-xs text-[var(--mm-text3)]">
+                  Effective work folder now:{" "}
+                  <span className={mmTechnicalMonoSmallClass}>
+                    {effectiveTvWorkPreview}
+                  </span>
                 </span>
-              ) : null}
-            </div>
-            <div>
+              </div>
               {renderFolderInput({
-                label: "Work / temp folder",
-                value: tvWork,
-                setter: setTvWork,
-                title: "Choose TV work folder",
+                label: "Output folder",
+                value: tvOutput,
+                setter: setTvOutput,
+                title: "Choose TV output folder",
               })}
-              <span className="mt-1 block text-xs text-[var(--mm-text3)]">
-                Effective work folder now: <span className={mmTechnicalMonoSmallClass}>{effectiveTvWorkPreview}</span>
-              </span>
-            </div>
-            {renderFolderInput({
-              label: "Output folder",
-              value: tvOutput,
-              setter: setTvOutput,
-              title: "Choose TV output folder",
-            })}
-            <div className="border-t border-[var(--mm-border)] pt-6 pb-6">
-              <span id={tvIntervalLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-                Watched folder interval
-              </span>
-              <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
-                How often this library is checked for periodic TV scans. Independent of Movies.
-              </p>
-              <MmListboxPicker
-                className="mt-2 max-w-md"
-                options={WATCHED_FOLDER_INTERVAL_OPTIONS}
-                value={tvWatchedFolderInterval}
-                disabled={!editable || save.isPending}
-                onChange={setTvWatchedFolderInterval}
-                ariaLabelledBy={tvIntervalLabelId}
-                placeholder="Select interval"
-              />
-            </div>
-            {tvOutputMissing ? (
-              <p className="text-xs text-amber-200/90">
-                Set a TV output folder before saving when TV watched is set.
-              </p>
-            ) : null}
+              <div className="border-t border-[var(--mm-border)] pt-6 pb-6">
+                <span
+                  id={tvIntervalLabelId}
+                  className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+                >
+                  Watched folder interval
+                </span>
+                <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+                  How often this library is checked for periodic TV scans.
+                  Independent of Movies.
+                </p>
+                <MmListboxPicker
+                  className="mt-2 max-w-md"
+                  options={WATCHED_FOLDER_INTERVAL_OPTIONS}
+                  value={tvWatchedFolderInterval}
+                  disabled={!editable || save.isPending}
+                  onChange={setTvWatchedFolderInterval}
+                  ariaLabelledBy={tvIntervalLabelId}
+                  placeholder="Select interval"
+                />
+              </div>
+              {tvOutputMissing ? (
+                <p className="text-xs text-amber-200/90">
+                  Set a TV output folder before saving when TV watched is set.
+                </p>
+              ) : null}
             </div>
             <div className="mm-card-action-footer">
               <button
                 type="button"
                 className={mmActionButtonClass({
                   variant: "primary",
-                  disabled: !editable || !tvDirty || save.isPending || tvOutputMissing,
+                  disabled:
+                    !editable || !tvDirty || save.isPending || tvOutputMissing,
                 })}
-                disabled={!editable || !tvDirty || save.isPending || tvOutputMissing}
+                disabled={
+                  !editable || !tvDirty || save.isPending || tvOutputMissing
+                }
                 onClick={() =>
                   save.mutate({
-                    refiner_watched_folder: watched.trim() ? watched.trim() : null,
+                    refiner_watched_folder: watched.trim()
+                      ? watched.trim()
+                      : null,
                     refiner_work_folder: work.trim() ? work.trim() : null,
                     refiner_output_folder: output.trim() ? output.trim() : null,
                     refiner_tv_paths_included: true,
-                    refiner_tv_watched_folder: tvWatched.trim() ? tvWatched.trim() : null,
-                    refiner_tv_work_folder: tvWork.trim() ? tvWork.trim() : null,
-                    refiner_tv_output_folder: tvOutput.trim() ? tvOutput.trim() : null,
-                    movie_watched_folder_check_interval_seconds: Number.parseInt(movieWatchedFolderInterval, 10),
-                    tv_watched_folder_check_interval_seconds: Number.parseInt(tvWatchedFolderInterval, 10),
+                    refiner_tv_watched_folder: tvWatched.trim()
+                      ? tvWatched.trim()
+                      : null,
+                    refiner_tv_work_folder: tvWork.trim()
+                      ? tvWork.trim()
+                      : null,
+                    refiner_tv_output_folder: tvOutput.trim()
+                      ? tvOutput.trim()
+                      : null,
+                    movie_watched_folder_check_interval_seconds:
+                      Number.parseInt(movieWatchedFolderInterval, 10),
+                    tv_watched_folder_check_interval_seconds: Number.parseInt(
+                      tvWatchedFolderInterval,
+                      10,
+                    ),
                   })
                 }
               >
@@ -312,66 +425,82 @@ export function RefinerPathSettingsSection() {
 
         <div className="mm-card mm-dash-card flex flex-col p-5 sm:p-6">
           <div className="border-b border-[var(--mm-border)] pb-4">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">Library</p>
-            <h3 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">Movies</h3>
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">
+              Library
+            </p>
+            <h3 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+              Movies
+            </h3>
           </div>
           <p className="mt-4 text-xs leading-relaxed text-[var(--mm-text3)]">
-            If work is blank, Refiner uses: <span className={mmTechnicalMonoSmallClass}>{d.resolved_default_work_folder}</span>
+            If work is blank, Refiner uses:{" "}
+            <span className={mmTechnicalMonoSmallClass}>
+              {d.resolved_default_work_folder}
+            </span>
           </p>
           <div className="mt-6 flex min-h-0 flex-1 flex-col">
             <div className="mm-card-action-body flex-1 min-h-0">
-            <div>
-              {renderFolderInput({
-                label: "Watched folder",
-                value: watched,
-                setter: setWatched,
-                title: "Choose Movies watched folder",
-              })}
-              {watched.trim() && !d.refiner_watched_folder_exists ? (
-                <span className="mt-1 block text-xs text-amber-200/90">
-                  This folder is not on disk yet. Save is allowed. Refiner will warn at runtime until it exists.
+              <div>
+                {renderFolderInput({
+                  label: "Watched folder",
+                  value: watched,
+                  setter: setWatched,
+                  title: "Choose Movies watched folder",
+                })}
+                {watched.trim() && !d.refiner_watched_folder_exists ? (
+                  <span className="mt-1 block text-xs text-amber-200/90">
+                    This folder is not on disk yet. Save is allowed. Refiner
+                    will warn at runtime until it exists.
+                  </span>
+                ) : null}
+              </div>
+              <div>
+                {renderFolderInput({
+                  label: "Work / temp folder",
+                  value: work,
+                  setter: setWork,
+                  title: "Choose Movies work folder",
+                })}
+                <span className="mt-1 block text-xs text-[var(--mm-text3)]">
+                  Effective work folder now:{" "}
+                  <span className={mmTechnicalMonoSmallClass}>
+                    {effectiveMovieWorkPreview}
+                  </span>
                 </span>
-              ) : null}
-            </div>
-            <div>
+              </div>
               {renderFolderInput({
-                label: "Work / temp folder",
-                value: work,
-                setter: setWork,
-                title: "Choose Movies work folder",
+                label: "Output folder",
+                value: output,
+                setter: setOutput,
+                title: "Choose Movies output folder",
+                required: true,
               })}
-              <span className="mt-1 block text-xs text-[var(--mm-text3)]">
-                Effective work folder now: <span className={mmTechnicalMonoSmallClass}>{effectiveMovieWorkPreview}</span>
-              </span>
-            </div>
-            {renderFolderInput({
-              label: "Output folder",
-              value: output,
-              setter: setOutput,
-              title: "Choose Movies output folder",
-              required: true,
-            })}
-            <div className="border-t border-[var(--mm-border)] pt-6 pb-6">
-              <span id={movieIntervalLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-                Watched folder interval
-              </span>
-              <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
-                How often this library is checked for periodic Movies scans. Independent of TV.
-              </p>
-              <MmListboxPicker
-                className="mt-2 max-w-md"
-                options={WATCHED_FOLDER_INTERVAL_OPTIONS}
-                value={movieWatchedFolderInterval}
-                disabled={!editable || save.isPending}
-                onChange={setMovieWatchedFolderInterval}
-                ariaLabelledBy={movieIntervalLabelId}
-                placeholder="Select interval"
-              />
-            </div>
+              <div className="border-t border-[var(--mm-border)] pt-6 pb-6">
+                <span
+                  id={movieIntervalLabelId}
+                  className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+                >
+                  Watched folder interval
+                </span>
+                <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+                  How often this library is checked for periodic Movies scans.
+                  Independent of TV.
+                </p>
+                <MmListboxPicker
+                  className="mt-2 max-w-md"
+                  options={WATCHED_FOLDER_INTERVAL_OPTIONS}
+                  value={movieWatchedFolderInterval}
+                  disabled={!editable || save.isPending}
+                  onChange={setMovieWatchedFolderInterval}
+                  ariaLabelledBy={movieIntervalLabelId}
+                  placeholder="Select interval"
+                />
+              </div>
             </div>
             {movieOutputMissing ? (
               <p className="text-xs text-amber-200/90">
-                Set a Movies output folder before saving when Movies watched is set.
+                Set a Movies output folder before saving when Movies watched is
+                set.
               </p>
             ) : null}
             <div className="mm-card-action-footer">
@@ -379,20 +508,41 @@ export function RefinerPathSettingsSection() {
                 type="button"
                 className={mmActionButtonClass({
                   variant: "primary",
-                  disabled: !editable || !moviesDirty || save.isPending || movieOutputMissing,
+                  disabled:
+                    !editable ||
+                    !moviesDirty ||
+                    save.isPending ||
+                    movieOutputMissing,
                 })}
-                disabled={!editable || !moviesDirty || save.isPending || movieOutputMissing}
+                disabled={
+                  !editable ||
+                  !moviesDirty ||
+                  save.isPending ||
+                  movieOutputMissing
+                }
                 onClick={() =>
                   save.mutate({
-                    refiner_watched_folder: watched.trim() ? watched.trim() : null,
+                    refiner_watched_folder: watched.trim()
+                      ? watched.trim()
+                      : null,
                     refiner_work_folder: work.trim() ? work.trim() : null,
                     refiner_output_folder: output.trim() ? output.trim() : null,
                     refiner_tv_paths_included: true,
-                    refiner_tv_watched_folder: tvWatched.trim() ? tvWatched.trim() : null,
-                    refiner_tv_work_folder: tvWork.trim() ? tvWork.trim() : null,
-                    refiner_tv_output_folder: tvOutput.trim() ? tvOutput.trim() : null,
-                    movie_watched_folder_check_interval_seconds: Number.parseInt(movieWatchedFolderInterval, 10),
-                    tv_watched_folder_check_interval_seconds: Number.parseInt(tvWatchedFolderInterval, 10),
+                    refiner_tv_watched_folder: tvWatched.trim()
+                      ? tvWatched.trim()
+                      : null,
+                    refiner_tv_work_folder: tvWork.trim()
+                      ? tvWork.trim()
+                      : null,
+                    refiner_tv_output_folder: tvOutput.trim()
+                      ? tvOutput.trim()
+                      : null,
+                    movie_watched_folder_check_interval_seconds:
+                      Number.parseInt(movieWatchedFolderInterval, 10),
+                    tv_watched_folder_check_interval_seconds: Number.parseInt(
+                      tvWatchedFolderInterval,
+                      10,
+                    ),
                   })
                 }
               >
@@ -404,17 +554,23 @@ export function RefinerPathSettingsSection() {
       </div>
 
       {save.isError ? (
-        <p className="mt-3 text-sm text-red-300" role="alert" data-testid="refiner-path-settings-save-error">
+        <p
+          className="mt-3 text-sm text-red-300"
+          role="alert"
+          data-testid="refiner-path-settings-save-error"
+        >
           {save.error instanceof Error ? save.error.message : "Save failed."}
         </p>
       ) : null}
 
       {save.isSuccess && !moviesDirty && !tvDirty ? (
-        <p className="mt-3 text-xs text-[var(--mm-text3)]" data-testid="refiner-path-settings-saved-hint">
+        <p
+          className="mt-3 text-xs text-[var(--mm-text3)]"
+          data-testid="refiner-path-settings-saved-hint"
+        >
           Saved.
         </p>
       ) : null}
-
     </div>
   );
 }

--- a/apps/web/src/pages/refiner/refiner-process-settings-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-process-settings-section.tsx
@@ -1,19 +1,31 @@
 import { useEffect, useId, useState } from "react";
-import { MmListboxPicker, type MmListboxOption } from "../../components/ui/mm-listbox-picker";
+import {
+  MmListboxPicker,
+  type MmListboxOption,
+} from "../../components/ui/mm-listbox-picker";
 import { PageLoading } from "../../components/shared/page-loading";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useMeQuery } from "../../lib/auth/queries";
-import { useRefinerOperatorSettingsQuery, useRefinerOperatorSettingsSaveMutation } from "../../lib/refiner/queries";
+import {
+  useRefinerOperatorSettingsQuery,
+  useRefinerOperatorSettingsSaveMutation,
+} from "../../lib/refiner/queries";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
 function canEdit(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
 }
 
-const FILES_AT_ONCE_OPTIONS: MmListboxOption[] = Array.from({ length: 8 }, (_, i) => ({
-  value: String(i + 1),
-  label: String(i + 1),
-}));
+const FILES_AT_ONCE_OPTIONS: MmListboxOption[] = Array.from(
+  { length: 8 },
+  (_, i) => ({
+    value: String(i + 1),
+    label: String(i + 1),
+  }),
+);
 
 /** Throughput and file-age gates (not paths or poll intervals — those live under Libraries). */
 export function RefinerProcessSettingsSection() {
@@ -35,7 +47,9 @@ export function RefinerProcessSettingsSection() {
     setMaxConcurrentFiles(String(q.data.max_concurrent_files));
     setMinFileAgeSeconds(String(q.data.min_file_age_seconds));
     setMinInputFileSizeMb(String(q.data.refiner_min_input_file_size_mb));
-    setMinimumFreeDiskSpaceGb(String(Math.max(0, q.data.minimum_free_disk_space_mb / 1024)));
+    setMinimumFreeDiskSpaceGb(
+      String(Math.max(0, q.data.minimum_free_disk_space_mb / 1024)),
+    );
   }, [q.data]);
 
   if (q.isPending || me.isPending) {
@@ -43,8 +57,13 @@ export function RefinerProcessSettingsSection() {
   }
   if (q.isError) {
     return (
-      <div className="mm-module-surface w-full min-w-0 rounded border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-200" role="alert">
-        <p className="font-semibold">Could not load Refiner processing settings</p>
+      <div
+        className="mm-module-surface w-full min-w-0 rounded border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-200"
+        role="alert"
+      >
+        <p className="font-semibold">
+          Could not load Refiner processing settings
+        </p>
         <p className="mt-1">
           {isLikelyNetworkFailure(q.error)
             ? "Check that the MediaMop API is running."
@@ -82,77 +101,84 @@ export function RefinerProcessSettingsSection() {
 
   return (
     <section className="mm-module-surface flex w-full min-w-0 flex-col rounded border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-6 text-sm leading-relaxed text-[var(--mm-text2)] sm:p-7">
-      <h2 className="text-base font-semibold text-[var(--mm-text)]">Processing settings</h2>
+      <h2 className="text-base font-semibold text-[var(--mm-text)]">
+        Processing settings
+      </h2>
       <p className="mt-2 max-w-3xl text-[var(--mm-text3)]">
-        Control how many files Refiner works on at once and how long a file must sit unchanged before processing.
-        Per-library watched-folder timers are under <strong className="text-[var(--mm-text2)]">Libraries</strong>.
+        Control how many files Refiner works on at once and how long a file must
+        sit unchanged before processing. Per-library watched-folder timers are
+        under <strong className="text-[var(--mm-text2)]">Libraries</strong>.
       </p>
       <p className="mt-2 max-w-3xl text-[var(--mm-text3)]">
-        Download-client disk limits are still recommended. MediaMop adds this final safety check before Refiner or Subber
-        writes to a target drive.
+        Download-client disk limits are still recommended. MediaMop adds this
+        final safety check before Refiner or Subber writes to a target drive.
       </p>
       <div className="mm-card-action-body mt-6 flex-1 min-h-0">
-      <div className="grid gap-4 sm:grid-cols-2 sm:gap-5">
-        <div className="block min-w-0">
-          <span id={filesAtOnceLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-            Files at once
-          </span>
-          <MmListboxPicker
-            className="w-full min-w-0"
-            options={FILES_AT_ONCE_OPTIONS}
-            value={maxConcurrentFiles}
-            disabled={!editable || save.isPending}
-            onChange={setMaxConcurrentFiles}
-            ariaLabelledBy={filesAtOnceLabelId}
-            placeholder="Select…"
-          />
+        <div className="grid gap-4 sm:grid-cols-2 sm:gap-5">
+          <div className="block min-w-0">
+            <span
+              id={filesAtOnceLabelId}
+              className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+            >
+              Files at once
+            </span>
+            <MmListboxPicker
+              className="w-full min-w-0"
+              options={FILES_AT_ONCE_OPTIONS}
+              value={maxConcurrentFiles}
+              disabled={!editable || save.isPending}
+              onChange={setMaxConcurrentFiles}
+              ariaLabelledBy={filesAtOnceLabelId}
+              placeholder="Select…"
+            />
+          </div>
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Minimum file age before processing (seconds)
+            </span>
+            <input
+              type="number"
+              min={0}
+              value={minFileAgeSeconds}
+              disabled={!editable || save.isPending}
+              onChange={(e) => setMinFileAgeSeconds(e.target.value)}
+              className="mm-input mt-1 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Minimum file size (MB) — files smaller than this will be skipped
+            </span>
+            <input
+              type="number"
+              min={0}
+              value={minInputFileSizeMb}
+              disabled={!editable || save.isPending}
+              onChange={(e) => setMinInputFileSizeMb(e.target.value)}
+              className="mm-input mt-1 w-full"
+            />
+          </label>
+          <label className="block">
+            <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Minimum free disk space (GB) — processing will not start below
+              this threshold
+            </span>
+            <input
+              type="number"
+              min={0}
+              step={0.1}
+              value={minimumFreeDiskSpaceGb}
+              disabled={!editable || save.isPending}
+              onChange={(e) => setMinimumFreeDiskSpaceGb(e.target.value)}
+              className="mm-input mt-1 w-full"
+            />
+          </label>
         </div>
-        <label className="block">
-          <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-            Minimum file age before processing (seconds)
-          </span>
-          <input
-            type="number"
-            min={0}
-            value={minFileAgeSeconds}
-            disabled={!editable || save.isPending}
-            onChange={(e) => setMinFileAgeSeconds(e.target.value)}
-            className="mm-input mt-1 w-full"
-          />
-        </label>
-        <label className="block">
-          <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-            Minimum file size (MB) — files smaller than this will be skipped
-          </span>
-          <input
-            type="number"
-            min={0}
-            value={minInputFileSizeMb}
-            disabled={!editable || save.isPending}
-            onChange={(e) => setMinInputFileSizeMb(e.target.value)}
-            className="mm-input mt-1 w-full"
-          />
-        </label>
-        <label className="block">
-          <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-            Minimum free disk space (GB) — processing will not start below this threshold
-          </span>
-          <input
-            type="number"
-            min={0}
-            step={0.1}
-            value={minimumFreeDiskSpaceGb}
-            disabled={!editable || save.isPending}
-            onChange={(e) => setMinimumFreeDiskSpaceGb(e.target.value)}
-            className="mm-input mt-1 w-full"
-          />
-        </label>
-      </div>
-      {save.isError ? (
-        <p className="mt-3 text-sm text-red-300" role="alert">
-          {save.error instanceof Error ? save.error.message : "Save failed."}
-        </p>
-      ) : null}
+        {save.isError ? (
+          <p className="mt-3 text-sm text-red-300" role="alert">
+            {save.error instanceof Error ? save.error.message : "Save failed."}
+          </p>
+        ) : null}
       </div>
       <div className="mm-card-action-footer">
         <button

--- a/apps/web/src/pages/refiner/refiner-remux-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-remux-section.tsx
@@ -1,23 +1,34 @@
 import { useEffect, useState } from "react";
-import { MmListboxPicker, type MmListboxOption } from "../../components/ui/mm-listbox-picker";
+import {
+  MmListboxPicker,
+  type MmListboxOption,
+} from "../../components/ui/mm-listbox-picker";
 import { MmMultiListboxPicker } from "../../components/ui/mm-multi-listbox-picker";
 import { MmOnOffSwitch } from "../../components/ui/mm-on-off-switch";
 import { PageLoading } from "../../components/shared/page-loading";
 import { useMeQuery } from "../../lib/auth/queries";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import {
   useRefinerRemuxRulesSettingsQuery,
   useRefinerRemuxRulesSettingsSaveMutation,
 } from "../../lib/refiner/queries";
 import { REFINER_STREAM_LANGUAGE_OPTIONS } from "../../lib/refiner/stream-language-options";
-import type { RefinerRemuxRulesScopeSettings, RefinerRemuxRulesSettingsPutBody } from "../../lib/refiner/types";
+import type {
+  RefinerRemuxRulesScopeSettings,
+  RefinerRemuxRulesSettingsPutBody,
+} from "../../lib/refiner/types";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
 function canEditRefiner(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
 }
 
-const KNOWN_REFINER_LANG_CODES = new Set(REFINER_STREAM_LANGUAGE_OPTIONS.map((o) => o.code));
+const KNOWN_REFINER_LANG_CODES = new Set(
+  REFINER_STREAM_LANGUAGE_OPTIONS.map((o) => o.code),
+);
 
 function primaryLanguageOptions(currentCode: string): MmListboxOption[] {
   const cur = currentCode.trim();
@@ -49,9 +60,18 @@ const DEFAULT_AUDIO_SLOT_OPTIONS: MmListboxOption[] = [
 ];
 
 const AUDIO_PREFERENCE_OPTIONS: MmListboxOption[] = [
-  { value: "preferred_langs_quality", label: "Match your language list first, then best quality" },
-  { value: "preferred_langs_strict", label: "Only keep tracks in your language list" },
-  { value: "quality_all_languages", label: "Ignore language list and keep the best quality track" },
+  {
+    value: "preferred_langs_quality",
+    label: "Match your language list first, then best quality",
+  },
+  {
+    value: "preferred_langs_strict",
+    label: "Only keep tracks in your language list",
+  },
+  {
+    value: "quality_all_languages",
+    label: "Ignore language list and keep the best quality track",
+  },
 ];
 
 const SUBTITLE_MODE_OPTIONS: MmListboxOption[] = [
@@ -59,10 +79,11 @@ const SUBTITLE_MODE_OPTIONS: MmListboxOption[] = [
   { value: "keep_selected", label: "Keep selected languages only" },
 ];
 
-const SUBTITLE_LANGUAGE_OPTIONS: MmListboxOption[] = REFINER_STREAM_LANGUAGE_OPTIONS.map((o) => ({
-  value: o.code,
-  label: `${o.label} (${o.code})`,
-}));
+const SUBTITLE_LANGUAGE_OPTIONS: MmListboxOption[] =
+  REFINER_STREAM_LANGUAGE_OPTIONS.map((o) => ({
+    value: o.code,
+    label: `${o.label} (${o.code})`,
+  }));
 
 function parseCsvCodes(raw: string): string[] {
   const seen = new Set<string>();
@@ -112,124 +133,174 @@ function ScopeCard({
   return (
     <section className="mm-card mm-dash-card flex flex-col p-6">
       <div className="border-b border-[var(--mm-border)] pb-4">
-        <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">Scope</p>
-        <h3 className="mt-1.5 text-base font-semibold text-[var(--mm-text1)]">{title}</h3>
+        <p className="text-[0.7rem] font-semibold uppercase tracking-[0.16em] text-[var(--mm-text3)]">
+          Scope
+        </p>
+        <h3 className="mt-1.5 text-base font-semibold text-[var(--mm-text1)]">
+          {title}
+        </h3>
       </div>
       <div className="mm-card-action-body mt-6 flex-1 min-h-0">
-      <div className="space-y-9">
-        <section className="min-w-0">
-          <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Audio</h4>
-          <div className="mt-3 grid gap-x-6 gap-y-6 sm:grid-cols-2">
-            <div className="sm:col-span-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Primary language</span>
-              <MmListboxPicker
-                disabled={disabled}
-                placeholder="Choose a language…"
-                options={primaryLanguageOptions(draft.primary_audio_lang)}
-                value={draft.primary_audio_lang}
-                onChange={(v) => setDraft({ ...draft, primary_audio_lang: v })}
-              />
+        <div className="space-y-9">
+          <section className="min-w-0">
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Audio
+            </h4>
+            <div className="mt-3 grid gap-x-6 gap-y-6 sm:grid-cols-2">
+              <div className="sm:col-span-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Primary language
+                </span>
+                <MmListboxPicker
+                  disabled={disabled}
+                  placeholder="Choose a language…"
+                  options={primaryLanguageOptions(draft.primary_audio_lang)}
+                  value={draft.primary_audio_lang}
+                  onChange={(v) =>
+                    setDraft({ ...draft, primary_audio_lang: v })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Secondary language
+                </span>
+                <MmListboxPicker
+                  disabled={disabled}
+                  placeholder="None"
+                  options={secondaryLanguageOptions(draft.secondary_audio_lang)}
+                  value={draft.secondary_audio_lang}
+                  onChange={(v) =>
+                    setDraft({ ...draft, secondary_audio_lang: v })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Tertiary language
+                </span>
+                <MmListboxPicker
+                  disabled={disabled}
+                  placeholder="None"
+                  options={secondaryLanguageOptions(draft.tertiary_audio_lang)}
+                  value={draft.tertiary_audio_lang}
+                  onChange={(v) =>
+                    setDraft({ ...draft, tertiary_audio_lang: v })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-1">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Default audio slot
+                </span>
+                <MmListboxPicker
+                  disabled={disabled}
+                  options={DEFAULT_AUDIO_SLOT_OPTIONS}
+                  value={draft.default_audio_slot}
+                  onChange={(v) =>
+                    setDraft({
+                      ...draft,
+                      default_audio_slot:
+                        v as RefinerRemuxRulesScopeSettings["default_audio_slot"],
+                    })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Audio selection policy
+                </span>
+                <MmListboxPicker
+                  disabled={disabled}
+                  options={AUDIO_PREFERENCE_OPTIONS}
+                  value={draft.audio_preference_mode}
+                  onChange={(v) =>
+                    setDraft({
+                      ...draft,
+                      audio_preference_mode:
+                        v as RefinerRemuxRulesScopeSettings["audio_preference_mode"],
+                    })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-2">
+                <MmOnOffSwitch
+                  id={`refiner-${title.toLowerCase()}-remove-commentary`}
+                  label="Remove commentary tracks"
+                  enabled={draft.remove_commentary}
+                  disabled={disabled}
+                  onChange={(v) => setDraft({ ...draft, remove_commentary: v })}
+                />
+              </div>
             </div>
-            <div className="sm:col-span-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Secondary language</span>
-              <MmListboxPicker
-                disabled={disabled}
-                placeholder="None"
-                options={secondaryLanguageOptions(draft.secondary_audio_lang)}
-                value={draft.secondary_audio_lang}
-                onChange={(v) => setDraft({ ...draft, secondary_audio_lang: v })}
-              />
+          </section>
+          <section className="min-w-0 border-t border-[var(--mm-border)] pt-9">
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Subtitles
+            </h4>
+            <div className="mt-3 grid gap-x-6 gap-y-6 sm:grid-cols-2">
+              <div className="sm:col-span-2">
+                <MmListboxPicker
+                  disabled={disabled}
+                  options={SUBTITLE_MODE_OPTIONS}
+                  value={draft.subtitle_mode}
+                  onChange={(v) =>
+                    setDraft({
+                      ...draft,
+                      subtitle_mode:
+                        v as RefinerRemuxRulesScopeSettings["subtitle_mode"],
+                    })
+                  }
+                />
+              </div>
+              <label className="block sm:col-span-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Subtitle languages
+                </span>
+                <MmMultiListboxPicker
+                  options={SUBTITLE_LANGUAGE_OPTIONS}
+                  values={subtitleCodes}
+                  disabled={disabled}
+                  onChange={(next) =>
+                    setDraft({ ...draft, subtitle_langs_csv: next.join(",") })
+                  }
+                  placeholder="Select subtitle languages"
+                  data-testid={pickerTestId}
+                />
+              </label>
+              <div className="sm:col-span-1">
+                <MmOnOffSwitch
+                  id={`refiner-${title.toLowerCase()}-keep-forced-subs`}
+                  label="Keep forced subtitles"
+                  enabled={draft.preserve_forced_subs}
+                  disabled={disabled || draft.subtitle_mode === "remove_all"}
+                  onChange={(v) =>
+                    setDraft({ ...draft, preserve_forced_subs: v })
+                  }
+                />
+              </div>
+              <div className="sm:col-span-1">
+                <MmOnOffSwitch
+                  id={`refiner-${title.toLowerCase()}-keep-default-subs`}
+                  label="Keep default subtitles"
+                  enabled={draft.preserve_default_subs}
+                  disabled={disabled || draft.subtitle_mode === "remove_all"}
+                  onChange={(v) =>
+                    setDraft({ ...draft, preserve_default_subs: v })
+                  }
+                />
+              </div>
             </div>
-            <div className="sm:col-span-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Tertiary language</span>
-              <MmListboxPicker
-                disabled={disabled}
-                placeholder="None"
-                options={secondaryLanguageOptions(draft.tertiary_audio_lang)}
-                value={draft.tertiary_audio_lang}
-                onChange={(v) => setDraft({ ...draft, tertiary_audio_lang: v })}
-              />
-            </div>
-            <div className="sm:col-span-1">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Default audio slot</span>
-              <MmListboxPicker
-                disabled={disabled}
-                options={DEFAULT_AUDIO_SLOT_OPTIONS}
-                value={draft.default_audio_slot}
-                onChange={(v) => setDraft({ ...draft, default_audio_slot: v as RefinerRemuxRulesScopeSettings["default_audio_slot"] })}
-              />
-            </div>
-            <div className="sm:col-span-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Audio selection policy</span>
-              <MmListboxPicker
-                disabled={disabled}
-                options={AUDIO_PREFERENCE_OPTIONS}
-                value={draft.audio_preference_mode}
-                onChange={(v) =>
-                  setDraft({ ...draft, audio_preference_mode: v as RefinerRemuxRulesScopeSettings["audio_preference_mode"] })
-                }
-              />
-            </div>
-            <div className="sm:col-span-2">
-              <MmOnOffSwitch
-                id={`refiner-${title.toLowerCase()}-remove-commentary`}
-                label="Remove commentary tracks"
-                enabled={draft.remove_commentary}
-                disabled={disabled}
-                onChange={(v) => setDraft({ ...draft, remove_commentary: v })}
-              />
-            </div>
-          </div>
-        </section>
-        <section className="min-w-0 border-t border-[var(--mm-border)] pt-9">
-          <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Subtitles</h4>
-          <div className="mt-3 grid gap-x-6 gap-y-6 sm:grid-cols-2">
-            <div className="sm:col-span-2">
-              <MmListboxPicker
-                disabled={disabled}
-                options={SUBTITLE_MODE_OPTIONS}
-                value={draft.subtitle_mode}
-                onChange={(v) => setDraft({ ...draft, subtitle_mode: v as RefinerRemuxRulesScopeSettings["subtitle_mode"] })}
-              />
-            </div>
-            <label className="block sm:col-span-2">
-              <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Subtitle languages</span>
-              <MmMultiListboxPicker
-                options={SUBTITLE_LANGUAGE_OPTIONS}
-                values={subtitleCodes}
-                disabled={disabled}
-                onChange={(next) => setDraft({ ...draft, subtitle_langs_csv: next.join(",") })}
-                placeholder="Select subtitle languages"
-                data-testid={pickerTestId}
-              />
-            </label>
-            <div className="sm:col-span-1">
-              <MmOnOffSwitch
-                id={`refiner-${title.toLowerCase()}-keep-forced-subs`}
-                label="Keep forced subtitles"
-                enabled={draft.preserve_forced_subs}
-                disabled={disabled || draft.subtitle_mode === "remove_all"}
-                onChange={(v) => setDraft({ ...draft, preserve_forced_subs: v })}
-              />
-            </div>
-            <div className="sm:col-span-1">
-              <MmOnOffSwitch
-                id={`refiner-${title.toLowerCase()}-keep-default-subs`}
-                label="Keep default subtitles"
-                enabled={draft.preserve_default_subs}
-                disabled={disabled || draft.subtitle_mode === "remove_all"}
-                onChange={(v) => setDraft({ ...draft, preserve_default_subs: v })}
-              />
-            </div>
-          </div>
-        </section>
-      </div>
-      {isError ? (
-        <p className="mt-3 text-sm text-red-300" role="alert">
-          {error instanceof Error ? error.message : "Save failed."}
-        </p>
-      ) : null}
-      {isSuccess && !dirty ? <p className="mt-4 text-xs text-[var(--mm-text3)]">Saved.</p> : null}
+          </section>
+        </div>
+        {isError ? (
+          <p className="mt-3 text-sm text-red-300" role="alert">
+            {error instanceof Error ? error.message : "Save failed."}
+          </p>
+        ) : null}
+        {isSuccess && !dirty ? (
+          <p className="mt-4 text-xs text-[var(--mm-text3)]">Saved.</p>
+        ) : null}
       </div>
       <div className="mm-card-action-footer">
         <button
@@ -255,8 +326,11 @@ export function RefinerRemuxSection() {
   const saveMovie = useRefinerRemuxRulesSettingsSaveMutation();
   const saveTv = useRefinerRemuxRulesSettingsSaveMutation();
 
-  const [movieDraft, setMovieDraft] = useState<RefinerRemuxRulesScopeSettings | null>(null);
-  const [tvDraft, setTvDraft] = useState<RefinerRemuxRulesScopeSettings | null>(null);
+  const [movieDraft, setMovieDraft] =
+    useState<RefinerRemuxRulesScopeSettings | null>(null);
+  const [tvDraft, setTvDraft] = useState<RefinerRemuxRulesScopeSettings | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!q.data) {
@@ -271,7 +345,10 @@ export function RefinerRemuxSection() {
     movieDraft !== null &&
     q.data !== undefined &&
     JSON.stringify(movieDraft) !== JSON.stringify(q.data.movie);
-  const tvDirty = tvDraft !== null && q.data !== undefined && JSON.stringify(tvDraft) !== JSON.stringify(q.data.tv);
+  const tvDirty =
+    tvDraft !== null &&
+    q.data !== undefined &&
+    JSON.stringify(tvDraft) !== JSON.stringify(q.data.tv);
 
   if (q.isPending || me.isPending) {
     return <PageLoading label="Loading audio and subtitle settings" />;
@@ -283,7 +360,9 @@ export function RefinerRemuxSection() {
         data-testid="refiner-remux-settings-error"
         role="alert"
       >
-        <p className="font-semibold">Could not load audio and subtitle settings</p>
+        <p className="font-semibold">
+          Could not load audio and subtitle settings
+        </p>
         <p className="mt-1">
           {isLikelyNetworkFailure(q.error)
             ? "Check that the MediaMop API is running."
@@ -298,28 +377,49 @@ export function RefinerRemuxSection() {
     return null;
   }
 
-  const saveMovieBody: RefinerRemuxRulesSettingsPutBody = { media_scope: "movie", ...movieDraft };
-  const saveTvBody: RefinerRemuxRulesSettingsPutBody = { media_scope: "tv", ...tvDraft };
+  const saveMovieBody: RefinerRemuxRulesSettingsPutBody = {
+    media_scope: "movie",
+    ...movieDraft,
+  };
+  const saveTvBody: RefinerRemuxRulesSettingsPutBody = {
+    media_scope: "tv",
+    ...tvDraft,
+  };
 
   return (
-    <div className="mm-bubble-stack flex w-full min-w-0 flex-col" data-testid="refiner-remux-section">
+    <div
+      className="mm-bubble-stack flex w-full min-w-0 flex-col"
+      data-testid="refiner-remux-section"
+    >
       <section
         className="mm-card mm-dash-card mm-module-surface w-full min-w-0 p-6 text-sm leading-relaxed text-[var(--mm-text2)] sm:p-7"
         aria-labelledby="refiner-audio-subtitles-saved-heading"
         data-testid="refiner-remux-defaults"
       >
-        <h2 id="refiner-audio-subtitles-saved-heading" className="text-base font-semibold text-[var(--mm-text)]">
+        <h2
+          id="refiner-audio-subtitles-saved-heading"
+          className="text-base font-semibold text-[var(--mm-text)]"
+        >
           Audio & subtitle defaults
         </h2>
         <p className="mt-2 max-w-3xl text-[var(--mm-text3)]">
-          TV and Movies each have their own defaults. Saving one side does not change the other.
+          TV and Movies each have their own defaults. Saving one side does not
+          change the other.
         </p>
         <p className="mt-2 max-w-3xl text-xs text-[var(--mm-text3)]">
           For folders and what Refiner can change or remove on disk, open{" "}
-          <strong className="text-[var(--mm-text2)]">Libraries</strong> and expand{" "}
-          <strong className="text-[var(--mm-text2)]">What happens to your files</strong>.
+          <strong className="text-[var(--mm-text2)]">Libraries</strong> and
+          expand{" "}
+          <strong className="text-[var(--mm-text2)]">
+            What happens to your files
+          </strong>
+          .
         </p>
-        {!editable ? <p className="mt-3 text-xs text-[var(--mm-text3)]">Operators and admins can edit these rules.</p> : null}
+        {!editable ? (
+          <p className="mt-3 text-xs text-[var(--mm-text3)]">
+            Operators and admins can edit these rules.
+          </p>
+        ) : null}
       </section>
       <div className="mm-dash-grid">
         <ScopeCard

--- a/apps/web/src/pages/refiner/refiner-schedules-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-schedules-section.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { PageLoading } from "../../components/shared/page-loading";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useMeQuery } from "../../lib/auth/queries";
 import {
   MM_SCHEDULE_TIME_WINDOW_HELPER,
@@ -27,7 +30,8 @@ export function RefinerSchedulesSection() {
   const saveTvSchedule = useRefinerOperatorSettingsSaveMutation();
   const saveMovieSchedule = useRefinerOperatorSettingsSaveMutation();
   const queueTvScan = useRefinerWatchedFolderRemuxScanDispatchEnqueueMutation();
-  const queueMovieScan = useRefinerWatchedFolderRemuxScanDispatchEnqueueMutation();
+  const queueMovieScan =
+    useRefinerWatchedFolderRemuxScanDispatchEnqueueMutation();
   const editable = canEdit(me.data?.role);
   const [tvHoursLimited, setTvHoursLimited] = useState(false);
   const [tvDays, setTvDays] = useState("");
@@ -88,7 +92,10 @@ export function RefinerSchedulesSection() {
   }
   if (q.isError || pathSettings.isError) {
     return (
-      <div className="mm-module-surface w-full min-w-0 rounded border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-200" role="alert">
+      <div
+        className="mm-module-surface w-full min-w-0 rounded border border-red-900/40 bg-red-950/20 p-4 text-sm text-red-200"
+        role="alert"
+      >
         <p className="font-semibold">Could not load Refiner schedules</p>
         <p className="mt-1">
           {isLikelyNetworkFailure(q.error ?? pathSettings.error)
@@ -105,51 +112,66 @@ export function RefinerSchedulesSection() {
   }
 
   const canQueueManual = editable;
-  const tvWatchedSet = Boolean((pathSettings.data.refiner_tv_watched_folder ?? "").trim());
-  const movieWatchedSet = Boolean((pathSettings.data.refiner_watched_folder ?? "").trim());
+  const tvWatchedSet = Boolean(
+    (pathSettings.data.refiner_tv_watched_folder ?? "").trim(),
+  );
+  const movieWatchedSet = Boolean(
+    (pathSettings.data.refiner_watched_folder ?? "").trim(),
+  );
 
   return (
-    <section className="mm-bubble-stack mm-module-surface w-full min-w-0" data-testid="refiner-schedules-section">
+    <section
+      className="mm-bubble-stack mm-module-surface w-full min-w-0"
+      data-testid="refiner-schedules-section"
+    >
       <div className="mm-dash-grid">
         <section className="mm-card mm-dash-card flex h-full min-h-0 min-w-0 flex-col">
           <div className="mm-card-action-body flex-1 min-h-0">
-          <div>
-            <h3 className="text-base font-semibold text-[var(--mm-text1)]">TV watched-folder window</h3>
-            <p className="mt-1 text-sm text-[var(--mm-text2)]">
-              Optional window for TV watched-folder checks from Libraries.
-            </p>
-          </div>
-          <div className="space-y-3">
             <div>
-              <span className="text-sm font-medium text-[var(--mm-text1)]">Schedule window</span>
-              <p className="mt-1 text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_TIME_WINDOW_HELPER}</p>
+              <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+                TV watched-folder window
+              </h3>
+              <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                Optional window for TV watched-folder checks from Libraries.
+              </p>
             </div>
-            <div className="space-y-4">
-              <MmOnOffSwitch
-                id="refiner-schedule-tv-hours-limited"
-                label="Limit to these hours"
-                enabled={tvHoursLimited}
-                disabled={!editable || saveTvSchedule.isPending}
-                onChange={setTvHoursLimited}
-              />
-              <div className="space-y-2">
-                <span className="text-sm font-medium text-[var(--mm-text1)]">Days</span>
-                <MmScheduleDayChips
-                  scheduleDaysCsv={tvDays}
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-[var(--mm-text1)]">
+                  Schedule window
+                </span>
+                <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                  {MM_SCHEDULE_TIME_WINDOW_HELPER}
+                </p>
+              </div>
+              <div className="space-y-4">
+                <MmOnOffSwitch
+                  id="refiner-schedule-tv-hours-limited"
+                  label="Limit to these hours"
+                  enabled={tvHoursLimited}
                   disabled={!editable || saveTvSchedule.isPending}
-                  onChangeCsv={setTvDays}
+                  onChange={setTvHoursLimited}
+                />
+                <div className="space-y-2">
+                  <span className="text-sm font-medium text-[var(--mm-text1)]">
+                    Days
+                  </span>
+                  <MmScheduleDayChips
+                    scheduleDaysCsv={tvDays}
+                    disabled={!editable || saveTvSchedule.isPending}
+                    onChangeCsv={setTvDays}
+                  />
+                </div>
+                <MmScheduleTimeFields
+                  idPrefix="refiner-schedule-tv-window"
+                  start={tvStart}
+                  end={tvEnd}
+                  disabled={!editable || saveTvSchedule.isPending}
+                  onStart={setTvStart}
+                  onEnd={setTvEnd}
                 />
               </div>
-              <MmScheduleTimeFields
-                idPrefix="refiner-schedule-tv-window"
-                start={tvStart}
-                end={tvEnd}
-                disabled={!editable || saveTvSchedule.isPending}
-                onStart={setTvStart}
-                onEnd={setTvEnd}
-              />
             </div>
-          </div>
           </div>
           <div className="mm-card-action-footer">
             <button
@@ -175,50 +197,59 @@ export function RefinerSchedulesSection() {
         </section>
         <section className="mm-card mm-dash-card flex h-full min-h-0 min-w-0 flex-col">
           <div className="mm-card-action-body flex-1 min-h-0">
-          <div>
-            <h3 className="text-base font-semibold text-[var(--mm-text1)]">Movies watched-folder window</h3>
-            <p className="mt-1 text-sm text-[var(--mm-text2)]">
-              Optional window for Movies watched-folder checks from Libraries.
-            </p>
-          </div>
-          <div className="space-y-3">
             <div>
-              <span className="text-sm font-medium text-[var(--mm-text1)]">Schedule window</span>
-              <p className="mt-1 text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_TIME_WINDOW_HELPER}</p>
+              <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+                Movies watched-folder window
+              </h3>
+              <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                Optional window for Movies watched-folder checks from Libraries.
+              </p>
             </div>
-            <div className="space-y-4">
-              <MmOnOffSwitch
-                id="refiner-schedule-movie-hours-limited"
-                label="Limit to these hours"
-                enabled={movieHoursLimited}
-                disabled={!editable || saveMovieSchedule.isPending}
-                onChange={setMovieHoursLimited}
-              />
-              <div className="space-y-2">
-                <span className="text-sm font-medium text-[var(--mm-text1)]">Days</span>
-                <MmScheduleDayChips
-                  scheduleDaysCsv={movieDays}
+            <div className="space-y-3">
+              <div>
+                <span className="text-sm font-medium text-[var(--mm-text1)]">
+                  Schedule window
+                </span>
+                <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                  {MM_SCHEDULE_TIME_WINDOW_HELPER}
+                </p>
+              </div>
+              <div className="space-y-4">
+                <MmOnOffSwitch
+                  id="refiner-schedule-movie-hours-limited"
+                  label="Limit to these hours"
+                  enabled={movieHoursLimited}
                   disabled={!editable || saveMovieSchedule.isPending}
-                  onChangeCsv={setMovieDays}
+                  onChange={setMovieHoursLimited}
+                />
+                <div className="space-y-2">
+                  <span className="text-sm font-medium text-[var(--mm-text1)]">
+                    Days
+                  </span>
+                  <MmScheduleDayChips
+                    scheduleDaysCsv={movieDays}
+                    disabled={!editable || saveMovieSchedule.isPending}
+                    onChangeCsv={setMovieDays}
+                  />
+                </div>
+                <MmScheduleTimeFields
+                  idPrefix="refiner-schedule-movie-window"
+                  start={movieStart}
+                  end={movieEnd}
+                  disabled={!editable || saveMovieSchedule.isPending}
+                  onStart={setMovieStart}
+                  onEnd={setMovieEnd}
                 />
               </div>
-              <MmScheduleTimeFields
-                idPrefix="refiner-schedule-movie-window"
-                start={movieStart}
-                end={movieEnd}
-                disabled={!editable || saveMovieSchedule.isPending}
-                onStart={setMovieStart}
-                onEnd={setMovieEnd}
-              />
             </div>
-          </div>
           </div>
           <div className="mm-card-action-footer">
             <button
               type="button"
               className={`${mmActionButtonClass({
                 variant: "primary",
-                disabled: !editable || !movieDirty || saveMovieSchedule.isPending,
+                disabled:
+                  !editable || !movieDirty || saveMovieSchedule.isPending,
               })} w-full`}
               disabled={!editable || !movieDirty || saveMovieSchedule.isPending}
               onClick={() =>
@@ -231,91 +262,143 @@ export function RefinerSchedulesSection() {
                 })
               }
             >
-              {saveMovieSchedule.isPending ? "Saving…" : "Save Movies schedule window"}
+              {saveMovieSchedule.isPending
+                ? "Saving…"
+                : "Save Movies schedule window"}
             </button>
           </div>
         </section>
       </div>
 
       <section className="mm-card mm-dash-card p-5 sm:p-6">
-        <h3 className="text-base font-semibold text-[var(--mm-text1)]">Run now</h3>
+        <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+          Run now
+        </h3>
         <p className="mt-1 text-sm text-[var(--mm-text2)]">
-          Run a scan immediately without waiting for the next folder poll or window.
+          Run a scan immediately without waiting for the next folder poll or
+          window.
         </p>
         <div className="mt-4 grid gap-4 sm:grid-cols-2">
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">TV</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              TV
+            </p>
             <p className="mt-1 text-xs text-[var(--mm-text3)]">
-              Checks the TV watched folder now and adds any ready files to Refiner.
+              Checks the TV watched folder now and adds any ready files to
+              Refiner.
             </p>
             {!tvWatchedSet ? (
-              <p className="mt-2 text-xs text-amber-200/90">Save a TV watched folder in Libraries before running this scan.</p>
+              <p className="mt-2 text-xs text-amber-200/90">
+                Save a TV watched folder in Libraries before running this scan.
+              </p>
             ) : null}
             {queueTvScan.isError ? (
               <p className="mt-2 text-xs text-red-300" role="alert">
-                {queueTvScan.error instanceof Error ? queueTvScan.error.message : "Queue TV scan failed."}
+                {queueTvScan.error instanceof Error
+                  ? queueTvScan.error.message
+                  : "Queue TV scan failed."}
               </p>
             ) : null}
             {queueTvScan.isSuccess ? (
-              <p className="mt-2 text-xs text-[var(--mm-text3)]">Queued TV scan job #{queueTvScan.data.job_id}.</p>
+              <p className="mt-2 text-xs text-[var(--mm-text3)]">
+                Queued TV scan job #{queueTvScan.data.job_id}.
+              </p>
             ) : null}
             <div className="mt-3">
               <button
                 type="button"
                 className={mmActionButtonClass({
                   variant: "secondary",
-                  disabled: !canQueueManual || !tvWatchedSet || queueTvScan.isPending,
+                  disabled:
+                    !canQueueManual || !tvWatchedSet || queueTvScan.isPending,
                 })}
-                disabled={!canQueueManual || !tvWatchedSet || queueTvScan.isPending}
-                onClick={() => queueTvScan.mutate({ enqueue_remux_jobs: true, media_scope: "tv" })}
+                disabled={
+                  !canQueueManual || !tvWatchedSet || queueTvScan.isPending
+                }
+                onClick={() =>
+                  queueTvScan.mutate({
+                    enqueue_remux_jobs: true,
+                    media_scope: "tv",
+                  })
+                }
               >
                 {queueTvScan.isPending ? "Starting TV scan..." : "Scan TV now"}
               </button>
             </div>
           </div>
           <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-4">
-            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Movies</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+              Movies
+            </p>
             <p className="mt-1 text-xs text-[var(--mm-text3)]">
-              Checks the Movies watched folder now and adds any ready files to Refiner.
+              Checks the Movies watched folder now and adds any ready files to
+              Refiner.
             </p>
             {!movieWatchedSet ? (
-              <p className="mt-2 text-xs text-amber-200/90">Save a Movies watched folder in Libraries before running this scan.</p>
+              <p className="mt-2 text-xs text-amber-200/90">
+                Save a Movies watched folder in Libraries before running this
+                scan.
+              </p>
             ) : null}
             {queueMovieScan.isError ? (
               <p className="mt-2 text-xs text-red-300" role="alert">
-                {queueMovieScan.error instanceof Error ? queueMovieScan.error.message : "Queue Movies scan failed."}
+                {queueMovieScan.error instanceof Error
+                  ? queueMovieScan.error.message
+                  : "Queue Movies scan failed."}
               </p>
             ) : null}
             {queueMovieScan.isSuccess ? (
-              <p className="mt-2 text-xs text-[var(--mm-text3)]">Queued Movies scan job #{queueMovieScan.data.job_id}.</p>
+              <p className="mt-2 text-xs text-[var(--mm-text3)]">
+                Queued Movies scan job #{queueMovieScan.data.job_id}.
+              </p>
             ) : null}
             <div className="mt-3">
               <button
                 type="button"
                 className={mmActionButtonClass({
                   variant: "secondary",
-                  disabled: !canQueueManual || !movieWatchedSet || queueMovieScan.isPending,
+                  disabled:
+                    !canQueueManual ||
+                    !movieWatchedSet ||
+                    queueMovieScan.isPending,
                 })}
-                disabled={!canQueueManual || !movieWatchedSet || queueMovieScan.isPending}
-                onClick={() => queueMovieScan.mutate({ enqueue_remux_jobs: true, media_scope: "movie" })}
+                disabled={
+                  !canQueueManual ||
+                  !movieWatchedSet ||
+                  queueMovieScan.isPending
+                }
+                onClick={() =>
+                  queueMovieScan.mutate({
+                    enqueue_remux_jobs: true,
+                    media_scope: "movie",
+                  })
+                }
               >
-                {queueMovieScan.isPending ? "Starting Movies scan..." : "Scan Movies now"}
+                {queueMovieScan.isPending
+                  ? "Starting Movies scan..."
+                  : "Scan Movies now"}
               </button>
             </div>
           </div>
         </div>
         {!canQueueManual ? (
-          <p className="mt-3 text-xs text-[var(--mm-text3)]">Operators and admins can queue manual scans.</p>
+          <p className="mt-3 text-xs text-[var(--mm-text3)]">
+            Operators and admins can queue manual scans.
+          </p>
         ) : null}
       </section>
       {saveTvSchedule.isError ? (
         <p className="mt-3 text-sm text-red-300" role="alert">
-          {saveTvSchedule.error instanceof Error ? saveTvSchedule.error.message : "Save TV schedule window failed."}
+          {saveTvSchedule.error instanceof Error
+            ? saveTvSchedule.error.message
+            : "Save TV schedule window failed."}
         </p>
       ) : null}
       {saveMovieSchedule.isError ? (
         <p className="mt-3 text-sm text-red-300" role="alert">
-          {saveMovieSchedule.error instanceof Error ? saveMovieSchedule.error.message : "Save Movies schedule window failed."}
+          {saveMovieSchedule.error instanceof Error
+            ? saveMovieSchedule.error.message
+            : "Save Movies schedule window failed."}
         </p>
       ) : null}
     </section>

--- a/apps/web/src/pages/responsive-smoke.test.tsx
+++ b/apps/web/src/pages/responsive-smoke.test.tsx
@@ -90,7 +90,10 @@ vi.mock("../lib/auth/queries", async (importOriginal) => {
   const original = (await importOriginal()) as Record<string, unknown>;
   return {
     ...original,
-    useMeQuery: vi.fn(() => ({ isPending: false, data: { id: 1, username: "admin", role: "admin" } })),
+    useMeQuery: vi.fn(() => ({
+      isPending: false,
+      data: { id: 1, username: "admin", role: "admin" },
+    })),
   };
 });
 
@@ -104,7 +107,11 @@ function withProviders(ui: ReactNode) {
 }
 
 function setViewport(width: number) {
-  Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: width });
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
   window.dispatchEvent(new Event("resize"));
 }
 
@@ -118,7 +125,9 @@ describe("responsive smoke", () => {
   it.each(VIEWPORTS)("renders Refiner jobs at %ipx", (width) => {
     setViewport(width);
     render(withProviders(<RefinerJobsInspectionSection />));
-    expect(screen.getByTestId("refiner-jobs-inspection-section")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("refiner-jobs-inspection-section"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Jobs")).toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -14,7 +14,13 @@ import {
   suiteSettingsQueryKey,
   suiteUpdateStatusQueryKey,
 } from "../../lib/suite/queries";
-import type { SuiteLogsOut, SuiteMetricsOut, SuiteSecurityOverviewOut, SuiteSettingsOut, SuiteUpdateStatusOut } from "../../lib/suite/types";
+import type {
+  SuiteLogsOut,
+  SuiteMetricsOut,
+  SuiteSecurityOverviewOut,
+  SuiteSettingsOut,
+  SuiteUpdateStatusOut,
+} from "../../lib/suite/types";
 import { SettingsPage } from "./settings-page";
 
 const operatorMe: UserPublic = { id: 1, username: "alice", role: "operator" };
@@ -89,13 +95,29 @@ function wrap(ui: ReactNode, client: QueryClient) {
 }
 
 function renderSettings(me: UserPublic) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
   qc.setQueryData(suiteSettingsQueryKey, minimalSuiteSettings);
   qc.setQueryData(suiteSecurityOverviewQueryKey, minimalSecurity);
   qc.setQueryData(qk.me, me);
-  qc.setQueryData(suiteConfigurationBackupsQueryKey, { directory: "C:/MediaMop/backups/suite-configuration", items: [] });
+  qc.setQueryData(suiteConfigurationBackupsQueryKey, {
+    directory: "C:/MediaMop/backups/suite-configuration",
+    items: [],
+  });
   qc.setQueryData(suiteUpdateStatusQueryKey, minimalUpdateStatus);
-  qc.setQueryData([...suiteLogsQueryKey, { level: undefined, search: undefined, has_exception: undefined, limit: 100 }], minimalLogs);
+  qc.setQueryData(
+    [
+      ...suiteLogsQueryKey,
+      {
+        level: undefined,
+        search: undefined,
+        has_exception: undefined,
+        limit: 100,
+      },
+    ],
+    minimalLogs,
+  );
   qc.setQueryData(suiteMetricsQueryKey, minimalMetrics);
   return render(wrap(<SettingsPage />, qc));
 }
@@ -125,17 +147,29 @@ describe("SettingsPage (suite settings)", () => {
     renderSettings(operatorMe);
     fireEvent.click(screen.getByRole("tab", { name: "Backup and restore" }));
     expect(screen.getByTestId("suite-settings-backup-restore")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Download configuration now" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Restore from file…" })).toBeEnabled();
-    expect(screen.getByRole("button", { name: "Save backup schedule" })).toBeDisabled();
-    expect(screen.queryByTestId("suite-settings-history-reset")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Download configuration now" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Restore from file…" }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: "Save backup schedule" }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByTestId("suite-settings-history-reset"),
+    ).not.toBeInTheDocument();
   });
 
   it("hides configuration backup for viewers", () => {
     renderSettings(viewerMe);
     fireEvent.click(screen.getByRole("tab", { name: "Backup and restore" }));
-    expect(screen.queryByTestId("suite-settings-backup-restore")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("suite-settings-history-reset")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-backup-restore"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-history-reset"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps General focused and splits Logs, Backup, and Upgrade to their own tabs", () => {
@@ -144,33 +178,60 @@ describe("SettingsPage (suite settings)", () => {
     expect(screen.queryByText("Application logs")).not.toBeInTheDocument();
     expect(screen.getByText("Timezone")).toBeInTheDocument();
     expect(screen.getByText("Setup wizard")).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "General" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
     expect(screen.getByText("System log retention (days)")).toBeInTheDocument();
-    expect(screen.getByText(/activity history is kept until you reset it/i)).toBeInTheDocument();
-    expect(screen.getByTestId("suite-settings-history-reset")).toBeInTheDocument();
-    expect(screen.queryByTestId("suite-settings-backup-restore")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("suite-settings-upgrade")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/activity history is kept until you reset it/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("suite-settings-history-reset"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-backup-restore"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-upgrade"),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("tab", { name: "Backup and restore" }));
     expect(screen.getByTestId("suite-settings-backup-tab")).toBeInTheDocument();
-    expect(screen.getByTestId("suite-settings-backup-restore")).toBeInTheDocument();
-    expect(screen.queryByText("System log retention (days)")).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("suite-settings-backup-restore"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("System log retention (days)"),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
-    expect(screen.getByTestId("suite-settings-upgrade-tab")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("suite-settings-upgrade-tab"),
+    ).toBeInTheDocument();
     expect(screen.getByTestId("suite-settings-upgrade")).toBeInTheDocument();
-    expect(screen.queryByText("System log retention (days)")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("System log retention (days)"),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("tab", { name: "Logs" }));
     expect(screen.getByText("Search logs")).toBeInTheDocument();
     expect(screen.getByText("System events")).toBeInTheDocument();
     expect(screen.getByText("Server diagnostics")).toBeInTheDocument();
-    expect(screen.queryByText("System log retention (days)")).not.toBeInTheDocument();
-    expect(screen.queryByText("Optional home dashboard notice")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("System log retention (days)"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Optional home dashboard notice"),
+    ).not.toBeInTheDocument();
   });
 
   it("shows change password only on Security tab", () => {
     renderSettings(operatorMe);
     fireEvent.click(screen.getByRole("tab", { name: "Security" }));
-    expect(screen.getByRole("heading", { name: "Change password" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Security posture" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Change password" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Security posture" }),
+    ).not.toBeInTheDocument();
   });
 
   it("change password fields use Show/Hide and reset visibility when cleared", () => {
@@ -197,7 +258,9 @@ describe("SettingsPage (suite settings)", () => {
     fireEvent.mouseDown(firstOption);
     fireEvent.click(firstOption);
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Timezone/ })).toHaveTextContent(chosenLabel);
+    expect(screen.getByRole("button", { name: /Timezone/ })).toHaveTextContent(
+      chosenLabel,
+    );
   });
 
   it("closes timezone dropdown on outside click", () => {
@@ -222,9 +285,13 @@ describe("SettingsPage (suite settings)", () => {
     renderSettings(viewerMe);
     expect(screen.getByTestId("suite-settings-display-density")).toBeTruthy();
     fireEvent.click(screen.getByText("Comfortable"));
-    expect(document.documentElement.getAttribute("data-mm-density")).toBe("comfortable");
+    expect(document.documentElement.getAttribute("data-mm-density")).toBe(
+      "comfortable",
+    );
     fireEvent.click(screen.getByText("Expanded"));
-    expect(document.documentElement.getAttribute("data-mm-density")).toBe("expanded");
+    expect(document.documentElement.getAttribute("data-mm-density")).toBe(
+      "expanded",
+    );
     fireEvent.click(screen.getByText("Balanced"));
     expect(document.documentElement.getAttribute("data-mm-density")).toBeNull();
   });

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -3,7 +3,10 @@ import type { ChangeEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PageLoading } from "../../components/shared/page-loading";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import { useChangePasswordMutation } from "../../lib/auth/queries";
 import { useMeQuery } from "../../lib/auth/queries";
 import {
@@ -11,8 +14,14 @@ import {
   curatedTimezoneOptionsSorted,
 } from "../../lib/suite/timezone-options";
 import { MmListboxPicker } from "../../components/ui/mm-listbox-picker";
-import { mmActionButtonClass, mmEditableTextFieldClass } from "../../lib/ui/mm-control-roles";
-import { mmModuleTabBlurbBandClass, mmModuleTabBlurbTextClass } from "../../lib/ui/mm-module-tab-blurb";
+import {
+  mmActionButtonClass,
+  mmEditableTextFieldClass,
+} from "../../lib/ui/mm-control-roles";
+import {
+  mmModuleTabBlurbBandClass,
+  mmModuleTabBlurbTextClass,
+} from "../../lib/ui/mm-module-tab-blurb";
 import {
   suiteConfigurationBackupsQueryKey,
   useSuiteConfigurationBackupsQuery,
@@ -24,7 +33,10 @@ import {
   useSuiteUpdateNowMutation,
   useSuiteUpdateStatusQuery,
 } from "../../lib/suite/queries";
-import type { SuiteLogEntry, SuiteSettingsPutBody } from "../../lib/suite/types";
+import type {
+  SuiteLogEntry,
+  SuiteSettingsPutBody,
+} from "../../lib/suite/types";
 import {
   fetchConfigurationBundle,
   fetchStoredConfigurationBackupBlob,
@@ -111,31 +123,45 @@ function logLevelBadgeTone(level: string): string {
 }
 
 function renderLogTechnicalDetails(entry: SuiteLogEntry) {
-  if (!entry.traceback && !entry.source && !entry.logger && !entry.correlation_id && !entry.job_id) {
+  if (
+    !entry.traceback &&
+    !entry.source &&
+    !entry.logger &&
+    !entry.correlation_id &&
+    !entry.job_id
+  ) {
     return null;
   }
   return (
     <details className="rounded-md border border-[var(--mm-border)] bg-black/10 px-3 py-2">
-      <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">Technical details</summary>
+      <summary className="cursor-pointer text-sm font-medium text-[var(--mm-text2)]">
+        Technical details
+      </summary>
       <div className="mt-3 space-y-2 text-sm text-[var(--mm-text2)]">
         {entry.source ? (
           <p>
-            <span className="font-medium text-[var(--mm-text1)]">Source:</span> {entry.source}
+            <span className="font-medium text-[var(--mm-text1)]">Source:</span>{" "}
+            {entry.source}
           </p>
         ) : null}
         {entry.logger ? (
           <p>
-            <span className="font-medium text-[var(--mm-text1)]">Logger:</span> {entry.logger}
+            <span className="font-medium text-[var(--mm-text1)]">Logger:</span>{" "}
+            {entry.logger}
           </p>
         ) : null}
         {entry.correlation_id ? (
           <p>
-            <span className="font-medium text-[var(--mm-text1)]">Request ID:</span> {entry.correlation_id}
+            <span className="font-medium text-[var(--mm-text1)]">
+              Request ID:
+            </span>{" "}
+            {entry.correlation_id}
           </p>
         ) : null}
         {entry.job_id ? (
           <p>
-            <span className="font-medium text-[var(--mm-text1)]">Job ID:</span> {entry.job_id}
+            <span className="font-medium text-[var(--mm-text1)]">Job ID:</span>{" "}
+            {entry.job_id}
           </p>
         ) : null}
         {entry.traceback ? (
@@ -148,11 +174,21 @@ function renderLogTechnicalDetails(entry: SuiteLogEntry) {
   );
 }
 
-function SettingsSummaryCard({ label, value }: { label: string; value: string }) {
+function SettingsSummaryCard({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
   return (
     <section className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3">
-      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">{label}</p>
-      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">{value}</p>
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
+        {label}
+      </p>
+      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">
+        {value}
+      </p>
     </section>
   );
 }
@@ -173,7 +209,9 @@ function formatAverageMs(value: number): string {
   return `${value >= 100 ? value.toFixed(0) : value.toFixed(1)} ms`;
 }
 
-function requestIssueSummary(statusCounts: Record<string, number> | undefined): { value: string; detail: string } {
+function requestIssueSummary(
+  statusCounts: Record<string, number> | undefined,
+): { value: string; detail: string } {
   const counts = statusCounts ?? {};
   const success = counts["2xx"] ?? 0;
   const redirects = counts["3xx"] ?? 0;
@@ -181,10 +219,16 @@ function requestIssueSummary(statusCounts: Record<string, number> | undefined): 
   const serverFailures = counts["5xx"] ?? 0;
   const detail = `Successful ${success} - Redirected ${redirects} - Rejected or not found ${rejectedOrMissing} - Server failures ${serverFailures}`;
   if (serverFailures > 0) {
-    return { value: `${serverFailures} server ${serverFailures === 1 ? "failure" : "failures"}`, detail };
+    return {
+      value: `${serverFailures} server ${serverFailures === 1 ? "failure" : "failures"}`,
+      detail,
+    };
   }
   if (rejectedOrMissing > 0) {
-    return { value: `${rejectedOrMissing} request ${rejectedOrMissing === 1 ? "issue" : "issues"}`, detail };
+    return {
+      value: `${rejectedOrMissing} request ${rejectedOrMissing === 1 ? "issue" : "issues"}`,
+      detail,
+    };
   }
   return { value: "No request issues", detail };
 }
@@ -203,25 +247,40 @@ export function SettingsPage() {
 
   const [tab, setTab] = useState<TabId>("general");
   const [appTimezone, setAppTimezone] = useState<string | null>(null);
-  const [logRetentionDaysDraft, setLogRetentionDaysDraft] = useState<string | null>(null);
+  const [logRetentionDaysDraft, setLogRetentionDaysDraft] = useState<
+    string | null
+  >(null);
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showCurrentPassword, setShowCurrentPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [changePasswordStatus, setChangePasswordStatus] = useState<string | null>(null);
-  const [displayDensity, setDisplayDensity] = useState<DisplayDensity>(() => readStoredDisplayDensity());
+  const [changePasswordStatus, setChangePasswordStatus] = useState<
+    string | null
+  >(null);
+  const [displayDensity, setDisplayDensity] = useState<DisplayDensity>(() =>
+    readStoredDisplayDensity(),
+  );
   const [backupBusy, setBackupBusy] = useState(false);
   const [backupMsg, setBackupMsg] = useState<string | null>(null);
   const [backupErr, setBackupErr] = useState<string | null>(null);
   const [upgradeMsg, setUpgradeMsg] = useState<string | null>(null);
   const [resetHistoryMsg, setResetHistoryMsg] = useState<string | null>(null);
   const [resetHistoryConfirm, setResetHistoryConfirm] = useState("");
-  const [configurationBackupEnabled, setConfigurationBackupEnabled] = useState(false);
-  const [configurationBackupIntervalHours, setConfigurationBackupIntervalHours] = useState(24);
-  const [configurationBackupPreferredTime, setConfigurationBackupPreferredTime] = useState("02:00");
-  const [lastSuiteSaveTarget, setLastSuiteSaveTarget] = useState<"timezone" | "logs" | "backup" | null>(null);
+  const [configurationBackupEnabled, setConfigurationBackupEnabled] =
+    useState(false);
+  const [
+    configurationBackupIntervalHours,
+    setConfigurationBackupIntervalHours,
+  ] = useState(24);
+  const [
+    configurationBackupPreferredTime,
+    setConfigurationBackupPreferredTime,
+  ] = useState("02:00");
+  const [lastSuiteSaveTarget, setLastSuiteSaveTarget] = useState<
+    "timezone" | "logs" | "backup" | null
+  >(null);
   const [logSearch, setLogSearch] = useState("");
   const [logLevel, setLogLevel] = useState<LogLevelFilter>("");
   const [tracebacksOnly, setTracebacksOnly] = useState(false);
@@ -234,20 +293,29 @@ export function SettingsPage() {
     const fromServer = settingsQ.data.app_timezone || "";
     setAppTimezone(CURATED_TIMEZONE_ID_SET.has(fromServer) ? fromServer : null);
     setLogRetentionDaysDraft(null);
-    setConfigurationBackupEnabled(Boolean(settingsQ.data.configuration_backup_enabled));
+    setConfigurationBackupEnabled(
+      Boolean(settingsQ.data.configuration_backup_enabled),
+    );
     setConfigurationBackupIntervalHours(
-      Number.isFinite(Number(settingsQ.data.configuration_backup_interval_hours))
+      Number.isFinite(
+        Number(settingsQ.data.configuration_backup_interval_hours),
+      )
         ? Number(settingsQ.data.configuration_backup_interval_hours)
         : 24,
     );
     setConfigurationBackupPreferredTime(
-      (settingsQ.data.configuration_backup_preferred_time || "02:00").trim() || "02:00",
+      (settingsQ.data.configuration_backup_preferred_time || "02:00").trim() ||
+        "02:00",
     );
   }, [settingsQ.data]);
 
   const editable = canEditSuiteGlobal(me.data?.role);
-  const backupsQ = useSuiteConfigurationBackupsQuery(editable && tab === "backup" && Boolean(settingsQ.data));
-  const updateStatusQ = useSuiteUpdateStatusQuery(tab === "upgrade" && Boolean(settingsQ.data));
+  const backupsQ = useSuiteConfigurationBackupsQuery(
+    editable && tab === "backup" && Boolean(settingsQ.data),
+  );
+  const updateStatusQ = useSuiteUpdateStatusQuery(
+    tab === "upgrade" && Boolean(settingsQ.data),
+  );
   const logsQ = useSuiteLogsQuery(
     {
       level: logLevel || undefined,
@@ -257,12 +325,18 @@ export function SettingsPage() {
     },
     tab === "logs" && Boolean(settingsQ.data),
   );
-  const metricsQ = useSuiteMetricsQuery(tab === "logs" && Boolean(settingsQ.data));
+  const metricsQ = useSuiteMetricsQuery(
+    tab === "logs" && Boolean(settingsQ.data),
+  );
 
   const serverCuratedTimezone =
-    settingsQ.data && CURATED_TIMEZONE_ID_SET.has(settingsQ.data.app_timezone || "") ? settingsQ.data.app_timezone : null;
+    settingsQ.data &&
+    CURATED_TIMEZONE_ID_SET.has(settingsQ.data.app_timezone || "")
+      ? settingsQ.data.app_timezone
+      : null;
 
-  const timezoneDirty = settingsQ.data !== undefined && appTimezone !== serverCuratedTimezone;
+  const timezoneDirty =
+    settingsQ.data !== undefined && appTimezone !== serverCuratedTimezone;
 
   const logsDirty =
     settingsQ.data !== undefined &&
@@ -270,9 +344,14 @@ export function SettingsPage() {
     logRetentionDaysDraft !== String(settingsQ.data.log_retention_days);
   const backupScheduleDirty =
     settingsQ.data !== undefined &&
-    (configurationBackupEnabled !== Boolean(settingsQ.data.configuration_backup_enabled) ||
-      configurationBackupIntervalHours !== Number(settingsQ.data.configuration_backup_interval_hours || 24) ||
-      configurationBackupPreferredTime !== ((settingsQ.data.configuration_backup_preferred_time || "02:00").trim() || "02:00"));
+    (configurationBackupEnabled !==
+      Boolean(settingsQ.data.configuration_backup_enabled) ||
+      configurationBackupIntervalHours !==
+        Number(settingsQ.data.configuration_backup_interval_hours || 24) ||
+      configurationBackupPreferredTime !==
+        ((
+          settingsQ.data.configuration_backup_preferred_time || "02:00"
+        ).trim() || "02:00"));
 
   const loadingAny = settingsQ.isPending || me.isPending;
 
@@ -282,7 +361,9 @@ export function SettingsPage() {
     setBackupBusy(true);
     try {
       const bundle = await fetchConfigurationBundle();
-      const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: "application/json" });
+      const blob = new Blob([JSON.stringify(bundle, null, 2)], {
+        type: "application/json",
+      });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
@@ -315,10 +396,16 @@ export function SettingsPage() {
       }
       const bundle = parsed as ConfigurationBundle;
       if (bundle.format_version !== 1) {
-        setBackupErr("This file is not a supported MediaMop configuration export.");
+        setBackupErr(
+          "This file is not a supported MediaMop configuration export.",
+        );
         return;
       }
-      if (!window.confirm("Replace suite and module settings on this server from this file? This cannot be undone.")) {
+      if (
+        !window.confirm(
+          "Replace suite and module settings on this server from this file? This cannot be undone.",
+        )
+      ) {
         return;
       }
       setBackupBusy(true);
@@ -367,7 +454,9 @@ export function SettingsPage() {
 
   const timezoneOptions = curatedTimezoneOptionsSorted();
   const normalizedLogRetentionDraft =
-    logRetentionDaysDraft !== null ? logRetentionDaysDraft : String(settingsQ.data.log_retention_days);
+    logRetentionDaysDraft !== null
+      ? logRetentionDaysDraft
+      : String(settingsQ.data.log_retention_days);
   const finalizeLogRetentionDays = (): number => {
     const raw = normalizedLogRetentionDraft.trim();
     if (raw === "") {
@@ -384,20 +473,26 @@ export function SettingsPage() {
     const d = settingsQ.data;
     const name = (d.product_display_name || "MediaMop").trim() || "MediaMop";
     const tz = (appTimezone ?? d.app_timezone ?? "UTC").trim() || "UTC";
-    const retention = Math.min(3650, Math.max(1, Math.trunc(Number(finalizeLogRetentionDays()))));
+    const retention = Math.min(
+      3650,
+      Math.max(1, Math.trunc(Number(finalizeLogRetentionDays()))),
+    );
     const body: SuiteSettingsPutBody = {
       product_display_name: name,
       signed_in_home_notice: d.signed_in_home_notice,
       setup_wizard_state: d.setup_wizard_state,
       app_timezone: tz,
-      log_retention_days: Number.isFinite(retention) ? retention : d.log_retention_days,
+      log_retention_days: Number.isFinite(retention)
+        ? retention
+        : d.log_retention_days,
       application_logs_enabled: true,
       configuration_backup_enabled: Boolean(configurationBackupEnabled),
       configuration_backup_interval_hours: Math.min(
         720,
         Math.max(1, Math.trunc(Number(configurationBackupIntervalHours))),
       ),
-      configuration_backup_preferred_time: configurationBackupPreferredTime.trim() || "02:00",
+      configuration_backup_preferred_time:
+        configurationBackupPreferredTime.trim() || "02:00",
     };
     return body;
   };
@@ -442,9 +537,13 @@ export function SettingsPage() {
       await save.mutateAsync(buildSuitePutBody());
       setLastSuiteSaveTarget(null);
       setBackupMsg("Backup schedule saved.");
-      await queryClient.invalidateQueries({ queryKey: suiteConfigurationBackupsQueryKey });
+      await queryClient.invalidateQueries({
+        queryKey: suiteConfigurationBackupsQueryKey,
+      });
     } catch (e) {
-      setBackupErr(e instanceof Error ? e.message : "Could not save backup schedule.");
+      setBackupErr(
+        e instanceof Error ? e.message : "Could not save backup schedule.",
+      );
     }
   }
 
@@ -457,12 +556,14 @@ export function SettingsPage() {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = fileLabel.replace(/[^\w.\-]+/g, "_").slice(0, 120);
+      a.download = fileLabel.replace(/[^\w.-]+/g, "_").slice(0, 120);
       a.click();
       URL.revokeObjectURL(url);
       setBackupMsg("Download started.");
     } catch (e) {
-      setBackupErr(e instanceof Error ? e.message : "Could not download snapshot.");
+      setBackupErr(
+        e instanceof Error ? e.message : "Could not download snapshot.",
+      );
     } finally {
       setBackupBusy(false);
     }
@@ -478,7 +579,9 @@ export function SettingsPage() {
           window.location.assign("/app/settings");
         }, 30_000);
       } else {
-        void queryClient.invalidateQueries({ queryKey: ["suite", "update-status"] });
+        void queryClient.invalidateQueries({
+          queryKey: ["suite", "update-status"],
+        });
       }
     } catch {
       /* surfaced below */
@@ -490,7 +593,9 @@ export function SettingsPage() {
     try {
       const result = await resetHistory.mutateAsync(resetHistoryConfirm);
       setResetHistoryConfirm("");
-      setResetHistoryMsg(`History reset. Removed ${result.total_deleted} old history ${result.total_deleted === 1 ? "item" : "items"}.`);
+      setResetHistoryMsg(
+        `History reset. Removed ${result.total_deleted} old history ${result.total_deleted === 1 ? "item" : "items"}.`,
+      );
     } catch {
       /* surfaced below */
     }
@@ -498,7 +603,9 @@ export function SettingsPage() {
 
   const changePasswordBusy = changePassword.isPending;
   const runtimeMetrics = metricsQ.data;
-  const runtimeRequestIssues = requestIssueSummary(runtimeMetrics?.status_counts);
+  const runtimeRequestIssues = requestIssueSummary(
+    runtimeMetrics?.status_counts,
+  );
 
   return (
     <div className="mm-page" data-testid="suite-settings-page">
@@ -506,8 +613,8 @@ export function SettingsPage() {
         <p className="mm-page__eyebrow">System</p>
         <h1 className="mm-page__title">Settings</h1>
         <p className="mm-page__lead">
-          MediaMop-wide choices that are not part of Refiner, Pruner, or Subber. Integration details stay on their module
-          pages.
+          MediaMop-wide choices that are not part of Refiner, Pruner, or Subber.
+          Integration details stay on their module pages.
         </p>
       </header>
 
@@ -568,268 +675,369 @@ export function SettingsPage() {
           <div data-testid="suite-settings-global" className="mm-bubble-stack">
             {!editable ? (
               <p className="text-sm text-[var(--mm-text3)]">
-                Operators and admins can edit General options; everyone can open the Logs tab to read recent events.
+                Operators and admins can edit General options; everyone can open
+                the Logs tab to read recent events.
               </p>
             ) : null}
 
             <div className="grid grid-cols-1 gap-5">
               <div className={mmModuleTabBlurbBandClass}>
                 <p className={mmModuleTabBlurbTextClass}>
-                  Suite-wide choices saved in the app database. Integration details for Refiner, Pruner, and Subber stay
-                  on those module pages.
+                  Suite-wide choices saved in the app database. Integration
+                  details for Refiner, Pruner, and Subber stay on those module
+                  pages.
                 </p>
               </div>
               <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-              <section className={SUITE_SETTINGS_DASH_CARD_CLASS} aria-labelledby="suite-settings-wizard-heading">
-                <div className="mm-card-action-body">
-                  <div>
-                    <h3 id="suite-settings-wizard-heading" className="text-base font-semibold text-[var(--mm-text1)]">
-                      Setup wizard
-                    </h3>
-                    <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                      Reopen the first-run wizard to adjust the basic suite setup flow at any time.
-                    </p>
-                  </div>
-                  <div className="space-y-2 text-sm text-[var(--mm-text2)]">
-                    <p>
-                      Current state:{" "}
-                      <span className="font-medium capitalize text-[var(--mm-text1)]">
-                        {settingsQ.data.setup_wizard_state || "pending"}
-                      </span>
-                    </p>
-                    <p>Use this when you want the guided setup again without exposing it in the sidebar.</p>
-                  </div>
-                </div>
-                <div className="mm-card-action-footer">
-                  <button
-                    type="button"
-                    className={mmActionButtonClass({ variant: "secondary", disabled: false })}
-                    data-testid="suite-settings-open-setup-wizard"
-                    onClick={() => navigate("/app/setup-wizard")}
-                  >
-                    Open setup wizard
-                  </button>
-                </div>
-              </section>
-              <section
-                className={SUITE_SETTINGS_DASH_CARD_CLASS}
-                aria-labelledby="suite-settings-timezone-heading"
-              >
-                <div className="mm-card-action-body">
-                <div>
-                  <h3 id="suite-settings-timezone-heading" className="text-base font-semibold text-[var(--mm-text1)]">
-                    Timezone
-                  </h3>
-                  <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                    Main-country timezones for suite-level time displays. Use Save timezone when you change the
-                    selection.
-                  </p>
-                </div>
-                <MmListboxPicker
-                  ariaLabelledBy="suite-settings-timezone-heading"
-                  ariaDescribedBy="suite-timezone-hint"
-                  placeholder="Select timezone"
-                  disabled={!editable || save.isPending}
-                  options={timezoneOptions.map((tz) => ({ value: tz.id, label: tz.label }))}
-                  value={appTimezone ?? ""}
-                  onChange={(v) => setAppTimezone(v)}
-                />
-                <p id="suite-timezone-hint" className="text-xs text-[var(--mm-text3)]">
-                  If you do not see your zone, pick the closest match — this only affects how times are labeled in the
-                  suite.
-                </p>
-                {save.isError && lastSuiteSaveTarget === "timezone" ? (
-                  <p className="text-sm text-red-300" role="alert" data-testid="suite-settings-timezone-save-error">
-                    {save.error instanceof Error ? save.error.message : "Could not save."}
-                  </p>
-                ) : null}
-                </div>
-                <div className="mm-card-action-footer">
-                <button
-                  type="button"
-                  className={mmActionButtonClass({
-                    variant: "primary",
-                    disabled: !editable || !timezoneDirty || save.isPending,
-                  })}
-                  disabled={!editable || !timezoneDirty || save.isPending}
-                  data-testid="suite-settings-save-timezone"
-                  onClick={() => void handleSaveTimezone()}
+                <section
+                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                  aria-labelledby="suite-settings-wizard-heading"
                 >
-                  {save.isPending ? "Saving…" : "Save timezone"}
-                </button>
-                </div>
-              </section>
-
-            </div>
-
-            <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
-            <section className={SUITE_SETTINGS_DASH_CARD_CLASS} aria-labelledby="suite-settings-log-retention-heading">
-              <div className="mm-card-action-body">
-              <div>
-                <h3 id="suite-settings-log-retention-heading" className="text-base font-semibold text-[var(--mm-text1)]">
-                  Log retention
-                </h3>
-                <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                  Decide how long MediaMop keeps persisted system log entries on disk.
-                </p>
-              </div>
-              <label className="block max-w-md">
-                <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
-                  System log retention (days)
-                </span>
-                <input
-                  type="number"
-                  min={1}
-                  max={3650}
-                  className={`${mmEditableTextFieldClass} mt-1`}
-                  value={normalizedLogRetentionDraft}
-                  disabled={!editable || save.isPending}
-                  onFocus={() => setLogRetentionDaysDraft(String(settingsQ.data.log_retention_days))}
-                  onChange={(e) => setLogRetentionDaysDraft(e.target.value)}
-                  onBlur={() => setLogRetentionDaysDraft(String(finalizeLogRetentionDays()))}
-                  aria-describedby="suite-general-log-retention-hint"
-                />
-                <p id="suite-general-log-retention-hint" className="mt-1 text-xs text-[var(--mm-text3)]">
-                  Between 1 and 3650 days. Older system log entries are removed automatically while MediaMop is running;
-                  activity history is kept until you reset it.
-                </p>
-              </label>
-              {save.isError && lastSuiteSaveTarget === "logs" ? (
-                <p className="text-sm text-red-300" role="alert" data-testid="suite-settings-logs-save-error">
-                  {save.error instanceof Error ? save.error.message : "Could not save."}
-                </p>
-              ) : null}
-              </div>
-              <div className="mm-card-action-footer">
-              <button
-                type="button"
-                className={mmActionButtonClass({
-                  variant: "primary",
-                  disabled: !editable || !logsDirty || save.isPending,
-                })}
-                disabled={!editable || !logsDirty || save.isPending}
-                data-testid="suite-settings-save-logs"
-                onClick={() => void handleSaveLogs()}
-              >
-                {save.isPending ? "Saving…" : "Save log retention"}
-              </button>
-              </div>
-            </section>
-            {editable ? (
-              <section
-                className={SUITE_SETTINGS_DASH_CARD_CLASS}
-                data-testid="suite-settings-history-reset"
-                aria-labelledby="suite-settings-history-reset-heading"
-              >
-                <div className="mm-card-action-body">
-                  <div>
-                    <h3 id="suite-settings-history-reset-heading" className="text-base font-semibold text-[var(--mm-text1)]">
-                      Dashboard and activity history
-                    </h3>
-                    <p className="mt-1 text-sm leading-6 text-[var(--mm-text2)]">
-                      History is kept until you reset it. Sign-outs, expired sessions, and log retention do not clear this
-                      data.
-                    </p>
+                  <div className="mm-card-action-body">
+                    <div>
+                      <h3
+                        id="suite-settings-wizard-heading"
+                        className="text-base font-semibold text-[var(--mm-text1)]"
+                      >
+                        Setup wizard
+                      </h3>
+                      <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                        Reopen the first-run wizard to adjust the basic suite
+                        setup flow at any time.
+                      </p>
+                    </div>
+                    <div className="space-y-2 text-sm text-[var(--mm-text2)]">
+                      <p>
+                        Current state:{" "}
+                        <span className="font-medium capitalize text-[var(--mm-text1)]">
+                          {settingsQ.data.setup_wizard_state || "pending"}
+                        </span>
+                      </p>
+                      <p>
+                        Use this when you want the guided setup again without
+                        exposing it in the sidebar.
+                      </p>
+                    </div>
                   </div>
-                  <label className="block text-sm text-[var(--mm-text2)]">
-                    <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
-                      Type RESET to confirm
-                    </span>
-                    <input
-                      type="text"
-                      className="mm-input w-full"
-                      value={resetHistoryConfirm}
-                      disabled={resetHistory.isPending}
-                      onChange={(e) => setResetHistoryConfirm(e.target.value)}
-                    />
-                    <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
-                      Clears Activity entries and finished job history only.
-                    </p>
-                  </label>
-                  {resetHistoryMsg ? (
-                    <p className="rounded-md border border-emerald-500/30 bg-emerald-950/20 px-3 py-2 text-sm text-emerald-200">
-                      {resetHistoryMsg}
-                    </p>
-                  ) : null}
-                  {resetHistory.isError ? (
-                    <p className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200" role="alert">
-                      {resetHistory.error instanceof Error
-                        ? resetHistory.error.message
-                        : "Could not reset dashboard and activity history."}
-                    </p>
-                  ) : null}
-                </div>
-                <div className="mm-card-action-footer">
-                  <button
-                    type="button"
-                    className={mmActionButtonClass({
-                      variant: "tertiary",
-                      disabled: resetHistory.isPending || resetHistoryConfirm.trim().toUpperCase() !== "RESET",
-                    })}
-                    disabled={resetHistory.isPending || resetHistoryConfirm.trim().toUpperCase() !== "RESET"}
-                    onClick={() => void handleResetOperationalHistory()}
-                  >
-                    {resetHistory.isPending ? "Resetting..." : "Reset history"}
-                  </button>
-                  </div>
-              </section>
-            ) : null}
-            <section className={SUITE_SETTINGS_DASH_CARD_CLASS} aria-labelledby="suite-settings-density-heading">
-              <fieldset className="min-w-0 border-0 p-0">
-                <legend id="suite-settings-density-heading" className="text-base font-semibold text-[var(--mm-text1)]">
-                  Display density (this browser)
-                </legend>
-                <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                  Adjust text, spacing, sidebar width, and card density for this browser. The change applies immediately.
-                </p>
-                <div
-                  className="mt-3 flex flex-col gap-2"
-                  data-testid="suite-settings-display-density"
-                  role="radiogroup"
-                  aria-label="Display density"
-                >
-                  {(
-                    [
-                      { id: "compact" as const, label: "Compact", hint: "Smaller, tighter app layout" },
-                      { id: "default" as const, label: "Balanced", hint: "Readable default" },
-                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger text and controls" },
-                      { id: "expanded" as const, label: "Expanded", hint: "Big-screen reading mode" },
-                    ] as const
-                  ).map(({ id, label, hint }) => (
-                    <label
-                      key={id}
-                      className={[
-                        "flex min-w-0 cursor-pointer items-center gap-2.5 rounded-md border px-3 py-2 text-sm transition-colors",
-                        displayDensity === id
-                          ? "border-[var(--mm-accent)] bg-[var(--mm-accent)]/12 text-[var(--mm-text)]"
-                          : "border-[var(--mm-border)] bg-transparent text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)]",
-                      ].join(" ")}
+                  <div className="mm-card-action-footer">
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: false,
+                      })}
+                      data-testid="suite-settings-open-setup-wizard"
+                      onClick={() => navigate("/app/setup-wizard")}
                     >
+                      Open setup wizard
+                    </button>
+                  </div>
+                </section>
+                <section
+                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                  aria-labelledby="suite-settings-timezone-heading"
+                >
+                  <div className="mm-card-action-body">
+                    <div>
+                      <h3
+                        id="suite-settings-timezone-heading"
+                        className="text-base font-semibold text-[var(--mm-text1)]"
+                      >
+                        Timezone
+                      </h3>
+                      <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                        Main-country timezones for suite-level time displays.
+                        Use Save timezone when you change the selection.
+                      </p>
+                    </div>
+                    <MmListboxPicker
+                      ariaLabelledBy="suite-settings-timezone-heading"
+                      ariaDescribedBy="suite-timezone-hint"
+                      placeholder="Select timezone"
+                      disabled={!editable || save.isPending}
+                      options={timezoneOptions.map((tz) => ({
+                        value: tz.id,
+                        label: tz.label,
+                      }))}
+                      value={appTimezone ?? ""}
+                      onChange={(v) => setAppTimezone(v)}
+                    />
+                    <p
+                      id="suite-timezone-hint"
+                      className="text-xs text-[var(--mm-text3)]"
+                    >
+                      If you do not see your zone, pick the closest match — this
+                      only affects how times are labeled in the suite.
+                    </p>
+                    {save.isError && lastSuiteSaveTarget === "timezone" ? (
+                      <p
+                        className="text-sm text-red-300"
+                        role="alert"
+                        data-testid="suite-settings-timezone-save-error"
+                      >
+                        {save.error instanceof Error
+                          ? save.error.message
+                          : "Could not save."}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="mm-card-action-footer">
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "primary",
+                        disabled: !editable || !timezoneDirty || save.isPending,
+                      })}
+                      disabled={!editable || !timezoneDirty || save.isPending}
+                      data-testid="suite-settings-save-timezone"
+                      onClick={() => void handleSaveTimezone()}
+                    >
+                      {save.isPending ? "Saving…" : "Save timezone"}
+                    </button>
+                  </div>
+                </section>
+              </div>
+
+              <div className="grid grid-cols-1 gap-5 xl:grid-cols-3">
+                <section
+                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                  aria-labelledby="suite-settings-log-retention-heading"
+                >
+                  <div className="mm-card-action-body">
+                    <div>
+                      <h3
+                        id="suite-settings-log-retention-heading"
+                        className="text-base font-semibold text-[var(--mm-text1)]"
+                      >
+                        Log retention
+                      </h3>
+                      <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                        Decide how long MediaMop keeps persisted system log
+                        entries on disk.
+                      </p>
+                    </div>
+                    <label className="block max-w-md">
+                      <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                        System log retention (days)
+                      </span>
                       <input
-                        type="radio"
-                        name="mm-display-density"
-                        className="h-4 w-4 shrink-0 accent-[var(--mm-accent)]"
-                        checked={displayDensity === id}
-                        onChange={() => {
-                          setDisplayDensity(id);
-                          persistDisplayDensity(id);
-                        }}
+                        type="number"
+                        min={1}
+                        max={3650}
+                        className={`${mmEditableTextFieldClass} mt-1`}
+                        value={normalizedLogRetentionDraft}
+                        disabled={!editable || save.isPending}
+                        onFocus={() =>
+                          setLogRetentionDaysDraft(
+                            String(settingsQ.data.log_retention_days),
+                          )
+                        }
+                        onChange={(e) =>
+                          setLogRetentionDaysDraft(e.target.value)
+                        }
+                        onBlur={() =>
+                          setLogRetentionDaysDraft(
+                            String(finalizeLogRetentionDays()),
+                          )
+                        }
+                        aria-describedby="suite-general-log-retention-hint"
                       />
-                      <span className="min-w-0 font-medium">{label}</span>
-                      <span className="text-xs text-[var(--mm-text3)]">({hint})</span>
+                      <p
+                        id="suite-general-log-retention-hint"
+                        className="mt-1 text-xs text-[var(--mm-text3)]"
+                      >
+                        Between 1 and 3650 days. Older system log entries are
+                        removed automatically while MediaMop is running;
+                        activity history is kept until you reset it.
+                      </p>
                     </label>
-                  ))}
-                </div>
-              </fieldset>
-            </section>
+                    {save.isError && lastSuiteSaveTarget === "logs" ? (
+                      <p
+                        className="text-sm text-red-300"
+                        role="alert"
+                        data-testid="suite-settings-logs-save-error"
+                      >
+                        {save.error instanceof Error
+                          ? save.error.message
+                          : "Could not save."}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="mm-card-action-footer">
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "primary",
+                        disabled: !editable || !logsDirty || save.isPending,
+                      })}
+                      disabled={!editable || !logsDirty || save.isPending}
+                      data-testid="suite-settings-save-logs"
+                      onClick={() => void handleSaveLogs()}
+                    >
+                      {save.isPending ? "Saving…" : "Save log retention"}
+                    </button>
+                  </div>
+                </section>
+                {editable ? (
+                  <section
+                    className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                    data-testid="suite-settings-history-reset"
+                    aria-labelledby="suite-settings-history-reset-heading"
+                  >
+                    <div className="mm-card-action-body">
+                      <div>
+                        <h3
+                          id="suite-settings-history-reset-heading"
+                          className="text-base font-semibold text-[var(--mm-text1)]"
+                        >
+                          Dashboard and activity history
+                        </h3>
+                        <p className="mt-1 text-sm leading-6 text-[var(--mm-text2)]">
+                          History is kept until you reset it. Sign-outs, expired
+                          sessions, and log retention do not clear this data.
+                        </p>
+                      </div>
+                      <label className="block text-sm text-[var(--mm-text2)]">
+                        <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+                          Type RESET to confirm
+                        </span>
+                        <input
+                          type="text"
+                          className="mm-input w-full"
+                          value={resetHistoryConfirm}
+                          disabled={resetHistory.isPending}
+                          onChange={(e) =>
+                            setResetHistoryConfirm(e.target.value)
+                          }
+                        />
+                        <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+                          Clears Activity entries and finished job history only.
+                        </p>
+                      </label>
+                      {resetHistoryMsg ? (
+                        <p className="rounded-md border border-emerald-500/30 bg-emerald-950/20 px-3 py-2 text-sm text-emerald-200">
+                          {resetHistoryMsg}
+                        </p>
+                      ) : null}
+                      {resetHistory.isError ? (
+                        <p
+                          className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                          role="alert"
+                        >
+                          {resetHistory.error instanceof Error
+                            ? resetHistory.error.message
+                            : "Could not reset dashboard and activity history."}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="mm-card-action-footer">
+                      <button
+                        type="button"
+                        className={mmActionButtonClass({
+                          variant: "tertiary",
+                          disabled:
+                            resetHistory.isPending ||
+                            resetHistoryConfirm.trim().toUpperCase() !==
+                              "RESET",
+                        })}
+                        disabled={
+                          resetHistory.isPending ||
+                          resetHistoryConfirm.trim().toUpperCase() !== "RESET"
+                        }
+                        onClick={() => void handleResetOperationalHistory()}
+                      >
+                        {resetHistory.isPending
+                          ? "Resetting..."
+                          : "Reset history"}
+                      </button>
+                    </div>
+                  </section>
+                ) : null}
+                <section
+                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                  aria-labelledby="suite-settings-density-heading"
+                >
+                  <fieldset className="min-w-0 border-0 p-0">
+                    <legend
+                      id="suite-settings-density-heading"
+                      className="text-base font-semibold text-[var(--mm-text1)]"
+                    >
+                      Display density (this browser)
+                    </legend>
+                    <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                      Adjust text, spacing, sidebar width, and card density for
+                      this browser. The change applies immediately.
+                    </p>
+                    <div
+                      className="mt-3 flex flex-col gap-2"
+                      data-testid="suite-settings-display-density"
+                      role="radiogroup"
+                      aria-label="Display density"
+                    >
+                      {(
+                        [
+                          {
+                            id: "compact" as const,
+                            label: "Compact",
+                            hint: "Smaller, tighter app layout",
+                          },
+                          {
+                            id: "default" as const,
+                            label: "Balanced",
+                            hint: "Readable default",
+                          },
+                          {
+                            id: "comfortable" as const,
+                            label: "Comfortable",
+                            hint: "Larger text and controls",
+                          },
+                          {
+                            id: "expanded" as const,
+                            label: "Expanded",
+                            hint: "Big-screen reading mode",
+                          },
+                        ] as const
+                      ).map(({ id, label, hint }) => (
+                        <label
+                          key={id}
+                          className={[
+                            "flex min-w-0 cursor-pointer items-center gap-2.5 rounded-md border px-3 py-2 text-sm transition-colors",
+                            displayDensity === id
+                              ? "border-[var(--mm-accent)] bg-[var(--mm-accent)]/12 text-[var(--mm-text)]"
+                              : "border-[var(--mm-border)] bg-transparent text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)]",
+                          ].join(" ")}
+                        >
+                          <input
+                            type="radio"
+                            name="mm-display-density"
+                            className="h-4 w-4 shrink-0 accent-[var(--mm-accent)]"
+                            checked={displayDensity === id}
+                            onChange={() => {
+                              setDisplayDensity(id);
+                              persistDisplayDensity(id);
+                            }}
+                          />
+                          <span className="min-w-0 font-medium">{label}</span>
+                          <span className="text-xs text-[var(--mm-text3)]">
+                            ({hint})
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </fieldset>
+                </section>
+              </div>
             </div>
-          </div>
           </div>
         ) : tab === "backup" ? (
-          <div data-testid="suite-settings-backup-tab" className="mm-bubble-stack">
+          <div
+            data-testid="suite-settings-backup-tab"
+            className="mm-bubble-stack"
+          >
             <div className={mmModuleTabBlurbBandClass}>
               <p className={mmModuleTabBlurbTextClass}>
-                Export, restore, and automatically snapshot MediaMop configuration.
+                Export, restore, and automatically snapshot MediaMop
+                configuration.
               </p>
             </div>
 
@@ -840,83 +1048,112 @@ export function SettingsPage() {
                 aria-labelledby="suite-settings-backup-heading"
               >
                 <div className="xl:col-span-3">
-                  <h3 id="suite-settings-backup-heading" className="text-base font-semibold text-[var(--mm-text1)]">
+                  <h3
+                    id="suite-settings-backup-heading"
+                    className="text-base font-semibold text-[var(--mm-text1)]"
+                  >
                     Backup and restore
                   </h3>
                   <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                    Keep a clean copy of MediaMop settings and restore them if something goes wrong.
+                    Keep a clean copy of MediaMop settings and restore them if
+                    something goes wrong.
                   </p>
                 </div>
 
                 <div className="contents">
                   <section className={SUITE_SETTINGS_DASH_CARD_CLASS}>
                     <div className="mm-card-action-body">
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
-                        Automatic protection
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
+                          Automatic protection
+                        </p>
+                        <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+                          Scheduled snapshots
+                        </h4>
+                        <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+                          MediaMop keeps the latest five configuration snapshots
+                          using the same restore-safe JSON format.
+                        </p>
+                      </div>
+                      <label className="flex cursor-pointer items-start gap-2.5 text-sm text-[var(--mm-text2)]">
+                        <input
+                          type="checkbox"
+                          className="mt-0.5 h-4 w-4 shrink-0 accent-[var(--mm-accent)]"
+                          checked={configurationBackupEnabled}
+                          disabled={!editable || save.isPending}
+                          onChange={(e) =>
+                            setConfigurationBackupEnabled(e.target.checked)
+                          }
+                        />
+                        <span>Run scheduled configuration backups</span>
+                      </label>
+                      <label className="block text-sm text-[var(--mm-text2)]">
+                        <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+                          Minimum time between runs
+                        </span>
+                        <select
+                          className="mm-input w-full max-w-xs"
+                          value={configurationBackupIntervalHours}
+                          disabled={!editable || save.isPending}
+                          onChange={(e) =>
+                            setConfigurationBackupIntervalHours(
+                              Number(e.target.value),
+                            )
+                          }
+                        >
+                          {CONFIGURATION_BACKUP_INTERVAL_HOURS.map((h) => (
+                            <option key={h} value={h}>
+                              {h === 168
+                                ? "Every 7 days (168 h)"
+                                : `Every ${h} hours`}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                      <label className="block text-sm text-[var(--mm-text2)]">
+                        <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
+                          Preferred backup time
+                        </span>
+                        <input
+                          type="time"
+                          className="mm-input w-full max-w-xs"
+                          value={configurationBackupPreferredTime}
+                          disabled={!editable || save.isPending}
+                          onChange={(e) =>
+                            setConfigurationBackupPreferredTime(
+                              e.target.value || "02:00",
+                            )
+                          }
+                        />
+                      </label>
+                      <p className="text-xs text-[var(--mm-text3)]">
+                        <span className="font-medium text-[var(--mm-text2)]">
+                          Last automatic run:
+                        </span>{" "}
+                        {settingsQ.data.configuration_backup_last_run_at
+                          ? new Date(
+                              settingsQ.data.configuration_backup_last_run_at,
+                            ).toLocaleString()
+                          : "—"}
                       </p>
-                      <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">Scheduled snapshots</h4>
-                      <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
-                        MediaMop keeps the latest five configuration snapshots using the same restore-safe JSON format.
+                      <p className="text-xs text-[var(--mm-text3)]">
+                        <span className="font-medium text-[var(--mm-text2)]">
+                          Target time:
+                        </span>{" "}
+                        {configurationBackupPreferredTime}
                       </p>
-                    </div>
-                    <label className="flex cursor-pointer items-start gap-2.5 text-sm text-[var(--mm-text2)]">
-                      <input
-                        type="checkbox"
-                        className="mt-0.5 h-4 w-4 shrink-0 accent-[var(--mm-accent)]"
-                        checked={configurationBackupEnabled}
-                        disabled={!editable || save.isPending}
-                        onChange={(e) => setConfigurationBackupEnabled(e.target.checked)}
-                      />
-                      <span>Run scheduled configuration backups</span>
-                    </label>
-                    <label className="block text-sm text-[var(--mm-text2)]">
-                      <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
-                        Minimum time between runs
-                      </span>
-                      <select
-                        className="mm-input w-full max-w-xs"
-                        value={configurationBackupIntervalHours}
-                        disabled={!editable || save.isPending}
-                        onChange={(e) => setConfigurationBackupIntervalHours(Number(e.target.value))}
-                      >
-                        {CONFIGURATION_BACKUP_INTERVAL_HOURS.map((h) => (
-                          <option key={h} value={h}>
-                            {h === 168 ? "Every 7 days (168 h)" : `Every ${h} hours`}
-                          </option>
-                        ))}
-                      </select>
-                    </label>
-                    <label className="block text-sm text-[var(--mm-text2)]">
-                      <span className="mb-1.5 block text-xs font-medium uppercase tracking-wide text-[var(--mm-text3)]">
-                        Preferred backup time
-                      </span>
-                      <input
-                        type="time"
-                        className="mm-input w-full max-w-xs"
-                        value={configurationBackupPreferredTime}
-                        disabled={!editable || save.isPending}
-                        onChange={(e) => setConfigurationBackupPreferredTime(e.target.value || "02:00")}
-                      />
-                    </label>
-                    <p className="text-xs text-[var(--mm-text3)]">
-                      <span className="font-medium text-[var(--mm-text2)]">Last automatic run:</span>{" "}
-                      {settingsQ.data.configuration_backup_last_run_at
-                        ? new Date(settingsQ.data.configuration_backup_last_run_at).toLocaleString()
-                        : "—"}
-                    </p>
-                    <p className="text-xs text-[var(--mm-text3)]">
-                      <span className="font-medium text-[var(--mm-text2)]">Target time:</span> {configurationBackupPreferredTime}
-                    </p>
                     </div>
                     <div className="mm-card-action-footer">
                       <button
                         type="button"
                         className={mmActionButtonClass({
                           variant: "secondary",
-                          disabled: !editable || !backupScheduleDirty || save.isPending,
+                          disabled:
+                            !editable || !backupScheduleDirty || save.isPending,
                         })}
-                        disabled={!editable || !backupScheduleDirty || save.isPending}
+                        disabled={
+                          !editable || !backupScheduleDirty || save.isPending
+                        }
                         onClick={() => void handleSaveBackupSchedule()}
                       >
                         {save.isPending ? "Saving…" : "Save backup schedule"}
@@ -927,7 +1164,9 @@ export function SettingsPage() {
                           role="alert"
                           data-testid="suite-settings-backup-save-error"
                         >
-                          {save.error instanceof Error ? save.error.message : "Could not save."}
+                          {save.error instanceof Error
+                            ? save.error.message
+                            : "Could not save."}
                         </p>
                       ) : null}
                     </div>
@@ -935,20 +1174,26 @@ export function SettingsPage() {
 
                   <section className={SUITE_SETTINGS_DASH_CARD_CLASS}>
                     <div className="mm-card-action-body">
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
-                        Manual control
-                      </p>
-                      <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">Export or restore now</h4>
-                      <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
-                        Download a full settings file, or restore a MediaMop configuration JSON from disk.
-                      </p>
-                    </div>
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
+                          Manual control
+                        </p>
+                        <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+                          Export or restore now
+                        </h4>
+                        <p className="mt-1 text-xs leading-relaxed text-[var(--mm-text3)]">
+                          Download a full settings file, or restore a MediaMop
+                          configuration JSON from disk.
+                        </p>
+                      </div>
                     </div>
                     <div className="mm-card-action-footer">
                       <button
                         type="button"
-                        className={mmActionButtonClass({ variant: "secondary", disabled: backupBusy || save.isPending })}
+                        className={mmActionButtonClass({
+                          variant: "secondary",
+                          disabled: backupBusy || save.isPending,
+                        })}
                         disabled={backupBusy || save.isPending}
                         onClick={() => void handleDownloadConfiguration()}
                       >
@@ -956,7 +1201,10 @@ export function SettingsPage() {
                       </button>
                       <button
                         type="button"
-                        className={mmActionButtonClass({ variant: "tertiary", disabled: backupBusy || save.isPending })}
+                        className={mmActionButtonClass({
+                          variant: "tertiary",
+                          disabled: backupBusy || save.isPending,
+                        })}
                         disabled={backupBusy || save.isPending}
                         onClick={() => restoreInputRef.current?.click()}
                       >
@@ -976,68 +1224,79 @@ export function SettingsPage() {
 
                 <section className={SUITE_SETTINGS_DASH_CARD_CLASS}>
                   <div className="mm-card-action-body">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
-                        Snapshot history
-                      </p>
-                      <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">Recent automatic snapshots</h4>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
+                          Snapshot history
+                        </p>
+                        <h4 className="mt-1 text-sm font-semibold text-[var(--mm-text1)]">
+                          Recent automatic snapshots
+                        </h4>
+                      </div>
+                      <span className="rounded-full border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-2.5 py-1 text-xs text-[var(--mm-text2)]">
+                        Keeps latest 5
+                      </span>
                     </div>
-                    <span className="rounded-full border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-2.5 py-1 text-xs text-[var(--mm-text2)]">
-                      Keeps latest 5
-                    </span>
-                  </div>
-                  {backupsQ.data ? (
-                    <p
-                      className="mt-1.5 break-all font-mono text-xs leading-snug text-[var(--mm-text2)]"
-                      data-testid="suite-configuration-backup-directory"
-                    >
-                      {backupsQ.data.directory}
-                    </p>
-                  ) : null}
-                  <div className="mt-3">
-                    {backupsQ.isLoading ? (
-                      <p className="text-sm text-[var(--mm-text3)]">Loading snapshot list…</p>
-                    ) : backupsQ.isError ? (
+                    {backupsQ.data ? (
                       <p
-                        className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
-                        role="alert"
+                        className="mt-1.5 break-all font-mono text-xs leading-snug text-[var(--mm-text2)]"
+                        data-testid="suite-configuration-backup-directory"
                       >
-                        {(backupsQ.error as Error).message}
+                        {backupsQ.data.directory}
                       </p>
-                    ) : (backupsQ.data?.items.length ?? 0) === 0 ? (
-                      <p className="text-sm text-[var(--mm-text3)]">
-                        No automatic snapshots yet.
-                      </p>
-                    ) : (
-                      <ul className="divide-y divide-[var(--mm-border)] overflow-hidden rounded-md border border-[var(--mm-border)] text-sm">
-                        {backupsQ.data!.items.map((row) => (
-                          <li
-                            key={row.id}
-                            className="flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
-                          >
-                            <div className="min-w-0 text-[var(--mm-text2)]">
-                              <div className="font-medium text-[var(--mm-text)]">
-                                {new Date(row.created_at).toLocaleString()}
-                              </div>
-                              <div className="text-xs text-[var(--mm-text3)]">{formatBackupBytes(row.size_bytes)}</div>
-                            </div>
-                            <button
-                              type="button"
-                              className={mmActionButtonClass({
-                                variant: "tertiary",
-                                disabled: backupBusy || save.isPending,
-                              })}
-                              disabled={backupBusy || save.isPending}
-                              onClick={() => void handleDownloadStoredBackup(row.id, row.file_name)}
+                    ) : null}
+                    <div className="mt-3">
+                      {backupsQ.isLoading ? (
+                        <p className="text-sm text-[var(--mm-text3)]">
+                          Loading snapshot list…
+                        </p>
+                      ) : backupsQ.isError ? (
+                        <p
+                          className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                          role="alert"
+                        >
+                          {(backupsQ.error as Error).message}
+                        </p>
+                      ) : (backupsQ.data?.items.length ?? 0) === 0 ? (
+                        <p className="text-sm text-[var(--mm-text3)]">
+                          No automatic snapshots yet.
+                        </p>
+                      ) : (
+                        <ul className="divide-y divide-[var(--mm-border)] overflow-hidden rounded-md border border-[var(--mm-border)] text-sm">
+                          {backupsQ.data!.items.map((row) => (
+                            <li
+                              key={row.id}
+                              className="flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
                             >
-                              Download snapshot
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </div>
+                              <div className="min-w-0 text-[var(--mm-text2)]">
+                                <div className="font-medium text-[var(--mm-text)]">
+                                  {new Date(row.created_at).toLocaleString()}
+                                </div>
+                                <div className="text-xs text-[var(--mm-text3)]">
+                                  {formatBackupBytes(row.size_bytes)}
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                className={mmActionButtonClass({
+                                  variant: "tertiary",
+                                  disabled: backupBusy || save.isPending,
+                                })}
+                                disabled={backupBusy || save.isPending}
+                                onClick={() =>
+                                  void handleDownloadStoredBackup(
+                                    row.id,
+                                    row.file_name,
+                                  )
+                                }
+                              >
+                                Download snapshot
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
                   </div>
                 </section>
 
@@ -1058,11 +1317,14 @@ export function SettingsPage() {
             ) : null}
           </div>
         ) : tab === "upgrade" ? (
-          <div data-testid="suite-settings-upgrade-tab" className="mm-bubble-stack">
+          <div
+            data-testid="suite-settings-upgrade-tab"
+            className="mm-bubble-stack"
+          >
             <div className={mmModuleTabBlurbBandClass}>
               <p className={mmModuleTabBlurbTextClass}>
-                Check the installed version, see the latest release, and start a guided in-app upgrade when this install
-                type supports it.
+                Check the installed version, see the latest release, and start a
+                guided in-app upgrade when this install type supports it.
               </p>
             </div>
 
@@ -1072,18 +1334,27 @@ export function SettingsPage() {
               aria-labelledby="suite-settings-upgrade-heading"
             >
               <div>
-                <h3 id="suite-settings-upgrade-heading" className="text-base font-semibold text-[var(--mm-text1)]">
+                <h3
+                  id="suite-settings-upgrade-heading"
+                  className="text-base font-semibold text-[var(--mm-text1)]"
+                >
                   Upgrade
                 </h3>
                 <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                  Check the running MediaMop version and install the latest release for this install type.
+                  Check the running MediaMop version and install the latest
+                  release for this install type.
                 </p>
               </div>
 
               {updateStatusQ.isPending ? (
-                <p className="text-sm text-[var(--mm-text3)]">Checking for updates…</p>
+                <p className="text-sm text-[var(--mm-text3)]">
+                  Checking for updates…
+                </p>
               ) : updateStatusQ.isError || !updateStatusQ.data ? (
-                <p className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200" role="alert">
+                <p
+                  className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                  role="alert"
+                >
                   {updateStatusQ.error instanceof Error
                     ? updateStatusQ.error.message
                     : "Could not check for updates right now."}
@@ -1114,25 +1385,33 @@ export function SettingsPage() {
 
                   <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
                     <div className={SUITE_SETTINGS_PREMIUM_TILE_CLASS}>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">Installed</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">
+                        Installed
+                      </div>
                       <div className="mt-1 text-base font-semibold text-[var(--mm-text1)]">
                         {updateStatusQ.data.current_version}
                       </div>
                     </div>
                     <div className={SUITE_SETTINGS_PREMIUM_TILE_CLASS}>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">Latest</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">
+                        Latest
+                      </div>
                       <div className="mt-1 text-base font-semibold text-[var(--mm-text1)]">
                         {updateStatusQ.data.latest_version || "Unknown"}
                       </div>
                     </div>
                     <div className={SUITE_SETTINGS_PREMIUM_TILE_CLASS}>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">Install type</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">
+                        Install type
+                      </div>
                       <div className="mt-1 text-base font-semibold capitalize text-[var(--mm-text1)]">
                         {updateStatusQ.data.install_type}
                       </div>
                     </div>
                     <div className={SUITE_SETTINGS_PREMIUM_TILE_CLASS}>
-                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">Status</div>
+                      <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-text3)]">
+                        Status
+                      </div>
                       <div className="mt-1 text-base font-semibold capitalize text-[var(--mm-text1)]">
                         {updateStatusQ.data.status.replaceAll("_", " ")}
                       </div>
@@ -1140,18 +1419,23 @@ export function SettingsPage() {
                   </div>
 
                   <div className={SUITE_SETTINGS_PREMIUM_PANEL_CLASS}>
-                    <h4 className="text-sm font-semibold text-[var(--mm-text1)]">What happens next</h4>
-                    {updateStatusQ.data.install_type === "windows" && updateStatusQ.data.status === "update_available" ? (
+                    <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
+                      What happens next
+                    </h4>
+                    {updateStatusQ.data.install_type === "windows" &&
+                    updateStatusQ.data.status === "update_available" ? (
                       <p className="text-sm leading-6 text-[var(--mm-text2)]">
-                        Upgrade now downloads the installer, closes MediaMop, installs the update, reopens the app, and
-                        refreshes this page after the server comes back.
+                        Upgrade now downloads the installer, closes MediaMop,
+                        installs the update, reopens the app, and refreshes this
+                        page after the server comes back.
                       </p>
                     ) : updateStatusQ.data.install_type === "windows" ? (
                       <p className="text-sm leading-6 text-[var(--mm-text2)]">
                         This Windows install does not need an update right now.
                       </p>
                     ) : null}
-                    {updateStatusQ.data.install_type === "docker" && updateStatusQ.data.docker_update_command ? (
+                    {updateStatusQ.data.install_type === "docker" &&
+                    updateStatusQ.data.docker_update_command ? (
                       <p className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 font-mono text-xs text-[var(--mm-text3)]">
                         {updateStatusQ.data.docker_update_command}
                       </p>
@@ -1161,7 +1445,10 @@ export function SettingsPage() {
                   <div className="mt-auto flex flex-wrap gap-2 border-t border-[var(--mm-border)] pt-4">
                     <button
                       type="button"
-                      className={mmActionButtonClass({ variant: "secondary", disabled: updateStatusQ.isFetching })}
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: updateStatusQ.isFetching,
+                      })}
                       disabled={updateStatusQ.isFetching}
                       onClick={() => void updateStatusQ.refetch()}
                     >
@@ -1172,16 +1459,24 @@ export function SettingsPage() {
                     updateStatusQ.data.windows_installer_url ? (
                       <button
                         type="button"
-                        className={mmActionButtonClass({ variant: "primary", disabled: updateNow.isPending })}
+                        className={mmActionButtonClass({
+                          variant: "primary",
+                          disabled: updateNow.isPending,
+                        })}
                         disabled={updateNow.isPending}
                         onClick={() => void handleUpgradeNow()}
                       >
-                        {updateNow.isPending ? "Starting upgrade…" : "Upgrade now"}
+                        {updateNow.isPending
+                          ? "Starting upgrade…"
+                          : "Upgrade now"}
                       </button>
                     ) : null}
                     {updateStatusQ.data.windows_installer_url ? (
                       <a
-                        className={mmActionButtonClass({ variant: "tertiary", disabled: false })}
+                        className={mmActionButtonClass({
+                          variant: "tertiary",
+                          disabled: false,
+                        })}
                         href={updateStatusQ.data.windows_installer_url}
                         target="_blank"
                         rel="noreferrer"
@@ -1191,7 +1486,10 @@ export function SettingsPage() {
                     ) : null}
                     {updateStatusQ.data.release_url ? (
                       <a
-                        className={mmActionButtonClass({ variant: "tertiary", disabled: false })}
+                        className={mmActionButtonClass({
+                          variant: "tertiary",
+                          disabled: false,
+                        })}
                         href={updateStatusQ.data.release_url}
                         target="_blank"
                         rel="noreferrer"
@@ -1206,8 +1504,13 @@ export function SettingsPage() {
                     </p>
                   ) : null}
                   {updateNow.isError ? (
-                    <p className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200" role="alert">
-                      {updateNow.error instanceof Error ? updateNow.error.message : "Could not start the upgrade."}
+                    <p
+                      className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                      role="alert"
+                    >
+                      {updateNow.error instanceof Error
+                        ? updateNow.error.message
+                        : "Could not start the upgrade."}
                     </p>
                   ) : null}
                 </>
@@ -1215,23 +1518,36 @@ export function SettingsPage() {
             </section>
           </div>
         ) : tab === "security" ? (
-          <div className="mm-bubble-stack w-full" data-testid="suite-settings-security">
+          <div
+            className="mm-bubble-stack w-full"
+            data-testid="suite-settings-security"
+          >
             <div className={mmModuleTabBlurbBandClass}>
               <p className={mmModuleTabBlurbTextClass}>
-                Change your MediaMop password here. Sign-in cookie, HTTPS, and rate-limit settings follow the server
-                configuration at startup — they are not edited in this UI.
+                Change your MediaMop password here. Sign-in cookie, HTTPS, and
+                rate-limit settings follow the server configuration at startup —
+                they are not edited in this UI.
               </p>
             </div>
-            <section className="mm-card w-full" aria-labelledby="suite-security-change-password-heading">
-              <h2 id="suite-security-change-password-heading" className="mm-card__title">
+            <section
+              className="mm-card w-full"
+              aria-labelledby="suite-security-change-password-heading"
+            >
+              <h2
+                id="suite-security-change-password-heading"
+                className="mm-card__title"
+              >
                 Change password
               </h2>
               <p className="mm-card__body text-sm text-[var(--mm-text2)]">
-                Update your sign-in password. After saving, MediaMop requires a fresh sign-in.
+                Update your sign-in password. After saving, MediaMop requires a
+                fresh sign-in.
               </p>
               <div className="mm-card__body space-y-3">
                 <label className="block">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Current password</span>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                    Current password
+                  </span>
                   <div className="mt-1 flex flex-wrap gap-2">
                     <input
                       type={showCurrentPassword ? "text" : "password"}
@@ -1250,7 +1566,10 @@ export function SettingsPage() {
                     />
                     <button
                       type="button"
-                      className={mmActionButtonClass({ variant: "tertiary", disabled: changePasswordBusy })}
+                      className={mmActionButtonClass({
+                        variant: "tertiary",
+                        disabled: changePasswordBusy,
+                      })}
                       disabled={changePasswordBusy}
                       onClick={() => setShowCurrentPassword((prev) => !prev)}
                     >
@@ -1259,7 +1578,9 @@ export function SettingsPage() {
                   </div>
                 </label>
                 <label className="block">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">New password</span>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                    New password
+                  </span>
                   <div className="mt-1 flex flex-wrap gap-2">
                     <input
                       type={showNewPassword ? "text" : "password"}
@@ -1278,7 +1599,10 @@ export function SettingsPage() {
                     />
                     <button
                       type="button"
-                      className={mmActionButtonClass({ variant: "tertiary", disabled: changePasswordBusy })}
+                      className={mmActionButtonClass({
+                        variant: "tertiary",
+                        disabled: changePasswordBusy,
+                      })}
                       disabled={changePasswordBusy}
                       onClick={() => setShowNewPassword((prev) => !prev)}
                     >
@@ -1308,7 +1632,10 @@ export function SettingsPage() {
                     />
                     <button
                       type="button"
-                      className={mmActionButtonClass({ variant: "tertiary", disabled: changePasswordBusy })}
+                      className={mmActionButtonClass({
+                        variant: "tertiary",
+                        disabled: changePasswordBusy,
+                      })}
                       disabled={changePasswordBusy}
                       onClick={() => setShowConfirmPassword((prev) => !prev)}
                     >
@@ -1361,7 +1688,9 @@ export function SettingsPage() {
                       setShowCurrentPassword(false);
                       setShowNewPassword(false);
                       setShowConfirmPassword(false);
-                      setChangePasswordStatus("Password changed. Sign in again with your new password.");
+                      setChangePasswordStatus(
+                        "Password changed. Sign in again with your new password.",
+                      );
                       navigate("/login", { replace: true });
                     } catch {
                       setShowCurrentPassword(false);
@@ -1377,23 +1706,48 @@ export function SettingsPage() {
             </section>
           </div>
         ) : (
-          <div data-testid="suite-settings-logs" className="mm-bubble-stack w-full">
+          <div
+            data-testid="suite-settings-logs"
+            className="mm-bubble-stack w-full"
+          >
             <div className={mmModuleTabBlurbBandClass}>
               <p className={mmModuleTabBlurbTextClass}>
-                System event logs from the MediaMop runtime. Use filters to narrow down warnings, failures, and
-                tracebacks. Advanced server diagnostics are available here when troubleshooting.
+                System event logs from the MediaMop runtime. Use filters to
+                narrow down warnings, failures, and tracebacks. Advanced server
+                diagnostics are available here when troubleshooting.
               </p>
             </div>
 
-            <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5" aria-label="Log summary">
-              <SettingsSummaryCard label="Showing now" value={`${logsQ.data?.items.length ?? 0} events`} />
-              <SettingsSummaryCard label="Matching events" value={`${logsQ.data?.total ?? 0} events`} />
-              <SettingsSummaryCard label="Errors" value={String(logsQ.data?.counts.error ?? 0)} />
-              <SettingsSummaryCard label="Warnings" value={String(logsQ.data?.counts.warning ?? 0)} />
-              <SettingsSummaryCard label="Information" value={String(logsQ.data?.counts.information ?? 0)} />
+            <section
+              className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5"
+              aria-label="Log summary"
+            >
+              <SettingsSummaryCard
+                label="Showing now"
+                value={`${logsQ.data?.items.length ?? 0} events`}
+              />
+              <SettingsSummaryCard
+                label="Matching events"
+                value={`${logsQ.data?.total ?? 0} events`}
+              />
+              <SettingsSummaryCard
+                label="Errors"
+                value={String(logsQ.data?.counts.error ?? 0)}
+              />
+              <SettingsSummaryCard
+                label="Warnings"
+                value={String(logsQ.data?.counts.warning ?? 0)}
+              />
+              <SettingsSummaryCard
+                label="Information"
+                value={String(logsQ.data?.counts.information ?? 0)}
+              />
             </section>
 
-            <section className="mm-card mm-dash-card w-full" aria-labelledby="suite-settings-diagnostics-heading">
+            <section
+              className="mm-card mm-dash-card w-full"
+              aria-labelledby="suite-settings-diagnostics-heading"
+            >
               <details>
                 <summary
                   id="suite-settings-diagnostics-heading"
@@ -1402,52 +1756,87 @@ export function SettingsPage() {
                   Server diagnostics
                 </summary>
                 <p className="mt-2 text-sm text-[var(--mm-text2)]">
-                  Advanced counters for troubleshooting. Request issues usually mean a browser or API request was rejected
-                  or asked for something that was not found; they are not the same as application failures.
+                  Advanced counters for troubleshooting. Request issues usually
+                  mean a browser or API request was rejected or asked for
+                  something that was not found; they are not the same as
+                  application failures.
                 </p>
                 {metricsQ.isError ? (
-                  <p className="mt-4 rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200" role="alert">
-                    {metricsQ.error instanceof Error ? metricsQ.error.message : "Could not load server diagnostics."}
+                  <p
+                    className="mt-4 rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                    role="alert"
+                  >
+                    {metricsQ.error instanceof Error
+                      ? metricsQ.error.message
+                      : "Could not load server diagnostics."}
                   </p>
                 ) : (
                   <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
                     <SettingsSummaryCard
                       label="Running for"
-                      value={runtimeMetrics ? formatRuntimeUptime(runtimeMetrics.uptime_seconds) : "Loading..."}
+                      value={
+                        runtimeMetrics
+                          ? formatRuntimeUptime(runtimeMetrics.uptime_seconds)
+                          : "Loading..."
+                      }
                     />
                     <SettingsSummaryCard
                       label="Requests handled"
-                      value={runtimeMetrics ? String(runtimeMetrics.total_requests) : "Loading..."}
+                      value={
+                        runtimeMetrics
+                          ? String(runtimeMetrics.total_requests)
+                          : "Loading..."
+                      }
                     />
                     <SettingsSummaryCard
                       label="Average response"
-                      value={runtimeMetrics ? formatAverageMs(runtimeMetrics.average_response_ms) : "Loading..."}
+                      value={
+                        runtimeMetrics
+                          ? formatAverageMs(runtimeMetrics.average_response_ms)
+                          : "Loading..."
+                      }
                     />
                     <SettingsSummaryCard
                       label="Logged failures"
-                      value={runtimeMetrics ? String(runtimeMetrics.error_log_count) : "Loading..."}
+                      value={
+                        runtimeMetrics
+                          ? String(runtimeMetrics.error_log_count)
+                          : "Loading..."
+                      }
                     />
                     <SettingsSummaryCard
                       label="Request issues"
-                      value={runtimeMetrics ? runtimeRequestIssues.value : "Loading..."}
+                      value={
+                        runtimeMetrics
+                          ? runtimeRequestIssues.value
+                          : "Loading..."
+                      }
                     />
                   </div>
                 )}
                 {runtimeMetrics ? (
-                  <p className="mt-3 text-xs text-[var(--mm-text3)]">{runtimeRequestIssues.detail}</p>
+                  <p className="mt-3 text-xs text-[var(--mm-text3)]">
+                    {runtimeRequestIssues.detail}
+                  </p>
                 ) : null}
               </details>
             </section>
 
-            <section className="mm-card mm-dash-card w-full" aria-labelledby="suite-settings-logs-filters-heading">
+            <section
+              className="mm-card mm-dash-card w-full"
+              aria-labelledby="suite-settings-logs-filters-heading"
+            >
               <div className="mm-card__body space-y-4">
                 <div>
-                  <h3 id="suite-settings-logs-filters-heading" className="text-base font-semibold text-[var(--mm-text1)]">
+                  <h3
+                    id="suite-settings-logs-filters-heading"
+                    className="text-base font-semibold text-[var(--mm-text1)]"
+                  >
                     Search logs
                   </h3>
                   <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                    Search message text, component names, tracebacks, request IDs, and job IDs. This view refreshes while
-                    it is open.
+                    Search message text, component names, tracebacks, request
+                    IDs, and job IDs. This view refreshes while it is open.
                   </p>
                 </div>
 
@@ -1467,7 +1856,9 @@ export function SettingsPage() {
                     <select
                       className={mmEditableTextFieldClass}
                       value={logLevel}
-                      onChange={(e) => setLogLevel(e.target.value as LogLevelFilter)}
+                      onChange={(e) =>
+                        setLogLevel(e.target.value as LogLevelFilter)
+                      }
                     >
                       <option value="">All levels</option>
                       <option value="INFO">Information</option>
@@ -1480,14 +1871,18 @@ export function SettingsPage() {
                     <div className="flex gap-2">
                       <button
                         type="button"
-                        className={mmActionButtonClass({ variant: tracebacksOnly ? "primary" : "tertiary" })}
+                        className={mmActionButtonClass({
+                          variant: tracebacksOnly ? "primary" : "tertiary",
+                        })}
                         onClick={() => setTracebacksOnly(true)}
                       >
                         On
                       </button>
                       <button
                         type="button"
-                        className={mmActionButtonClass({ variant: !tracebacksOnly ? "primary" : "tertiary" })}
+                        className={mmActionButtonClass({
+                          variant: !tracebacksOnly ? "primary" : "tertiary",
+                        })}
                         onClick={() => setTracebacksOnly(false)}
                       >
                         Off
@@ -1497,7 +1892,10 @@ export function SettingsPage() {
                   <div className="flex flex-wrap items-end gap-2">
                     <button
                       type="button"
-                      className={mmActionButtonClass({ variant: "secondary", disabled: logsQ.isFetching })}
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: logsQ.isFetching,
+                      })}
                       disabled={logsQ.isFetching}
                       onClick={() => void logsQ.refetch()}
                     >
@@ -1507,9 +1905,12 @@ export function SettingsPage() {
                       type="button"
                       className={mmActionButtonClass({
                         variant: "tertiary",
-                        disabled: !logSearch.trim() && !logLevel && !tracebacksOnly,
+                        disabled:
+                          !logSearch.trim() && !logLevel && !tracebacksOnly,
                       })}
-                      disabled={!logSearch.trim() && !logLevel && !tracebacksOnly}
+                      disabled={
+                        !logSearch.trim() && !logLevel && !tracebacksOnly
+                      }
                       onClick={() => {
                         setLogSearch("");
                         setLogLevel("");
@@ -1543,14 +1944,21 @@ export function SettingsPage() {
               </div>
             </section>
 
-            <section className="mm-card mm-dash-card w-full" aria-labelledby="suite-settings-logs-list-heading">
+            <section
+              className="mm-card mm-dash-card w-full"
+              aria-labelledby="suite-settings-logs-list-heading"
+            >
               <div className="mm-card__body space-y-4">
                 <div>
-                  <h3 id="suite-settings-logs-list-heading" className="text-base font-semibold text-[var(--mm-text1)]">
+                  <h3
+                    id="suite-settings-logs-list-heading"
+                    className="text-base font-semibold text-[var(--mm-text1)]"
+                  >
                     System events
                   </h3>
                   <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                    Recent runtime events, warnings, and failures captured by MediaMop.
+                    Recent runtime events, warnings, and failures captured by
+                    MediaMop.
                   </p>
                 </div>
 
@@ -1559,8 +1967,13 @@ export function SettingsPage() {
                     Loading logs...
                   </div>
                 ) : logsQ.isError ? (
-                  <div className="rounded-lg border border-red-500/40 bg-red-950/25 px-4 py-4 text-sm text-red-200" role="alert">
-                    {logsQ.error instanceof Error ? logsQ.error.message : "Could not load logs."}
+                  <div
+                    className="rounded-lg border border-red-500/40 bg-red-950/25 px-4 py-4 text-sm text-red-200"
+                    role="alert"
+                  >
+                    {logsQ.error instanceof Error
+                      ? logsQ.error.message
+                      : "Could not load logs."}
                   </div>
                 ) : (logsQ.data?.items.length ?? 0) === 0 ? (
                   <div className="rounded-lg border border-[var(--mm-border)] bg-black/10 px-4 py-4 text-sm text-[var(--mm-text2)]">
@@ -1584,15 +1997,27 @@ export function SettingsPage() {
                                 <span
                                   className={`rounded-full border px-2.5 py-1 text-xs font-medium ${logLevelBadgeTone(entry.level)}`}
                                 >
-                                  {entry.level === "INFO" ? "Information" : entry.level}
+                                  {entry.level === "INFO"
+                                    ? "Information"
+                                    : entry.level}
                                 </span>
                               </div>
-                              <h4 className="text-sm font-semibold text-[var(--mm-text1)]">{entry.message}</h4>
-                              {entry.detail ? <p className="text-sm leading-6 text-[var(--mm-text2)]">{entry.detail}</p> : null}
+                              <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
+                                {entry.message}
+                              </h4>
+                              {entry.detail ? (
+                                <p className="text-sm leading-6 text-[var(--mm-text2)]">
+                                  {entry.detail}
+                                </p>
+                              ) : null}
                             </div>
-                            <time className="text-sm text-[var(--mm-text3)]">{formatDateTime(entry.timestamp)}</time>
+                            <time className="text-sm text-[var(--mm-text3)]">
+                              {formatDateTime(entry.timestamp)}
+                            </time>
                           </div>
-                          {technicalDetails ? <div className="mt-3">{technicalDetails}</div> : null}
+                          {technicalDetails ? (
+                            <div className="mt-3">{technicalDetails}</div>
+                          ) : null}
                         </article>
                       );
                     })}
@@ -1606,4 +2031,3 @@ export function SettingsPage() {
     </div>
   );
 }
-

--- a/apps/web/src/pages/setup/setup-page.test.tsx
+++ b/apps/web/src/pages/setup/setup-page.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,6 +82,11 @@ describe("SetupPage", () => {
     expect(mutateAsyncMock).toHaveBeenCalledWith({
       username: "admin",
       password: "password-strong",
+    });
+    await waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/login?bootstrap=created", {
+        replace: true,
+      });
     });
   });
 });

--- a/apps/web/src/pages/setup/setup-page.test.tsx
+++ b/apps/web/src/pages/setup/setup-page.test.tsx
@@ -33,7 +33,9 @@ vi.mock("../../lib/auth/queries", () => ({
 }));
 
 function wrap(ui: ReactNode) {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   return (
     <QueryClientProvider client={client}>
       <MemoryRouter>{ui}</MemoryRouter>
@@ -50,12 +52,18 @@ describe("SetupPage", () => {
   it("blocks bootstrap submit when password is shorter than 8 characters", async () => {
     render(wrap(<SetupPage />));
 
-    fireEvent.change(screen.getByTestId("setup-username"), { target: { value: "admin" } });
-    fireEvent.change(screen.getByTestId("setup-password"), { target: { value: "short" } });
+    fireEvent.change(screen.getByTestId("setup-username"), {
+      target: { value: "admin" },
+    });
+    fireEvent.change(screen.getByTestId("setup-password"), {
+      target: { value: "short" },
+    });
     fireEvent.submit(screen.getByTestId("setup-form"));
 
     expect(mutateAsyncMock).not.toHaveBeenCalled();
-    expect(screen.getByRole("alert")).toHaveTextContent("Password must be at least 8 characters.");
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Password must be at least 8 characters.",
+    );
   });
 
   it("submits bootstrap when username and password meet the requirements", async () => {
@@ -63,7 +71,9 @@ describe("SetupPage", () => {
 
     render(wrap(<SetupPage />));
 
-    fireEvent.change(screen.getByTestId("setup-username"), { target: { value: " admin " } });
+    fireEvent.change(screen.getByTestId("setup-username"), {
+      target: { value: " admin " },
+    });
     fireEvent.change(screen.getByTestId("setup-password"), {
       target: { value: "password-strong" },
     });

--- a/apps/web/src/pages/setup/setup-page.tsx
+++ b/apps/web/src/pages/setup/setup-page.tsx
@@ -60,7 +60,7 @@ export function SetupPage() {
     setValidationError(null);
     try {
       await bootstrap.mutateAsync({ username: trimmedUsername, password });
-      navigate("/login", { replace: true, state: { fromSetup: true } });
+      navigate("/login?bootstrap=created", { replace: true });
     } catch {
       /* surfaced below */
     }

--- a/apps/web/src/pages/setup/setup-page.tsx
+++ b/apps/web/src/pages/setup/setup-page.tsx
@@ -3,7 +3,11 @@ import { Link, Navigate, useNavigate } from "react-router-dom";
 import { AuthBrandStack } from "../../components/brand/auth-brand-stack";
 import { ApiEntryError } from "../../components/shared/api-entry-error";
 import { PageLoading } from "../../components/shared/page-loading";
-import { useBootstrapMutation, useBootstrapStatusQuery, useMeQuery } from "../../lib/auth/queries";
+import {
+  useBootstrapMutation,
+  useBootstrapStatusQuery,
+  useMeQuery,
+} from "../../lib/auth/queries";
 
 export function SetupPage() {
   const navigate = useNavigate();
@@ -70,11 +74,16 @@ export function SetupPage() {
           <p className="mm-auth-eyebrow">First run</p>
           <h1 className="mm-auth-title">Create admin</h1>
           <p className="mm-auth-lead">
-            This workspace has no administrator yet. Choose credentials for the initial account.
-            After you sign in, MediaMop will run the first-run setup wizard.
+            This workspace has no administrator yet. Choose credentials for the
+            initial account. After you sign in, MediaMop will run the first-run
+            setup wizard.
           </p>
 
-          <form data-testid="setup-form" className="mm-auth-form" onSubmit={onSubmit}>
+          <form
+            data-testid="setup-form"
+            className="mm-auth-form"
+            onSubmit={onSubmit}
+          >
             <label className="mm-auth-label" htmlFor="setup-user">
               Admin username
             </label>
@@ -122,7 +131,9 @@ export function SetupPage() {
             ) : null}
             {bootstrap.isError ? (
               <p className="mm-auth-banner" role="alert">
-                {bootstrap.error instanceof Error ? bootstrap.error.message : "Setup failed."}
+                {bootstrap.error instanceof Error
+                  ? bootstrap.error.message
+                  : "Setup failed."}
               </p>
             ) : null}
             <button

--- a/apps/web/src/pages/setup/setup-wizard-page.test.tsx
+++ b/apps/web/src/pages/setup/setup-wizard-page.test.tsx
@@ -52,7 +52,8 @@ vi.mock("react-router-dom", async (importOriginal) => {
 });
 
 vi.mock("../../lib/suite/queries", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../lib/suite/queries")>();
+  const actual =
+    await importOriginal<typeof import("../../lib/suite/queries")>();
   return {
     ...actual,
     useSuiteSettingsSaveMutation: () => ({
@@ -97,7 +98,8 @@ vi.mock("../../lib/pruner/api", () => ({
 }));
 
 vi.mock("../../lib/api/auth-api", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../lib/api/auth-api")>();
+  const actual =
+    await importOriginal<typeof import("../../lib/api/auth-api")>();
   return {
     ...actual,
     fetchCsrfToken: vi.fn().mockResolvedValue("csrf-token"),
@@ -113,7 +115,9 @@ function wrap(ui: ReactNode, client: QueryClient) {
 }
 
 function renderWizard() {
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } });
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
   client.setQueryData(qk.me, { id: 1, username: "admin", role: "admin" });
   client.setQueryData(suiteSettingsQueryKey, {
     product_display_name: "MediaMop",
@@ -164,13 +168,27 @@ describe("SetupWizardPage", () => {
   it("completes and saves backup plus module starter settings", async () => {
     renderWizard();
 
-    fireEvent.change(screen.getByDisplayValue("02:00"), { target: { value: "03:30" } });
-    fireEvent.change(screen.getByPlaceholderText("Movies watched folder"), { target: { value: "D:\\Movies" } });
-    fireEvent.change(screen.getByPlaceholderText("Movies output folder"), { target: { value: "E:\\MoviesOut" } });
-    fireEvent.change(screen.getByPlaceholderText("http://127.0.0.1:8989"), { target: { value: "http://sonarr:8989" } });
-    fireEvent.change(screen.getByPlaceholderText("Sonarr API key"), { target: { value: "sonarr-key" } });
-    fireEvent.change(screen.getByPlaceholderText("http://127.0.0.1:8096"), { target: { value: "http://jf:8096" } });
-    fireEvent.change(screen.getByPlaceholderText("API key"), { target: { value: "jf-key" } });
+    fireEvent.change(screen.getByDisplayValue("02:00"), {
+      target: { value: "03:30" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Movies watched folder"), {
+      target: { value: "D:\\Movies" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Movies output folder"), {
+      target: { value: "E:\\MoviesOut" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("http://127.0.0.1:8989"), {
+      target: { value: "http://sonarr:8989" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Sonarr API key"), {
+      target: { value: "sonarr-key" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("http://127.0.0.1:8096"), {
+      target: { value: "http://jf:8096" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("API key"), {
+      target: { value: "jf-key" },
+    });
     fireEvent.click(screen.getByText("Refiner"));
     fireEvent.click(screen.getByRole("button", { name: "Finish setup" }));
 
@@ -203,7 +221,9 @@ describe("SetupWizardPage", () => {
       }),
     );
     await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith("/app/refiner", { replace: true });
+      expect(navigateMock).toHaveBeenCalledWith("/app/refiner", {
+        replace: true,
+      });
     });
   });
 });

--- a/apps/web/src/pages/setup/setup-wizard-page.tsx
+++ b/apps/web/src/pages/setup/setup-wizard-page.tsx
@@ -7,16 +7,33 @@ import { MmListboxPicker } from "../../components/ui/mm-listbox-picker";
 import { ServerFolderPickerButton } from "../../components/ui/server-folder-picker-button";
 import { fetchCsrfToken } from "../../lib/api/auth-api";
 import { useMeQuery } from "../../lib/auth/queries";
-import { patchPrunerInstance, postPrunerInstance, type PrunerServerInstance } from "../../lib/pruner/api";
+import {
+  patchPrunerInstance,
+  postPrunerInstance,
+  type PrunerServerInstance,
+} from "../../lib/pruner/api";
 import { usePrunerInstancesQuery } from "../../lib/pruner/queries";
-import { useRefinerPathSettingsQuery, useRefinerPathSettingsSaveMutation } from "../../lib/refiner/queries";
+import {
+  useRefinerPathSettingsQuery,
+  useRefinerPathSettingsSaveMutation,
+} from "../../lib/refiner/queries";
 import {
   curatedTimezoneOptionsSorted,
   CURATED_TIMEZONE_ID_SET,
 } from "../../lib/suite/timezone-options";
-import { useSuiteSettingsQuery, useSuiteSettingsSaveMutation } from "../../lib/suite/queries";
-import { usePutSubberSettingsMutation, useSubberSettingsQuery } from "../../lib/subber/subber-queries";
-import { persistDisplayDensity, readStoredDisplayDensity, type DisplayDensity } from "../../lib/ui/display-density";
+import {
+  useSuiteSettingsQuery,
+  useSuiteSettingsSaveMutation,
+} from "../../lib/suite/queries";
+import {
+  usePutSubberSettingsMutation,
+  useSubberSettingsQuery,
+} from "../../lib/subber/subber-queries";
+import {
+  persistDisplayDensity,
+  readStoredDisplayDensity,
+  type DisplayDensity,
+} from "../../lib/ui/display-density";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 
 const LANDING_OPTIONS = [
@@ -49,7 +66,9 @@ function WizardSection({
 }) {
   return (
     <section className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/40 p-4">
-      <h2 className="text-base font-semibold text-[var(--mm-text1)]">{title}</h2>
+      <h2 className="text-base font-semibold text-[var(--mm-text1)]">
+        {title}
+      </h2>
       <p className="mt-1 text-sm text-[var(--mm-text2)]">{description}</p>
       <div className="mt-4 space-y-4">{children}</div>
     </section>
@@ -74,8 +93,12 @@ function labelForPrunerSecret(provider: string): string {
   return provider === "plex" ? "Plex token" : "API key";
 }
 
-function defaultPrunerDisplayName(provider: "jellyfin" | "emby" | "plex"): string {
-  const label = PRUNER_PROVIDER_OPTIONS.find((option) => option.value === provider)?.label ?? "Media server";
+function defaultPrunerDisplayName(
+  provider: "jellyfin" | "emby" | "plex",
+): string {
+  const label =
+    PRUNER_PROVIDER_OPTIONS.find((option) => option.value === provider)
+      ?.label ?? "Media server";
   return `${label} server`;
 }
 
@@ -91,7 +114,9 @@ export function SetupWizardPage() {
   const saveSubber = usePutSubberSettingsMutation();
 
   const [appTimezone, setAppTimezone] = useState<string>("UTC");
-  const [displayDensity, setDisplayDensity] = useState<DisplayDensity>(() => readStoredDisplayDensity());
+  const [displayDensity, setDisplayDensity] = useState<DisplayDensity>(() =>
+    readStoredDisplayDensity(),
+  );
   const [landingPath, setLandingPath] = useState<string>("/app");
   const [backupEnabled, setBackupEnabled] = useState(false);
   const [backupIntervalHours, setBackupIntervalHours] = useState("24");
@@ -100,7 +125,9 @@ export function SetupWizardPage() {
   const [movieOutputFolder, setMovieOutputFolder] = useState("");
   const [tvWatchedFolder, setTvWatchedFolder] = useState("");
   const [tvOutputFolder, setTvOutputFolder] = useState("");
-  const [prunerProvider, setPrunerProvider] = useState<"jellyfin" | "emby" | "plex">("jellyfin");
+  const [prunerProvider, setPrunerProvider] = useState<
+    "jellyfin" | "emby" | "plex"
+  >("jellyfin");
   const [prunerBaseUrl, setPrunerBaseUrl] = useState("");
   const [prunerSecret, setPrunerSecret] = useState("");
   const [sonarrBaseUrl, setSonarrBaseUrl] = useState("");
@@ -118,8 +145,13 @@ export function SetupWizardPage() {
     const tz = (settingsQ.data.app_timezone || "UTC").trim() || "UTC";
     setAppTimezone(CURATED_TIMEZONE_ID_SET.has(tz) ? tz : "UTC");
     setBackupEnabled(Boolean(settingsQ.data.configuration_backup_enabled));
-    setBackupIntervalHours(String(settingsQ.data.configuration_backup_interval_hours || 24));
-    setBackupPreferredTime((settingsQ.data.configuration_backup_preferred_time || "02:00").trim() || "02:00");
+    setBackupIntervalHours(
+      String(settingsQ.data.configuration_backup_interval_hours || 24),
+    );
+    setBackupPreferredTime(
+      (settingsQ.data.configuration_backup_preferred_time || "02:00").trim() ||
+        "02:00",
+    );
   }, [settingsQ.data]);
 
   useEffect(() => {
@@ -139,7 +171,9 @@ export function SetupWizardPage() {
     setSonarrBaseUrl(subberQ.data.sonarr_base_url ?? "");
     setRadarrBaseUrl(subberQ.data.radarr_base_url ?? "");
     setLanguagePreferencesCsv(
-      subberQ.data.language_preferences.length > 0 ? subberQ.data.language_preferences.join(", ") : "en",
+      subberQ.data.language_preferences.length > 0
+        ? subberQ.data.language_preferences.join(", ")
+        : "en",
     );
   }, [subberQ.data]);
 
@@ -153,14 +187,24 @@ export function SetupWizardPage() {
     setPrunerBaseUrl(first.base_url || "");
   }, [prunerInstancesQ.data]);
 
-  const wizardState = (settingsQ.data?.setup_wizard_state || "pending").trim().toLowerCase();
+  const wizardState = (settingsQ.data?.setup_wizard_state || "pending")
+    .trim()
+    .toLowerCase();
   const timezoneOptions = useMemo(
-    () => curatedTimezoneOptionsSorted().map((tz) => ({ value: tz.id, label: tz.label })),
+    () =>
+      curatedTimezoneOptionsSorted().map((tz) => ({
+        value: tz.id,
+        label: tz.label,
+      })),
     [],
   );
 
   const loading =
-    me.isPending || settingsQ.isPending || refinerQ.isPending || subberQ.isPending || prunerInstancesQ.isPending;
+    me.isPending ||
+    settingsQ.isPending ||
+    refinerQ.isPending ||
+    subberQ.isPending ||
+    prunerInstancesQ.isPending;
 
   if (loading) {
     return <PageLoading label="Loading setup wizard" />;
@@ -177,7 +221,8 @@ export function SetupWizardPage() {
             <p className="mm-auth-eyebrow">Setup wizard</p>
             <h1 className="mm-auth-title">Could not load setup</h1>
             <p className="mm-auth-lead">
-              The wizard could not load the current suite settings. Open Settings later and try again.
+              The wizard could not load the current suite settings. Open
+              Settings later and try again.
             </p>
             <p className="mm-auth-footer-link">
               <Link to="/app">Continue to the app</Link>
@@ -189,9 +234,7 @@ export function SetupWizardPage() {
   }
 
   const savePending =
-    saveSuite.isPending ||
-    saveRefiner.isPending ||
-    saveSubber.isPending;
+    saveSuite.isPending || saveRefiner.isPending || saveSubber.isPending;
 
   function renderFolderInput({
     value,
@@ -213,7 +256,12 @@ export function SetupWizardPage() {
           placeholder={placeholder}
           disabled={savePending}
         />
-        <ServerFolderPickerButton title={title} value={value} disabled={savePending} onSelect={setter} />
+        <ServerFolderPickerButton
+          title={title}
+          value={value}
+          disabled={savePending}
+          onSelect={setter}
+        />
       </div>
     );
   }
@@ -225,15 +273,24 @@ export function SetupWizardPage() {
     const subberCurrent = subberQ.data;
 
     if (tvWatchedFolder.trim() && !tvOutputFolder.trim()) {
-      setStatusMessage("TV Refiner setup needs an output folder when a TV watched folder is set.");
+      setStatusMessage(
+        "TV Refiner setup needs an output folder when a TV watched folder is set.",
+      );
       return;
     }
     if (movieWatchedFolder.trim() && !movieOutputFolder.trim()) {
-      setStatusMessage("Movies Refiner setup needs an output folder when a Movies watched folder is set.");
+      setStatusMessage(
+        "Movies Refiner setup needs an output folder when a Movies watched folder is set.",
+      );
       return;
     }
-    if ((prunerBaseUrl.trim() && !prunerSecret.trim()) || (!prunerBaseUrl.trim() && prunerSecret.trim())) {
-      setStatusMessage("Pruner setup needs both a base URL and a connection secret.");
+    if (
+      (prunerBaseUrl.trim() && !prunerSecret.trim()) ||
+      (!prunerBaseUrl.trim() && prunerSecret.trim())
+    ) {
+      setStatusMessage(
+        "Pruner setup needs both a base URL and a connection secret.",
+      );
       return;
     }
 
@@ -248,21 +305,34 @@ export function SetupWizardPage() {
         log_retention_days: current.log_retention_days,
         application_logs_enabled: true,
         configuration_backup_enabled: backupEnabled,
-        configuration_backup_interval_hours: Number.parseInt(backupIntervalHours, 10),
+        configuration_backup_interval_hours: Number.parseInt(
+          backupIntervalHours,
+          10,
+        ),
         configuration_backup_preferred_time: backupPreferredTime,
       });
 
       if (refinerCurrent) {
         await saveRefiner.mutateAsync({
-          refiner_watched_folder: movieWatchedFolder.trim() ? movieWatchedFolder.trim() : null,
+          refiner_watched_folder: movieWatchedFolder.trim()
+            ? movieWatchedFolder.trim()
+            : null,
           refiner_work_folder: refinerCurrent.refiner_work_folder,
-          refiner_output_folder: movieOutputFolder.trim() ? movieOutputFolder.trim() : null,
+          refiner_output_folder: movieOutputFolder.trim()
+            ? movieOutputFolder.trim()
+            : null,
           refiner_tv_paths_included: true,
-          refiner_tv_watched_folder: tvWatchedFolder.trim() ? tvWatchedFolder.trim() : null,
+          refiner_tv_watched_folder: tvWatchedFolder.trim()
+            ? tvWatchedFolder.trim()
+            : null,
           refiner_tv_work_folder: refinerCurrent.refiner_tv_work_folder,
-          refiner_tv_output_folder: tvOutputFolder.trim() ? tvOutputFolder.trim() : null,
-          movie_watched_folder_check_interval_seconds: refinerCurrent.movie_watched_folder_check_interval_seconds,
-          tv_watched_folder_check_interval_seconds: refinerCurrent.tv_watched_folder_check_interval_seconds,
+          refiner_tv_output_folder: tvOutputFolder.trim()
+            ? tvOutputFolder.trim()
+            : null,
+          movie_watched_folder_check_interval_seconds:
+            refinerCurrent.movie_watched_folder_check_interval_seconds,
+          tv_watched_folder_check_interval_seconds:
+            refinerCurrent.tv_watched_folder_check_interval_seconds,
         });
       }
 
@@ -285,7 +355,9 @@ export function SetupWizardPage() {
           prunerProvider === "plex"
             ? { auth_token: prunerSecret.trim() }
             : { api_key: prunerSecret.trim() };
-        const displayName = existing?.display_name?.trim() || defaultPrunerDisplayName(prunerProvider);
+        const displayName =
+          existing?.display_name?.trim() ||
+          defaultPrunerDisplayName(prunerProvider);
         if (existing) {
           await patchPrunerInstance(existing.id, {
             display_name: displayName,
@@ -305,7 +377,9 @@ export function SetupWizardPage() {
 
       navigate(landingPath, { replace: true });
     } catch (err) {
-      setStatusMessage(err instanceof Error ? err.message : "Could not save setup.");
+      setStatusMessage(
+        err instanceof Error ? err.message : "Could not save setup.",
+      );
     }
   }
 
@@ -317,7 +391,8 @@ export function SetupWizardPage() {
           <p className="mm-auth-eyebrow">First run</p>
           <h1 className="mm-auth-title">Setup wizard</h1>
           <p className="mm-auth-lead">
-            Set the suite basics, backup schedule, and starter connections now. You can skip this and reopen it later from Settings.
+            Set the suite basics, backup schedule, and starter connections now.
+            You can skip this and reopen it later from Settings.
           </p>
 
           <div className="grid gap-4 lg:grid-cols-2">
@@ -346,7 +421,11 @@ export function SetupWizardPage() {
                   <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
                     Open first
                   </label>
-                  <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label="Open first">
+                  <div
+                    className="grid gap-2 sm:grid-cols-2"
+                    role="radiogroup"
+                    aria-label="Open first"
+                  >
                     {LANDING_OPTIONS.map((option) => (
                       <label
                         key={option.value}
@@ -364,21 +443,45 @@ export function SetupWizardPage() {
                           checked={landingPath === option.value}
                           onChange={() => setLandingPath(option.value)}
                         />
-                        <span className="min-w-0 whitespace-nowrap font-medium text-[var(--mm-text)]">{option.label}</span>
+                        <span className="min-w-0 whitespace-nowrap font-medium text-[var(--mm-text)]">
+                          {option.label}
+                        </span>
                       </label>
                     ))}
                   </div>
                 </div>
               </div>
               <div>
-                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">Display density</p>
-                <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4" role="radiogroup" aria-label="Display density">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+                  Display density
+                </p>
+                <div
+                  className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4"
+                  role="radiogroup"
+                  aria-label="Display density"
+                >
                   {(
                     [
-                      { id: "compact" as const, label: "Compact", hint: "Smaller layout" },
-                      { id: "default" as const, label: "Balanced", hint: "Readable default" },
-                      { id: "comfortable" as const, label: "Comfortable", hint: "Larger controls" },
-                      { id: "expanded" as const, label: "Expanded", hint: "Big-screen mode" },
+                      {
+                        id: "compact" as const,
+                        label: "Compact",
+                        hint: "Smaller layout",
+                      },
+                      {
+                        id: "default" as const,
+                        label: "Balanced",
+                        hint: "Readable default",
+                      },
+                      {
+                        id: "comfortable" as const,
+                        label: "Comfortable",
+                        hint: "Larger controls",
+                      },
+                      {
+                        id: "expanded" as const,
+                        label: "Expanded",
+                        hint: "Big-screen mode",
+                      },
                     ] as const
                   ).map(({ id, label, hint }) => (
                     <label
@@ -398,8 +501,12 @@ export function SetupWizardPage() {
                         onChange={() => setDisplayDensity(id)}
                       />
                       <span className="min-w-0">
-                        <span className="block font-medium text-[var(--mm-text)]">{label}</span>
-                        <span className="block text-xs text-[var(--mm-text3)]">{hint}</span>
+                        <span className="block font-medium text-[var(--mm-text)]">
+                          {label}
+                        </span>
+                        <span className="block text-xs text-[var(--mm-text3)]">
+                          {hint}
+                        </span>
                       </span>
                     </label>
                   ))}
@@ -447,7 +554,9 @@ export function SetupWizardPage() {
                     className="mm-input w-full"
                     value={backupPreferredTime}
                     disabled={!backupEnabled}
-                    onChange={(e) => setBackupPreferredTime(e.target.value || "02:00")}
+                    onChange={(e) =>
+                      setBackupPreferredTime(e.target.value || "02:00")
+                    }
                   />
                 </label>
               </div>
@@ -459,7 +568,9 @@ export function SetupWizardPage() {
             >
               <div className="grid gap-4 lg:grid-cols-2">
                 <div className="space-y-3">
-                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">TV</h3>
+                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+                    TV
+                  </h3>
                   {renderFolderInput({
                     value: tvWatchedFolder,
                     setter: setTvWatchedFolder,
@@ -474,7 +585,9 @@ export function SetupWizardPage() {
                   })}
                 </div>
                 <div className="space-y-3">
-                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">Movies</h3>
+                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+                    Movies
+                  </h3>
                   {renderFolderInput({
                     value: movieWatchedFolder,
                     setter: setMovieWatchedFolder,
@@ -503,7 +616,11 @@ export function SetupWizardPage() {
                   <select
                     className="mm-input w-full"
                     value={prunerProvider}
-                    onChange={(e) => setPrunerProvider(e.target.value as "jellyfin" | "emby" | "plex")}
+                    onChange={(e) =>
+                      setPrunerProvider(
+                        e.target.value as "jellyfin" | "emby" | "plex",
+                      )
+                    }
                   >
                     {PRUNER_PROVIDER_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -522,7 +639,11 @@ export function SetupWizardPage() {
                     className="mm-input w-full"
                     value={prunerBaseUrl}
                     onChange={(e) => setPrunerBaseUrl(e.target.value)}
-                    placeholder={prunerProvider === "plex" ? "http://127.0.0.1:32400" : "http://127.0.0.1:8096"}
+                    placeholder={
+                      prunerProvider === "plex"
+                        ? "http://127.0.0.1:32400"
+                        : "http://127.0.0.1:8096"
+                    }
                   />
                 </label>
                 <label className="block text-sm text-[var(--mm-text2)]">
@@ -545,7 +666,9 @@ export function SetupWizardPage() {
             >
               <div className="grid gap-4 lg:grid-cols-2">
                 <div className="space-y-3">
-                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">Sonarr</h3>
+                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+                    Sonarr
+                  </h3>
                   <input
                     className="mm-input w-full"
                     value={sonarrBaseUrl}
@@ -560,7 +683,9 @@ export function SetupWizardPage() {
                   />
                 </div>
                 <div className="space-y-3">
-                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">Radarr</h3>
+                  <h3 className="text-sm font-semibold text-[var(--mm-text1)]">
+                    Radarr
+                  </h3>
                   <input
                     className="mm-input w-full"
                     value={radarrBaseUrl}
@@ -615,7 +740,11 @@ export function SetupWizardPage() {
               onClick={() => void saveWizardState("completed")}
               disabled={savePending}
             >
-              {savePending ? "Saving..." : wizardState === "pending" ? "Finish setup" : "Save changes"}
+              {savePending
+                ? "Saving..."
+                : wizardState === "pending"
+                  ? "Finish setup"
+                  : "Save changes"}
             </button>
             <button
               type="button"

--- a/apps/web/src/pages/subber/subber-connections-sections.tsx
+++ b/apps/web/src/pages/subber/subber-connections-sections.tsx
@@ -4,11 +4,15 @@ type SubberConnectionSectionProps = {
   children: ReactNode;
 };
 
-export function SonarrConnectionSection({ children }: SubberConnectionSectionProps) {
+export function SonarrConnectionSection({
+  children,
+}: SubberConnectionSectionProps) {
   return <>{children}</>;
 }
 
-export function RadarrConnectionSection({ children }: SubberConnectionSectionProps) {
+export function RadarrConnectionSection({
+  children,
+}: SubberConnectionSectionProps) {
   return <>{children}</>;
 }
 

--- a/apps/web/src/pages/subber/subber-connections-tab.tsx
+++ b/apps/web/src/pages/subber/subber-connections-tab.tsx
@@ -33,7 +33,11 @@ type ConnectionCheckState = {
   quotaNote?: string;
 };
 
-const initialCheck: ConnectionCheckState = { outcome: null, at: null, detail: "" };
+const initialCheck: ConnectionCheckState = {
+  outcome: null,
+  at: null,
+  detail: "",
+};
 
 function ConnectionStatusPanel({
   check,
@@ -45,19 +49,32 @@ function ConnectionStatusPanel({
   fmt: (iso: string | null) => string;
 }) {
   const main =
-    check.outcome === null ? "Not connected yet" : check.outcome === "ok" ? "Connected" : "Connection failed";
+    check.outcome === null
+      ? "Not connected yet"
+      : check.outcome === "ok"
+        ? "Connected"
+        : "Connection failed";
   return (
     <div className="mt-4 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-3.5 text-sm text-[var(--mm-text2)]">
       <p className="text-sm font-medium text-[var(--mm-text)]">{main}</p>
       <p className="mt-1 text-xs text-[var(--mm-text2)]">
-        Last completed check: <span className="font-medium text-[var(--mm-text)]">{fmt(check.at)}</span>
+        Last completed check:{" "}
+        <span className="font-medium text-[var(--mm-text)]">
+          {fmt(check.at)}
+        </span>
       </p>
-      {check.outcome === "ok" && check.quotaNote ? <p className="mt-1 text-xs text-[var(--mm-text2)]">{check.quotaNote}</p> : null}
+      {check.outcome === "ok" && check.quotaNote ? (
+        <p className="mt-1 text-xs text-[var(--mm-text2)]">{check.quotaNote}</p>
+      ) : null}
       {check.outcome === "ok" && check.detail && !check.quotaNote ? (
         <p className="mt-1 text-xs text-[var(--mm-text2)]">{check.detail}</p>
       ) : null}
-      {check.outcome === "fail" && check.detail ? <p className="mt-1 text-xs text-red-400">{check.detail}</p> : null}
-      {check.outcome === null && idleHelper ? <p className="mt-2 text-xs text-[var(--mm-text2)]">{idleHelper}</p> : null}
+      {check.outcome === "fail" && check.detail ? (
+        <p className="mt-1 text-xs text-red-400">{check.detail}</p>
+      ) : null}
+      {check.outcome === null && idleHelper ? (
+        <p className="mt-2 text-xs text-[var(--mm-text2)]">{idleHelper}</p>
+      ) : null}
     </div>
   );
 }
@@ -100,7 +117,9 @@ function SubberSettingsSection({
     >
       <header className="border-b border-[var(--mm-border)] bg-black/10 px-5 py-4">
         {eyebrow ? (
-          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">{eyebrow}</p>
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">
+            {eyebrow}
+          </p>
         ) : null}
         <h2
           className={
@@ -111,17 +130,29 @@ function SubberSettingsSection({
         >
           {title}
         </h2>
-        {description ? <div className="mt-2 text-sm leading-relaxed text-[var(--mm-text2)]">{description}</div> : null}
+        {description ? (
+          <div className="mt-2 text-sm leading-relaxed text-[var(--mm-text2)]">
+            {description}
+          </div>
+        ) : null}
       </header>
       <div className="mm-bubble-stack px-5 py-5">{children}</div>
     </section>
   );
 }
 
-function SubberSettingsSubsection({ title, children }: { title: string; children: ReactNode }) {
+function SubberSettingsSubsection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
   return (
     <div className="rounded-md border border-[var(--mm-border)] bg-black/[0.06] p-4">
-      <h3 className="mb-3 text-sm font-semibold text-[var(--mm-text)]">{title}</h3>
+      <h3 className="mb-3 text-sm font-semibold text-[var(--mm-text)]">
+        {title}
+      </h3>
       <div className="space-y-3">{children}</div>
     </div>
   );
@@ -158,20 +189,39 @@ function ArrRootFolderChoices({
   return (
     <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
       {error ? <p className="text-xs text-red-400">{error}</p> : null}
-      {message ? <p className="text-xs text-[var(--mm-text2)]">{message}</p> : null}
+      {message ? (
+        <p className="text-xs text-[var(--mm-text2)]">{message}</p>
+      ) : null}
       {folders.length ? (
         <div className="mt-2 grid gap-2">
           {folders.map((folder) => {
             const free = formatBytes(folder.free_space);
             return (
-              <div key={folder.path} className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-2.5">
-                <p className="break-all font-mono text-xs text-[var(--mm-text)]">{folder.path}</p>
-                {free ? <p className="mt-1 text-[0.7rem] text-[var(--mm-text2)]">{free}</p> : null}
+              <div
+                key={folder.path}
+                className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-2.5"
+              >
+                <p className="break-all font-mono text-xs text-[var(--mm-text)]">
+                  {folder.path}
+                </p>
+                {free ? (
+                  <p className="mt-1 text-[0.7rem] text-[var(--mm-text2)]">
+                    {free}
+                  </p>
+                ) : null}
                 <div className="mt-2 flex flex-wrap gap-2">
-                  <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onUseArr(folder.path)}>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "secondary" })}
+                    onClick={() => onUseArr(folder.path)}
+                  >
                     Use as {label} path
                   </button>
-                  <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => onUseBoth(folder.path)}>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "secondary" })}
+                    onClick={() => onUseBoth(folder.path)}
+                  >
                     Use for both
                   </button>
                 </div>
@@ -209,10 +259,22 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
   const [radSub, setRadSub] = useState("");
   const [sonCheck, setSonCheck] = useState<ConnectionCheckState>(initialCheck);
   const [radCheck, setRadCheck] = useState<ConnectionCheckState>(initialCheck);
-  const [saveSon, setSaveSon] = useState({ ok: false, err: null as string | null });
-  const [saveRad, setSaveRad] = useState({ ok: false, err: null as string | null });
-  const [saveSonMap, setSaveSonMap] = useState({ ok: false, err: null as string | null });
-  const [saveRadMap, setSaveRadMap] = useState({ ok: false, err: null as string | null });
+  const [saveSon, setSaveSon] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [saveRad, setSaveRad] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [saveSonMap, setSaveSonMap] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [saveRadMap, setSaveRadMap] = useState({
+    ok: false,
+    err: null as string | null,
+  });
   const [tvSyncOk, setTvSyncOk] = useState(false);
   const [moviesSyncOk, setMoviesSyncOk] = useState(false);
   const [tvSyncErr, setTvSyncErr] = useState<string | null>(null);
@@ -221,8 +283,12 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
   const [radDirty, setRadDirty] = useState(false);
   const [sonMapDirty, setSonMapDirty] = useState(false);
   const [radMapDirty, setRadMapDirty] = useState(false);
-  const [sonRootFolders, setSonRootFolders] = useState<SubberArrRootFolderOut[]>([]);
-  const [radRootFolders, setRadRootFolders] = useState<SubberArrRootFolderOut[]>([]);
+  const [sonRootFolders, setSonRootFolders] = useState<
+    SubberArrRootFolderOut[]
+  >([]);
+  const [radRootFolders, setRadRootFolders] = useState<
+    SubberArrRootFolderOut[]
+  >([]);
   const [sonRootMessage, setSonRootMessage] = useState<string | null>(null);
   const [radRootMessage, setRadRootMessage] = useState<string | null>(null);
   const [sonRootError, setSonRootError] = useState<string | null>(null);
@@ -258,7 +324,10 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
     setSaveSon({ ok: false, err: null });
     try {
       const csrf_token = await fetchCsrfToken();
-      const body: Parameters<typeof put.mutateAsync>[0] = { csrf_token, sonarr_base_url: sonUrl.trim() };
+      const body: Parameters<typeof put.mutateAsync>[0] = {
+        csrf_token,
+        sonarr_base_url: sonUrl.trim(),
+      };
       if (sonKey.trim()) body.sonarr_api_key = sonKey;
       await put.mutateAsync(body);
       flashSave(setSaveSon);
@@ -272,7 +341,10 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
     setSaveRad({ ok: false, err: null });
     try {
       const csrf_token = await fetchCsrfToken();
-      const body: Parameters<typeof put.mutateAsync>[0] = { csrf_token, radarr_base_url: radUrl.trim() };
+      const body: Parameters<typeof put.mutateAsync>[0] = {
+        csrf_token,
+        radarr_base_url: radUrl.trim(),
+      };
       if (radKey.trim()) body.radarr_api_key = radKey;
       await put.mutateAsync(body);
       flashSave(setSaveRad);
@@ -323,7 +395,11 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
       if (r.ok) {
         setSonCheck({ outcome: "ok", at, detail: r.message || "OK" });
       } else {
-        setSonCheck({ outcome: "fail", at, detail: r.message || "Unknown error" });
+        setSonCheck({
+          outcome: "fail",
+          at,
+          detail: r.message || "Unknown error",
+        });
       }
     } catch (e) {
       setSonCheck({ outcome: "fail", at, detail: (e as Error).message });
@@ -337,7 +413,11 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
       if (r.ok) {
         setRadCheck({ outcome: "ok", at, detail: r.message || "OK" });
       } else {
-        setRadCheck({ outcome: "fail", at, detail: r.message || "Unknown error" });
+        setRadCheck({
+          outcome: "fail",
+          at,
+          detail: r.message || "Unknown error",
+        });
       }
     } catch (e) {
       setRadCheck({ outcome: "fail", at, detail: (e as Error).message });
@@ -376,8 +456,10 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
     }
   }
 
-  if (q.isLoading) return <p className="text-sm text-[var(--mm-text2)]">Loading settings…</p>;
-  if (q.isError) return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
+  if (q.isLoading)
+    return <p className="text-sm text-[var(--mm-text2)]">Loading settings…</p>;
+  if (q.isError)
+    return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
 
   const sonHint = (q.data?.arr_library_sonarr_base_url_hint || "").trim();
   const radHint = (q.data?.arr_library_radarr_base_url_hint || "").trim();
@@ -393,216 +475,253 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
             data-testid="subber-settings-sonarr"
           >
             <SonarrConnectionSection>
-            <SubberSettingsSubsection title="Connection">
-              {sonHint ? (
-                <p className="text-sm text-[var(--mm-text2)]">
-                  Arr library already uses <span className="font-mono text-[var(--mm-text)]">{sonHint}</span> — you can paste the same base URL here.
-                </p>
-              ) : null}
-              <label className="block text-sm font-medium text-[var(--mm-text)]" htmlFor="subber-son-url">
-                Base URL
-              </label>
-              <input
-                id="subber-son-url"
-                className="mm-input mt-1 w-full max-w-xl font-mono text-sm"
-                value={sonUrl}
-                disabled={dis}
-                onChange={(e) => {
-                  setSonUrl(e.target.value);
-                  setSonDirty(true);
-                }}
-                placeholder="http://127.0.0.1:8989"
-              />
-              <label className="mt-3 block text-sm font-medium text-[var(--mm-text)]" htmlFor="subber-son-key">
-                API key
-              </label>
-              <div className="mt-1 flex max-w-xl gap-2">
+              <SubberSettingsSubsection title="Connection">
+                {sonHint ? (
+                  <p className="text-sm text-[var(--mm-text2)]">
+                    Arr library already uses{" "}
+                    <span className="font-mono text-[var(--mm-text)]">
+                      {sonHint}
+                    </span>{" "}
+                    — you can paste the same base URL here.
+                  </p>
+                ) : null}
+                <label
+                  className="block text-sm font-medium text-[var(--mm-text)]"
+                  htmlFor="subber-son-url"
+                >
+                  Base URL
+                </label>
                 <input
-                  id="subber-son-key"
-                  className="mm-input min-w-0 flex-1 font-mono text-sm"
-                  type={showSonKey ? "text" : "password"}
-                  value={sonKey}
-                  placeholder={q.data?.sonarr_api_key_set ? MASK : ""}
+                  id="subber-son-url"
+                  className="mm-input mt-1 w-full max-w-xl font-mono text-sm"
+                  value={sonUrl}
                   disabled={dis}
                   onChange={(e) => {
-                    setSonKey(e.target.value);
+                    setSonUrl(e.target.value);
                     setSonDirty(true);
                   }}
+                  placeholder="http://127.0.0.1:8989"
                 />
-                <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => setShowSonKey(!showSonKey)}>
-                  {showSonKey ? "Hide" : "Show"}
-                </button>
-              </div>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: sonDirty ? "primary" : "secondary", disabled: dis || !sonDirty })}
-                  disabled={dis || !sonDirty}
-                  onClick={() => void saveSonarr()}
-                  data-testid="subber-save-sonarr"
+                <label
+                  className="mt-3 block text-sm font-medium text-[var(--mm-text)]"
+                  htmlFor="subber-son-key"
                 >
-                  Save connection
-                </button>
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: "secondary", disabled: dis || testSon.isPending })}
-                  disabled={dis || testSon.isPending}
-                  onClick={() => void runTestSon()}
-                  data-testid="subber-test-sonarr"
-                >
-                  Test Sonarr
-                </button>
-              </div>
-              <SaveFeedback ok={saveSon.ok} err={saveSon.err} />
-              <ConnectionStatusPanel
-                check={sonCheck}
-                idleHelper="Save your URL and API key, then run a test to confirm Sonarr is reachable."
-                fmt={fmt}
-              />
-            </SubberSettingsSubsection>
+                  API key
+                </label>
+                <div className="mt-1 flex max-w-xl gap-2">
+                  <input
+                    id="subber-son-key"
+                    className="mm-input min-w-0 flex-1 font-mono text-sm"
+                    type={showSonKey ? "text" : "password"}
+                    value={sonKey}
+                    placeholder={q.data?.sonarr_api_key_set ? MASK : ""}
+                    disabled={dis}
+                    onChange={(e) => {
+                      setSonKey(e.target.value);
+                      setSonDirty(true);
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "secondary" })}
+                    onClick={() => setShowSonKey(!showSonKey)}
+                  >
+                    {showSonKey ? "Hide" : "Show"}
+                  </button>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({
+                      variant: sonDirty ? "primary" : "secondary",
+                      disabled: dis || !sonDirty,
+                    })}
+                    disabled={dis || !sonDirty}
+                    onClick={() => void saveSonarr()}
+                    data-testid="subber-save-sonarr"
+                  >
+                    Save connection
+                  </button>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({
+                      variant: "secondary",
+                      disabled: dis || testSon.isPending,
+                    })}
+                    disabled={dis || testSon.isPending}
+                    onClick={() => void runTestSon()}
+                    data-testid="subber-test-sonarr"
+                  >
+                    Test Sonarr
+                  </button>
+                </div>
+                <SaveFeedback ok={saveSon.ok} err={saveSon.err} />
+                <ConnectionStatusPanel
+                  check={sonCheck}
+                  idleHelper="Save your URL and API key, then run a test to confirm Sonarr is reachable."
+                  fmt={fmt}
+                />
+              </SubberSettingsSubsection>
             </SonarrConnectionSection>
 
             <SyncActionsSection>
-            <SubberSettingsSubsection title="Library sync">
-              <button
-                type="button"
-                className={mmActionButtonClass({ variant: "secondary", disabled: dis || syncTv.isPending })}
-                disabled={dis || syncTv.isPending}
-                onClick={() => {
-                  setTvSyncOk(false);
-                  setTvSyncErr(null);
-                  void syncTv.mutate(undefined, {
-                    onSuccess: () => setTvSyncOk(true),
-                    onError: (e) => setTvSyncErr((e as Error).message),
-                  });
-                }}
-                data-testid="subber-sync-tv-library"
-              >
-                {syncTv.isPending ? "Syncing…" : "Sync TV library from Sonarr"}
-              </button>
-              <p className="text-xs text-[var(--mm-text2)]">
-                One-time pull of your Sonarr library so the TV tab shows coverage. Check the Jobs tab for progress.
-              </p>
-              {tvSyncOk ? (
-                <p className="text-xs text-[var(--mm-text)]">
-                  TV library sync started — your TV tab will populate shortly. Check the Jobs tab for progress.
+              <SubberSettingsSubsection title="Library sync">
+                <button
+                  type="button"
+                  className={mmActionButtonClass({
+                    variant: "secondary",
+                    disabled: dis || syncTv.isPending,
+                  })}
+                  disabled={dis || syncTv.isPending}
+                  onClick={() => {
+                    setTvSyncOk(false);
+                    setTvSyncErr(null);
+                    void syncTv.mutate(undefined, {
+                      onSuccess: () => setTvSyncOk(true),
+                      onError: (e) => setTvSyncErr((e as Error).message),
+                    });
+                  }}
+                  data-testid="subber-sync-tv-library"
+                >
+                  {syncTv.isPending
+                    ? "Syncing…"
+                    : "Sync TV library from Sonarr"}
+                </button>
+                <p className="text-xs text-[var(--mm-text2)]">
+                  One-time pull of your Sonarr library so the TV tab shows
+                  coverage. Check the Jobs tab for progress.
                 </p>
-              ) : null}
-              {tvSyncErr ? (
-                <p className="text-xs text-red-400" role="alert">
-                  {tvSyncErr}
-                </p>
-              ) : null}
-            </SubberSettingsSubsection>
+                {tvSyncOk ? (
+                  <p className="text-xs text-[var(--mm-text)]">
+                    TV library sync started — your TV tab will populate shortly.
+                    Check the Jobs tab for progress.
+                  </p>
+                ) : null}
+                {tvSyncErr ? (
+                  <p className="text-xs text-red-400" role="alert">
+                    {tvSyncErr}
+                  </p>
+                ) : null}
+              </SubberSettingsSubsection>
             </SyncActionsSection>
           </SubberSettingsSection>
 
           <PathMappingSection>
-          <SubberSettingsSection
-            title="Path mapping"
-            description="Only needed when Subber and Sonarr run in separate containers."
-          >
-            <MmOnOffSwitch
-              id="subber-son-map"
-              label="Enable Sonarr path mapping"
-              enabled={sonMapEn}
-              disabled={dis}
-              onChange={(v) => {
-                setSonMapEn(v);
-                setSonMapDirty(true);
-              }}
-            />
-            {sonMapEn ? (
-              <>
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-                  <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
-                    Path as Sonarr reports it
-                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-                      <input
-                        className="mm-input w-full font-mono text-sm"
-                        value={sonArr}
-                        disabled={dis}
-                        onChange={(e) => {
-                          setSonArr(e.target.value);
-                          setSonMapDirty(true);
-                        }}
-                      />
-                      <ServerFolderPickerButton
-                        title="Choose Sonarr TV path"
-                        value={sonArr}
-                        disabled={dis}
-                        onSelect={(path) => {
-                          setSonArr(path);
-                          setSonMapDirty(true);
-                        }}
-                      />
-                    </div>
-                  </label>
-                  <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
-                    Path as MediaMop sees it
-                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-                      <input
-                        className="mm-input w-full font-mono text-sm"
-                        value={sonSub}
-                        disabled={dis}
-                        onChange={(e) => {
-                          setSonSub(e.target.value);
-                          setSonMapDirty(true);
-                        }}
-                      />
-                      <ServerFolderPickerButton
-                        title="Choose MediaMop TV path"
-                        value={sonSub}
-                        disabled={dis}
-                        onSelect={(path) => {
-                          setSonSub(path);
-                          setSonMapDirty(true);
-                        }}
-                      />
-                    </div>
-                  </label>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    className={mmActionButtonClass({ variant: "secondary", disabled: dis || sonRootFoldersFetch.isPending })}
-                    disabled={dis || sonRootFoldersFetch.isPending}
-                    onClick={() => void detectSonarrRootFolders()}
-                  >
-                    {sonRootFoldersFetch.isPending ? "Detecting..." : "Detect Sonarr paths"}
-                  </button>
-                  <p className="basis-full text-xs text-[var(--mm-text2)]">
-                    Pulls Sonarr root folders through the API. Use these when Sonarr reports container or NAS paths differently from MediaMop.
-                  </p>
-                </div>
-                <ArrRootFolderChoices
-                  label="Sonarr"
-                  folders={sonRootFolders}
-                  message={sonRootMessage}
-                  error={sonRootError}
-                  onUseArr={(path) => {
-                    setSonArr(path);
-                    setSonMapDirty(true);
-                  }}
-                  onUseBoth={(path) => {
-                    setSonArr(path);
-                    setSonSub(path);
-                    setSonMapDirty(true);
-                  }}
-                />
-              </>
-            ) : null}
-            <button
-              type="button"
-              className={mmActionButtonClass({ variant: sonMapDirty ? "primary" : "secondary", disabled: dis || !sonMapDirty })}
-              disabled={dis || !sonMapDirty}
-              onClick={() => void saveSonarrPathMapping()}
-              data-testid="subber-save-sonarr-path-mapping"
+            <SubberSettingsSection
+              title="Path mapping"
+              description="Only needed when Subber and Sonarr run in separate containers."
             >
-              Save Sonarr path mapping
-            </button>
-            <SaveFeedback ok={saveSonMap.ok} err={saveSonMap.err} />
-          </SubberSettingsSection>
+              <MmOnOffSwitch
+                id="subber-son-map"
+                label="Enable Sonarr path mapping"
+                enabled={sonMapEn}
+                disabled={dis}
+                onChange={(v) => {
+                  setSonMapEn(v);
+                  setSonMapDirty(true);
+                }}
+              />
+              {sonMapEn ? (
+                <>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                    <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
+                      Path as Sonarr reports it
+                      <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                        <input
+                          className="mm-input w-full font-mono text-sm"
+                          value={sonArr}
+                          disabled={dis}
+                          onChange={(e) => {
+                            setSonArr(e.target.value);
+                            setSonMapDirty(true);
+                          }}
+                        />
+                        <ServerFolderPickerButton
+                          title="Choose Sonarr TV path"
+                          value={sonArr}
+                          disabled={dis}
+                          onSelect={(path) => {
+                            setSonArr(path);
+                            setSonMapDirty(true);
+                          }}
+                        />
+                      </div>
+                    </label>
+                    <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
+                      Path as MediaMop sees it
+                      <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                        <input
+                          className="mm-input w-full font-mono text-sm"
+                          value={sonSub}
+                          disabled={dis}
+                          onChange={(e) => {
+                            setSonSub(e.target.value);
+                            setSonMapDirty(true);
+                          }}
+                        />
+                        <ServerFolderPickerButton
+                          title="Choose MediaMop TV path"
+                          value={sonSub}
+                          disabled={dis}
+                          onSelect={(path) => {
+                            setSonSub(path);
+                            setSonMapDirty(true);
+                          }}
+                        />
+                      </div>
+                    </label>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: dis || sonRootFoldersFetch.isPending,
+                      })}
+                      disabled={dis || sonRootFoldersFetch.isPending}
+                      onClick={() => void detectSonarrRootFolders()}
+                    >
+                      {sonRootFoldersFetch.isPending
+                        ? "Detecting..."
+                        : "Detect Sonarr paths"}
+                    </button>
+                    <p className="basis-full text-xs text-[var(--mm-text2)]">
+                      Pulls Sonarr root folders through the API. Use these when
+                      Sonarr reports container or NAS paths differently from
+                      MediaMop.
+                    </p>
+                  </div>
+                  <ArrRootFolderChoices
+                    label="Sonarr"
+                    folders={sonRootFolders}
+                    message={sonRootMessage}
+                    error={sonRootError}
+                    onUseArr={(path) => {
+                      setSonArr(path);
+                      setSonMapDirty(true);
+                    }}
+                    onUseBoth={(path) => {
+                      setSonArr(path);
+                      setSonSub(path);
+                      setSonMapDirty(true);
+                    }}
+                  />
+                </>
+              ) : null}
+              <button
+                type="button"
+                className={mmActionButtonClass({
+                  variant: sonMapDirty ? "primary" : "secondary",
+                  disabled: dis || !sonMapDirty,
+                })}
+                disabled={dis || !sonMapDirty}
+                onClick={() => void saveSonarrPathMapping()}
+                data-testid="subber-save-sonarr-path-mapping"
+              >
+                Save Sonarr path mapping
+              </button>
+              <SaveFeedback ok={saveSonMap.ok} err={saveSonMap.err} />
+            </SubberSettingsSection>
           </PathMappingSection>
         </div>
 
@@ -614,216 +733,253 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
             data-testid="subber-settings-radarr"
           >
             <RadarrConnectionSection>
-            <SubberSettingsSubsection title="Connection">
-              {radHint ? (
-                <p className="text-sm text-[var(--mm-text2)]">
-                  Arr library already uses <span className="font-mono text-[var(--mm-text)]">{radHint}</span> — you can paste the same base URL here.
-                </p>
-              ) : null}
-              <label className="block text-sm font-medium text-[var(--mm-text)]" htmlFor="subber-rad-url">
-                Base URL
-              </label>
-              <input
-                id="subber-rad-url"
-                className="mm-input mt-1 w-full max-w-xl font-mono text-sm"
-                value={radUrl}
-                disabled={dis}
-                onChange={(e) => {
-                  setRadUrl(e.target.value);
-                  setRadDirty(true);
-                }}
-                placeholder="http://127.0.0.1:7878"
-              />
-              <label className="mt-3 block text-sm font-medium text-[var(--mm-text)]" htmlFor="subber-rad-key">
-                API key
-              </label>
-              <div className="mt-1 flex max-w-xl gap-2">
+              <SubberSettingsSubsection title="Connection">
+                {radHint ? (
+                  <p className="text-sm text-[var(--mm-text2)]">
+                    Arr library already uses{" "}
+                    <span className="font-mono text-[var(--mm-text)]">
+                      {radHint}
+                    </span>{" "}
+                    — you can paste the same base URL here.
+                  </p>
+                ) : null}
+                <label
+                  className="block text-sm font-medium text-[var(--mm-text)]"
+                  htmlFor="subber-rad-url"
+                >
+                  Base URL
+                </label>
                 <input
-                  id="subber-rad-key"
-                  className="mm-input min-w-0 flex-1 font-mono text-sm"
-                  type={showRadKey ? "text" : "password"}
-                  value={radKey}
-                  placeholder={q.data?.radarr_api_key_set ? MASK : ""}
+                  id="subber-rad-url"
+                  className="mm-input mt-1 w-full max-w-xl font-mono text-sm"
+                  value={radUrl}
                   disabled={dis}
                   onChange={(e) => {
-                    setRadKey(e.target.value);
+                    setRadUrl(e.target.value);
                     setRadDirty(true);
                   }}
+                  placeholder="http://127.0.0.1:7878"
                 />
-                <button type="button" className={mmActionButtonClass({ variant: "secondary" })} onClick={() => setShowRadKey(!showRadKey)}>
-                  {showRadKey ? "Hide" : "Show"}
-                </button>
-              </div>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: radDirty ? "primary" : "secondary", disabled: dis || !radDirty })}
-                  disabled={dis || !radDirty}
-                  onClick={() => void saveRadarr()}
-                  data-testid="subber-save-radarr"
+                <label
+                  className="mt-3 block text-sm font-medium text-[var(--mm-text)]"
+                  htmlFor="subber-rad-key"
                 >
-                  Save connection
-                </button>
-                <button
-                  type="button"
-                  className={mmActionButtonClass({ variant: "secondary", disabled: dis || testRad.isPending })}
-                  disabled={dis || testRad.isPending}
-                  onClick={() => void runTestRad()}
-                  data-testid="subber-test-radarr"
-                >
-                  Test Radarr
-                </button>
-              </div>
-              <SaveFeedback ok={saveRad.ok} err={saveRad.err} />
-              <ConnectionStatusPanel
-                check={radCheck}
-                idleHelper="Save your URL and API key, then run a test to confirm Radarr is reachable."
-                fmt={fmt}
-              />
-            </SubberSettingsSubsection>
+                  API key
+                </label>
+                <div className="mt-1 flex max-w-xl gap-2">
+                  <input
+                    id="subber-rad-key"
+                    className="mm-input min-w-0 flex-1 font-mono text-sm"
+                    type={showRadKey ? "text" : "password"}
+                    value={radKey}
+                    placeholder={q.data?.radarr_api_key_set ? MASK : ""}
+                    disabled={dis}
+                    onChange={(e) => {
+                      setRadKey(e.target.value);
+                      setRadDirty(true);
+                    }}
+                  />
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "secondary" })}
+                    onClick={() => setShowRadKey(!showRadKey)}
+                  >
+                    {showRadKey ? "Hide" : "Show"}
+                  </button>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({
+                      variant: radDirty ? "primary" : "secondary",
+                      disabled: dis || !radDirty,
+                    })}
+                    disabled={dis || !radDirty}
+                    onClick={() => void saveRadarr()}
+                    data-testid="subber-save-radarr"
+                  >
+                    Save connection
+                  </button>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({
+                      variant: "secondary",
+                      disabled: dis || testRad.isPending,
+                    })}
+                    disabled={dis || testRad.isPending}
+                    onClick={() => void runTestRad()}
+                    data-testid="subber-test-radarr"
+                  >
+                    Test Radarr
+                  </button>
+                </div>
+                <SaveFeedback ok={saveRad.ok} err={saveRad.err} />
+                <ConnectionStatusPanel
+                  check={radCheck}
+                  idleHelper="Save your URL and API key, then run a test to confirm Radarr is reachable."
+                  fmt={fmt}
+                />
+              </SubberSettingsSubsection>
             </RadarrConnectionSection>
 
             <SyncActionsSection>
-            <SubberSettingsSubsection title="Library sync">
-              <button
-                type="button"
-                className={mmActionButtonClass({ variant: "secondary", disabled: dis || syncMovies.isPending })}
-                disabled={dis || syncMovies.isPending}
-                onClick={() => {
-                  setMoviesSyncOk(false);
-                  setMoviesSyncErr(null);
-                  void syncMovies.mutate(undefined, {
-                    onSuccess: () => setMoviesSyncOk(true),
-                    onError: (e) => setMoviesSyncErr((e as Error).message),
-                  });
-                }}
-                data-testid="subber-sync-movies-library"
-              >
-                {syncMovies.isPending ? "Syncing…" : "Sync Movies library from Radarr"}
-              </button>
-              <p className="text-xs text-[var(--mm-text2)]">
-                One-time pull of your Radarr library so the Movies tab shows coverage. Check the Jobs tab for progress.
-              </p>
-              {moviesSyncOk ? (
-                <p className="text-xs text-[var(--mm-text)]">
-                  Movies library sync started — your Movies tab will populate shortly. Check the Jobs tab for progress.
+              <SubberSettingsSubsection title="Library sync">
+                <button
+                  type="button"
+                  className={mmActionButtonClass({
+                    variant: "secondary",
+                    disabled: dis || syncMovies.isPending,
+                  })}
+                  disabled={dis || syncMovies.isPending}
+                  onClick={() => {
+                    setMoviesSyncOk(false);
+                    setMoviesSyncErr(null);
+                    void syncMovies.mutate(undefined, {
+                      onSuccess: () => setMoviesSyncOk(true),
+                      onError: (e) => setMoviesSyncErr((e as Error).message),
+                    });
+                  }}
+                  data-testid="subber-sync-movies-library"
+                >
+                  {syncMovies.isPending
+                    ? "Syncing…"
+                    : "Sync Movies library from Radarr"}
+                </button>
+                <p className="text-xs text-[var(--mm-text2)]">
+                  One-time pull of your Radarr library so the Movies tab shows
+                  coverage. Check the Jobs tab for progress.
                 </p>
-              ) : null}
-              {moviesSyncErr ? (
-                <p className="text-xs text-red-400" role="alert">
-                  {moviesSyncErr}
-                </p>
-              ) : null}
-            </SubberSettingsSubsection>
+                {moviesSyncOk ? (
+                  <p className="text-xs text-[var(--mm-text)]">
+                    Movies library sync started — your Movies tab will populate
+                    shortly. Check the Jobs tab for progress.
+                  </p>
+                ) : null}
+                {moviesSyncErr ? (
+                  <p className="text-xs text-red-400" role="alert">
+                    {moviesSyncErr}
+                  </p>
+                ) : null}
+              </SubberSettingsSubsection>
             </SyncActionsSection>
           </SubberSettingsSection>
 
           <PathMappingSection>
-          <SubberSettingsSection
-            title="Path mapping"
-            description="Only needed when Subber and Radarr run in separate containers."
-          >
-            <MmOnOffSwitch
-              id="subber-rad-map"
-              label="Enable Radarr path mapping"
-              enabled={radMapEn}
-              disabled={dis}
-              onChange={(v) => {
-                setRadMapEn(v);
-                setRadMapDirty(true);
-              }}
-            />
-            {radMapEn ? (
-              <>
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-                  <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
-                    Path as Radarr reports it
-                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-                      <input
-                        className="mm-input w-full font-mono text-sm"
-                        value={radArr}
-                        disabled={dis}
-                        onChange={(e) => {
-                          setRadArr(e.target.value);
-                          setRadMapDirty(true);
-                        }}
-                      />
-                      <ServerFolderPickerButton
-                        title="Choose Radarr Movies path"
-                        value={radArr}
-                        disabled={dis}
-                        onSelect={(path) => {
-                          setRadArr(path);
-                          setRadMapDirty(true);
-                        }}
-                      />
-                    </div>
-                  </label>
-                  <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
-                    Path as MediaMop sees it
-                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
-                      <input
-                        className="mm-input w-full font-mono text-sm"
-                        value={radSub}
-                        disabled={dis}
-                        onChange={(e) => {
-                          setRadSub(e.target.value);
-                          setRadMapDirty(true);
-                        }}
-                      />
-                      <ServerFolderPickerButton
-                        title="Choose MediaMop Movies path"
-                        value={radSub}
-                        disabled={dis}
-                        onSelect={(path) => {
-                          setRadSub(path);
-                          setRadMapDirty(true);
-                        }}
-                      />
-                    </div>
-                  </label>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    className={mmActionButtonClass({ variant: "secondary", disabled: dis || radRootFoldersFetch.isPending })}
-                    disabled={dis || radRootFoldersFetch.isPending}
-                    onClick={() => void detectRadarrRootFolders()}
-                  >
-                    {radRootFoldersFetch.isPending ? "Detecting..." : "Detect Radarr paths"}
-                  </button>
-                  <p className="basis-full text-xs text-[var(--mm-text2)]">
-                    Pulls Radarr root folders through the API. Use these when Radarr reports container or NAS paths differently from MediaMop.
-                  </p>
-                </div>
-                <ArrRootFolderChoices
-                  label="Radarr"
-                  folders={radRootFolders}
-                  message={radRootMessage}
-                  error={radRootError}
-                  onUseArr={(path) => {
-                    setRadArr(path);
-                    setRadMapDirty(true);
-                  }}
-                  onUseBoth={(path) => {
-                    setRadArr(path);
-                    setRadSub(path);
-                    setRadMapDirty(true);
-                  }}
-                />
-              </>
-            ) : null}
-            <button
-              type="button"
-              className={mmActionButtonClass({ variant: radMapDirty ? "primary" : "secondary", disabled: dis || !radMapDirty })}
-              disabled={dis || !radMapDirty}
-              onClick={() => void saveRadarrPathMapping()}
-              data-testid="subber-save-radarr-path-mapping"
+            <SubberSettingsSection
+              title="Path mapping"
+              description="Only needed when Subber and Radarr run in separate containers."
             >
-              Save Radarr path mapping
-            </button>
-            <SaveFeedback ok={saveRadMap.ok} err={saveRadMap.err} />
-          </SubberSettingsSection>
+              <MmOnOffSwitch
+                id="subber-rad-map"
+                label="Enable Radarr path mapping"
+                enabled={radMapEn}
+                disabled={dis}
+                onChange={(v) => {
+                  setRadMapEn(v);
+                  setRadMapDirty(true);
+                }}
+              />
+              {radMapEn ? (
+                <>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                    <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
+                      Path as Radarr reports it
+                      <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                        <input
+                          className="mm-input w-full font-mono text-sm"
+                          value={radArr}
+                          disabled={dis}
+                          onChange={(e) => {
+                            setRadArr(e.target.value);
+                            setRadMapDirty(true);
+                          }}
+                        />
+                        <ServerFolderPickerButton
+                          title="Choose Radarr Movies path"
+                          value={radArr}
+                          disabled={dis}
+                          onSelect={(path) => {
+                            setRadArr(path);
+                            setRadMapDirty(true);
+                          }}
+                        />
+                      </div>
+                    </label>
+                    <label className="block min-w-0 flex-1 text-sm text-[var(--mm-text2)]">
+                      Path as MediaMop sees it
+                      <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                        <input
+                          className="mm-input w-full font-mono text-sm"
+                          value={radSub}
+                          disabled={dis}
+                          onChange={(e) => {
+                            setRadSub(e.target.value);
+                            setRadMapDirty(true);
+                          }}
+                        />
+                        <ServerFolderPickerButton
+                          title="Choose MediaMop Movies path"
+                          value={radSub}
+                          disabled={dis}
+                          onSelect={(path) => {
+                            setRadSub(path);
+                            setRadMapDirty(true);
+                          }}
+                        />
+                      </div>
+                    </label>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: dis || radRootFoldersFetch.isPending,
+                      })}
+                      disabled={dis || radRootFoldersFetch.isPending}
+                      onClick={() => void detectRadarrRootFolders()}
+                    >
+                      {radRootFoldersFetch.isPending
+                        ? "Detecting..."
+                        : "Detect Radarr paths"}
+                    </button>
+                    <p className="basis-full text-xs text-[var(--mm-text2)]">
+                      Pulls Radarr root folders through the API. Use these when
+                      Radarr reports container or NAS paths differently from
+                      MediaMop.
+                    </p>
+                  </div>
+                  <ArrRootFolderChoices
+                    label="Radarr"
+                    folders={radRootFolders}
+                    message={radRootMessage}
+                    error={radRootError}
+                    onUseArr={(path) => {
+                      setRadArr(path);
+                      setRadMapDirty(true);
+                    }}
+                    onUseBoth={(path) => {
+                      setRadArr(path);
+                      setRadSub(path);
+                      setRadMapDirty(true);
+                    }}
+                  />
+                </>
+              ) : null}
+              <button
+                type="button"
+                className={mmActionButtonClass({
+                  variant: radMapDirty ? "primary" : "secondary",
+                  disabled: dis || !radMapDirty,
+                })}
+                disabled={dis || !radMapDirty}
+                onClick={() => void saveRadarrPathMapping()}
+                data-testid="subber-save-radarr-path-mapping"
+              >
+                Save Radarr path mapping
+              </button>
+              <SaveFeedback ok={saveRadMap.ok} err={saveRadMap.err} />
+            </SubberSettingsSection>
           </PathMappingSection>
         </div>
       </div>

--- a/apps/web/src/pages/subber/subber-jobs-tab.tsx
+++ b/apps/web/src/pages/subber/subber-jobs-tab.tsx
@@ -40,7 +40,9 @@ export function SubberJobsTab() {
   const fmt = useAppDateFormatter();
 
   const filtered =
-    statusFilter === "recent" ? (q.data?.jobs ?? []) : (q.data?.jobs ?? []).filter((j) => j.status === statusFilter);
+    statusFilter === "recent"
+      ? (q.data?.jobs ?? [])
+      : (q.data?.jobs ?? []).filter((j) => j.status === statusFilter);
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const pagedRows = filtered.slice((page - 1) * pageSize, page * pageSize);
 
@@ -60,20 +62,30 @@ export function SubberJobsTab() {
       data-testid="subber-jobs-tab"
     >
       <header className="border-b border-[var(--mm-border)] bg-black/10 px-4 py-3.5 sm:px-5 sm:py-4">
-        <h2 className="text-lg font-semibold tracking-tight text-[var(--mm-text)]">Jobs</h2>
-        <p className="mt-1 text-sm text-[var(--mm-text2)]">Pending, running, and recent Subber work.</p>
+        <h2 className="text-lg font-semibold tracking-tight text-[var(--mm-text)]">
+          Jobs
+        </h2>
+        <p className="mt-1 text-sm text-[var(--mm-text2)]">
+          Pending, running, and recent Subber work.
+        </p>
       </header>
       <div className="space-y-4 px-4 py-4 sm:px-5 sm:py-5">
         <div className="flex flex-col gap-3 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3.5 py-3.5 sm:flex-row sm:items-end sm:justify-between sm:px-5 sm:py-4">
           <label className="block min-w-0 flex-1">
-            <span id={filterLabelId} className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]">
+            <span
+              id={filterLabelId}
+              className="text-xs font-semibold uppercase tracking-wide text-[var(--mm-text3)]"
+            >
               Show jobs
             </span>
             <MmListboxPicker
               className="mt-2 max-w-xl"
               ariaLabelledBy={filterLabelId}
               placeholder="Recent (all statuses, newest first)"
-              options={JOB_FILTER_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+              options={JOB_FILTER_OPTIONS.map((o) => ({
+                value: o.value,
+                label: o.label,
+              }))}
               value={statusFilter}
               onChange={(v) => setStatusFilter(v)}
             />
@@ -87,42 +99,57 @@ export function SubberJobsTab() {
         ) : filtered.length > 0 ? (
           <>
             <div className="overflow-x-auto rounded border border-[var(--mm-border)]">
-            <table className="w-full min-w-[32rem] text-left text-sm">
-              <thead className="bg-black/20 text-[var(--mm-text2)]">
-                <tr>
-                  <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">Job</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Scope</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Status</th>
-                  <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">Updated</th>
-                </tr>
-              </thead>
-              <tbody>
-                {pagedRows.map((j) => (
-                  <tr key={j.id} className="border-t border-[var(--mm-border)]">
-                    <td className="sticky left-0 z-[1] max-w-[14rem] break-words bg-[var(--mm-card-bg)] px-3 py-2">
-                      {jobLabel(j.job_kind)}
-                    </td>
-                    <td className="px-3 py-2 capitalize text-[var(--mm-text2)]">{j.scope ?? "—"}</td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={
-                          j.status === "completed"
-                            ? "text-emerald-500"
-                            : j.status === "failed"
-                              ? "text-red-400"
-                              : j.status === "running"
-                                ? "text-amber-400"
-                                : "text-[var(--mm-text2)]"
-                        }
-                      >
-                        {j.status}
-                      </span>
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-xs text-[var(--mm-text2)]">{fmt(j.updated_at)}</td>
+              <table className="w-full min-w-[32rem] text-left text-sm">
+                <thead className="bg-black/20 text-[var(--mm-text2)]">
+                  <tr>
+                    <th className="sticky left-0 top-0 z-30 bg-black/20 px-3 py-2 font-medium">
+                      Job
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Scope
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Status
+                    </th>
+                    <th className="sticky top-0 z-20 bg-black/20 px-3 py-2 font-medium">
+                      Updated
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {pagedRows.map((j) => (
+                    <tr
+                      key={j.id}
+                      className="border-t border-[var(--mm-border)]"
+                    >
+                      <td className="sticky left-0 z-[1] max-w-[14rem] break-words bg-[var(--mm-card-bg)] px-3 py-2">
+                        {jobLabel(j.job_kind)}
+                      </td>
+                      <td className="px-3 py-2 capitalize text-[var(--mm-text2)]">
+                        {j.scope ?? "—"}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={
+                            j.status === "completed"
+                              ? "text-emerald-500"
+                              : j.status === "failed"
+                                ? "text-red-400"
+                                : j.status === "running"
+                                  ? "text-amber-400"
+                                  : "text-[var(--mm-text2)]"
+                          }
+                        >
+                          {j.status}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 text-xs text-[var(--mm-text2)]">
+                        {fmt(j.updated_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
             <MmJobsPagination
               page={page}
@@ -135,7 +162,9 @@ export function SubberJobsTab() {
           </>
         ) : (
           <div className="space-y-1 rounded border border-[var(--mm-border)] bg-black/10 px-5 py-10 text-center">
-            <p className="text-sm font-medium text-[var(--mm-text)]">No jobs match this view</p>
+            <p className="text-sm font-medium text-[var(--mm-text)]">
+              No jobs match this view
+            </p>
             <p className="text-xs text-[var(--mm-text2)]">
               {statusFilter !== "recent"
                 ? `Nothing with status "${statusFilter}" yet. Try Recent (all statuses) for the latest rows.`
@@ -145,8 +174,12 @@ export function SubberJobsTab() {
         )}
 
         <p className="text-xs text-[var(--mm-text2)]">
-          Full detail on every subtitle search, sync result, and any errors is in the{" "}
-          <Link to="/app/activity" className="text-[var(--mm-accent)] underline">
+          Full detail on every subtitle search, sync result, and any errors is
+          in the{" "}
+          <Link
+            to="/app/activity"
+            className="text-[var(--mm-accent)] underline"
+          >
             Activity log
           </Link>
           .

--- a/apps/web/src/pages/subber/subber-library-details.tsx
+++ b/apps/web/src/pages/subber/subber-library-details.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from "react";
 import type { SubberSubtitleLangState } from "../../lib/subber/subber-api";
 import { subberLanguageLabel } from "../../lib/subber/subber-languages";
 
-export function subberProviderDisplayLabel(key: string | null | undefined): string {
+export function subberProviderDisplayLabel(
+  key: string | null | undefined,
+): string {
   if (!key) return "—";
   const labels: Record<string, string> = {
     opensubtitles_org: "OpenSubtitles.org",
@@ -14,11 +16,21 @@ export function subberProviderDisplayLabel(key: string | null | undefined): stri
   return labels[key] ?? key;
 }
 
-function DetailField({ label, children }: { label: string; children: ReactNode }) {
+function DetailField({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
   return (
     <div className="min-w-0">
-      <div className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">{label}</div>
-      <div className="mt-1 text-sm leading-snug text-[var(--mm-text)]">{children}</div>
+      <div className="text-[0.65rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">
+        {label}
+      </div>
+      <div className="mt-1 text-sm leading-snug text-[var(--mm-text)]">
+        {children}
+      </div>
     </div>
   );
 }
@@ -27,7 +39,9 @@ function DetailField({ label, children }: { label: string; children: ReactNode }
 export function SubberMediaFilePathBlock({ path }: { path: string }) {
   return (
     <section className="space-y-1.5">
-      <h4 className="text-[0.7rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">Media file</h4>
+      <h4 className="text-[0.7rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">
+        Media file
+      </h4>
       <div className="max-w-full overflow-x-auto rounded-md border border-[var(--mm-border)] bg-black/20 px-2.5 py-2 font-mono text-xs leading-relaxed text-[var(--mm-text)]">
         {path}
       </div>
@@ -35,10 +49,16 @@ export function SubberMediaFilePathBlock({ path }: { path: string }) {
   );
 }
 
-export function SubberLanguageTracksDetails({ languages }: { languages: SubberSubtitleLangState[] }) {
+export function SubberLanguageTracksDetails({
+  languages,
+}: {
+  languages: SubberSubtitleLangState[];
+}) {
   return (
     <section className="space-y-2">
-      <h4 className="text-[0.7rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">Per-language state</h4>
+      <h4 className="text-[0.7rem] font-semibold uppercase tracking-wide text-[var(--mm-text2)]">
+        Per-language state
+      </h4>
       <ul className="space-y-2.5">
         {languages.map((l) => (
           <li
@@ -47,18 +67,28 @@ export function SubberLanguageTracksDetails({ languages }: { languages: SubberSu
           >
             <p className="border-b border-[var(--mm-border)]/80 pb-2 text-sm font-medium text-[var(--mm-text)]">
               {subberLanguageLabel(l.language_code)}
-              <span className="ml-1.5 text-xs font-normal text-[var(--mm-text2)]">({l.language_code})</span>
+              <span className="ml-1.5 text-xs font-normal text-[var(--mm-text2)]">
+                ({l.language_code})
+              </span>
             </p>
             <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
               <DetailField label="Subtitle file">
-                <span className="break-all font-mono text-xs">{l.subtitle_path ?? "—"}</span>
+                <span className="break-all font-mono text-xs">
+                  {l.subtitle_path ?? "—"}
+                </span>
               </DetailField>
-              <DetailField label="Last search">{l.last_searched_at ?? "—"}</DetailField>
+              <DetailField label="Last search">
+                {l.last_searched_at ?? "—"}
+              </DetailField>
               <DetailField label="Search count">{l.search_count}</DetailField>
               <DetailField label="Source">{l.source ?? "—"}</DetailField>
-              <DetailField label="Provider">{subberProviderDisplayLabel(l.provider_key)}</DetailField>
+              <DetailField label="Provider">
+                {subberProviderDisplayLabel(l.provider_key)}
+              </DetailField>
               <DetailField label="Upgrades">
-                {(l.upgrade_count ?? 0) > 0 ? `${l.upgrade_count} time(s)` : "None"}
+                {(l.upgrade_count ?? 0) > 0
+                  ? `${l.upgrade_count} time(s)`
+                  : "None"}
               </DetailField>
             </div>
           </li>

--- a/apps/web/src/pages/subber/subber-library-pager.tsx
+++ b/apps/web/src/pages/subber/subber-library-pager.tsx
@@ -59,10 +59,14 @@ export function SubberLibraryPager({
           <>No {itemLabel} match the current filters.</>
         ) : (
           <>
-            Showing <span className="font-medium text-[var(--mm-text)]">{start}</span>
+            Showing{" "}
+            <span className="font-medium text-[var(--mm-text)]">{start}</span>
             {"–"}
-            <span className="font-medium text-[var(--mm-text)]">{end}</span> of{" "}
-            <span className="font-medium text-[var(--mm-text)]">{total}</span> {itemLabel}
+            <span className="font-medium text-[var(--mm-text)]">
+              {end}
+            </span> of{" "}
+            <span className="font-medium text-[var(--mm-text)]">{total}</span>{" "}
+            {itemLabel}
           </>
         )}
       </p>

--- a/apps/web/src/pages/subber/subber-movies-tab.test.tsx
+++ b/apps/web/src/pages/subber/subber-movies-tab.test.tsx
@@ -23,7 +23,9 @@ describe("SubberMoviesTab", () => {
 
   beforeEach(() => {
     vi.spyOn(subberQueries, "useSubberSettingsQuery").mockReturnValue({
-      data: { language_preferences: ["en"] } as ReturnType<typeof subberQueries.useSubberSettingsQuery>["data"],
+      data: { language_preferences: ["en"] } as ReturnType<
+        typeof subberQueries.useSubberSettingsQuery
+      >["data"],
       isLoading: false,
       isError: false,
     } as unknown as ReturnType<typeof subberQueries.useSubberSettingsQuery>);
@@ -34,28 +36,49 @@ describe("SubberMoviesTab", () => {
             file_path: "/m.mkv",
             movie_title: "Inception",
             movie_year: 2010,
-            languages: [{ state_id: 2, language_code: "en", status: "missing", subtitle_path: null, last_searched_at: null, search_count: 0, source: null }],
+            languages: [
+              {
+                state_id: 2,
+                language_code: "en",
+                status: "missing",
+                subtitle_path: null,
+                last_searched_at: null,
+                search_count: 0,
+                source: null,
+              },
+            ],
           },
         ],
         total: 1,
       },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberLibraryMoviesQuery>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberLibraryMoviesQuery
+    >);
     vi.spyOn(subberQueries, "useSubberSearchNowMutation").mockReturnValue({
       mutate,
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchNowMutation>);
-    vi.spyOn(subberQueries, "useSubberSearchAllMissingMoviesMutation").mockReturnValue({
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchNowMutation
+    >);
+    vi.spyOn(
+      subberQueries,
+      "useSubberSearchAllMissingMoviesMutation",
+    ).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchAllMissingMoviesMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchAllMissingMoviesMutation
+    >);
   });
 
   it("renders movie row and Search now", async () => {
     const client = new QueryClient();
     render(wrap(<SubberMoviesTab canOperate />, client));
-    await waitFor(() => expect(screen.getByText(/Inception/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/Inception/)).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByTestId("subber-movies-search-now"));
     expect(mutate).toHaveBeenCalledWith(2);
   });
@@ -65,9 +88,13 @@ describe("SubberMoviesTab", () => {
       data: { movies: [], total: 0 },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberLibraryMoviesQuery>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberLibraryMoviesQuery
+    >);
     const client = new QueryClient();
     render(wrap(<SubberMoviesTab canOperate={false} />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-movies-empty")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-movies-empty")).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/pages/subber/subber-movies-tab.tsx
+++ b/apps/web/src/pages/subber/subber-movies-tab.tsx
@@ -34,9 +34,14 @@ function langBadge(status: string, code: string) {
   );
 }
 
-function pickSearchStateId(row: SubberMovieRow, prefs: string[]): number | null {
+function pickSearchStateId(
+  row: SubberMovieRow,
+  prefs: string[],
+): number | null {
   for (const p of prefs) {
-    const lang = row.languages.find((l) => l.language_code.toLowerCase() === p.toLowerCase());
+    const lang = row.languages.find(
+      (l) => l.language_code.toLowerCase() === p.toLowerCase(),
+    );
     if (lang && lang.status !== "found") return lang.state_id;
   }
   const any = row.languages.find((l) => l.status !== "found");
@@ -45,9 +50,16 @@ function pickSearchStateId(row: SubberMovieRow, prefs: string[]): number | null 
 
 function coverageState(row: SubberMovieRow, prefs: string[]): string {
   const preferredRows = prefs
-    .map((code) => row.languages.find((item) => item.language_code.toLowerCase() === code.toLowerCase()))
+    .map((code) =>
+      row.languages.find(
+        (item) => item.language_code.toLowerCase() === code.toLowerCase(),
+      ),
+    )
     .filter((item): item is NonNullable<typeof item> => Boolean(item));
-  if (preferredRows.length > 0 && preferredRows.every((item) => item.status === "found")) {
+  if (
+    preferredRows.length > 0 &&
+    preferredRows.every((item) => item.status === "found")
+  ) {
     return "Preferred subtitle found";
   }
   return "Still missing";
@@ -59,7 +71,9 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
   const [status, setStatus] = useState<string>("all");
   const [search, setSearch] = useState("");
   const [language, setLanguage] = useState("");
-  const [pageSize, setPageSizeState] = useState<SubberLibraryPageSize>(() => readSubberLibraryPageSize());
+  const [pageSize, setPageSizeState] = useState<SubberLibraryPageSize>(() =>
+    readSubberLibraryPageSize(),
+  );
   const [page, setPage] = useState(0);
 
   const filters = useMemo(
@@ -78,7 +92,8 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
 
   const total = libQ.data?.total ?? 0;
   const movies = libQ.data?.movies ?? [];
-  const hasActiveFilters = status !== "all" || Boolean(search.trim()) || Boolean(language.trim());
+  const hasActiveFilters =
+    status !== "all" || Boolean(search.trim()) || Boolean(language.trim());
 
   useEffect(() => {
     setPage(0);
@@ -100,7 +115,9 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
   return (
     <div className="space-y-4" data-testid="subber-movies-tab">
       <div className="rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/30 p-4">
-        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">Filters</p>
+        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">
+          Filters
+        </p>
         <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
             Search
@@ -113,7 +130,11 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
           </label>
           <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
             Subtitles
-            <select className="mm-input min-w-[11rem]" value={status} onChange={(e) => setStatus(e.target.value)}>
+            <select
+              className="mm-input min-w-[11rem]"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
               <option value="all">All titles</option>
               <option value="missing">Missing subtitles</option>
               <option value="complete">All preferred languages found</option>
@@ -141,10 +162,17 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
           ) : null}
         </div>
       </div>
-      {libQ.isLoading ? <p className="text-sm text-[var(--mm-text2)]">Loading movies…</p> : null}
-      {libQ.isError ? <p className="text-sm text-red-600">{(libQ.error as Error).message}</p> : null}
+      {libQ.isLoading ? (
+        <p className="text-sm text-[var(--mm-text2)]">Loading movies…</p>
+      ) : null}
+      {libQ.isError ? (
+        <p className="text-sm text-red-600">{(libQ.error as Error).message}</p>
+      ) : null}
       {!libQ.isLoading && !libQ.isError && total === 0 ? (
-        <p className="text-sm text-[var(--mm-text2)]" data-testid="subber-movies-empty">
+        <p
+          className="text-sm text-[var(--mm-text2)]"
+          data-testid="subber-movies-empty"
+        >
           {hasActiveFilters
             ? "No movies match the current filters. Try All titles or clear search."
             : "No movies are tracked yet. Open Connections and run Sync Movies library from Radarr, or wait for a new Radarr import."}
@@ -173,10 +201,21 @@ export function SubberMoviesTab({ canOperate }: { canOperate: boolean }) {
                 <div className="min-w-0 flex-1 space-y-2">
                   <h3 className="text-base font-semibold leading-tight text-[var(--mm-text)]">
                     {m.movie_title ?? m.file_path}
-                    {m.movie_year != null ? <span className="text-[var(--mm-text2)]"> ({m.movie_year})</span> : null}
+                    {m.movie_year != null ? (
+                      <span className="text-[var(--mm-text2)]">
+                        {" "}
+                        ({m.movie_year})
+                      </span>
+                    ) : null}
                   </h3>
-                  <p className="text-sm text-[var(--mm-text2)]">{coverageState(m, prefs)}</p>
-                  <div className="flex flex-wrap gap-1">{m.languages.map((l) => langBadge(l.status, l.language_code))}</div>
+                  <p className="text-sm text-[var(--mm-text2)]">
+                    {coverageState(m, prefs)}
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {m.languages.map((l) =>
+                      langBadge(l.status, l.language_code),
+                    )}
+                  </div>
                 </div>
                 {canOperate && hasMissing && sid != null ? (
                   <div className="flex shrink-0 sm:pt-0.5">

--- a/apps/web/src/pages/subber/subber-overview-tab.tsx
+++ b/apps/web/src/pages/subber/subber-overview-tab.tsx
@@ -9,7 +9,10 @@ import {
   MmStatTile,
   MmStatTileRow,
 } from "../../components/overview/mm-overview-cards";
-import { isHttpErrorFromApi, isLikelyNetworkFailure } from "../../lib/api/error-guards";
+import {
+  isHttpErrorFromApi,
+  isLikelyNetworkFailure,
+} from "../../lib/api/error-guards";
 import {
   useSubberOverviewQuery,
   useSubberProvidersQuery,
@@ -19,7 +22,10 @@ function formatWhen(iso: string | null | undefined): string {
   if (!iso) return "—";
   const d = new Date(iso);
   if (Number.isNaN(d.valueOf())) return "—";
-  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(d);
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(d);
 }
 
 type AttentionTarget = "settings" | "tv" | "movies";
@@ -29,7 +35,11 @@ type SubberOverviewNavTab = "settings" | "tv" | "movies" | "schedule" | "jobs";
 const SUBBER_NEXT_STEPS_BODY =
   "Use Settings to connect OpenSubtitles, Sonarr, and Radarr. Check TV and Movies to see your library and search for missing subtitles. Use Schedule to automate searches and Jobs for recent activity.";
 
-function SubberOverviewNextSteps({ onOpenTab }: { onOpenTab?: (tab: SubberOverviewNavTab) => void }) {
+function SubberOverviewNextSteps({
+  onOpenTab,
+}: {
+  onOpenTab?: (tab: SubberOverviewNavTab) => void;
+}) {
   return (
     <MmOverviewSection
       headingId="subber-overview-next-steps-heading"
@@ -41,10 +51,19 @@ function SubberOverviewNextSteps({ onOpenTab }: { onOpenTab?: (tab: SubberOvervi
         <p className="leading-relaxed">{SUBBER_NEXT_STEPS_BODY}</p>
         {onOpenTab ? (
           <div className="flex flex-wrap gap-2.5 border-t border-[var(--mm-border)] pt-4">
-            <MmNextStepsButton label="Settings" onClick={() => onOpenTab("settings")} />
+            <MmNextStepsButton
+              label="Settings"
+              onClick={() => onOpenTab("settings")}
+            />
             <MmNextStepsButton label="TV" onClick={() => onOpenTab("tv")} />
-            <MmNextStepsButton label="Movies" onClick={() => onOpenTab("movies")} />
-            <MmNextStepsButton label="Schedule" onClick={() => onOpenTab("schedule")} />
+            <MmNextStepsButton
+              label="Movies"
+              onClick={() => onOpenTab("movies")}
+            />
+            <MmNextStepsButton
+              label="Schedule"
+              onClick={() => onOpenTab("schedule")}
+            />
             <MmNextStepsButton label="Jobs" onClick={() => onOpenTab("jobs")} />
           </div>
         ) : null}
@@ -76,14 +95,16 @@ function buildSubberNeedsAttention(args: {
     });
   }
 
-  const sonConnected = Boolean(s.sonarr_base_url?.trim()) && Boolean(s.sonarr_api_key_set);
+  const sonConnected =
+    Boolean(s.sonarr_base_url?.trim()) && Boolean(s.sonarr_api_key_set);
   if (!sonConnected) {
     items.push({
       text: "Connect Sonarr in Settings to track your TV library.",
       target: "settings",
     });
   }
-  const radConnected = Boolean(s.radarr_base_url?.trim()) && Boolean(s.radarr_api_key_set);
+  const radConnected =
+    Boolean(s.radarr_base_url?.trim()) && Boolean(s.radarr_api_key_set);
   if (!radConnected) {
     items.push({
       text: "Connect Radarr in Settings to track your Movies library.",
@@ -136,7 +157,11 @@ function SubberOverviewLoadError({ err }: { err: unknown }) {
             ? "The server refused this request. Sign in again or check API logs."
             : "Could not load Subber overview."}
       </p>
-      {err instanceof Error ? <p className="mm-page__lead font-mono text-sm text-[var(--mm-text3)]">{err.message}</p> : null}
+      {err instanceof Error ? (
+        <p className="mm-page__lead font-mono text-sm text-[var(--mm-text3)]">
+          {err.message}
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -174,13 +199,21 @@ export function SubberOverviewTab({
   const plist = providersQ.data;
   const st = overviewQ.data;
 
-  const sonConnected = Boolean(s.sonarr_base_url?.trim() && s.sonarr_api_key_set);
-  const radConnected = Boolean(s.radarr_base_url?.trim() && s.radarr_api_key_set);
+  const sonConnected = Boolean(
+    s.sonarr_base_url?.trim() && s.sonarr_api_key_set,
+  );
+  const radConnected = Boolean(
+    s.radarr_base_url?.trim() && s.radarr_api_key_set,
+  );
   const enabledProviders = plist.filter((p) => p.enabled).length;
   const providerTotal = plist.length;
   const enabledProviderList = plist.filter((p) => p.enabled);
 
-  const attentionItems = buildSubberNeedsAttention({ settings: s, providers: plist, stats: st });
+  const attentionItems = buildSubberNeedsAttention({
+    settings: s,
+    providers: plist,
+    stats: st,
+  });
 
   const providersGlanceBody = (
     <div className="space-y-1.5">
@@ -206,15 +239,21 @@ export function SubberOverviewTab({
     <div className="space-y-1.5">
       <p>
         <span className="text-[var(--mm-text3)]">Status:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{sonConnected ? "Credentials saved" : "Not configured"}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {sonConnected ? "Credentials saved" : "Not configured"}
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">TV tracked:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{st.tv_tracked} episodes</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {st.tv_tracked} episodes
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">Last sync:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{formatWhen(s.tv_last_scheduled_scan_enqueued_at)}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {formatWhen(s.tv_last_scheduled_scan_enqueued_at)}
+        </span>
       </p>
     </div>
   );
@@ -223,15 +262,21 @@ export function SubberOverviewTab({
     <div className="space-y-1.5">
       <p>
         <span className="text-[var(--mm-text3)]">Status:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{radConnected ? "Credentials saved" : "Not configured"}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {radConnected ? "Credentials saved" : "Not configured"}
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">Movies tracked:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{st.movies_tracked} movies</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {st.movies_tracked} movies
+        </span>
       </p>
       <p>
         <span className="text-[var(--mm-text3)]">Last sync:</span>{" "}
-        <span className="font-medium text-[var(--mm-text1)]">{formatWhen(s.movies_last_scheduled_scan_enqueued_at)}</span>
+        <span className="font-medium text-[var(--mm-text1)]">
+          {formatWhen(s.movies_last_scheduled_scan_enqueued_at)}
+        </span>
       </p>
     </div>
   );
@@ -244,13 +289,19 @@ export function SubberOverviewTab({
         <MmStatTile label="Not found" value={st.not_found_last_30_days} />
       </MmStatTileRow>
       <MmStatCaption>
-        {st.upgrades_last_30_days === 1 ? "1 upgrade" : `${st.upgrades_last_30_days} upgrades`} downloaded · last 30 days
+        {st.upgrades_last_30_days === 1
+          ? "1 upgrade"
+          : `${st.upgrades_last_30_days} upgrades`}{" "}
+        downloaded · last 30 days
       </MmStatCaption>
     </div>
   );
 
   return (
-    <div data-testid="subber-overview-tab" className="mm-bubble-stack w-full min-w-0">
+    <div
+      data-testid="subber-overview-tab"
+      className="mm-bubble-stack w-full min-w-0"
+    >
       <MmOverviewSection
         headingId="subber-overview-at-a-glance-heading"
         heading="At a glance"
@@ -271,7 +322,12 @@ export function SubberOverviewTab({
             body={sonarrBody}
             gridClassName="lg:col-span-4"
             footer={
-              onOpenTab ? <MmNextStepsButton label="Settings" onClick={() => onOpenTab("settings")} /> : undefined
+              onOpenTab ? (
+                <MmNextStepsButton
+                  label="Settings"
+                  onClick={() => onOpenTab("settings")}
+                />
+              ) : undefined
             }
           />
           <MmAtGlanceCard
@@ -280,7 +336,12 @@ export function SubberOverviewTab({
             body={radarrBody}
             gridClassName="lg:col-span-4"
             footer={
-              onOpenTab ? <MmNextStepsButton label="Settings" onClick={() => onOpenTab("settings")} /> : undefined
+              onOpenTab ? (
+                <MmNextStepsButton
+                  label="Settings"
+                  onClick={() => onOpenTab("settings")}
+                />
+              ) : undefined
             }
           />
           <MmAtGlanceCard
@@ -289,7 +350,12 @@ export function SubberOverviewTab({
             body={providersGlanceBody}
             gridClassName="sm:col-span-2 lg:col-span-12"
             footer={
-              onOpenTab ? <MmNextStepsButton label="Open Settings" onClick={() => onOpenTab("settings")} /> : undefined
+              onOpenTab ? (
+                <MmNextStepsButton
+                  label="Open Settings"
+                  onClick={() => onOpenTab("settings")}
+                />
+              ) : undefined
             }
           />
         </MmAtGlanceGrid>
@@ -305,7 +371,10 @@ export function SubberOverviewTab({
           items={attentionItems.map((row) => row.text)}
           actions={
             onOpenTab && attentionItems.length > 0 ? (
-              <MmNextStepsButton label="Open Settings" onClick={() => onOpenTab("settings")} />
+              <MmNextStepsButton
+                label="Open Settings"
+                onClick={() => onOpenTab("settings")}
+              />
             ) : undefined
           }
         />

--- a/apps/web/src/pages/subber/subber-page.test.tsx
+++ b/apps/web/src/pages/subber/subber-page.test.tsx
@@ -58,6 +58,8 @@ describe("SubberPage", () => {
           priority: 0,
           requires_account: true,
           has_credentials: false,
+          available: true,
+          availability_note: null,
         },
       ],
       isLoading: false,

--- a/apps/web/src/pages/subber/subber-page.test.tsx
+++ b/apps/web/src/pages/subber/subber-page.test.tsx
@@ -106,7 +106,9 @@ describe("SubberPage", () => {
       data: { movies: [] },
       isLoading: false,
       isError: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberLibraryMoviesQuery>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberLibraryMoviesQuery
+    >);
     vi.spyOn(subberQueries, "useSubberJobsQuery").mockReturnValue({
       data: { jobs: [], default_recent_slice: true },
       isLoading: false,
@@ -115,37 +117,62 @@ describe("SubberPage", () => {
     vi.spyOn(subberQueries, "usePutSubberSettingsMutation").mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.usePutSubberSettingsMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.usePutSubberSettingsMutation
+    >);
     vi.spyOn(subberQueries, "useSubberSearchNowMutation").mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchNowMutation>);
-    vi.spyOn(subberQueries, "useSubberSearchAllMissingTvMutation").mockReturnValue({
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchNowMutation
+    >);
+    vi.spyOn(
+      subberQueries,
+      "useSubberSearchAllMissingTvMutation",
+    ).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchAllMissingTvMutation>);
-    vi.spyOn(subberQueries, "useSubberSearchAllMissingMoviesMutation").mockReturnValue({
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchAllMissingTvMutation
+    >);
+    vi.spyOn(
+      subberQueries,
+      "useSubberSearchAllMissingMoviesMutation",
+    ).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchAllMissingMoviesMutation>);
-    vi.spyOn(subberQueries, "useSubberTestOpensubtitlesMutation").mockReturnValue({
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchAllMissingMoviesMutation
+    >);
+    vi.spyOn(
+      subberQueries,
+      "useSubberTestOpensubtitlesMutation",
+    ).mockReturnValue({
       mutateAsync: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestOpensubtitlesMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestOpensubtitlesMutation
+    >);
     vi.spyOn(subberQueries, "useSubberTestSonarrMutation").mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestSonarrMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestSonarrMutation
+    >);
     vi.spyOn(subberQueries, "useSubberTestRadarrMutation").mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestRadarrMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestRadarrMutation
+    >);
   });
 
   it("renders tabs with Overview selected by default", async () => {
     const client = new QueryClient();
     render(wrap(<SubberPage />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-top-level-tabs")).toBeInTheDocument(),
+    );
     const tabs = screen.getByTestId("subber-top-level-tabs");
     expect(tabs.textContent).toMatch(/Overview/);
     expect(tabs.textContent).toMatch(/TV/);
@@ -155,8 +182,12 @@ describe("SubberPage", () => {
   it("switches to TV tab", async () => {
     const client = new QueryClient();
     render(wrap(<SubberPage />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-top-level-tabs")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-top-level-tabs")).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByRole("tab", { name: "TV" }));
-    await waitFor(() => expect(screen.getByTestId("subber-tv-tab")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-tv-tab")).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/pages/subber/subber-page.tsx
+++ b/apps/web/src/pages/subber/subber-page.tsx
@@ -9,19 +9,35 @@ import { SubberPreferencesTab } from "./subber-preferences-tab";
 import { SubberProvidersTab } from "./subber-providers-tab";
 import { SubberScheduleTab } from "./subber-schedule-tab";
 import { SubberTvTab } from "./subber-tv-tab";
-import { mmModuleTabBlurbBandClass, mmModuleTabBlurbTextClass } from "../../lib/ui/mm-module-tab-blurb";
+import {
+  mmModuleTabBlurbBandClass,
+  mmModuleTabBlurbTextClass,
+} from "../../lib/ui/mm-module-tab-blurb";
 
-type TopTab = "overview" | "tv" | "movies" | "connections" | "providers" | "preferences" | "schedule" | "jobs";
+type TopTab =
+  | "overview"
+  | "tv"
+  | "movies"
+  | "connections"
+  | "providers"
+  | "preferences"
+  | "schedule"
+  | "jobs";
 
 const SUBBER_TAB_BLURBS: Record<TopTab, string> = {
-  overview: "Review subtitle coverage, provider status, and recent Subber activity.",
+  overview:
+    "Review subtitle coverage, provider status, and recent Subber activity.",
   tv: "Review tracked TV episodes, subtitle coverage, and run TV subtitle searches when needed.",
-  movies: "Review tracked movies, subtitle coverage, and run movie subtitle searches when needed.",
-  connections: "Save and test the service connections and credentials Subber depends on.",
+  movies:
+    "Review tracked movies, subtitle coverage, and run movie subtitle searches when needed.",
+  connections:
+    "Save and test the service connections and credentials Subber depends on.",
   providers:
     "Choose which subtitle sources Subber uses and the order it tries them (lower number = searched first). Open a row to set credentials, enable a source, or test it—keep at least one provider on.",
-  preferences: "Set subtitle language, matching, and selection behavior for downloads.",
-  schedule: "Control automatic subtitle scan timing for TV and Movies, including optional windows.",
+  preferences:
+    "Set subtitle language, matching, and selection behavior for downloads.",
+  schedule:
+    "Control automatic subtitle scan timing for TV and Movies, including optional windows.",
   jobs: "View queued, running, and recent Subber jobs.",
 };
 
@@ -46,7 +62,10 @@ export function SubberPage() {
       <header className="mm-page__intro !mb-0">
         <p className="mm-page__eyebrow">MediaMop</p>
         <h1 className="mm-page__title">Subber</h1>
-        <p className="mm-page__subtitle">Automatically find and download subtitles for your movies and TV shows.</p>
+        <p className="mm-page__subtitle">
+          Automatically find and download subtitles for your movies and TV
+          shows.
+        </p>
       </header>
 
       <nav
@@ -70,18 +89,37 @@ export function SubberPage() {
 
       <div className="mm-bubble-stack" role="tabpanel">
         <div className="mm-bubble-stack min-w-0">
-          <div className={mmModuleTabBlurbBandClass} data-testid="subber-tab-blurb">
-            <p className={mmModuleTabBlurbTextClass}>{SUBBER_TAB_BLURBS[tab]}</p>
+          <div
+            className={mmModuleTabBlurbBandClass}
+            data-testid="subber-tab-blurb"
+          >
+            <p className={mmModuleTabBlurbTextClass}>
+              {SUBBER_TAB_BLURBS[tab]}
+            </p>
           </div>
           {tab === "overview" ? (
-            <SubberOverviewTab onOpenTab={(t) => setTab(t === "settings" ? "connections" : t)} />
+            <SubberOverviewTab
+              onOpenTab={(t) => setTab(t === "settings" ? "connections" : t)}
+            />
           ) : null}
-          {tab === "tv" ? <SubberTvTab canOperate={Boolean(canOperate)} /> : null}
-          {tab === "movies" ? <SubberMoviesTab canOperate={Boolean(canOperate)} /> : null}
-          {tab === "connections" ? <SubberConnectionsTab canOperate={Boolean(canOperate)} /> : null}
-          {tab === "providers" ? <SubberProvidersTab canOperate={Boolean(canOperate)} /> : null}
-          {tab === "preferences" ? <SubberPreferencesTab canOperate={Boolean(canOperate)} /> : null}
-          {tab === "schedule" ? <SubberScheduleTab canOperate={Boolean(canOperate)} /> : null}
+          {tab === "tv" ? (
+            <SubberTvTab canOperate={Boolean(canOperate)} />
+          ) : null}
+          {tab === "movies" ? (
+            <SubberMoviesTab canOperate={Boolean(canOperate)} />
+          ) : null}
+          {tab === "connections" ? (
+            <SubberConnectionsTab canOperate={Boolean(canOperate)} />
+          ) : null}
+          {tab === "providers" ? (
+            <SubberProvidersTab canOperate={Boolean(canOperate)} />
+          ) : null}
+          {tab === "preferences" ? (
+            <SubberPreferencesTab canOperate={Boolean(canOperate)} />
+          ) : null}
+          {tab === "schedule" ? (
+            <SubberScheduleTab canOperate={Boolean(canOperate)} />
+          ) : null}
           {tab === "jobs" ? <SubberJobsTab /> : null}
         </div>
       </div>

--- a/apps/web/src/pages/subber/subber-preferences-tab.tsx
+++ b/apps/web/src/pages/subber/subber-preferences-tab.tsx
@@ -5,8 +5,14 @@ import { MmListboxPicker } from "../../components/ui/mm-listbox-picker";
 import { ServerFolderPickerButton } from "../../components/ui/server-folder-picker-button";
 import type { MmListboxOption } from "../../components/ui/mm-listbox-picker";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
-import { SUBBER_LANGUAGE_OPTIONS, subberLanguageLabel } from "../../lib/subber/subber-languages";
-import { usePutSubberSettingsMutation, useSubberSettingsQuery } from "../../lib/subber/subber-queries";
+import {
+  SUBBER_LANGUAGE_OPTIONS,
+  subberLanguageLabel,
+} from "../../lib/subber/subber-languages";
+import {
+  usePutSubberSettingsMutation,
+  useSubberSettingsQuery,
+} from "../../lib/subber/subber-queries";
 
 function SaveFeedback({ ok, err }: { ok: boolean; err: string | null }) {
   if (err) {
@@ -53,7 +59,9 @@ function SubberSettingsSection({
     >
       <header className="shrink-0 border-b border-[var(--mm-border)] bg-black/10 px-5 py-4">
         {eyebrow ? (
-          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">{eyebrow}</p>
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">
+            {eyebrow}
+          </p>
         ) : null}
         <h2
           className={
@@ -64,7 +72,11 @@ function SubberSettingsSection({
         >
           {title}
         </h2>
-        {description ? <div className="mt-2 text-sm leading-relaxed text-[var(--mm-text2)]">{description}</div> : null}
+        {description ? (
+          <div className="mt-2 text-sm leading-relaxed text-[var(--mm-text2)]">
+            {description}
+          </div>
+        ) : null}
       </header>
       <div className="flex min-h-0 flex-1 flex-col px-5 py-5">
         <div className="mm-card-action-body min-h-0 flex-1">{children}</div>
@@ -93,15 +105,29 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
   const [adaptDirty, setAdaptDirty] = useState(false);
   const [upgradeDirty, setUpgradeDirty] = useState(false);
 
-  const [saveLang, setSaveLang] = useState({ ok: false, err: null as string | null });
-  const [savePrefs, setSavePrefs] = useState({ ok: false, err: null as string | null });
-  const [saveFreq, setSaveFreq] = useState({ ok: false, err: null as string | null });
-  const [saveUpgrade, setSaveUpgrade] = useState({ ok: false, err: null as string | null });
+  const [saveLang, setSaveLang] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [savePrefs, setSavePrefs] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [saveFreq, setSaveFreq] = useState({
+    ok: false,
+    err: null as string | null,
+  });
+  const [saveUpgrade, setSaveUpgrade] = useState({
+    ok: false,
+    err: null as string | null,
+  });
 
   useEffect(() => {
     const d = q.data;
     if (!d) return;
-    setLangs(d.language_preferences?.length ? [...d.language_preferences] : ["en"]);
+    setLangs(
+      d.language_preferences?.length ? [...d.language_preferences] : ["en"],
+    );
     setFolder(d.subtitle_folder ?? "");
     setEnabled(d.enabled);
     setExcludeHi(Boolean(d.exclude_hearing_impaired));
@@ -110,7 +136,12 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
     setAdaptDelayH(d.adaptive_searching_delay_hours ?? 168);
     setAdaptPerm(d.permanent_skip_after_attempts ?? 10);
     setUpEn(Boolean(d.upgrade_enabled));
-    setUpIntervalMin(Math.max(60, Math.round((d.upgrade_schedule_interval_seconds ?? 604800) / 60)));
+    setUpIntervalMin(
+      Math.max(
+        60,
+        Math.round((d.upgrade_schedule_interval_seconds ?? 604800) / 60),
+      ),
+    );
     setLangDirty(false);
     setPrefsDirty(false);
     setAdaptDirty(false);
@@ -178,7 +209,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
       await put.mutateAsync({
         csrf_token,
         upgrade_enabled: upEn,
-        upgrade_schedule_interval_seconds: Math.max(60, Math.min(365 * 24 * 3600, upIntervalMin * 60)),
+        upgrade_schedule_interval_seconds: Math.max(
+          60,
+          Math.min(365 * 24 * 3600, upIntervalMin * 60),
+        ),
       });
       flashSave(setSaveUpgrade);
       setUpgradeDirty(false);
@@ -187,8 +221,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
     }
   }
 
-  if (q.isLoading) return <p className="text-sm text-[var(--mm-text2)]">Loading settings…</p>;
-  if (q.isError) return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
+  if (q.isLoading)
+    return <p className="text-sm text-[var(--mm-text2)]">Loading settings…</p>;
+  if (q.isError)
+    return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
 
   return (
     <div className="mm-bubble-stack" data-testid="subber-preferences-tab">
@@ -196,94 +232,110 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
       <div className="mm-bubble-grid min-w-0 lg:grid-cols-2">
         <section className="order-1 flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] shadow-sm lg:order-none">
           <header className="shrink-0 border-b border-[var(--mm-border)] bg-black/10 px-5 py-4">
-            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">Search order</p>
-            <h2 className="mt-1 text-lg font-semibold tracking-tight text-[var(--mm-text)]">Subtitle languages</h2>
+            <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">
+              Search order
+            </p>
+            <h2 className="mt-1 text-lg font-semibold tracking-tight text-[var(--mm-text)]">
+              Subtitle languages
+            </h2>
             <div className="mt-2 text-sm leading-relaxed text-[var(--mm-text2)]">
-              Subber tries languages in this order. If the first is not found it tries the next automatically.
+              Subber tries languages in this order. If the first is not found it
+              tries the next automatically.
             </div>
           </header>
           <div className="flex min-h-0 flex-1 flex-col px-5 py-5">
             <div className="mm-card-action-body min-h-0 flex-1">
               <div className="flex flex-wrap items-center gap-2">
                 {langs.map((code, idx) => (
-                <span
-                  key={`${code}-${idx}`}
-                  className="inline-flex items-center gap-1 rounded-full border border-[var(--mm-border)] bg-black/15 px-2.5 py-1 text-sm text-[var(--mm-text)]"
-                >
-                  <span>{subberLanguageLabel(code)}</span>
-                  <span className="flex items-center gap-0.5 border-l border-[var(--mm-border)] pl-1.5">
+                  <span
+                    key={`${code}-${idx}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-[var(--mm-border)] bg-black/15 px-2.5 py-1 text-sm text-[var(--mm-text)]"
+                  >
+                    <span>{subberLanguageLabel(code)}</span>
+                    <span className="flex items-center gap-0.5 border-l border-[var(--mm-border)] pl-1.5">
+                      <button
+                        type="button"
+                        className="rounded px-1 text-xs text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)] disabled:opacity-30"
+                        disabled={dis || idx === 0}
+                        aria-label={`Move ${code} up`}
+                        onClick={() => {
+                          const n = [...langs];
+                          [n[idx - 1], n[idx]] = [n[idx], n[idx - 1]];
+                          setLangs(n);
+                          setLangDirty(true);
+                        }}
+                      >
+                        ↑
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded px-1 text-xs text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)] disabled:opacity-30"
+                        disabled={dis || idx >= langs.length - 1}
+                        aria-label={`Move ${code} down`}
+                        onClick={() => {
+                          const n = [...langs];
+                          [n[idx + 1], n[idx]] = [n[idx], n[idx + 1]];
+                          setLangs(n);
+                          setLangDirty(true);
+                        }}
+                      >
+                        ↓
+                      </button>
+                    </span>
                     <button
                       type="button"
-                      className="rounded px-1 text-xs text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)] disabled:opacity-30"
-                      disabled={dis || idx === 0}
-                      aria-label={`Move ${code} up`}
+                      className="ml-0.5 rounded px-1.5 text-base leading-none text-[var(--mm-text2)] hover:bg-red-950/30 hover:text-red-300"
+                      disabled={dis}
+                      aria-label={`Remove ${subberLanguageLabel(code)}`}
                       onClick={() => {
-                        const n = [...langs];
-                        [n[idx - 1], n[idx]] = [n[idx], n[idx - 1]];
-                        setLangs(n);
+                        setLangs(langs.filter((_, i) => i !== idx));
                         setLangDirty(true);
                       }}
                     >
-                      ↑
-                    </button>
-                    <button
-                      type="button"
-                      className="rounded px-1 text-xs text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)] disabled:opacity-30"
-                      disabled={dis || idx >= langs.length - 1}
-                      aria-label={`Move ${code} down`}
-                      onClick={() => {
-                        const n = [...langs];
-                        [n[idx + 1], n[idx]] = [n[idx], n[idx + 1]];
-                        setLangs(n);
-                        setLangDirty(true);
-                      }}
-                    >
-                      ↓
+                      ×
                     </button>
                   </span>
-                  <button
-                    type="button"
-                    className="ml-0.5 rounded px-1.5 text-base leading-none text-[var(--mm-text2)] hover:bg-red-950/30 hover:text-red-300"
-                    disabled={dis}
-                    aria-label={`Remove ${subberLanguageLabel(code)}`}
-                    onClick={() => {
-                      setLangs(langs.filter((_, i) => i !== idx));
-                      setLangDirty(true);
-                    }}
-                  >
-                    ×
-                  </button>
-                </span>
                 ))}
               </div>
               <div>
-              <span id="subber-add-language-label" className="block text-sm text-[var(--mm-text2)]">
-                Add language
-              </span>
-              <MmListboxPicker
-                className="mt-1 max-w-xs"
-                ariaLabelledBy="subber-add-language-label"
-                placeholder="Choose…"
-                disabled={dis}
-                options={[
-                  { value: "", label: "Choose…" },
-                  ...SUBBER_LANGUAGE_OPTIONS.filter((o) => !langs.includes(o.code)).map(
-                    (o): MmListboxOption => ({ value: o.code, label: o.label }),
-                  ),
-                ]}
-                value=""
-                onChange={(v) => {
-                  if (!v || langs.includes(v)) return;
-                  setLangs([...langs, v]);
-                  setLangDirty(true);
-                }}
-              />
+                <span
+                  id="subber-add-language-label"
+                  className="block text-sm text-[var(--mm-text2)]"
+                >
+                  Add language
+                </span>
+                <MmListboxPicker
+                  className="mt-1 max-w-xs"
+                  ariaLabelledBy="subber-add-language-label"
+                  placeholder="Choose…"
+                  disabled={dis}
+                  options={[
+                    { value: "", label: "Choose…" },
+                    ...SUBBER_LANGUAGE_OPTIONS.filter(
+                      (o) => !langs.includes(o.code),
+                    ).map(
+                      (o): MmListboxOption => ({
+                        value: o.code,
+                        label: o.label,
+                      }),
+                    ),
+                  ]}
+                  value=""
+                  onChange={(v) => {
+                    if (!v || langs.includes(v)) return;
+                    setLangs([...langs, v]);
+                    setLangDirty(true);
+                  }}
+                />
               </div>
             </div>
             <div className="mm-card-action-footer">
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: langDirty ? "primary" : "secondary", disabled: dis || !langDirty })}
+                className={mmActionButtonClass({
+                  variant: langDirty ? "primary" : "secondary",
+                  disabled: dis || !langDirty,
+                })}
                 disabled={dis || !langDirty}
                 onClick={() => void saveLanguages()}
                 data-testid="subber-save-languages"
@@ -304,7 +356,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
             <>
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: adaptDirty ? "primary" : "secondary", disabled: dis || !adaptDirty })}
+                className={mmActionButtonClass({
+                  variant: adaptDirty ? "primary" : "secondary",
+                  disabled: dis || !adaptDirty,
+                })}
                 disabled={dis || !adaptDirty}
                 onClick={() => void saveSearchFrequency()}
               >
@@ -327,7 +382,9 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
           {adaptEn ? (
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm text-[var(--mm-text2)]">Back off after</span>
+                <span className="text-sm text-[var(--mm-text2)]">
+                  Back off after
+                </span>
                 <input
                   type="number"
                   className="mm-input max-w-24"
@@ -340,7 +397,9 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
                     setAdaptDirty(true);
                   }}
                 />
-                <span className="text-sm text-[var(--mm-text2)]">failed attempts</span>
+                <span className="text-sm text-[var(--mm-text2)]">
+                  failed attempts
+                </span>
               </div>
               <div className="flex flex-wrap items-center gap-2">
                 <span className="text-sm text-[var(--mm-text2)]">Wait</span>
@@ -356,10 +415,14 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
                     setAdaptDirty(true);
                   }}
                 />
-                <span className="text-sm text-[var(--mm-text2)]">hours before retrying</span>
+                <span className="text-sm text-[var(--mm-text2)]">
+                  hours before retrying
+                </span>
               </div>
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm text-[var(--mm-text2)]">Give up after</span>
+                <span className="text-sm text-[var(--mm-text2)]">
+                  Give up after
+                </span>
                 <input
                   type="number"
                   className="mm-input max-w-24"
@@ -372,7 +435,9 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
                     setAdaptDirty(true);
                   }}
                 />
-                <span className="text-sm text-[var(--mm-text2)]">total attempts</span>
+                <span className="text-sm text-[var(--mm-text2)]">
+                  total attempts
+                </span>
               </div>
             </div>
           ) : null}
@@ -387,7 +452,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
             <>
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: prefsDirty ? "primary" : "secondary", disabled: dis || !prefsDirty })}
+                className={mmActionButtonClass({
+                  variant: prefsDirty ? "primary" : "secondary",
+                  disabled: dis || !prefsDirty,
+                })}
                 disabled={dis || !prefsDirty}
                 onClick={() => void savePreferences()}
                 data-testid="subber-save-subtitle-folder"
@@ -399,7 +467,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
           }
         >
           <div>
-            <label className="block text-sm font-medium text-[var(--mm-text)]" htmlFor="subber-subtitle-folder">
+            <label
+              className="block text-sm font-medium text-[var(--mm-text)]"
+              htmlFor="subber-subtitle-folder"
+            >
               Subtitle folder
             </label>
             <input
@@ -425,8 +496,8 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
               />
             </div>
             <p className="mt-1 text-xs text-[var(--mm-text2)]">
-              Leave empty to save subtitles next to your media file. Subtitles are named to match — Movie.2023.en.srt alongside
-              Movie.2023.mkv.
+              Leave empty to save subtitles next to your media file. Subtitles
+              are named to match — Movie.2023.en.srt alongside Movie.2023.mkv.
             </p>
           </div>
           <div className="space-y-2">
@@ -442,7 +513,8 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
               }}
             />
             <p className="max-w-xl text-xs text-[var(--mm-text2)]">
-              When on, skips subtitles with sound descriptions like [DOOR CREAKS] or [TENSE MUSIC].
+              When on, skips subtitles with sound descriptions like [DOOR
+              CREAKS] or [TENSE MUSIC].
             </p>
           </div>
           <div className="space-y-2">
@@ -458,7 +530,9 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
               }}
             />
             <p className="max-w-xl text-xs text-[var(--mm-text2)]">
-              {enabled ? "Subber is on. Searches run on import and schedule." : "Subber is off. No automatic searches will run."}
+              {enabled
+                ? "Subber is on. Searches run on import and schedule."
+                : "Subber is off. No automatic searches will run."}
             </p>
           </div>
         </SubberSettingsSection>
@@ -472,7 +546,10 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
             <>
               <button
                 type="button"
-                className={mmActionButtonClass({ variant: upgradeDirty ? "primary" : "secondary", disabled: dis || !upgradeDirty })}
+                className={mmActionButtonClass({
+                  variant: upgradeDirty ? "primary" : "secondary",
+                  disabled: dis || !upgradeDirty,
+                })}
                 disabled={dis || !upgradeDirty}
                 onClick={() => void saveUpgradePrefs()}
               >
@@ -507,7 +584,12 @@ export function SubberPreferencesTab({ canOperate }: { canOperate: boolean }) {
                 className="mm-input mt-1 w-full max-w-xs"
                 value={upIntervalMin}
                 onChange={(e) => {
-                  setUpIntervalMin(Math.max(60, Math.min(525600, Number(e.target.value) || 60)));
+                  setUpIntervalMin(
+                    Math.max(
+                      60,
+                      Math.min(525600, Number(e.target.value) || 60),
+                    ),
+                  );
                   setUpgradeDirty(true);
                 }}
                 disabled={dis}

--- a/apps/web/src/pages/subber/subber-providers-tab.test.tsx
+++ b/apps/web/src/pages/subber/subber-providers-tab.test.tsx
@@ -35,6 +35,8 @@ describe("SubberProvidersTab", () => {
           priority: 0,
           requires_account: true,
           has_credentials: false,
+          available: true,
+          availability_note: null,
         },
       ],
       isLoading: false,
@@ -86,5 +88,27 @@ describe("SubberProvidersTab", () => {
     await waitFor(() => expect(screen.getByTestId("subber-test-opensubtitles")).toBeInTheDocument());
     fireEvent.click(screen.getByTestId("subber-test-opensubtitles"));
     await waitFor(() => expect(testMut).toHaveBeenCalled());
+  });
+
+  it("shows unavailable providers as not available", async () => {
+    vi.spyOn(subberQueries, "useSubberProvidersQuery").mockReturnValue({
+      data: [
+        {
+          provider_key: "subscene",
+          display_name: "Subscene",
+          enabled: false,
+          priority: 9,
+          requires_account: false,
+          has_credentials: false,
+          available: false,
+          availability_note: "Not available in this version.",
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof subberQueries.useSubberProvidersQuery>);
+    const client = new QueryClient();
+    render(wrap(<SubberProvidersTab canOperate />, client));
+    await waitFor(() => expect(screen.getByText("Not available in this version.")).toBeInTheDocument());
   });
 });

--- a/apps/web/src/pages/subber/subber-providers-tab.test.tsx
+++ b/apps/web/src/pages/subber/subber-providers-tab.test.tsx
@@ -22,10 +22,15 @@ describe("SubberProvidersTab", () => {
 
   beforeEach(() => {
     vi.spyOn(authApi, "fetchCsrfToken").mockResolvedValue("csrf");
-    vi.spyOn(subberQueries, "useSubberTestOpensubtitlesMutation").mockReturnValue({
+    vi.spyOn(
+      subberQueries,
+      "useSubberTestOpensubtitlesMutation",
+    ).mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue({ ok: true, message: "ok" }),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestOpensubtitlesMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestOpensubtitlesMutation
+    >);
     vi.spyOn(subberQueries, "useSubberProvidersQuery").mockReturnValue({
       data: [
         {
@@ -45,11 +50,15 @@ describe("SubberProvidersTab", () => {
     vi.spyOn(subberQueries, "usePutSubberProviderMutation").mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue({}),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.usePutSubberProviderMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.usePutSubberProviderMutation
+    >);
     vi.spyOn(subberQueries, "useSubberTestProviderMutation").mockReturnValue({
       mutateAsync: vi.fn().mockResolvedValue({ ok: true, message: "ok" }),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestProviderMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestProviderMutation
+    >);
   });
 
   it("saves OpenSubtitles when Save is clicked", async () => {
@@ -57,14 +66,26 @@ describe("SubberProvidersTab", () => {
     vi.spyOn(subberQueries, "usePutSubberProviderMutation").mockReturnValue({
       mutateAsync: putProvMutate,
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.usePutSubberProviderMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.usePutSubberProviderMutation
+    >);
 
     const client = new QueryClient();
     render(wrap(<SubberProvidersTab canOperate />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-providers-tab")).toBeInTheDocument());
-    fireEvent.click(screen.getByRole("button", { name: /OpenSubtitles\.org/i }));
-    await waitFor(() => expect(screen.getByTestId("subber-save-opensubtitles")).toBeInTheDocument());
-    fireEvent.change(screen.getByLabelText("Username"), { target: { value: "u" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-providers-tab")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /OpenSubtitles\.org/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("subber-save-opensubtitles"),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: "u" },
+    });
     fireEvent.click(screen.getByTestId("subber-save-opensubtitles"));
     await waitFor(() => expect(putProvMutate).toHaveBeenCalled());
   });
@@ -72,20 +93,39 @@ describe("SubberProvidersTab", () => {
   it("renders subtitle providers section", async () => {
     const client = new QueryClient();
     render(wrap(<SubberProvidersTab canOperate />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-providers-section")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("subber-providers-section"),
+      ).toBeInTheDocument(),
+    );
   });
 
   it("runs test connection when Test is clicked", async () => {
-    const testMut = vi.fn().mockResolvedValue({ ok: true, message: "Connected" });
-    vi.spyOn(subberQueries, "useSubberTestOpensubtitlesMutation").mockReturnValue({
+    const testMut = vi
+      .fn()
+      .mockResolvedValue({ ok: true, message: "Connected" });
+    vi.spyOn(
+      subberQueries,
+      "useSubberTestOpensubtitlesMutation",
+    ).mockReturnValue({
       mutateAsync: testMut,
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberTestOpensubtitlesMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberTestOpensubtitlesMutation
+    >);
     const client = new QueryClient();
     render(wrap(<SubberProvidersTab canOperate />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-providers-tab")).toBeInTheDocument());
-    fireEvent.click(screen.getByRole("button", { name: /OpenSubtitles\.org/i }));
-    await waitFor(() => expect(screen.getByTestId("subber-test-opensubtitles")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-providers-tab")).toBeInTheDocument(),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /OpenSubtitles\.org/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("subber-test-opensubtitles"),
+      ).toBeInTheDocument(),
+    );
     fireEvent.click(screen.getByTestId("subber-test-opensubtitles"));
     await waitFor(() => expect(testMut).toHaveBeenCalled());
   });
@@ -109,6 +149,10 @@ describe("SubberProvidersTab", () => {
     } as unknown as ReturnType<typeof subberQueries.useSubberProvidersQuery>);
     const client = new QueryClient();
     render(wrap(<SubberProvidersTab canOperate />, client));
-    await waitFor(() => expect(screen.getByText("Not available in this version.")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText("Not available in this version."),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/pages/subber/subber-providers-tab.tsx
+++ b/apps/web/src/pages/subber/subber-providers-tab.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState, type ReactNode } from "react";
 import { fetchCsrfToken } from "../../lib/api/auth-api";
 import { MmOnOffSwitch } from "../../components/ui/mm-on-off-switch";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
-import type { SubberProviderOut, SubberProviderPutIn } from "../../lib/subber/subber-api";
+import type {
+  SubberProviderOut,
+  SubberProviderPutIn,
+} from "../../lib/subber/subber-api";
 import {
   usePutSubberProviderMutation,
   useSubberProvidersQuery,
@@ -35,7 +38,9 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
   const [provPri, setProvPri] = useState<Record<string, number | null>>({});
   const [provMsg, setProvMsg] = useState<Record<string, string | null>>({});
   const [provDirty, setProvDirty] = useState<Record<string, boolean>>({});
-  const [expandedProviderKey, setExpandedProviderKey] = useState<string | null>(null);
+  const [expandedProviderKey, setExpandedProviderKey] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     if (!pq.data) return;
@@ -50,9 +55,17 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
 
   const dis = !canOperate || putProv.isPending;
 
-  async function saveProviderRow(pk: string, enabledP: boolean, priority: number | null) {
+  async function saveProviderRow(
+    pk: string,
+    enabledP: boolean,
+    priority: number | null,
+  ) {
     const csrf_token = await fetchCsrfToken();
-    const body: SubberProviderPutIn = { csrf_token, enabled: enabledP, priority: priority ?? undefined };
+    const body: SubberProviderPutIn = {
+      csrf_token,
+      enabled: enabledP,
+      priority: priority ?? undefined,
+    };
     const u = provUser[pk]?.trim();
     const p = provPass[pk]?.trim();
     const k = provKey[pk]?.trim();
@@ -62,7 +75,11 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
     await putProv.mutateAsync({ providerKey: pk, body });
   }
 
-  async function saveExpandedProvider(pk: string, enabledP: boolean, priority: number | null) {
+  async function saveExpandedProvider(
+    pk: string,
+    enabledP: boolean,
+    priority: number | null,
+  ) {
     try {
       await saveProviderRow(pk, enabledP, priority);
       setProvDirty((d) => ({ ...d, [pk]: false }));
@@ -86,7 +103,10 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
     setProvMsg((m) => ({ ...m, [pk]: null }));
     try {
       const r = await testOs.mutateAsync();
-      setProvMsg((m) => ({ ...m, [pk]: r.ok ? "Connected" : r.message ?? "Error" }));
+      setProvMsg((m) => ({
+        ...m,
+        [pk]: r.ok ? "Connected" : (r.message ?? "Error"),
+      }));
     } catch (e) {
       setProvMsg((m) => ({ ...m, [pk]: (e as Error).message }));
     }
@@ -94,7 +114,8 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
 
   const sorted = [...(pq.data ?? [])].sort(
     (a, b) =>
-      (a.priority ?? 999_999) - (b.priority ?? 999_999) || a.provider_key.localeCompare(b.provider_key),
+      (a.priority ?? 999_999) - (b.priority ?? 999_999) ||
+      a.provider_key.localeCompare(b.provider_key),
   );
 
   return (
@@ -104,14 +125,20 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
         data-testid="subber-providers-section"
       >
         <header className="border-b border-[var(--mm-border)] bg-black/10 px-5 py-4">
-          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">Sources</p>
-          <h2 className="mt-1 text-lg font-semibold tracking-tight text-[var(--mm-text)]">Subtitle providers</h2>
+          <p className="text-[0.7rem] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text2)]">
+            Sources
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight text-[var(--mm-text)]">
+            Subtitle providers
+          </h2>
         </header>
         <div className="px-5 py-5">
           {pq.isLoading ? (
             <p className="text-sm text-[var(--mm-text2)]">Loading providers…</p>
           ) : pq.isError ? (
-            <p className="text-sm text-red-600">{(pq.error as Error).message}</p>
+            <p className="text-sm text-red-600">
+              {(pq.error as Error).message}
+            </p>
           ) : (
             <ul className="divide-y divide-[var(--mm-border)] rounded-md border border-[var(--mm-border)] bg-black/10">
               {sorted.map((p) => {
@@ -124,24 +151,43 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                 if (provMsgText) {
                   statusEl =
                     provMsgText === "Connected" ? (
-                      <span className="text-xs font-medium text-emerald-600">{provMsgText}</span>
+                      <span className="text-xs font-medium text-emerald-600">
+                        {provMsgText}
+                      </span>
                     ) : (
-                      <span className="max-w-[14rem] truncate text-xs text-[var(--mm-text2)]" title={provMsgText}>
+                      <span
+                        className="max-w-[14rem] truncate text-xs text-[var(--mm-text2)]"
+                        title={provMsgText}
+                      >
                         {provMsgText}
                       </span>
                     );
                 } else if (!p.available) {
-                  statusEl = <span className="text-xs text-amber-400">{p.availability_note ?? "Not available"}</span>;
+                  statusEl = (
+                    <span className="text-xs text-amber-400">
+                      {p.availability_note ?? "Not available"}
+                    </span>
+                  );
                 } else if (p.requires_account) {
                   statusEl = p.has_credentials ? (
-                    <span className="text-xs font-medium text-emerald-600">Configured</span>
+                    <span className="text-xs font-medium text-emerald-600">
+                      Configured
+                    </span>
                   ) : (
-                    <span className="text-xs text-[var(--mm-text2)]">Not configured</span>
+                    <span className="text-xs text-[var(--mm-text2)]">
+                      Not configured
+                    </span>
                   );
                 } else if (p.provider_key === "podnapisi") {
-                  statusEl = <span className="text-xs text-[var(--mm-text2)]">Optional credentials</span>;
+                  statusEl = (
+                    <span className="text-xs text-[var(--mm-text2)]">
+                      Optional credentials
+                    </span>
+                  );
                 } else {
-                  statusEl = <span className="text-xs text-[var(--mm-text2)]">—</span>;
+                  statusEl = (
+                    <span className="text-xs text-[var(--mm-text2)]">—</span>
+                  );
                 }
                 return (
                   <li
@@ -157,23 +203,35 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                       type="button"
                       className="flex w-full items-center gap-4 px-4 py-3.5 text-left transition-colors hover:bg-white/[0.02]"
                       disabled={!p.available}
-                      onClick={() => setExpandedProviderKey(expanded ? null : p.provider_key)}
+                      onClick={() =>
+                        setExpandedProviderKey(expanded ? null : p.provider_key)
+                      }
                     >
                       <span
                         className={[
                           "h-2 w-2 shrink-0 rounded-full",
-                          p.enabled && (p.has_credentials || !p.requires_account)
+                          p.enabled &&
+                          (p.has_credentials || !p.requires_account)
                             ? "bg-emerald-500"
-                            : p.enabled && p.requires_account && !p.has_credentials
+                            : p.enabled &&
+                                p.requires_account &&
+                                !p.has_credentials
                               ? "bg-red-500"
                               : "bg-[var(--mm-border)]",
                         ].join(" ")}
                       />
-                      <span className="min-w-[10rem] text-sm font-semibold text-[var(--mm-text)]">{p.display_name}</span>
-                      <span className="text-xs text-[var(--mm-text2)]">{statusEl}</span>
+                      <span className="min-w-[10rem] text-sm font-semibold text-[var(--mm-text)]">
+                        {p.display_name}
+                      </span>
+                      <span className="text-xs text-[var(--mm-text2)]">
+                        {statusEl}
+                      </span>
                       <span className="ml-auto flex items-center gap-3">
                         <span className="text-xs text-[var(--mm-text3)]">
-                          Priority {p.priority !== null && p.priority !== undefined ? p.priority : "—"}
+                          Priority{" "}
+                          {p.priority !== null && p.priority !== undefined
+                            ? p.priority
+                            : "—"}
                         </span>
                         <svg
                           aria-hidden
@@ -192,8 +250,11 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                     {expanded ? (
                       <div className="border-t border-[var(--mm-border)] bg-black/20 px-4 pb-4 pt-4">
                         <div className="space-y-4">
-                          {p.provider_key === "podnapisi" && !p.requires_account ? (
-                            <p className="text-xs text-[var(--mm-text2)]">No account required — credentials optional.</p>
+                          {p.provider_key === "podnapisi" &&
+                          !p.requires_account ? (
+                            <p className="text-xs text-[var(--mm-text2)]">
+                              No account required — credentials optional.
+                            </p>
                           ) : null}
                           {p.requires_account ? (
                             <div className="grid gap-3 sm:grid-cols-2">
@@ -204,14 +265,24 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   disabled={dis}
                                   value={provUser[p.provider_key] ?? ""}
                                   onChange={(e) => {
-                                    setProvUser((x) => ({ ...x, [p.provider_key]: e.target.value }));
-                                    setProvDirty((d) => ({ ...d, [p.provider_key]: true }));
+                                    setProvUser((x) => ({
+                                      ...x,
+                                      [p.provider_key]: e.target.value,
+                                    }));
+                                    setProvDirty((d) => ({
+                                      ...d,
+                                      [p.provider_key]: true,
+                                    }));
                                   }}
                                 />
                               </label>
                               <label className="block text-xs text-[var(--mm-text2)]">
                                 Password{" "}
-                                {p.has_credentials ? <span className="text-[0.7rem]">(leave blank to keep)</span> : null}
+                                {p.has_credentials ? (
+                                  <span className="text-[0.7rem]">
+                                    (leave blank to keep)
+                                  </span>
+                                ) : null}
                                 <input
                                   type="password"
                                   className="mm-input mt-1 w-full"
@@ -219,8 +290,14 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   placeholder={p.has_credentials ? MASK : ""}
                                   value={provPass[p.provider_key] ?? ""}
                                   onChange={(e) => {
-                                    setProvPass((x) => ({ ...x, [p.provider_key]: e.target.value }));
-                                    setProvDirty((d) => ({ ...d, [p.provider_key]: true }));
+                                    setProvPass((x) => ({
+                                      ...x,
+                                      [p.provider_key]: e.target.value,
+                                    }));
+                                    setProvDirty((d) => ({
+                                      ...d,
+                                      [p.provider_key]: true,
+                                    }));
                                   }}
                                 />
                               </label>
@@ -234,8 +311,14 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                     placeholder={p.has_credentials ? MASK : ""}
                                     value={provKey[p.provider_key] ?? ""}
                                     onChange={(e) => {
-                                      setProvKey((x) => ({ ...x, [p.provider_key]: e.target.value }));
-                                      setProvDirty((d) => ({ ...d, [p.provider_key]: true }));
+                                      setProvKey((x) => ({
+                                        ...x,
+                                        [p.provider_key]: e.target.value,
+                                      }));
+                                      setProvDirty((d) => ({
+                                        ...d,
+                                        [p.provider_key]: true,
+                                      }));
                                     }}
                                   />
                                 </label>
@@ -250,8 +333,14 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   disabled={dis}
                                   value={provUser[p.provider_key] ?? ""}
                                   onChange={(e) => {
-                                    setProvUser((x) => ({ ...x, [p.provider_key]: e.target.value }));
-                                    setProvDirty((d) => ({ ...d, [p.provider_key]: true }));
+                                    setProvUser((x) => ({
+                                      ...x,
+                                      [p.provider_key]: e.target.value,
+                                    }));
+                                    setProvDirty((d) => ({
+                                      ...d,
+                                      [p.provider_key]: true,
+                                    }));
                                   }}
                                 />
                               </label>
@@ -264,8 +353,14 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   placeholder={p.has_credentials ? MASK : ""}
                                   value={provPass[p.provider_key] ?? ""}
                                   onChange={(e) => {
-                                    setProvPass((x) => ({ ...x, [p.provider_key]: e.target.value }));
-                                    setProvDirty((d) => ({ ...d, [p.provider_key]: true }));
+                                    setProvPass((x) => ({
+                                      ...x,
+                                      [p.provider_key]: e.target.value,
+                                    }));
+                                    setProvDirty((d) => ({
+                                      ...d,
+                                      [p.provider_key]: true,
+                                    }));
                                   }}
                                 />
                               </label>
@@ -284,11 +379,22 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   const v = e.target.value;
                                   setProvPri((x) => ({
                                     ...x,
-                                    [p.provider_key]: v === "" ? null : Math.max(0, Math.min(9999, Number(v) || 0)),
+                                    [p.provider_key]:
+                                      v === ""
+                                        ? null
+                                        : Math.max(
+                                            0,
+                                            Math.min(9999, Number(v) || 0),
+                                          ),
                                   }));
                                 }}
                                 onBlur={() => {
-                                  if (pri !== p.priority) void saveProviderRow(p.provider_key, p.enabled, pri);
+                                  if (pri !== p.priority)
+                                    void saveProviderRow(
+                                      p.provider_key,
+                                      p.enabled,
+                                      pri,
+                                    );
                                 }}
                               />
                             </label>
@@ -298,8 +404,14 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                 label="Enabled"
                                 layout="inline"
                                 enabled={p.enabled}
-                                disabled={dis || putProv.isPending || !providerImplemented(p.provider_key)}
-                                onChange={(v) => void saveProviderRow(p.provider_key, v, pri)}
+                                disabled={
+                                  dis ||
+                                  putProv.isPending ||
+                                  !providerImplemented(p.provider_key)
+                                }
+                                onChange={(v) =>
+                                  void saveProviderRow(p.provider_key, v, pri)
+                                }
                               />
                             </div>
                             <div className="ml-auto flex gap-2">
@@ -308,13 +420,25 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                   <button
                                     type="button"
                                     className={mmActionButtonClass({
-                                      variant: isDirty ? "primary" : "secondary",
-                                      disabled: dis || putProv.isPending || !isDirty,
+                                      variant: isDirty
+                                        ? "primary"
+                                        : "secondary",
+                                      disabled:
+                                        dis || putProv.isPending || !isDirty,
                                     })}
-                                    disabled={dis || putProv.isPending || !isDirty}
-                                    onClick={() => void saveExpandedProvider(p.provider_key, p.enabled, pri)}
+                                    disabled={
+                                      dis || putProv.isPending || !isDirty
+                                    }
+                                    onClick={() =>
+                                      void saveExpandedProvider(
+                                        p.provider_key,
+                                        p.enabled,
+                                        pri,
+                                      )
+                                    }
                                     data-testid={
-                                      p.provider_key === "opensubtitles_org" || p.provider_key === "opensubtitles_com"
+                                      p.provider_key === "opensubtitles_org" ||
+                                      p.provider_key === "opensubtitles_com"
                                         ? "subber-save-opensubtitles"
                                         : undefined
                                     }
@@ -327,7 +451,8 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                       variant: "secondary",
                                       disabled:
                                         dis ||
-                                        (p.provider_key === "opensubtitles_org" ||
+                                        (p.provider_key ===
+                                          "opensubtitles_org" ||
                                         p.provider_key === "opensubtitles_com"
                                           ? testOs.isPending
                                           : testProv.isPending),
@@ -341,7 +466,8 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                     }
                                     onClick={() => {
                                       if (
-                                        p.provider_key === "opensubtitles_org" ||
+                                        p.provider_key ===
+                                          "opensubtitles_org" ||
                                         p.provider_key === "opensubtitles_com"
                                       ) {
                                         void runTestOs(p.provider_key);
@@ -350,7 +476,8 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                                       }
                                     }}
                                     data-testid={
-                                      p.provider_key === "opensubtitles_org" || p.provider_key === "opensubtitles_com"
+                                      p.provider_key === "opensubtitles_org" ||
+                                      p.provider_key === "opensubtitles_com"
                                         ? "subber-test-opensubtitles"
                                         : undefined
                                     }
@@ -366,7 +493,9 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                             <p
                               className={[
                                 "text-xs",
-                                provMsg[p.provider_key] === "Connected" ? "text-emerald-500" : "text-red-400",
+                                provMsg[p.provider_key] === "Connected"
+                                  ? "text-emerald-500"
+                                  : "text-red-400",
                               ].join(" ")}
                             >
                               {provMsg[p.provider_key]}

--- a/apps/web/src/pages/subber/subber-providers-tab.tsx
+++ b/apps/web/src/pages/subber/subber-providers-tab.tsx
@@ -13,8 +13,7 @@ import {
 const MASK = "\u2022".repeat(10);
 
 function providerNeedsConfigureButton(p: SubberProviderOut): boolean {
-  if (p.provider_key === "subscene") return false;
-  if (p.provider_key === "addic7ed") return false;
+  if (!p.available) return false;
   if (p.requires_account) return true;
   if (p.provider_key === "podnapisi") return true;
   return false;
@@ -131,8 +130,8 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                         {provMsgText}
                       </span>
                     );
-                } else if (p.provider_key === "subscene" || p.provider_key === "addic7ed") {
-                  statusEl = <span className="text-xs text-amber-400">Not implemented yet</span>;
+                } else if (!p.available) {
+                  statusEl = <span className="text-xs text-amber-400">{p.availability_note ?? "Not available"}</span>;
                 } else if (p.requires_account) {
                   statusEl = p.has_credentials ? (
                     <span className="text-xs font-medium text-emerald-600">Configured</span>
@@ -157,6 +156,7 @@ export function SubberProvidersTab({ canOperate }: { canOperate: boolean }) {
                     <button
                       type="button"
                       className="flex w-full items-center gap-4 px-4 py-3.5 text-left transition-colors hover:bg-white/[0.02]"
+                      disabled={!p.available}
                       onClick={() => setExpandedProviderKey(expanded ? null : p.provider_key)}
                     >
                       <span

--- a/apps/web/src/pages/subber/subber-schedule-tab.tsx
+++ b/apps/web/src/pages/subber/subber-schedule-tab.tsx
@@ -8,7 +8,10 @@ import {
 } from "../../components/ui/mm-schedule-window-controls";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
-import { usePutSubberSettingsMutation, useSubberSettingsQuery } from "../../lib/subber/subber-queries";
+import {
+  usePutSubberSettingsMutation,
+  useSubberSettingsQuery,
+} from "../../lib/subber/subber-queries";
 
 const RUN_INTERVAL_HELPER = "How often this search runs automatically.";
 
@@ -69,13 +72,25 @@ function ScheduleCard({
     <section className="mm-card mm-dash-card flex h-full min-h-0 min-w-0 flex-col">
       <div className="mm-card-action-body flex-1 min-h-0">
         <div>
-          <h3 className="text-base font-semibold text-[var(--mm-text1)]">{title}</h3>
+          <h3 className="text-base font-semibold text-[var(--mm-text1)]">
+            {title}
+          </h3>
           <p className="mt-1 text-sm text-[var(--mm-text2)]">{helper}</p>
         </div>
-        <MmOnOffSwitch id={`${idPrefix}-en`} label="Enable timed scans" enabled={enabled} disabled={dis} onChange={setEnabled} />
+        <MmOnOffSwitch
+          id={`${idPrefix}-en`}
+          label="Enable timed scans"
+          enabled={enabled}
+          disabled={dis}
+          onChange={setEnabled}
+        />
         <div>
-          <span className="text-sm font-medium text-[var(--mm-text1)]">Run interval (minutes)</span>
-          <p className="mt-1 text-xs text-[var(--mm-text3)]">{RUN_INTERVAL_HELPER}</p>
+          <span className="text-sm font-medium text-[var(--mm-text1)]">
+            Run interval (minutes)
+          </span>
+          <p className="mt-1 text-xs text-[var(--mm-text3)]">
+            {RUN_INTERVAL_HELPER}
+          </p>
           <input
             type="number"
             min={1}
@@ -83,13 +98,21 @@ function ScheduleCard({
             className="mm-input mt-2 w-full"
             value={intervalMinutes}
             disabled={dis}
-            onChange={(e) => setIntervalMinutes(Math.max(1, Math.min(intervalMax, Number(e.target.value) || 1)))}
+            onChange={(e) =>
+              setIntervalMinutes(
+                Math.max(1, Math.min(intervalMax, Number(e.target.value) || 1)),
+              )
+            }
           />
         </div>
         <div className="space-y-3">
           <div>
-            <span className="text-sm font-medium text-[var(--mm-text1)]">Schedule window</span>
-            <p className="mt-1 text-xs text-[var(--mm-text3)]">{MM_SCHEDULE_TIME_WINDOW_HELPER}</p>
+            <span className="text-sm font-medium text-[var(--mm-text1)]">
+              Schedule window
+            </span>
+            <p className="mt-1 text-xs text-[var(--mm-text3)]">
+              {MM_SCHEDULE_TIME_WINDOW_HELPER}
+            </p>
           </div>
           <div className="space-y-4">
             <MmOnOffSwitch
@@ -100,14 +123,30 @@ function ScheduleCard({
               onChange={setHoursLimited}
             />
             <div className="space-y-2">
-              <span className="text-sm font-medium text-[var(--mm-text1)]">Days</span>
-              <MmScheduleDayChips scheduleDaysCsv={daysCsv} disabled={dis} onChangeCsv={setDaysCsv} />
+              <span className="text-sm font-medium text-[var(--mm-text1)]">
+                Days
+              </span>
+              <MmScheduleDayChips
+                scheduleDaysCsv={daysCsv}
+                disabled={dis}
+                onChangeCsv={setDaysCsv}
+              />
             </div>
-            <MmScheduleTimeFields idPrefix={idPrefix} start={start} end={end} disabled={dis} onStart={setStart} onEnd={setEnd} />
+            <MmScheduleTimeFields
+              idPrefix={idPrefix}
+              start={start}
+              end={end}
+              disabled={dis}
+              onStart={setStart}
+              onEnd={setEnd}
+            />
           </div>
         </div>
         <p className="text-xs text-[var(--mm-text3)]">
-          Last run: <span className="font-medium text-[var(--mm-text1)]">{fmt(lastRun)}</span>
+          Last run:{" "}
+          <span className="font-medium text-[var(--mm-text1)]">
+            {fmt(lastRun)}
+          </span>
         </p>
       </div>
       <div className="mm-card-action-footer">
@@ -161,7 +200,8 @@ export function SubberScheduleTab({ canOperate }: { canOperate: boolean }) {
   const tvDirty =
     q.data !== undefined &&
     (tvEn !== q.data.tv_schedule_enabled ||
-      tvMin !== Math.max(1, Math.round(q.data.tv_schedule_interval_seconds / 60)) ||
+      tvMin !==
+        Math.max(1, Math.round(q.data.tv_schedule_interval_seconds / 60)) ||
       tvHl !== q.data.tv_schedule_hours_limited ||
       tvDays !== (q.data.tv_schedule_days ?? "") ||
       tvStart !== (q.data.tv_schedule_start ?? "00:00") ||
@@ -170,7 +210,8 @@ export function SubberScheduleTab({ canOperate }: { canOperate: boolean }) {
   const mvDirty =
     q.data !== undefined &&
     (mvEn !== q.data.movies_schedule_enabled ||
-      mvMin !== Math.max(1, Math.round(q.data.movies_schedule_interval_seconds / 60)) ||
+      mvMin !==
+        Math.max(1, Math.round(q.data.movies_schedule_interval_seconds / 60)) ||
       mvHl !== q.data.movies_schedule_hours_limited ||
       mvDays !== (q.data.movies_schedule_days ?? "") ||
       mvStart !== (q.data.movies_schedule_start ?? "00:00") ||
@@ -181,7 +222,10 @@ export function SubberScheduleTab({ canOperate }: { canOperate: boolean }) {
     await put.mutateAsync({
       csrf_token,
       tv_schedule_enabled: tvEn,
-      tv_schedule_interval_seconds: Math.max(60, Math.min(7 * 24 * 3600, tvMin * 60)),
+      tv_schedule_interval_seconds: Math.max(
+        60,
+        Math.min(7 * 24 * 3600, tvMin * 60),
+      ),
       tv_schedule_hours_limited: tvHl,
       tv_schedule_days: tvDays,
       tv_schedule_start: tvStart,
@@ -194,7 +238,10 @@ export function SubberScheduleTab({ canOperate }: { canOperate: boolean }) {
     await put.mutateAsync({
       csrf_token,
       movies_schedule_enabled: mvEn,
-      movies_schedule_interval_seconds: Math.max(60, Math.min(7 * 24 * 3600, mvMin * 60)),
+      movies_schedule_interval_seconds: Math.max(
+        60,
+        Math.min(7 * 24 * 3600, mvMin * 60),
+      ),
       movies_schedule_hours_limited: mvHl,
       movies_schedule_days: mvDays,
       movies_schedule_start: mvStart,
@@ -202,8 +249,10 @@ export function SubberScheduleTab({ canOperate }: { canOperate: boolean }) {
     });
   }
 
-  if (q.isLoading) return <p className="text-sm text-[var(--mm-text2)]">Loading schedule…</p>;
-  if (q.isError) return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
+  if (q.isLoading)
+    return <p className="text-sm text-[var(--mm-text2)]">Loading schedule…</p>;
+  if (q.isError)
+    return <p className="text-sm text-red-600">{(q.error as Error).message}</p>;
 
   return (
     <div className="mm-dash-grid" data-testid="subber-schedule-tab">

--- a/apps/web/src/pages/subber/subber-tv-tab.test.tsx
+++ b/apps/web/src/pages/subber/subber-tv-tab.test.tsx
@@ -23,7 +23,9 @@ describe("SubberTvTab", () => {
 
   beforeEach(() => {
     vi.spyOn(subberQueries, "useSubberSettingsQuery").mockReturnValue({
-      data: { language_preferences: ["en", "fr"] } as ReturnType<typeof subberQueries.useSubberSettingsQuery>["data"],
+      data: { language_preferences: ["en", "fr"] } as ReturnType<
+        typeof subberQueries.useSubberSettingsQuery
+      >["data"],
       isLoading: false,
       isError: false,
     } as unknown as ReturnType<typeof subberQueries.useSubberSettingsQuery>);
@@ -41,8 +43,24 @@ describe("SubberTvTab", () => {
                     episode_number: 1,
                     episode_title: "Pilot",
                     languages: [
-                      { state_id: 7, language_code: "en", status: "found", subtitle_path: null, last_searched_at: null, search_count: 0, source: null },
-                      { state_id: 8, language_code: "fr", status: "missing", subtitle_path: null, last_searched_at: null, search_count: 0, source: null },
+                      {
+                        state_id: 7,
+                        language_code: "en",
+                        status: "found",
+                        subtitle_path: null,
+                        last_searched_at: null,
+                        search_count: 0,
+                        source: null,
+                      },
+                      {
+                        state_id: 8,
+                        language_code: "fr",
+                        status: "missing",
+                        subtitle_path: null,
+                        last_searched_at: null,
+                        search_count: 0,
+                        source: null,
+                      },
                     ],
                   },
                 ],
@@ -58,11 +76,18 @@ describe("SubberTvTab", () => {
     vi.spyOn(subberQueries, "useSubberSearchNowMutation").mockReturnValue({
       mutate,
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchNowMutation>);
-    vi.spyOn(subberQueries, "useSubberSearchAllMissingTvMutation").mockReturnValue({
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchNowMutation
+    >);
+    vi.spyOn(
+      subberQueries,
+      "useSubberSearchAllMissingTvMutation",
+    ).mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
-    } as unknown as ReturnType<typeof subberQueries.useSubberSearchAllMissingTvMutation>);
+    } as unknown as ReturnType<
+      typeof subberQueries.useSubberSearchAllMissingTvMutation
+    >);
   });
 
   it("renders episode and Search now triggers mutation", async () => {
@@ -81,6 +106,8 @@ describe("SubberTvTab", () => {
     } as unknown as ReturnType<typeof subberQueries.useSubberLibraryTvQuery>);
     const client = new QueryClient();
     render(wrap(<SubberTvTab canOperate={false} />, client));
-    await waitFor(() => expect(screen.getByTestId("subber-tv-empty")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByTestId("subber-tv-empty")).toBeInTheDocument(),
+    );
   });
 });

--- a/apps/web/src/pages/subber/subber-tv-tab.tsx
+++ b/apps/web/src/pages/subber/subber-tv-tab.tsx
@@ -34,9 +34,14 @@ function langBadge(status: string, code: string) {
   );
 }
 
-function pickSearchStateId(ep: SubberTvEpisode, prefs: string[]): number | null {
+function pickSearchStateId(
+  ep: SubberTvEpisode,
+  prefs: string[],
+): number | null {
   for (const p of prefs) {
-    const row = ep.languages.find((l) => l.language_code.toLowerCase() === p.toLowerCase());
+    const row = ep.languages.find(
+      (l) => l.language_code.toLowerCase() === p.toLowerCase(),
+    );
     if (row && row.status !== "found") return row.state_id;
   }
   const any = ep.languages.find((l) => l.status !== "found");
@@ -45,9 +50,16 @@ function pickSearchStateId(ep: SubberTvEpisode, prefs: string[]): number | null 
 
 function coverageState(ep: SubberTvEpisode, prefs: string[]): string {
   const preferredRows = prefs
-    .map((code) => ep.languages.find((row) => row.language_code.toLowerCase() === code.toLowerCase()))
+    .map((code) =>
+      ep.languages.find(
+        (row) => row.language_code.toLowerCase() === code.toLowerCase(),
+      ),
+    )
     .filter((row): row is NonNullable<typeof row> => Boolean(row));
-  if (preferredRows.length > 0 && preferredRows.every((row) => row.status === "found")) {
+  if (
+    preferredRows.length > 0 &&
+    preferredRows.every((row) => row.status === "found")
+  ) {
     return "Preferred subtitle found";
   }
   return "Still missing";
@@ -59,7 +71,9 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
   const [status, setStatus] = useState<string>("all");
   const [search, setSearch] = useState("");
   const [language, setLanguage] = useState("");
-  const [pageSize, setPageSizeState] = useState<SubberLibraryPageSize>(() => readSubberLibraryPageSize());
+  const [pageSize, setPageSizeState] = useState<SubberLibraryPageSize>(() =>
+    readSubberLibraryPageSize(),
+  );
   const [page, setPage] = useState(0);
 
   const filters = useMemo(
@@ -77,7 +91,8 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
   const searchAll = useSubberSearchAllMissingTvMutation();
 
   const total = libQ.data?.total ?? 0;
-  const hasActiveFilters = status !== "all" || Boolean(search.trim()) || Boolean(language.trim());
+  const hasActiveFilters =
+    status !== "all" || Boolean(search.trim()) || Boolean(language.trim());
 
   useEffect(() => {
     setPage(0);
@@ -99,7 +114,9 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
   return (
     <div className="space-y-4" data-testid="subber-tv-tab">
       <div className="rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/30 p-4">
-        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">Filters</p>
+        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">
+          Filters
+        </p>
         <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
             Search
@@ -112,7 +129,11 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
           </label>
           <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
             Subtitles
-            <select className="mm-input min-w-[11rem]" value={status} onChange={(e) => setStatus(e.target.value)}>
+            <select
+              className="mm-input min-w-[11rem]"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+            >
               <option value="all">All episodes</option>
               <option value="missing">Missing subtitles</option>
               <option value="complete">All preferred languages found</option>
@@ -140,10 +161,17 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
           ) : null}
         </div>
       </div>
-      {libQ.isLoading ? <p className="text-sm text-[var(--mm-text2)]">Loading TV library…</p> : null}
-      {libQ.isError ? <p className="text-sm text-red-600">{(libQ.error as Error).message}</p> : null}
+      {libQ.isLoading ? (
+        <p className="text-sm text-[var(--mm-text2)]">Loading TV library…</p>
+      ) : null}
+      {libQ.isError ? (
+        <p className="text-sm text-red-600">{(libQ.error as Error).message}</p>
+      ) : null}
       {!libQ.isLoading && !libQ.isError && total === 0 ? (
-        <p className="text-sm text-[var(--mm-text2)]" data-testid="subber-tv-empty">
+        <p
+          className="text-sm text-[var(--mm-text2)]"
+          data-testid="subber-tv-empty"
+        >
           {hasActiveFilters
             ? "No episodes match the current filters. Try All episodes or clear search."
             : "No TV episodes are tracked yet. Open Connections and run Sync TV library from Sonarr, or wait for a new Sonarr import."}
@@ -160,16 +188,25 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
         />
       ) : null}
       {libQ.data?.shows.map((show) => (
-        <section key={show.show_title} className="rounded-lg border border-[var(--mm-border)] bg-black/10 p-3">
-          <h3 className="text-base font-semibold text-[var(--mm-text)]">{show.show_title}</h3>
+        <section
+          key={show.show_title}
+          className="rounded-lg border border-[var(--mm-border)] bg-black/10 p-3"
+        >
+          <h3 className="text-base font-semibold text-[var(--mm-text)]">
+            {show.show_title}
+          </h3>
           <div className="mt-2 space-y-3">
             {show.seasons.map((season) => (
               <div key={String(season.season_number)}>
-                <p className="text-sm font-medium text-[var(--mm-text2)]">Season {season.season_number ?? "?"}</p>
+                <p className="text-sm font-medium text-[var(--mm-text2)]">
+                  Season {season.season_number ?? "?"}
+                </p>
                 <ul className="mt-1 space-y-2">
                   {season.episodes.map((ep) => {
                     const sid = pickSearchStateId(ep, prefs);
-                    const hasMissing = ep.languages.some((l) => l.status !== "found");
+                    const hasMissing = ep.languages.some(
+                      (l) => l.status !== "found",
+                    );
                     return (
                       <li
                         key={ep.file_path}
@@ -178,18 +215,34 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
                         <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
                           <div className="min-w-0 flex-1 space-y-2">
                             <h4 className="text-sm font-semibold leading-snug text-[var(--mm-text)]">
-                              S{String(season.season_number ?? 0).padStart(2, "0")}E{String(ep.episode_number ?? 0).padStart(2, "0")}
-                              <span className="font-normal text-[var(--mm-text2)]"> · </span>
+                              S
+                              {String(season.season_number ?? 0).padStart(
+                                2,
+                                "0",
+                              )}
+                              E{String(ep.episode_number ?? 0).padStart(2, "0")}
+                              <span className="font-normal text-[var(--mm-text2)]">
+                                {" "}
+                                ·{" "}
+                              </span>
                               {ep.episode_title ?? "Episode"}
                             </h4>
-                            <p className="text-sm text-[var(--mm-text2)]">{coverageState(ep, prefs)}</p>
-                            <div className="flex flex-wrap gap-1">{ep.languages.map((l) => langBadge(l.status, l.language_code))}</div>
+                            <p className="text-sm text-[var(--mm-text2)]">
+                              {coverageState(ep, prefs)}
+                            </p>
+                            <div className="flex flex-wrap gap-1">
+                              {ep.languages.map((l) =>
+                                langBadge(l.status, l.language_code),
+                              )}
+                            </div>
                           </div>
                           {canOperate && hasMissing && sid != null ? (
                             <div className="flex shrink-0">
                               <button
                                 type="button"
-                                className={mmActionButtonClass({ variant: "secondary" })}
+                                className={mmActionButtonClass({
+                                  variant: "secondary",
+                                })}
                                 disabled={searchNow.isPending}
                                 data-testid="subber-tv-search-now"
                                 onClick={() => searchNow.mutate(sid)}
@@ -206,7 +259,9 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
                           </summary>
                           <div className="space-y-4 border-t border-[var(--mm-border)] px-2.5 pb-3.5 pt-3.5">
                             <SubberMediaFilePathBlock path={ep.file_path} />
-                            <SubberLanguageTracksDetails languages={ep.languages} />
+                            <SubberLanguageTracksDetails
+                              languages={ep.languages}
+                            />
                           </div>
                         </details>
                       </li>

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -96,10 +96,16 @@ body.mm-body {
   border: 1px solid var(--mm-border);
   border-radius: var(--mm-radius-pill);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.01)),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.045),
+      rgba(255, 255, 255, 0.01)
+    ),
     color-mix(in srgb, var(--mm-card-bg) 88%, transparent);
   color: var(--mm-text2);
-  box-shadow: var(--mm-shadow-card-inner), 0 8px 24px rgba(0, 0, 0, 0.16);
+  box-shadow:
+    var(--mm-shadow-card-inner),
+    0 8px 24px rgba(0, 0, 0, 0.16);
   cursor: pointer;
   font: inherit;
   font-size: 0.8125rem;
@@ -138,9 +144,15 @@ body.mm-body {
 
 html[data-mm-theme="light"] .mm-theme-toggle {
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 250, 240, 0.78)),
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.86),
+      rgba(255, 250, 240, 0.78)
+    ),
     var(--mm-card-bg);
-  box-shadow: var(--mm-shadow-card-inner), 0 10px 30px rgba(88, 65, 20, 0.1);
+  box-shadow:
+    var(--mm-shadow-card-inner),
+    0 10px 30px rgba(88, 65, 20, 0.1);
 }
 
 .mm-sidebar {
@@ -153,7 +165,8 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
-  padding: calc(8px * var(--mm-density-ui-scale)) 0 calc(14px * var(--mm-density-ui-scale));
+  padding: calc(8px * var(--mm-density-ui-scale)) 0
+    calc(14px * var(--mm-density-ui-scale));
   overflow-y: auto;
   position: relative;
   z-index: 2;
@@ -164,9 +177,11 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   flex-direction: column;
   align-items: flex-start;
   text-align: left;
-  padding: 0 calc(16px * var(--mm-density-ui-scale)) calc(4px * var(--mm-density-ui-scale));
+  padding: 0 calc(16px * var(--mm-density-ui-scale))
+    calc(4px * var(--mm-density-ui-scale));
   border-bottom: 1px solid var(--mm-border);
-  margin: 0 calc(10px * var(--mm-density-ui-scale)) calc(3px * var(--mm-density-ui-scale));
+  margin: 0 calc(10px * var(--mm-density-ui-scale))
+    calc(3px * var(--mm-density-ui-scale));
   text-decoration: none;
   color: inherit;
   transition: opacity 0.15s ease;
@@ -238,14 +253,14 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: calc(2px * var(--mm-density-ui-scale)) calc(10px * var(--mm-density-ui-scale)) 0;
+  padding: calc(2px * var(--mm-density-ui-scale))
+    calc(10px * var(--mm-density-ui-scale)) 0;
   gap: calc(3px * var(--mm-density-ui-scale));
 }
 
 .mm-sidebar-section-label {
   margin: 0;
-  padding:
-    calc(6px * var(--mm-density-ui-scale))
+  padding: calc(6px * var(--mm-density-ui-scale))
     calc(14px * var(--mm-density-ui-scale))
     calc(1px * var(--mm-density-ui-scale))
     calc(16px * var(--mm-density-ui-scale));
@@ -279,8 +294,10 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   display: flex;
   align-items: center;
   gap: calc(11px * var(--mm-density-ui-scale));
-  padding: calc(10px * var(--mm-density-ui-scale)) calc(14px * var(--mm-density-ui-scale));
-  margin: 0 calc(4px * var(--mm-density-ui-scale)) 0 calc(2px * var(--mm-density-ui-scale));
+  padding: calc(10px * var(--mm-density-ui-scale))
+    calc(14px * var(--mm-density-ui-scale));
+  margin: 0 calc(4px * var(--mm-density-ui-scale)) 0
+    calc(2px * var(--mm-density-ui-scale));
   border-radius: var(--mm-radius-pill);
   color: var(--mm-text2);
   text-decoration: none;
@@ -324,13 +341,13 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-sidebar-footer {
-  padding: 0 calc(10px * var(--mm-density-ui-scale)) calc(6px * var(--mm-density-ui-scale));
+  padding: 0 calc(10px * var(--mm-density-ui-scale))
+    calc(6px * var(--mm-density-ui-scale));
   margin-top: auto;
 }
 
 .mm-sidebar-footer-panel {
-  padding:
-    calc(14px * var(--mm-density-ui-scale))
+  padding: calc(14px * var(--mm-density-ui-scale))
     calc(14px * var(--mm-density-ui-scale))
     calc(12px * var(--mm-density-ui-scale));
   border-radius: 11px;
@@ -397,7 +414,8 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 .mm-main {
   flex: 1;
   height: 100vh;
-  padding: var(--mm-main-pad-y) var(--mm-main-pad-x) calc(40px * var(--mm-density-ui-scale));
+  padding: var(--mm-main-pad-y) var(--mm-main-pad-x)
+    calc(40px * var(--mm-density-ui-scale));
   overflow-y: auto;
   overflow-x: hidden;
   position: relative;
@@ -414,8 +432,16 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   top: 0;
   height: min(52vh, 480px);
   background:
-    radial-gradient(ellipse 78% 88% at 50% -12%, rgba(212, 175, 55, 0.06), transparent 60%),
-    radial-gradient(ellipse 45% 55% at 92% 18%, var(--mm-indigo-soft), transparent 50%);
+    radial-gradient(
+      ellipse 78% 88% at 50% -12%,
+      rgba(212, 175, 55, 0.06),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 45% 55% at 92% 18%,
+      var(--mm-indigo-soft),
+      transparent 50%
+    );
   pointer-events: none;
   z-index: 0;
 }
@@ -469,8 +495,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-card {
-    padding:
-      calc(1.45rem * var(--mm-density-ui-scale))
+    padding: calc(1.45rem * var(--mm-density-ui-scale))
       calc(1.55rem * var(--mm-density-ui-scale));
   }
 
@@ -532,8 +557,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   }
 
   .mm-card {
-    padding:
-      calc(1.5rem * var(--mm-density-ui-scale))
+    padding: calc(1.5rem * var(--mm-density-ui-scale))
       calc(1.6rem * var(--mm-density-ui-scale));
   }
 
@@ -714,8 +738,7 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-card {
-  padding:
-    calc(1.35rem * var(--mm-density-ui-scale))
+  padding: calc(1.35rem * var(--mm-density-ui-scale))
     calc(1.45rem * var(--mm-density-ui-scale));
   min-height: 5rem;
   background: var(--mm-card-bg);
@@ -725,12 +748,15 @@ html[data-mm-theme="light"] .mm-theme-toggle {
 }
 
 .mm-card--shell {
-  padding:
-    calc(1.45rem * var(--mm-density-ui-scale))
+  padding: calc(1.45rem * var(--mm-density-ui-scale))
     calc(1.55rem * var(--mm-density-ui-scale))
     calc(1.5rem * var(--mm-density-ui-scale));
   border-color: rgba(212, 175, 55, 0.2);
-  background: linear-gradient(150deg, rgba(212, 175, 55, 0.06) 0%, var(--mm-card-bg) 50%);
+  background: linear-gradient(
+    150deg,
+    rgba(212, 175, 55, 0.06) 0%,
+    var(--mm-card-bg) 50%
+  );
   box-shadow: var(--mm-shadow-card), var(--mm-shadow-card-inner);
 }
 
@@ -1278,7 +1304,11 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   padding: 1.2rem 1.3rem 1.25rem;
   border-radius: var(--mm-radius);
   border: 1px solid rgba(231, 231, 234, 0.08);
-  background: linear-gradient(165deg, var(--mm-indigo-soft) 0%, rgba(31, 35, 42, 0.95) 55%);
+  background: linear-gradient(
+    165deg,
+    var(--mm-indigo-soft) 0%,
+    rgba(31, 35, 42, 0.95) 55%
+  );
 }
 
 .mm-shell-aside__title {
@@ -1510,7 +1540,11 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   border-radius: var(--mm-radius-sm);
   border: 1px solid var(--mm-input-border);
   background-color: var(--mm-input-bg);
-  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.018) 0%, transparent 52%);
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.018) 0%,
+    transparent 52%
+  );
   color: var(--mm-text);
   box-shadow:
     inset 0 1px 3px rgba(0, 0, 0, 0.26),
@@ -1570,8 +1604,12 @@ select.mm-input {
     url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' fill='none' viewBox='0 0 14 14'%3E%3Cpath stroke='%23aeb4bf' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.65' d='m3.5 5.5 3.5 3.5 3.5-3.5'/%3E%3C/svg%3E"),
     linear-gradient(180deg, rgba(255, 255, 255, 0.018) 0%, transparent 52%);
   background-repeat: no-repeat, no-repeat;
-  background-position: right 0.65rem center, 0 0;
-  background-size: 0.7rem auto, auto;
+  background-position:
+    right 0.65rem center,
+    0 0;
+  background-size:
+    0.7rem auto,
+    auto;
 }
 
 select.mm-input::-ms-expand {

--- a/apps/web/src/styles/mediamop-tokens.css
+++ b/apps/web/src/styles/mediamop-tokens.css
@@ -39,7 +39,9 @@
   /* Main column: never wider than the pane; cap scales slightly with display density. */
   --mm-main-max: min(100%, var(--mm-main-max-cap));
   --mm-space: calc(clamp(1.125rem, 3vw, 1.75rem) * var(--mm-density-ui-scale));
-  --mm-space-lg: calc(clamp(1.65rem, 4vw, 2.35rem) * var(--mm-density-ui-scale));
+  --mm-space-lg: calc(
+    clamp(1.65rem, 4vw, 2.35rem) * var(--mm-density-ui-scale)
+  );
   --mm-bubble-stack-gap-mobile: calc(1.25rem * var(--mm-density-ui-scale));
   --mm-bubble-stack-gap-desktop: calc(1.75rem * var(--mm-density-ui-scale));
   --mm-bubble-grid-gap-mobile: calc(1.25rem * var(--mm-density-ui-scale));

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -91,6 +91,9 @@ export default defineConfig(({ mode }) => {
       __WEB_PACKAGE_VERSION__: JSON.stringify(packageJson.version),
     },
     plugins: [react()],
+    build: {
+      sourcemap: "hidden",
+    },
     server: {
       // ``true`` = listen on all interfaces (0.0.0.0). Required so **http://localhost:<port>**
       // works on Windows: ``localhost`` often resolves to ``::1`` (IPv6) while binding only

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -19,8 +19,16 @@ type DevPortsFile = {
   };
 };
 
-const devPortsPath = path.join(__dirname, "..", "..", "scripts", "dev-ports.json");
-const devPorts = JSON.parse(readFileSync(devPortsPath, "utf-8")) as DevPortsFile;
+const devPortsPath = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "dev-ports.json",
+);
+const devPorts = JSON.parse(
+  readFileSync(devPortsPath, "utf-8"),
+) as DevPortsFile;
 const dev = devPorts.development;
 
 /** ``run-dev-stack.mjs`` may bump the port when the default from ``dev-ports.json`` is busy. */
@@ -37,13 +45,17 @@ const devWebPort = (() => {
 
 function apiProxyTarget(mode: string, envDir: string): string {
   // Takes precedence over .env* (loadEnv) so automation can pin /api to a known backend.
-  const forced = (process.env.MEDIAMOP_SCREENSHOT_API_PROXY_TARGET || "").trim();
+  const forced = (
+    process.env.MEDIAMOP_SCREENSHOT_API_PROXY_TARGET || ""
+  ).trim();
   if (forced) {
     return forced;
   }
   // ``run-dev-stack.mjs`` sets this when the default API port holds an outdated build but a
   // fresh uvicorn is started on another port (see stale Subber route probe).
-  const devStackProxy = (process.env.MEDIAMOP_DEV_STACK_API_PROXY_TARGET || "").trim();
+  const devStackProxy = (
+    process.env.MEDIAMOP_DEV_STACK_API_PROXY_TARGET || ""
+  ).trim();
   if (devStackProxy) {
     return devStackProxy;
   }

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,6 +24,8 @@ services:
       # MEDIAMOP_SESSION_SECRET: ${MEDIAMOP_SESSION_SECRET}
       # Recommended before saving Pruner/Subber/Sonarr/Radarr credentials:
       # MEDIAMOP_CREDENTIALS_SECRET: ${MEDIAMOP_CREDENTIALS_SECRET}
+      # Optional bearer token for Prometheus or other machine scrapes of /metrics:
+      # MEDIAMOP_METRICS_BEARER_TOKEN: ${MEDIAMOP_METRICS_BEARER_TOKEN}
     volumes:
       - mediamop_data:/data/mediamop
     restart: unless-stopped

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,6 +3,8 @@
 ADRs in this folder capture locked structural and platform choices for this repository.
 They override ad hoc experimentation when the two conflict.
 
+Some ADR numbers are intentionally absent. Those numbers were reserved for drafts or withdrawn decisions that were never accepted into the repository; gaps do not mean documents are missing from source control.
+
 **Durable-job timing:** operator-controlled intervals, schedules, cooldowns, retries, last-run,
 and timing-based pruning must follow [ADR-0009](ADR-0009-suite-wide-timing-isolation.md)
 (per module, then per job family).

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -39,6 +39,7 @@ Or manually:
 ```powershell
 cd apps/backend
 $env:PYTHONPATH = "src"
+alembic check
 alembic upgrade head
 ```
 
@@ -83,7 +84,7 @@ The default SQLite file is **`{MEDIAMOP_HOME}/data/mediamop.sqlite3`** unless **
 
 The **`Test`** workflow (`.github/workflows/ci.yml`):
 
-1. Runs **`apps/backend`** tests with **`MEDIAMOP_HOME`** on the runner temp dir, **`alembic upgrade head`**, then **`pytest`** (no Postgres service).
+1. Runs **`apps/backend`** tests with **`MEDIAMOP_HOME`** on the runner temp dir, **`alembic check`**, **`alembic upgrade head`**, then **`pytest`** (no Postgres service).
 2. Runs **`npm ci` → `npm run build` → `npm run test`** in **`apps/web`**.
 3. Runs **E2E** with **`MEDIAMOP_E2E=1`**, **`MEDIAMOP_HOME`** on a temp dir, uvicorn + **`vite preview`** + Playwright (from repo-root **`tests/e2e/mediamop/`**, same as local optional E2E below).
 

--- a/docs/operator-messaging-standard.md
+++ b/docs/operator-messaging-standard.md
@@ -45,6 +45,12 @@ Failures must use the shared failure helper in `mediamop.platform.observability.
 - No-op work is still successful when the target already matched the configured plan. It should say `No changes needed`, not `warning`.
 - Secrets must never appear in messages, Activity details, or logs.
 
+## Visible = Truthful
+
+- Any feature, provider, rule, or setting shown in the UI must either work in this release or be explicitly labelled `Not available`, `Coming soon`, or `Unsupported in this version`.
+- Backend handlers must never silently no-op on operator-visible work. If nothing was done, log at least a debug line; if a configured capability is unavailable, log a warning and make the UI disclose that state.
+- MediaMop must not spend provider/network quota on features whose results will always be discarded.
+
 ## Implementation
 
 Backend producers should use `mediamop.platform.observability.operator_messages` for shared labels, titles, and detail envelopes. Frontend pages may render richer layouts, but must preserve the same result/severity meaning and must not invent success states that the backend did not report.

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -21,6 +21,7 @@ This checklist defines the current practical hardening baseline for MediaMop.
 - Docker can generate a persistent session secret when one is not provided.
 - `MEDIAMOP_SESSION_SECRET` signs sessions and CSRF tokens; `MEDIAMOP_CREDENTIALS_SECRET` encrypts saved provider
   credentials. Keep them separate.
+- `MEDIAMOP_METRICS_BEARER_TOKEN` can gate machine access to `/metrics` without requiring an operator browser session.
 - To rotate `MEDIAMOP_CREDENTIALS_SECRET`, set the new value as `MEDIAMOP_CREDENTIALS_SECRET`, add the old value to
   `MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS`, restart MediaMop, then re-save Pruner, Subber, Sonarr, and Radarr
   credentials. After every saved credential has been re-written with the new value, remove the old value from

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -5,7 +5,7 @@ This checklist defines the current practical hardening baseline for MediaMop.
 ## Authentication and setup
 
 - First-run bootstrap is only available when no admin user exists.
-- Passwords shorter than 8 characters must be blocked by both frontend and backend validation.
+- Passwords shorter than 12 characters must be blocked by both frontend and backend validation.
 - Login and bootstrap routes are rate-limited.
 - Authenticated state-changing browser requests require CSRF protection.
 - Session cookies are HTTP-only.
@@ -35,6 +35,7 @@ This checklist defines the current practical hardening baseline for MediaMop.
 - CodeQL code scanning runs on `main`, pull requests to `main`, weekly schedule, and manual dispatch.
 - Security vulnerabilities are reported privately through `SECURITY.md`.
 - Public issues are not used for unpatched vulnerabilities.
+- CI runs `bandit`, `pip-audit`, and `npm audit` in addition to CodeQL and standard test gates.
 
 ## Release controls
 

--- a/docs/settings-truthfulness-audit.md
+++ b/docs/settings-truthfulness-audit.md
@@ -30,5 +30,6 @@ MediaMop settings must describe runtime behaviour as shipped, not intended behav
 
 - Sonarr/Radarr connections and path mappings are saved immediately and used by new sync/search work.
 - Provider settings are saved per provider and used by the next subtitle search.
+- Providers that are present for roadmap or compatibility reasons but not functional in this release must stay visibly labelled as unavailable and must not silently discard downloaded results.
 - Schedule windows affect scheduled search work; import/webhook searches can still run immediately and are labelled separately.
 - Preference and upgrade settings are database-backed and used by new Subber jobs after save.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -32,6 +32,7 @@ MediaMop issues should stay practical and reproducible. Every issue needs a clea
 
 ## Backlog references
 
+- The 1.0.30 backlog hardening tranche added operator-visible logging and explicit unavailability disclosure to several previously silent no-op paths. New operator-visible no-op paths must log at debug or higher and disclose unavailable functionality explicitly.
 - Release governance: [`release-governance.md`](release-governance.md)
 - Windows and Docker smoke checks: [`smoke-checklists.md`](smoke-checklists.md)
 - Security hardening: [`security-hardening.md`](security-hardening.md)

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -32,7 +32,7 @@ MediaMop issues should stay practical and reproducible. Every issue needs a clea
 
 ## Backlog references
 
-- The 1.0.30 backlog hardening tranche added operator-visible logging and explicit unavailability disclosure to several previously silent no-op paths. New operator-visible no-op paths must log at debug or higher and disclose unavailable functionality explicitly.
+- Silent failure and truthfulness audit completed in the 1.0.30 backlog hardening tranche. New operator-visible no-op paths must log at debug or higher and disclose unavailable functionality explicitly.
 - Release governance: [`release-governance.md`](release-governance.md)
 - Windows and Docker smoke checks: [`smoke-checklists.md`](smoke-checklists.md)
 - Security hardening: [`security-hardening.md`](security-hardening.md)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -80,11 +80,49 @@ begin
   );
 end;
 
+function QueryProcessRunning(ProcessName: String): Boolean;
+var
+  ResultCode: Integer;
+  OutputPath: String;
+  TasklistOk: Boolean;
+  OutputText: AnsiString;
+begin
+  OutputPath := ExpandConstant('{tmp}\mm-tasklist.txt');
+  DeleteFile(OutputPath);
+  TasklistOk := Exec(
+    ExpandConstant('{cmd}'),
+    '/C ""' + ExpandConstant('{sys}\tasklist.exe') + '" /FI "IMAGENAME eq ' + ProcessName + '" /NH > "' + OutputPath + '""',
+    '',
+    SW_HIDE,
+    ewWaitUntilTerminated,
+    ResultCode
+  );
+  if (not TasklistOk) or (ResultCode <> 0) or (not LoadStringFromFile(OutputPath, OutputText)) then
+  begin
+    Result := False;
+    Exit;
+  end;
+  Result := Pos(LowerCase(ProcessName), LowerCase(String(OutputText))) > 0;
+end;
+
+procedure WaitForMediaMopProcessesToExit();
+var
+  Deadline: Integer;
+begin
+  Deadline := GetTickCount() + 10000;
+  while GetTickCount() < Deadline do
+  begin
+    if (not QueryProcessRunning('MediaMop.exe')) and (not QueryProcessRunning('MediaMopServer.exe')) then
+      Exit;
+    Sleep(250);
+  end;
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   StopMediaMopProcess('MediaMop.exe');
   StopMediaMopProcess('MediaMopServer.exe');
-  Sleep(1000);
+  WaitForMediaMopProcessesToExit();
   Result := '';
 end;
 
@@ -127,11 +165,9 @@ procedure InstallUpgradeTask();
 var
   ResultCode: Integer;
   TaskCommand: String;
-  UserName: String;
 begin
-  UserName := ExpandConstant('{username}');
   TaskCommand :=
-    '/Create /TN "MediaMop Upgrade" /SC ONDEMAND /RL HIGHEST /IT /F /RU "' + UserName +
+    '/Create /TN "MediaMop Upgrade" /SC ONDEMAND /RL HIGHEST /IT /F ' +
     '" /TR "\"' + ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe') +
     '\" -NoProfile -ExecutionPolicy Bypass -File \"' + ExpandConstant('{app}\MediaMopUpgrade.ps1') + '\""';
 

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -107,14 +107,15 @@ end;
 
 procedure WaitForMediaMopProcessesToExit();
 var
-  Deadline: Integer;
+  Attempts: Integer;
 begin
-  Deadline := GetTickCount() + 10000;
-  while GetTickCount() < Deadline do
+  Attempts := 40;
+  while Attempts > 0 do
   begin
     if (not QueryProcessRunning('MediaMop.exe')) and (not QueryProcessRunning('MediaMopServer.exe')) then
       Exit;
     Sleep(250);
+    Attempts := Attempts - 1;
   end;
 end;
 

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -13,6 +13,9 @@ $distRoot = Join-Path $repoRoot "dist\\windows"
 $ffmpegVendorDir = Join-Path $PSScriptRoot "vendor\\ffmpeg"
 $venvScriptsDir = Join-Path $backendDir ".venv\\Scripts"
 $py = Join-Path $venvScriptsDir "python.exe"
+$ffmpegArchiveName = "ffmpeg-N-124254-g397c7c7524-win64-lgpl.zip"
+$ffmpegArchiveUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-29-13-28/$ffmpegArchiveName"
+$ffmpegArchiveSha256 = "42f9457901fcc1928834ded69f0fc4903bd16c9a41c185234a40490060bda9fb"
 
 function Resolve-VenvExecutable {
   param(
@@ -113,14 +116,17 @@ function Ensure-WindowsFfmpegRuntime {
   }
 
   $downloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-ffmpeg-" + [System.Guid]::NewGuid().ToString("N"))
-  $archivePath = Join-Path $downloadRoot "ffmpeg.zip"
+  $archivePath = Join-Path $downloadRoot $ffmpegArchiveName
   $extractRoot = Join-Path $downloadRoot "extract"
-  $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl.zip"
   try {
     New-Item -ItemType Directory -Path $downloadRoot | Out-Null
     New-Item -ItemType Directory -Path $extractRoot | Out-Null
     Write-Host "Downloading Windows FFmpeg runtime..."
-    Invoke-WebRequest -Uri $url -OutFile $archivePath -UseBasicParsing
+    Invoke-WebRequest -Uri $ffmpegArchiveUrl -OutFile $archivePath -UseBasicParsing
+    $actualSha256 = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $ffmpegArchiveSha256) {
+      throw "Downloaded FFmpeg archive hash mismatch. Expected $ffmpegArchiveSha256 but got $actualSha256."
+    }
     Expand-Archive -LiteralPath $archivePath -DestinationPath $extractRoot -Force
     $binDir = Get-ChildItem -Path $extractRoot -Recurse -Directory |
       Where-Object {

--- a/tests/e2e/mediamop/conftest.py
+++ b/tests/e2e/mediamop/conftest.py
@@ -47,37 +47,21 @@ def _e2e_home() -> str:
 
 
 def _truncate_auth_tables(home: str) -> None:
-    """Clear auth rows in a **subprocess** (same pattern as Alembic).
-
-    The pytest parent process can still fail ``import mediamop`` on CI (editable hooks,
-    importlib mode, sys.path ordering). A fresh ``python -c`` with an explicit ``src``
-    prefix matches the working uvicorn/alembic children.
-    """
-
-    src = str(SRC_PATH.resolve())
-    code = (
-        "import os, sys\n"
-        "sys.path.insert(0, os.environ['MEDIAMOP_BACKEND_SRC'])\n"
-        "os.environ['MEDIAMOP_HOME'] = os.environ['MEDIAMOP_E2E_TRUNCATE_HOME']\n"
-        "from sqlalchemy import delete\n"
-        "from mediamop.core.config import MediaMopSettings\n"
-        "from mediamop.core.db import create_db_engine, create_session_factory\n"
-        "from mediamop.platform.auth.models import User, UserSession\n"
-        "settings = MediaMopSettings.load()\n"
-        "eng = create_db_engine(settings)\n"
-        "fac = create_session_factory(eng)\n"
-        "with fac() as db:\n"
-        "    db.execute(delete(UserSession))\n"
-        "    db.execute(delete(User))\n"
-        "    db.commit()\n"
-        "eng.dispose()\n"
-    )
     subprocess.run(
-        [sys.executable, "-c", code],
-        cwd=str(BACKEND_DIR.resolve()),
+        [
+            sys.executable,
+            "-c",
+            (
+                "from tests.e2e.mediamop.utils import clear_auth_tables_for_home;"
+                "clear_auth_tables_for_home(__import__('os').environ['MEDIAMOP_E2E_TRUNCATE_HOME'])"
+            ),
+        ],
+        cwd=str(REPO_ROOT.resolve()),
         env={
             **os.environ,
-            "MEDIAMOP_BACKEND_SRC": src,
+            "PYTHONPATH": os.pathsep.join(
+                [str(REPO_ROOT.resolve()), str(SRC_PATH.resolve())]
+            ),
             "MEDIAMOP_E2E_TRUNCATE_HOME": home,
         },
         check=True,
@@ -112,7 +96,7 @@ def _wait_http(url: str, *, timeout_s: float = 60.0) -> None:
     raise RuntimeError(f"timeout waiting for {url}: {last!r}")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def mediamop_runtime() -> dict[str, str]:
     if os.environ.get("MEDIAMOP_E2E") != "1":
         pytest.skip("MEDIAMOP_E2E=1 required")
@@ -211,6 +195,11 @@ def mediamop_runtime() -> dict[str, str]:
             api_proc.wait(timeout=8)
         except subprocess.TimeoutExpired:
             api_proc.kill()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def _reset_runtime_auth_state(mediamop_runtime: dict[str, str]) -> None:
+    _truncate_auth_tables(mediamop_runtime["home"])
 
 
 @pytest.fixture(scope="function")

--- a/tests/e2e/mediamop/utils.py
+++ b/tests/e2e/mediamop/utils.py
@@ -7,6 +7,7 @@ from sqlalchemy import delete
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.auth.models import User, UserSession
+from mediamop.platform.suite_settings.model import SuiteSettingsRow
 
 
 def clear_auth_tables_for_home(home: str) -> None:
@@ -17,5 +18,6 @@ def clear_auth_tables_for_home(home: str) -> None:
     with factory() as db:
         db.execute(delete(UserSession))
         db.execute(delete(User))
+        db.execute(delete(SuiteSettingsRow))
         db.commit()
     engine.dispose()

--- a/tests/e2e/mediamop/utils.py
+++ b/tests/e2e/mediamop/utils.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import delete
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.platform.auth.models import User, UserSession
+
+
+def clear_auth_tables_for_home(home: str) -> None:
+    os.environ["MEDIAMOP_HOME"] = home
+    settings = MediaMopSettings.load()
+    engine = create_db_engine(settings)
+    factory = create_session_factory(engine)
+    with factory() as db:
+        db.execute(delete(UserSession))
+        db.execute(delete(User))
+        db.commit()
+    engine.dispose()


### PR DESCRIPTION
## Summary
- harden CI and release validation with stricter backend coverage, `alembic check`, Bandit, pip-audit, npm audit, and safer session-secret handling
- switch Pruner and Subber credential envelopes to HKDF-derived Fernet keys while preserving legacy decrypt compatibility
- tighten Subber, Refiner, Pruner, and platform reliability with explicit operator-visible logging on previously silent no-op paths, atomic subtitle writes, ZIP member size caps, provider registry dispatch, safer ffmpeg stderr capture, and non-blocking worker-loop settings reads
- self-host the web font stack end to end by removing Google Fonts from the HTML CSP path and documenting the bundled Outfit font in third-party notices
- improve login and shell resilience with clearer auth failures, lightweight client-side session-expiry redirects, hidden production sourcemaps, and installer task/process shutdown polish
- stabilize backend and e2e harnesses by restoring isolated migrated test homes, resetting worker health between tests, and scoping auth-table resets to each test without rebuilding the whole runtime

## Validation
- apps/backend: `.venv\\Scripts\\python.exe -m pytest -q`
- apps/backend: `.venv\\Scripts\\python.exe -m ruff check src tests`
- apps/backend: `.venv\\Scripts\\python.exe -m pip freeze --exclude-editable > pip-audit-requirements.txt; .venv\\Scripts\\python.exe -m pip_audit --strict -r pip-audit-requirements.txt`
- apps/web: `npm run lint`
- apps/web: `npm run format`
- apps/web: `npm test`
- apps/web: `npm run build`

## Backlog mapping
- closes #115
- closes #116
- closes #117
- closes #118
- closes #119
- closes #120
- closes #121
- closes #123
- closes #124
- closes #125
- closes #126
- closes #131
- closes #132
- closes #133
- closes #135
- closes #136
- closes #137
- closes #138
- closes #139
- closes #140
- closes #141
