### PR TITLE
Release 2.0.3: updater readiness and startup gating fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,51 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Validate release version alignment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          tag_version = os.environ["TAG_VERSION"].strip()
+          if tag_version.startswith("v"):
+              tag_version = tag_version[1:]
+
+          backend = tomllib.loads(Path("apps/backend/pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+          web = json.loads(Path("apps/web/package.json").read_text(encoding="utf-8"))["version"]
+          iss = Path("packaging/windows/MediaMop.iss").read_text(encoding="utf-8")
+          match = re.search(r'#define\\s+AppVersion\\s+"([^"]+)"', iss)
+          if not match:
+              print("ERROR: Could not find AppVersion define in packaging/windows/MediaMop.iss", file=sys.stderr)
+              raise SystemExit(1)
+          installer = match.group(1)
+
+          mismatches = []
+          for name, value in [
+              ("apps/backend/pyproject.toml [project].version", backend),
+              ("apps/web/package.json version", web),
+              ("packaging/windows/MediaMop.iss AppVersion", installer),
+          ]:
+              if value != tag_version:
+                  mismatches.append((name, value))
+
+          if mismatches:
+              print(f"ERROR: Release tag v{tag_version} does not match versioned files:", file=sys.stderr)
+              for name, value in mismatches:
+                  print(f"  - {name}: {value}", file=sys.stderr)
+              raise SystemExit(1)
+
+          print(f"Release versions aligned at {tag_version}.")
+          PY
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+
       - uses: actions/setup-node@v6
         with:
           node-version: "20"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.0"
+version = "2.0.3"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -26,6 +26,7 @@ _WINDOWS_LEGACY_UPGRADE_SUMMARY = (
     "This Windows install does not have the MediaMop updater service yet. "
     "Remote in-app upgrade is not available until one newer installer has been run locally as administrator."
 )
+_WINDOWS_UPDATER_READY_SUMMARY = "Remote in-app upgrade is ready on this Windows install."
 
 
 def _detect_install_type() -> str:
@@ -140,8 +141,13 @@ def _updater_headers(settings: MediaMopSettings | None = None) -> dict[str, str]
 
 
 def _windows_updater_service_ready(settings: MediaMopSettings | None = None) -> bool:
+    ready, _summary = _windows_updater_service_state(settings)
+    return ready
+
+
+def _windows_updater_service_state(settings: MediaMopSettings | None = None) -> tuple[bool, str]:
     if os.name != "nt":
-        return False
+        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY
     headers = _updater_headers(settings)
     if not headers:
         logger.warning(
@@ -149,12 +155,27 @@ def _windows_updater_service_ready(settings: MediaMopSettings | None = None) -> 
             "Ensure the updater service has been installed by running the MediaMop installer as administrator.",
             _updater_token_path(settings),
         )
-        return False
+        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY
     try:
         response = httpx.get(f"{_updater_base_url()}/api/v1/status", headers=headers, timeout=3.0)
-        return response.status_code == 200
     except Exception:
-        return False
+        return (
+            False,
+            "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service. "
+            "Ensure the MediaMop Updater service is running on this computer, then click Check again.",
+        )
+    if response.status_code == 200:
+        return True, _WINDOWS_UPDATER_READY_SUMMARY
+    if response.status_code in {401, 403}:
+        return (
+            False,
+            "Remote in-app upgrade is unavailable because the local updater service token did not match this app "
+            "install. Run the latest MediaMop installer locally once as administrator to repair updater pairing.",
+        )
+    return (
+        False,
+        f"Remote in-app upgrade is unavailable because the local updater service returned HTTP {response.status_code}.",
+    )
 
 
 def _assert_safe_installer_url(installer_url: str) -> str:
@@ -211,7 +232,10 @@ def _start_windows_updater_service_apply(
 def build_suite_update_status(settings: MediaMopSettings | None = None) -> SuiteUpdateStatusOut:
     install_type = _detect_install_type()
     current_version = __version__ or "1.0.0"
-    windows_updater_ready = install_type == "windows" and _windows_updater_service_ready(settings)
+    windows_updater_ready = False
+    windows_upgrade_summary: str | None = None
+    if install_type == "windows":
+        windows_updater_ready, windows_upgrade_summary = _windows_updater_service_state(settings)
     try:
         payload = _fetch_latest_release_payload()
     except httpx.HTTPStatusError as exc:
@@ -223,15 +247,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
                 summary="No public MediaMop release is published yet.",
                 docker_image=DOCKER_IMAGE if install_type == "docker" else None,
                 in_app_upgrade_supported=windows_updater_ready,
-                in_app_upgrade_summary=(
-                    None
-                    if install_type != "windows"
-                    else (
-                        "Remote in-app upgrade is ready on this Windows install."
-                        if windows_updater_ready
-                        else _WINDOWS_LEGACY_UPGRADE_SUMMARY
-                    )
-                ),
+                in_app_upgrade_summary=windows_upgrade_summary,
             )
         return SuiteUpdateStatusOut(
             current_version=current_version,
@@ -240,15 +256,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
             summary="Could not check for updates right now.",
             docker_image=DOCKER_IMAGE if install_type == "docker" else None,
             in_app_upgrade_supported=windows_updater_ready,
-            in_app_upgrade_summary=(
-                None
-                if install_type != "windows"
-                else (
-                    "Remote in-app upgrade is ready on this Windows install."
-                    if windows_updater_ready
-                    else _WINDOWS_LEGACY_UPGRADE_SUMMARY
-                )
-            ),
+            in_app_upgrade_summary=windows_upgrade_summary,
         )
     except Exception:
         return SuiteUpdateStatusOut(
@@ -258,15 +266,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
             summary="Could not check for updates right now.",
             docker_image=DOCKER_IMAGE if install_type == "docker" else None,
             in_app_upgrade_supported=windows_updater_ready,
-            in_app_upgrade_summary=(
-                None
-                if install_type != "windows"
-                else (
-                    "Remote in-app upgrade is ready on this Windows install."
-                    if windows_updater_ready
-                    else _WINDOWS_LEGACY_UPGRADE_SUMMARY
-                )
-            ),
+            in_app_upgrade_summary=windows_upgrade_summary,
         )
 
     tag_name = str(payload.get("tag_name") or "").strip()
@@ -309,15 +309,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
         docker_tag=docker_tag,
         docker_update_command=docker_update_command,
         in_app_upgrade_supported=windows_updater_ready,
-        in_app_upgrade_summary=(
-            None
-            if install_type != "windows"
-            else (
-                "Remote in-app upgrade is ready on this Windows install."
-                if windows_updater_ready
-                else _WINDOWS_LEGACY_UPGRADE_SUMMARY
-            )
-        ),
+        in_app_upgrade_summary=windows_upgrade_summary,
     )
 
 

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -150,7 +150,7 @@ def _lan_urls(port: int) -> list[str]:
 
 def _wait_for_health(
     port: int,
-    timeout_seconds: float = 30.0,
+    timeout_seconds: float = 60.0,
     process: subprocess.Popen[str] | None = None,
 ) -> None:
     import http.client
@@ -163,12 +163,12 @@ def _wait_for_health(
             )
         try:
             conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
-            conn.request("GET", "/health")
+            conn.request("GET", "/ready")
             response = conn.getresponse()
             if response.status == 200:
                 return
         except (OSError, http.client.HTTPException):
-            time.sleep(0.35)
+            time.sleep(0.25)
         finally:
             try:
                 conn.close()

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -337,6 +337,26 @@ describe("SettingsPage (suite settings)", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not show one-time bootstrap guidance when updater service is installed but unreachable", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...minimalUpdateStatus,
+        install_type: "windows",
+        status: "update_available",
+        in_app_upgrade_supported: false,
+        in_app_upgrade_summary:
+          "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service. Ensure the MediaMop Updater service is running on this computer, then click Check again.",
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.queryByText("One-time setup required"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/could not reach the local updater service/i),
+    ).toBeInTheDocument();
+  });
+
   it("shows change password only on Security tab", () => {
     renderSettings(operatorMe);
     fireEvent.click(screen.getByRole("tab", { name: "Security" }));

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -377,6 +377,12 @@ export function SettingsPage() {
         ((
           settingsQ.data.configuration_backup_preferred_time || "02:00"
         ).trim() || "02:00"));
+  const upgradeBootstrapRequired =
+    updateStatusQ.data?.install_type === "windows" &&
+    !updateStatusQ.data.in_app_upgrade_supported &&
+    (updateStatusQ.data.in_app_upgrade_summary || "")
+      .toLowerCase()
+      .includes("does not have the mediamop updater service yet");
 
   const loadingAny = settingsQ.isPending || me.isPending;
 
@@ -1447,8 +1453,7 @@ export function SettingsPage() {
                     <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
                       What happens next
                     </h4>
-                    {updateStatusQ.data.install_type === "windows" &&
-                    !updateStatusQ.data.in_app_upgrade_supported ? (
+                    {upgradeBootstrapRequired ? (
                       <div className="rounded-lg border border-amber-400/25 bg-amber-400/[0.06] px-3 py-2">
                         <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
                           One-time setup required

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.0"
+  #define AppVersion "2.0.3"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- gate tray browser open on \/ready (not \/health) and increase readiness timeout
- improve Windows updater readiness diagnostics and UI messaging
- bump app/runtime/package versions to 2.0.3
- add release workflow guard to fail when tag/version files are misaligned

## Validation
- py -3 -m pytest -q apps/backend/tests/test_suite_settings_api.py (20 passed)
- 
pm run test -- src/pages/settings/settings-page.test.tsx (14 passed)
