### PR TITLE
Add v2.0.1 user-facing release notes

### DIFF
--- a/docs/release-notes/v2.0.1.md
+++ b/docs/release-notes/v2.0.1.md
@@ -1,0 +1,32 @@
+# MediaMop v2.0.1
+
+Date: 2026-05-05
+
+This release focuses on reducing Windows install size by packaging only the FFmpeg tools MediaMop actually uses.
+
+## What Changed
+
+- Windows packaging now vendors only `ffmpeg.exe` and `ffprobe.exe`.
+- `ffplay.exe` is no longer bundled in MediaMop Windows builds.
+- The FFmpeg vendor folder is cleaned before each package build to prevent stale binaries from being carried forward.
+
+## Fixes And Stability
+
+- Fixed a packaging defect where wildcard file copy pulled in unnecessary FFmpeg binaries.
+- Prevented stale `vendor/ffmpeg` contents from surviving across build runs.
+- Added explicit build-time validation so packaging fails fast if required FFmpeg binaries are missing.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No operator action is required for this packaging change beyond normal upgrade flow.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.0.1`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.0.0...v2.0.1


### PR DESCRIPTION
Summary: add docs/release-notes/v2.0.1.md with plain-language notes, upgrade guidance, and v2.0.0...v2.0.1 compare link.