### PR TITLE
Fix expired-session login route fallback

### DIFF
--- a/apps/backend/src/mediamop/api/factory.py
+++ b/apps/backend/src/mediamop/api/factory.py
@@ -54,6 +54,33 @@ def _register_web_spa_history_fallback(application: FastAPI) -> None:
         return FileResponse(root / "index.html", media_type="text/html")
 
 
+def _is_browser_document_request(request: Request) -> bool:
+    accept = (request.headers.get("accept") or "").lower()
+    if "text/html" in accept:
+        return True
+    sec_fetch_dest = (request.headers.get("sec-fetch-dest") or "").lower()
+    return sec_fetch_dest == "document"
+
+
+def _is_spa_history_404(request: Request, exc: StarletteHTTPException) -> bool:
+    """Serve the React shell for browser refreshes on client-side routes.
+
+    FastAPI still owns JSON/API routes and missing static assets. We only convert
+    document-style GET/HEAD 404s without a file suffix into ``index.html``.
+    """
+
+    if exc.status_code != status.HTTP_404_NOT_FOUND or request.method not in {"GET", "HEAD"}:
+        return False
+    if not _is_browser_document_request(request):
+        return False
+    path = request.url.path
+    if path.startswith(("/api", "/health", "/ready", "/metrics")):
+        return False
+    if Path(path).suffix:
+        return False
+    return _web_dist_root() is not None
+
+
 def _is_upgrade_browser_landing_404(request: Request, exc: StarletteHTTPException) -> bool:
     """Redirect stale/legacy in-app-upgrade browser landings back to the SPA.
 
@@ -85,6 +112,10 @@ def create_app() -> FastAPI:
     async def _friendly_upgrade_landing_handler(request: Request, exc: StarletteHTTPException):
         if _is_upgrade_browser_landing_404(request, exc):
             return RedirectResponse(url="/app/settings", status_code=status.HTTP_303_SEE_OTHER)
+        if _is_spa_history_404(request, exc):
+            root = _web_dist_root()
+            if root is not None:
+                return FileResponse(root / "index.html", media_type="text/html")
         return await http_exception_handler(request, exc)
 
     if settings.cors_origins:

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -858,3 +858,32 @@ def test_bundled_html_csp_does_not_allow_inline_styles(monkeypatch: pytest.Monke
     assert "fonts.googleapis.com" not in csp
     assert "fonts.gstatic.com" not in csp
     assert "'unsafe-inline'" not in csp
+
+
+def test_spa_login_route_serves_index_html(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist = tmp_path / "web"
+    dist.mkdir(parents=True)
+    html = "<!doctype html><html><body><div id='root'>MediaMop</div></body></html>"
+    (dist / "index.html").write_text(html, encoding="utf-8")
+    monkeypatch.setenv("MEDIAMOP_WEB_DIST", str(dist))
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/login?session=expired", headers={"Accept": "text/html"})
+
+    assert response.status_code == 200
+    assert "text/html" in (response.headers.get("content-type") or "").lower()
+    assert "MediaMop" in response.text
+
+
+def test_missing_static_asset_still_returns_404(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dist = tmp_path / "web"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<!doctype html><div id='root'></div>", encoding="utf-8")
+    monkeypatch.setenv("MEDIAMOP_WEB_DIST", str(dist))
+
+    app = create_app()
+    with TestClient(app) as client:
+        response = client.get("/assets/missing.js", headers={"Accept": "*/*"})
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- serve the React shell for browser refreshes on client-side routes like /login and /setup when the production backend hosts the SPA
- keep API routes and missing static assets as real 404s
- add coverage for direct /login document requests and missing asset behavior

## Validation
- apps/backend: `.venv\\Scripts\\python.exe -m pytest tests/test_auth_api.py -q`
- apps/backend: `.venv\\Scripts\\python.exe -m ruff check src tests`
- apps/backend: `.venv\\Scripts\\python.exe -m pytest -q`
