### PR TITLE
Release 1.0.32

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "1.0.31"
+version = "1.0.32"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "1.0.31",
+  "version": "1.0.32",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Release bump to 1.0.32 for the Windows updater service, direct login route fallback, upgrade messaging, and CI cleanup.