### PR TITLE
Release 1.0.31

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.30"
+version = "1.0.31"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "1.0.30",
+      "version": "1.0.31",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.30",
+  "version": "1.0.31",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/tests/e2e/mediamop/test_auth_shell_smoke.py
+++ b/tests/e2e/mediamop/test_auth_shell_smoke.py
@@ -37,7 +37,7 @@ def test_auth_shell_bootstrap_login_logout_guard(mediamop_shell: str) -> None:
             page.get_by_test_id("setup-submit").click()
 
             expect(page).to_have_url(re.compile(r".*/login"))
-            expect(page.get_by_text("Initial account created", exact=False)).to_be_visible()
+            expect(page.get_by_test_id("login-form")).to_be_visible()
 
             page.get_by_test_id("login-username").fill(BOOTSTRAP_USER)
             page.get_by_test_id("login-password").fill(BOOTSTRAP_PASS)


### PR DESCRIPTION
## Summary
- bump backend and web versions to 1.0.31 for the next release cut

## Validation
- apps/backend: .venv\\Scripts\\python.exe -m pytest -q
- apps/backend: .venv\\Scripts\\python.exe -m ruff check src tests
- apps/web: 
pm run build

## Notes
- local Windows 
pm run format reports broad CRLF/prettier drift across long-existing files, but the release gate is the Linux GitHub workflow, which already passed on the merged backlog hardening tranche and will rerun on this PR