### PR TITLE
Fix Windows in-app upgrade version loop and release 2.0.5 metadata

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.4"
+version = "2.0.5"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.0.5.md
+++ b/docs/release-notes/v2.0.5.md
@@ -1,0 +1,21 @@
+# MediaMop v2.0.5
+
+Release date: 2026-05-06
+
+## What changed
+
+- Fixed a Windows packaging issue that could ship stale backend version metadata.
+  - This could make in-app upgrade appear to run but leave the app reporting an older version.
+  - The Windows build now force-reinstalls the backend package metadata before PyInstaller runs.
+  - The build now fails fast if the installed backend version does not match the intended release version.
+- Updated Windows installer versioning and web package version to `2.0.5`.
+
+## User impact
+
+- In-app upgrade on Windows now has a reliable version transition target.
+- Upgrade checks should no longer loop on the same release because of stale packaged version metadata.
+
+## Artifacts
+
+- `MediaMopSetup.exe`
+- `ghcr.io/jampat000/mediamop:v2.0.5`

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.4"
+  #define AppVersion "2.0.5"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -188,10 +188,11 @@ function Ensure-WindowsServiceWrapper {
 }
 
 $iscc = Resolve-IsccPath
+$backendProjectVersion = ((Get-Content -Path (Join-Path $backendDir "pyproject.toml")) | Where-Object { $_ -match '^version = ' } | Select-Object -First 1).Split('"')[1]
 $buildVersion = if ($env:MEDIAMOP_BUILD_VERSION) {
   $env:MEDIAMOP_BUILD_VERSION
 } else {
-  ((Get-Content -Path (Join-Path $backendDir "pyproject.toml")) | Where-Object { $_ -match '^version = ' } | Select-Object -First 1).Split('"')[1]
+  $backendProjectVersion
 }
 
 if (-not (Test-Path $py)) {
@@ -254,7 +255,14 @@ try {
   Invoke-Native -FilePath $py -ArgumentList @("-m", "ensurepip", "--upgrade")
   $pip = Resolve-VenvExecutable -ScriptsDir $venvScriptsDir -NamePattern "pip*.exe" -MissingMessage "pip launcher was not created in the backend virtual environment."
   Invoke-Native -FilePath $py -ArgumentList @("-m", "pip", "install", "--upgrade", "pip")
-  Invoke-Native -FilePath $pip -ArgumentList @("install", "-e", ".")
+  Invoke-Native -FilePath $pip -ArgumentList @("install", "--upgrade", "--force-reinstall", "-e", ".")
+  $installedBackendVersion = (& $py -c "import importlib.metadata as m; print(m.version('mediamop-backend'))").Trim()
+  if (-not $installedBackendVersion) {
+    throw "Could not resolve installed mediamop-backend version after editable install."
+  }
+  if ($installedBackendVersion -ne $backendProjectVersion) {
+    throw "Installed mediamop-backend version '$installedBackendVersion' does not match backend project version '$backendProjectVersion'."
+  }
   Invoke-Native -FilePath $pip -ArgumentList @("install", "pillow>=11.0.0", "pyinstaller>=6.12.0", "pystray>=0.19.5")
   $pyinstaller = Resolve-VenvExecutable -ScriptsDir $venvScriptsDir -NamePattern "pyinstaller*.exe" -MissingMessage "pyinstaller launcher was not installed in the backend virtual environment."
 } finally {

--- a/packaging/windows/mediamop-tray.spec
+++ b/packaging/windows/mediamop-tray.spec
@@ -12,7 +12,7 @@ TRAY_ICON_ICO = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.
 FFMPEG_VENDOR = ROOT / "packaging" / "windows" / "vendor" / "ffmpeg"
 THIRD_PARTY_NOTICES = ROOT / "THIRD_PARTY_NOTICES.md"
 
-hiddenimports = collect_submodules("mediamop")
+hiddenimports = collect_submodules("mediamop") + collect_submodules("uvicorn")
 datas = [
     (str(BACKEND / "alembic"), "alembic"),
     (str(BACKEND / "alembic.ini"), "."),


### PR DESCRIPTION
## Summary\n- force editable backend reinstall during Windows packaging (--upgrade --force-reinstall --no-deps)\n- fail build if installed backend version and release version diverge\n- bump version metadata to 2.0.5 (backend/web/installer default)\n- add docs/release-notes/v2.0.5.md\n\n## Validation\n- pps/backend: .venv/Scripts/python.exe -m pytest -q -> 777 passed, 2 skipped\n- pps/web: 
pm run test -> 162 passed\n- pps/web: 
pm run build -> passed\n- packaging/windows/build.ps1 -SkipWebBuild -> passed, produced dist/windows/MediaMop/_internal/mediamop_backend-2.0.5.dist-info and dist/windows/MediaMopSetup.exe\n