### PR TITLE
Release 2.0.4

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.3"
+version = "2.0.4"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.0.4.md
+++ b/docs/release-notes/v2.0.4.md
@@ -1,0 +1,32 @@
+# MediaMop v2.0.4
+
+Date: 2026-05-06
+
+This release focuses on hardening upgrade and backlog reliability work before the next feature wave.
+
+## What Changed
+
+- Closed the current backlog sweep changes from PR #168 on `main`, including updater and module reliability fixes.
+- Improved Windows updater behavior and diagnostics so upgrade readiness states are clearer and easier to troubleshoot.
+- Strengthened backend and packaging test coverage around updater service and version resolution paths.
+
+## Fixes And Stability
+
+- Fixed Linux CI instability caused by Windows-only path handling in backend tests.
+- Scoped updater-related test monkeypatching to prevent cross-test environment leakage.
+- Stabilized updater thread-failure API test behavior so server-side failures are asserted consistently.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No additional operator action is required for this release.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.0.4`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.0.3...v2.0.4

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.3"
+  #define AppVersion "2.0.4"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary\n- bump backend/web/windows installer versions to 2.0.4\n- add user-facing release notes for v2.0.4\n- prepare tag-driven release artifacts\n\n## Validation\n- backend: pytest -q (777 passed, 2 skipped)\n- web: npm run build\n- web: npm run test -- --run