### PR TITLE
Fix v2.0.3 release workflow guard and add release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           backend = tomllib.loads(Path("apps/backend/pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
           web = json.loads(Path("apps/web/package.json").read_text(encoding="utf-8"))["version"]
           iss = Path("packaging/windows/MediaMop.iss").read_text(encoding="utf-8")
-          match = re.search(r'#define\\s+AppVersion\\s+"([^"]+)"', iss)
+          match = re.search(r'#define\s+AppVersion\s+"([^"]+)"', iss)
           if not match:
               print("ERROR: Could not find AppVersion define in packaging/windows/MediaMop.iss", file=sys.stderr)
               raise SystemExit(1)

--- a/docs/release-notes/v2.0.3.md
+++ b/docs/release-notes/v2.0.3.md
@@ -1,0 +1,32 @@
+# MediaMop v2.0.3
+
+Date: 2026-05-06
+
+This release focuses on making Windows in-app upgrade behavior more reliable and easier to diagnose.
+
+## What Changed
+
+- Improved startup gating for the tray app so the browser opens only when the app is fully ready.
+- Improved Windows updater readiness messaging in Settings so unavailable states explain the real cause.
+- Added release-time version alignment validation so tag/version mismatches are blocked before artifacts are built.
+
+## Fixes And Stability
+
+- Tray startup now waits on `/ready` instead of `/health`, with a longer timeout and faster readiness polling.
+- Windows updater status now distinguishes missing token, unreachable updater service, and token mismatch scenarios.
+- Added test coverage for Settings upgrade availability messaging to prevent regressions.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No additional operator action is required for this release.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.0.3`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.0.2...v2.0.3


### PR DESCRIPTION
## Summary
- fix escaped regex in release workflow AppVersion extraction
- add required docs/release-notes/v2.0.3.md so tagged release can publish

## Why
- previous v2.0.3 release run failed before build due regex mismatch
- release publish step requires tag-specific release notes file
