### PR TITLE
Reconcile updater state after installer restart and prep v2.0.7

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.6"
+version = "2.0.7"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -160,6 +160,32 @@ def _append_service_log(message: str) -> None:
         handle.write(f"[{stamp}] {message}\n")
 
 
+def _reconcile_post_restart_state() -> None:
+    try:
+        state = _read_state()
+    except NotImplementedError:
+        return
+    phase = str(state.get("phase") or "").strip().lower()
+    if phase != "installer_running":
+        return
+    target_version = str(state.get("target_version") or "").strip()
+    if not target_version or target_version != __version__:
+        return
+    installer_log_path = str(state.get("installer_log_path") or _setup_log_path())
+    _append_service_log(
+        "Detected updater service restart after successful install; "
+        f"marking upgrade completed for {target_version}.",
+    )
+    _write_state(
+        phase="completed",
+        message=f"MediaMop {target_version} upgrade completed.",
+        target_version=target_version,
+        installer_log_path=installer_log_path,
+        last_completed_at=_iso_now(),
+        last_error=None,
+    )
+
+
 def _validate_installer_url(installer_url: str) -> str:
     parsed = urlparse(installer_url)
     host = (parsed.hostname or "").lower()
@@ -323,6 +349,7 @@ class ApplyRequest(BaseModel):
 
 def create_updater_app() -> FastAPI:
     app = FastAPI(title="MediaMop Updater Service", version=__version__)
+    _reconcile_post_restart_state()
     shared_token = _load_or_create_token()
 
     def _require_token(x_mediamop_updater_token: str | None = Header(default=None, alias="X-MediaMop-Updater-Token")) -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.6",
+  "version": "2.0.7",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.0.7.md
+++ b/docs/release-notes/v2.0.7.md
@@ -1,0 +1,20 @@
+# MediaMop v2.0.7
+
+Release date: 2026-05-06
+
+## What changed
+
+- Fixed Windows updater state reconciliation after installer-driven service restart.
+  - If the updater service restarts during install and the target version now matches the running version, MediaMop now marks the upgrade as completed instead of leaving state stuck at `installer_running`.
+  - This prevents stale upgrade state from blocking later upgrade attempts or showing misleading in-progress status.
+- Bumped backend/web/installer version metadata to `2.0.7`.
+
+## User impact
+
+- In-app upgrade state on Windows now recovers cleanly when the updater service is restarted by the installer.
+- Operators see a completed upgrade state instead of a stuck running state after successful install.
+
+## Artifacts
+
+- `MediaMopSetup.exe`
+- `ghcr.io/jampat000/mediamop:v2.0.7`

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.6"
+  #define AppVersion "2.0.7"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- add updater startup reconciliation for stale installer_running state after installer-driven service restart
- if target version now matches running version, mark upgrade as completed automatically
- bump backend/web/installer versions to 2.0.7
- add v2.0.7 release notes

## Validation
- uv run python -m pytest -q (apps/backend): 777 passed, 2 skipped
- 
pm run ci (apps/web): passed
- packaging/windows/build.ps1: passed