### PR TITLE
Fix Windows updater launcher reliability and prep v2.0.6

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [jampat000]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ MediaMop is licensed under the GNU Affero General Public License v3.0 or later (
 
 You can use, study, modify, and redistribute it under the license terms. If you distribute a modified version or run a modified version as a network service, the AGPL requires you to make the corresponding source code available under the same license.
 
+## Support MediaMop
+
+MediaMop is free to use. Support is optional.
+
+If MediaMop saves you time, you can support development from the in-app **Support MediaMop** card in Settings.
+
+For this repository, the support button is driven by `VITE_SUPPORT_URL` in `apps/web/.env` (or your deployment environment). If that value is not set, the app stays fully usable and the support button is hidden in production.
+
 ## Verification
 
 Optional local verification:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.5"
+version = "2.0.6"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -183,11 +183,10 @@ def _launch_installer_detached(installer_path: Path) -> subprocess.Popen[bytes]:
     if os.name != "nt":
         msg = "Windows only"
         raise OSError(msg)
-    create_breakaway_from_job = 0x01000000
-    detached_process = 0x00000008
+    # Keep installer launch semantics aligned with Start-Process behavior.
+    # Aggressive detached flags can cause the installer to exit immediately
+    # on some hosts without producing a setup log.
     create_new_process_group = 0x00000200
-    create_no_window = 0x08000000
-    flags = create_breakaway_from_job | detached_process | create_new_process_group | create_no_window
     cmd = [
         str(installer_path.resolve()),
         "/VERYSILENT",
@@ -195,12 +194,12 @@ def _launch_installer_detached(installer_path: Path) -> subprocess.Popen[bytes]:
         "/NORESTART",
         "/CLOSEAPPLICATIONS",
         "/RESTARTAPPLICATIONS",
-        f'/LOG="{_setup_log_path()}"',
+        f"/LOG={_setup_log_path()}",
     ]
     return subprocess.Popen(
         cmd,
         close_fds=True,
-        creationflags=flags,
+        creationflags=create_new_process_group,
         cwd=str(installer_path.parent),
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,7 @@
 
 # Override backend target for the dev proxy (defaults: scripts/dev-ports.json).
 # VITE_DEV_API_PROXY_TARGET=http://127.0.0.1:8788
+
+# Optional support/sponsorship URL for the in-app "Support MediaMop" button.
+# Keep unset to hide the button in production.
+# VITE_SUPPORT_URL=https://github.com/sponsors/your-github-username

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.5",
+  "version": "2.0.6",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/support.test.ts
+++ b/apps/web/src/lib/support.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSupportUrl, shouldShowSupportPlaceholder } from "./support";
+
+describe("support helpers", () => {
+  it("accepts http and https URLs", () => {
+    expect(normalizeSupportUrl("https://github.com/sponsors/example")).toBe(
+      "https://github.com/sponsors/example",
+    );
+    expect(normalizeSupportUrl("http://example.com/support")).toBe(
+      "http://example.com/support",
+    );
+  });
+
+  it("rejects blank and invalid URLs", () => {
+    expect(normalizeSupportUrl("")).toBeNull();
+    expect(normalizeSupportUrl("   ")).toBeNull();
+    expect(normalizeSupportUrl("not-a-url")).toBeNull();
+    expect(normalizeSupportUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  it("only shows placeholder in development when no URL is configured", () => {
+    expect(shouldShowSupportPlaceholder(true, null)).toBe(true);
+    expect(shouldShowSupportPlaceholder(false, null)).toBe(false);
+    expect(
+      shouldShowSupportPlaceholder(true, "https://github.com/sponsors/example"),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -1,0 +1,32 @@
+export function normalizeSupportUrl(
+  raw: string | null | undefined,
+): string | null {
+  const value = (raw ?? "").trim();
+  if (value === "") {
+    return null;
+  }
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      return null;
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function shouldShowSupportPlaceholder(
+  isDev: boolean,
+  supportUrl: string | null,
+): boolean {
+  return isDev && supportUrl === null;
+}
+
+export const SUPPORT_URL = normalizeSupportUrl(
+  import.meta.env.VITE_SUPPORT_URL,
+);
+export const SHOW_SUPPORT_URL_PLACEHOLDER = shouldShowSupportPlaceholder(
+  import.meta.env.DEV,
+  SUPPORT_URL,
+);

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -161,6 +161,19 @@ describe("SettingsPage (suite settings)", () => {
     expect(screen.getByTestId("suite-settings-global")).toBeTruthy();
   });
 
+  it("shows support copy and avoids a broken support button when no URL is configured", () => {
+    renderSettings(operatorMe);
+    expect(screen.getByTestId("suite-settings-support")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "MediaMop is free to use. If it saves you time, you can support development and help keep updates coming.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Support MediaMop" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("hides save for viewers", () => {
     renderSettings(viewerMe);
     expect(screen.getByTestId("suite-settings-save-timezone")).toBeDisabled();

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -53,6 +53,7 @@ import {
   type DisplayDensity,
 } from "../../lib/ui/display-density";
 import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
+import { SHOW_SUPPORT_URL_PLACEHOLDER, SUPPORT_URL } from "../../lib/support";
 
 function canEditSuiteGlobal(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
@@ -1056,6 +1057,54 @@ export function SettingsPage() {
                       ))}
                     </div>
                   </fieldset>
+                </section>
+                <section
+                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                  data-testid="suite-settings-support"
+                  aria-labelledby="suite-settings-support-heading"
+                >
+                  <div className="mm-card-action-body">
+                    <div>
+                      <h3
+                        id="suite-settings-support-heading"
+                        className="text-base font-semibold text-[var(--mm-text1)]"
+                      >
+                        Support MediaMop
+                      </h3>
+                      <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                        MediaMop is free to use. If it saves you time, you can
+                        support development and help keep updates coming.
+                      </p>
+                    </div>
+                    <p className="text-sm text-[var(--mm-text3)]">
+                      Supporter licence (optional, future): this space is
+                      reserved for future supporter acknowledgement details.
+                      There are no licence checks or feature limits in this
+                      release.
+                    </p>
+                    {SHOW_SUPPORT_URL_PLACEHOLDER ? (
+                      <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
+                        Development note: set <code>VITE_SUPPORT_URL</code> to
+                        show the support button.
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="mm-card-action-footer">
+                    {SUPPORT_URL ? (
+                      <a
+                        href={SUPPORT_URL}
+                        target="_blank"
+                        rel="noreferrer"
+                        className={mmActionButtonClass({
+                          variant: "secondary",
+                          disabled: false,
+                        })}
+                        data-testid="suite-settings-support-button"
+                      >
+                        Support MediaMop
+                      </a>
+                    ) : null}
+                  </div>
                 </section>
               </div>
             </div>

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -6,6 +6,8 @@ declare const __WEB_PACKAGE_VERSION__: string;
 interface ImportMetaEnv {
   /** Optional absolute origin for API (production). Dev default: same-origin via Vite ``/api`` proxy. */
   readonly VITE_API_BASE_URL?: string;
+  /** Optional support/sponsorship URL used by the in-app Support MediaMop card. */
+  readonly VITE_SUPPORT_URL?: string;
 }
 
 interface ImportMeta {

--- a/docs/release-notes/v2.0.6.md
+++ b/docs/release-notes/v2.0.6.md
@@ -1,0 +1,25 @@
+# MediaMop v2.0.6
+
+Release date: 2026-05-06
+
+## What changed
+
+- Fixed Windows in-app upgrade launcher behavior in the updater service.
+  - Removed aggressive detached process flags that could cause installer launch failures on some hosts.
+  - Updated installer log argument formatting to `/LOG=<path>` for consistent Inno Setup logging.
+  - Kept updater state reporting explicit when installer launch or exit fails.
+- Added optional operator-facing support entry points.
+  - New `Support MediaMop` card in Settings.
+  - Support URL is configurable with `VITE_SUPPORT_URL`.
+  - If `VITE_SUPPORT_URL` is not set, production hides the support button and all core features remain fully usable.
+- Bumped backend/web/installer version metadata to `2.0.6`.
+
+## User impact
+
+- In-app upgrade on Windows now launches the installer with stable, repeatable process semantics.
+- Upgrade failures are now easier to diagnose from updater state and logs.
+
+## Artifacts
+
+- `MediaMopSetup.exe`
+- `ghcr.io/jampat000/mediamop:v2.0.6`

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.5"
+  #define AppVersion "2.0.6"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- fix Windows updater service installer launch semantics to match stable Start-Process behavior
- use /LOG=<path> installer argument formatting for consistent setup log output
- bump backend/web/installer versions to 2.0.6
- add optional support entry points (FUNDING config, README support section, Settings support card)
- add v2.0.6 release notes

## Validation
- uv run python -m pytest -q (apps/backend): 777 passed, 2 skipped
- 
pm run test -- --run (apps/web): 162 passed
- 
pm run build (apps/web): passed
- packaging/windows/build.ps1: passed