### PR TITLE
Standardize user-friendly release notes for all tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,27 +183,20 @@ jobs:
         if: always()
         run: docker rm -f mediamop-release-smoke >/dev/null 2>&1 || true
 
+      - name: Prepare user-facing release notes
+        run: |
+          notes_file="docs/release-notes/${GITHUB_REF_NAME}.md"
+          if [ ! -f "$notes_file" ]; then
+            echo "::error::Missing required release notes file: $notes_file"
+            echo "::error::Create it from docs/release-notes/TEMPLATE.md before tagging."
+            exit 1
+          fi
+          cp "$notes_file" "$GITHUB_WORKSPACE/release-notes.md"
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             mediamop-web-dist.zip
             windows-artifact/MediaMopSetup.exe
-          generate_release_notes: true
-          body: |
-            **MediaMop** release `${{ github.ref_name }}`.
-
-            **Included artifacts**
-            - `mediamop-web-dist.zip` - production web bundle from `apps/web/dist`
-            - `MediaMopSetup.exe` - Windows desktop installer with tray host and bundled web UI
-
-            **Container image**
-            - `ghcr.io/${{ github.repository }}:${{ github.ref_name }}`
-            - `ghcr.io/${{ github.repository }}:latest`
-
-            **Registry publishing**
-            - workflow publishes with the repository `GITHUB_TOKEN`
-
-            **Run instructions**
-            - Windows installer and release notes: `docs/release.md`
-            - Docker: `docker/README.md`
+          body_path: release-notes.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This directory is the repository-local system of record. Keep durable decisions 
 - [`triage.md`](triage.md) - issue labels, impact triage, and backlog expectations.
 - [`release-governance.md`](release-governance.md) - release controls and pre/post-release gates.
 - [`release.md`](release.md) - release procedure and artifacts.
+- [`release-notes/TEMPLATE.md`](release-notes/TEMPLATE.md) - required plain-language release notes template.
 - [`smoke-checklists.md`](smoke-checklists.md) - Windows and Docker smoke paths.
 
 ## Architecture And Runtime

--- a/docs/release-governance.md
+++ b/docs/release-governance.md
@@ -23,13 +23,15 @@ This is the canonical governance checklist for keeping MediaMop releases control
 3. Confirm `.github/workflows/ci.yml` and `.github/workflows/release.yml` still expose the required check names listed above.
 4. Confirm Dependabot has no stale action-runtime holds that conflict with the workflow pins.
 5. Confirm open issues tagged `priority: critical` or `priority: high` are either fixed, intentionally deferred, or not release-blocking.
-6. Run the release path from `docs/release.md`.
+6. Create `docs/release-notes/vX.Y.Z.md` from `docs/release-notes/TEMPLATE.md` with plain-language user-facing notes.
+7. Run the release path from `docs/release.md`.
 
 ## After every release
 
 1. Confirm the GitHub Release exists for the pushed tag.
 2. Confirm `MediaMopSetup.exe` is attached to the release.
-3. Confirm the release notes/install guidance explicitly tell Windows users to run `MediaMopSetup.exe` as administrator, and note the one-time updater-service bootstrap requirement for older installs.
-4. Confirm the GHCR image exists for both `vX.Y.Z` and `latest`.
-5. Confirm the release workflow completed `mediamop`, Docker publish, Docker smoke, and Windows package jobs.
-6. Open a follow-up issue for any manual smoke-test failure.
+3. Confirm the published release body is plain-language and matches the approved `docs/release-notes/vX.Y.Z.md` content.
+4. Confirm the release notes/install guidance explicitly tell Windows users to run `MediaMopSetup.exe` as administrator, and note the one-time updater-service bootstrap requirement for older installs.
+5. Confirm the GHCR image exists for both `vX.Y.Z` and `latest`.
+6. Confirm the release workflow completed `mediamop`, Docker publish, Docker smoke, and Windows package jobs.
+7. Open a follow-up issue for any manual smoke-test failure.

