### PR TITLE
Windows build: copy only ffmpeg/ffprobe and clean stale vendor dir

### DIFF
--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -145,7 +145,13 @@ function Ensure-WindowsFfmpegRuntime {
       Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
     }
     New-Item -ItemType Directory -Path $ffmpegVendorDir | Out-Null
-    Copy-Item -Path (Join-Path $binDir.FullName "*") -Destination $ffmpegVendorDir -Recurse -Force
+    foreach ($name in @("ffmpeg.exe", "ffprobe.exe")) {
+      $src = Join-Path $binDir.FullName $name
+      if (-not (Test-Path -LiteralPath $src)) {
+        throw "Expected $name was not found in the downloaded FFmpeg archive at $src"
+      }
+      Copy-Item -LiteralPath $src -Destination (Join-Path $ffmpegVendorDir $name) -Force
+    }
   } finally {
     if (Test-Path $downloadRoot) {
       Remove-Item -LiteralPath $downloadRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -259,6 +265,11 @@ if (Test-Path $distRoot) {
   Remove-Item -LiteralPath $distRoot -Recurse -Force
 }
 New-Item -ItemType Directory -Path $distRoot | Out-Null
+
+if (Test-Path -LiteralPath $ffmpegVendorDir) {
+  Write-Host "Cleaning stale FFmpeg vendor folder..."
+  Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
+}
 
 Ensure-WindowsFfmpegRuntime
 Ensure-WindowsServiceWrapper


### PR DESCRIPTION
## Summary
- clean packaging/windows/vendor/ffmpeg before runtime vendoring in uild.ps1
- replace wildcard FFmpeg bin copy with explicit copy of fmpeg.exe and fprobe.exe
- fail fast if either expected binary is missing from the archive

## Validation
- rebuilt Windows dist
- confirmed packaging/windows/vendor/ffmpeg contains only fmpeg.exe and fprobe.exe
- confirmed dist/windows/MediaMop/_internal/bin/ffmpeg contains only fmpeg.exe and fprobe.exe
- observed dist size drop from 573.0 MB to 424.8 MB in this run