--- a/docs/release-notes/TEMPLATE.md
+++ b/docs/release-notes/TEMPLATE.md
@@ -1,0 +1,41 @@
+# MediaMop vX.Y.Z
+
+Date: YYYY-MM-DD
+
+This release focuses on <plain-language summary in one sentence>.
+
+## What Changed
+
+- <User-facing change 1>
+- <User-facing change 2>
+- <User-facing change 3>
+
+## Fixes And Stability
+
+- <Reliability fix 1>
+- <Reliability fix 2>
+- <Reliability fix 3>
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- <Any additional one-time action or compatibility warning>
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:vX.Y.Z`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/vPREVIOUS...vX.Y.Z
+
+---
+
+Authoring guidance:
+
+- Write for operators, not developers.
+- Explain impact first, implementation second.
+- Avoid internal module names unless the user already sees that term in the UI.
+- Keep each bullet short and concrete.

--- a/docs/release-notes/v2.0.0.md
+++ b/docs/release-notes/v2.0.0.md
@@ -1,0 +1,35 @@
+# MediaMop v2.0.0
+
+Date: 2026-05-05
+
+This release improves upgrade reliability, first-run/login flow, and overall day-to-day stability across Refiner, Dashboard, and the Windows app.
+
+## What Changed
+
+- App pages now live at cleaner root URLs (for example `/settings` instead of `/app/settings`), which improves direct links and browser behavior.
+- Setup and login flow was cleaned up so first-run bootstrap, login, and setup wizard transitions are more consistent.
+- Settings layout was reorganized into clearer tabs: **General**, **Backup and restore**, **Upgrade**, **Security**, and **Logs**.
+- Dev/runtime version reporting was corrected to avoid stale version metadata being shown in development environments.
+
+## Fixes And Stability
+
+- Refiner no longer repeatedly remuxes the same file after a successful output when source cleanup temporarily fails due to a Windows/NAS file lock.
+- Activity stream handling was hardened so temporary backend read issues do not cause noisy reconnect loops.
+- Worker health reporting was adjusted to avoid false “stale/degraded” signals during valid long-running jobs.
+- Windows tray app now detects unexpected backend process exits and surfaces a clear “server stopped” indication.
+- Dashboard/activity history retention behavior was corrected so session expiry/log retention no longer clears history unexpectedly.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- In-app upgrade readiness messaging is now more explicit when the updater service token/service is missing.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.0.0`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v1.0.33...v2.0.0

--- a/docs/release.md
+++ b/docs/release.md
@@ -16,7 +16,12 @@ MediaMop is released under AGPL-3.0-or-later. Release artifacts are built from t
    - `apps/backend/pyproject.toml`
    - `apps/web/package.json`
 2. Merge to `main` after `Test / mediamop` passes.
-3. Create an annotated tag on the merge commit:
+3. Create user-facing release notes for the target tag before pushing it:
+
+   - Create `docs/release-notes/vX.Y.Z.md` using `docs/release-notes/TEMPLATE.md`.
+   - Keep wording operator-friendly and focused on what changed for users.
+
+4. Create an annotated tag on the merge commit:
 
    ```bash
    git fetch origin
@@ -26,7 +31,8 @@ MediaMop is released under AGPL-3.0-or-later. Release artifacts are built from t
    git push origin vX.Y.Z
    ```
 
-4. Pushing `v*` triggers `.github/workflows/release.yml`.
+5. Pushing `v*` triggers `.github/workflows/release.yml`.
+6. The release workflow requires `docs/release-notes/vX.Y.Z.md` for the tag and publishes that file as the GitHub Release body.
 
 Local Docker is not required for this release path. Docker build, publish,
 manifest verification, and container smoke testing all run on GitHub-hosted


### PR DESCRIPTION
## Summary\n- add a reusable plain-language release notes template\n- add docs/release-notes/v2.0.0.md as the first canonical notes file\n- require tag-specific notes files in the release workflow before publishing\n- update release docs/governance so notes are a pre-release gate\n\n## Why\nFuture release builds should always publish clear user-facing notes that explain what changed and what users need to do after upgrading.