### PR TITLE
Finalize updater lifecycle and close remaining backlog issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,8 +146,6 @@ jobs:
         run: choco install innosetup --no-progress -y
 
       - name: Build MediaMop Windows installer
-        env:
-          MEDIAMOP_BUILD_VERSION: ci-${{ github.run_number }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
       - name: Smoke test packaged Windows server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,20 +113,36 @@ jobs:
           $hash = (Get-FileHash -LiteralPath "dist/windows/MediaMopSetup.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
           "$hash  MediaMopSetup.exe" | Set-Content -LiteralPath "dist/windows/MediaMopSetup.exe.sha256" -Encoding ascii
 
+      - name: Detect Windows code signing configuration
+        id: codesign
+        shell: bash
+        env:
+          WINDOWS_CODESIGN_PFX_BASE64: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
+        run: |
+          if [[ -n "${WINDOWS_CODESIGN_PFX_BASE64}" && -n "${WINDOWS_CODESIGN_PASSWORD}" ]]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Sign MediaMop Windows installer
-        if: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 != '' && secrets.WINDOWS_CODESIGN_PASSWORD != '' }}
+        if: ${{ steps.codesign.outputs.enabled == 'true' }}
         shell: powershell
+        env:
+          WINDOWS_CODESIGN_PFX_BASE64: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 }}
+          WINDOWS_CODESIGN_PASSWORD: ${{ secrets.WINDOWS_CODESIGN_PASSWORD }}
         run: |
           $pfxPath = Join-Path $env:RUNNER_TEMP "mediamop-codesign.pfx"
-          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String("${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 }}"))
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WINDOWS_CODESIGN_PFX_BASE64))
           $signtool = (Get-Command signtool.exe -ErrorAction Stop).Source
-          & $signtool sign /f $pfxPath /p "${{ secrets.WINDOWS_CODESIGN_PASSWORD }}" /fd sha256 /tr http://timestamp.digicert.com /td sha256 "dist/windows/MediaMopSetup.exe"
+          & $signtool sign /f $pfxPath /p $env:WINDOWS_CODESIGN_PASSWORD /fd sha256 /tr http://timestamp.digicert.com /td sha256 "dist/windows/MediaMopSetup.exe"
           if ($LASTEXITCODE -ne 0) {
             throw "signtool failed with exit code $LASTEXITCODE"
           }
 
       - name: Verify MediaMop Windows installer signature
-        if: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 != '' && secrets.WINDOWS_CODESIGN_PASSWORD != '' }}
+        if: ${{ steps.codesign.outputs.enabled == 'true' }}
         shell: powershell
         run: |
           $signature = Get-AuthenticodeSignature -FilePath "dist/windows/MediaMopSetup.exe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Normalize tag version
+        id: version
+        shell: bash
+        run: echo "plain=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
@@ -96,17 +101,47 @@ jobs:
 
       - name: Build MediaMop Windows installer
         env:
-          MEDIAMOP_BUILD_VERSION: ${{ github.ref_name }}
+          MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
       - name: Smoke test packaged Windows server
-        run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1
+        run: powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1 -ExpectedVersion "${{ steps.version.outputs.plain }}"
+
+      - name: Generate installer checksum manifest
+        shell: powershell
+        run: |
+          $hash = (Get-FileHash -LiteralPath "dist/windows/MediaMopSetup.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  MediaMopSetup.exe" | Set-Content -LiteralPath "dist/windows/MediaMopSetup.exe.sha256" -Encoding ascii
+
+      - name: Sign MediaMop Windows installer
+        if: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 != '' && secrets.WINDOWS_CODESIGN_PASSWORD != '' }}
+        shell: powershell
+        run: |
+          $pfxPath = Join-Path $env:RUNNER_TEMP "mediamop-codesign.pfx"
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String("${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 }}"))
+          $signtool = (Get-Command signtool.exe -ErrorAction Stop).Source
+          & $signtool sign /f $pfxPath /p "${{ secrets.WINDOWS_CODESIGN_PASSWORD }}" /fd sha256 /tr http://timestamp.digicert.com /td sha256 "dist/windows/MediaMopSetup.exe"
+          if ($LASTEXITCODE -ne 0) {
+            throw "signtool failed with exit code $LASTEXITCODE"
+          }
+
+      - name: Verify MediaMop Windows installer signature
+        if: ${{ secrets.WINDOWS_CODESIGN_PFX_BASE64 != '' && secrets.WINDOWS_CODESIGN_PASSWORD != '' }}
+        shell: powershell
+        run: |
+          $signature = Get-AuthenticodeSignature -FilePath "dist/windows/MediaMopSetup.exe"
+          if ($signature.Status -ne "Valid") {
+            throw "Installer signature verification failed: $($signature.Status) $($signature.StatusMessage)"
+          }
 
       - name: Upload MediaMop Windows installer
         uses: actions/upload-artifact@v7
         with:
           name: mediamop-windows-installer
-          path: dist/windows/MediaMopSetup.exe
+          if-no-files-found: error
+          path: |
+            dist/windows/MediaMopSetup.exe
+            dist/windows/MediaMopSetup.exe.sha256
 
   tagged-release:
     runs-on: ubuntu-latest
@@ -174,6 +209,10 @@ jobs:
         id: image
         run: echo "name=${REGISTRY}/$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
+      - name: Normalize tag version
+        id: version
+        run: echo "plain=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Download MediaMop Windows installer
         uses: actions/download-artifact@v8
         with:
@@ -198,12 +237,12 @@ jobs:
           provenance: true
           sbom: true
           tags: |
-            ${{ steps.image.outputs.name }}:${{ github.ref_name }}
+            ${{ steps.image.outputs.name }}:${{ steps.version.outputs.plain }}
             ${{ steps.image.outputs.name }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ github.ref_name }}
+            org.opencontainers.image.version=${{ steps.version.outputs.plain }}
 
       - name: Verify published Docker manifest
         run: docker manifest inspect "${{ steps.image.outputs.name }}:latest"
@@ -244,4 +283,5 @@ jobs:
           files: |
             mediamop-web-dist.zip
             windows-artifact/MediaMopSetup.exe
+            windows-artifact/MediaMopSetup.exe.sha256
           body_path: release-notes.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     ca-certificates \
     curl \
     ffmpeg \
+    gosu \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/mediamop
@@ -47,8 +48,6 @@ ENV MEDIAMOP_ENV=production
 # never be sent on http://, which breaks sign-in. Set MEDIAMOP_SESSION_COOKIE_SECURE=true when
 # browsers always use HTTPS (e.g. TLS terminated at a reverse proxy in front of this container).
 ENV MEDIAMOP_SESSION_COOKIE_SECURE=false
-
-USER mediamop
 
 EXPOSE 8788
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ You can use, study, modify, and redistribute it under the license terms. If you 
 
 MediaMop is free to use. Support is optional.
 
-If MediaMop saves you time, you can support development from the in-app **Support MediaMop** card in Settings.
+If MediaMop saves you time or helps keep your library cleaner, you can support ongoing development.
 
-For this repository, the support button is driven by `VITE_SUPPORT_URL` in `apps/web/.env` (or your deployment environment). If that value is not set, the app stays fully usable and the support button is hidden in production.
+Set `VITE_SUPPORT_URL` in `apps/web/.env` or your deployment environment to show the in-app support button.
 
 ## Verification
 
@@ -140,5 +140,9 @@ docker compose up -d
 
 No env file is required for the default Docker path. The container will generate and persist
 its own session secret if you do not provide one.
+
+If you need the container to write as a specific NAS or host user, set `MEDIAMOP_PUID` /
+`MEDIAMOP_PGID` and the relevant `MEDIAMOP_CHOWN_*` flags for Refiner watched/work/output
+folders. Full examples and migration notes live in [`docker/README.md`](docker/README.md).
 
 Full Docker instructions: [`docker/README.md`](docker/README.md)

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.0.7"
+version = "2.1.0"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -515,6 +515,8 @@ def run_refiner_file_remux_pass(
         "audio_after": after_a,
         "subs_before": before_s,
         "subs_after": after_s,
+        "removed_audio": list(plan.removed_audio),
+        "removed_subtitles": list(plan.removed_subtitles),
         "after_track_lines_meaning": "Planned output layout for this live pass.",
         "remux_required": remux_needed,
         "ffmpeg_argv": [str(x) for x in argv],

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/visibility.py
@@ -82,8 +82,8 @@ def clip_remux_pass_payload_for_activity(payload: dict[str, Any]) -> dict[str, A
             result=result,
             media_scope=out.get("media_scope") if isinstance(out.get("media_scope"), str) else None,
             counts={
-                "audio_removed": len(out.get("audio_removed") or []),
-                "subtitles_removed": len(out.get("subtitles_removed") or []),
+                "audio_removed": len(out.get("removed_audio") or []),
+                "subtitles_removed": len(out.get("removed_subtitles") or []),
             },
             user_message=remux_pass_activity_title(out),
             next_action=str(out.get("reason") or "") if result == DiagnosticResult.FAILED else None,

--- a/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
@@ -92,7 +92,11 @@ def make_subber_webhook_import_handler(
                     session,
                     event_type=C.SUBBER_WEBHOOK_IMPORT_ENQUEUED,
                     title=f"Subber webhook import ({media_scope})",
-                    detail={"enqueued": enqueued, "file_path": file_path},
+                    detail={
+                        "enqueued": enqueued,
+                        "file_path": file_path,
+                        "media_scope": media_scope,
+                    },
                 )
 
     _ = webhook_job_kind

--- a/apps/backend/src/mediamop/platform/activity/constants.py
+++ b/apps/backend/src/mediamop/platform/activity/constants.py
@@ -7,6 +7,7 @@ AUTH_LOGOUT = "auth.logout"
 AUTH_BOOTSTRAP_SUCCEEDED = "auth.bootstrap_succeeded"
 AUTH_BOOTSTRAP_DENIED = "auth.bootstrap_denied"
 AUTH_PASSWORD_CHANGED = "auth.password_changed"
+SYSTEM_RECONCILIATION_REPAIR = "system.reconciliation.repair"
 
 # Shared *arr library (Sonarr/Radarr) — operator-triggered connection checks
 ARR_LIBRARY_CONNECTION_TEST_SUCCEEDED = "arr_library.connection_test_succeeded"

--- a/apps/backend/src/mediamop/platform/docker_runtime.py
+++ b/apps/backend/src/mediamop/platform/docker_runtime.py
@@ -1,0 +1,297 @@
+"""Docker runtime ownership helpers for Linux container launches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _first_env(env: Mapping[str, str], *names: str) -> str | None:
+    for name in names:
+        raw = str(env.get(name, "")).strip()
+        if raw:
+            return raw
+    return None
+
+
+def _parse_non_negative_int(raw: str, *, name: str) -> int:
+    if not raw.isdigit():
+        raise ValueError(f"{name} must be a non-negative integer.")
+    return int(raw)
+
+
+def _parse_boolish(raw: str | None, *, name: str, default: bool) -> bool:
+    if raw is None or not raw.strip():
+        return default
+    value = raw.strip().lower()
+    if value in _TRUE_VALUES:
+        return True
+    if value in _FALSE_VALUES:
+        return False
+    raise ValueError(f"{name} must be one of: true/false, 1/0, yes/no, on/off.")
+
+
+def _parse_directory_mode(raw: str | None, *, name: str) -> int | None:
+    if raw is None or not raw.strip():
+        return None
+    value = raw.strip()
+    if len(value) not in {3, 4} or any(ch not in "01234567" for ch in value):
+        raise ValueError(f"{name} must be an octal directory mode such as 775 or 2775.")
+    return int(value, 8)
+
+
+@dataclass(frozen=True, slots=True)
+class DockerOwnershipPlan:
+    puid: int
+    pgid: int
+    chown_watched: bool
+    chown_temp: bool
+    chown_output: bool
+    watched_dir_mode: int | None
+    temp_dir_mode: int | None
+    output_dir_mode: int | None
+
+
+def load_docker_ownership_plan(
+    env: Mapping[str, str] | None = None,
+) -> DockerOwnershipPlan:
+    values = dict(os.environ if env is None else env)
+    puid = _parse_non_negative_int(
+        _first_env(values, "MEDIAMOP_PUID", "PUID") or "1000",
+        name="MEDIAMOP_PUID",
+    )
+    pgid = _parse_non_negative_int(
+        _first_env(values, "MEDIAMOP_PGID", "PGID") or "1000",
+        name="MEDIAMOP_PGID",
+    )
+    return DockerOwnershipPlan(
+        puid=puid,
+        pgid=pgid,
+        chown_watched=_parse_boolish(
+            values.get("MEDIAMOP_CHOWN_WATCHED"),
+            name="MEDIAMOP_CHOWN_WATCHED",
+            default=False,
+        ),
+        chown_temp=_parse_boolish(
+            values.get("MEDIAMOP_CHOWN_TEMP"),
+            name="MEDIAMOP_CHOWN_TEMP",
+            default=False,
+        ),
+        chown_output=_parse_boolish(
+            values.get("MEDIAMOP_CHOWN_OUTPUT"),
+            name="MEDIAMOP_CHOWN_OUTPUT",
+            default=False,
+        ),
+        watched_dir_mode=_parse_directory_mode(
+            values.get("MEDIAMOP_DIR_MODE_WATCHED"),
+            name="MEDIAMOP_DIR_MODE_WATCHED",
+        ),
+        temp_dir_mode=_parse_directory_mode(
+            values.get("MEDIAMOP_DIR_MODE_TEMP"),
+            name="MEDIAMOP_DIR_MODE_TEMP",
+        ),
+        output_dir_mode=_parse_directory_mode(
+            values.get("MEDIAMOP_DIR_MODE_OUTPUT"),
+            name="MEDIAMOP_DIR_MODE_OUTPUT",
+        ),
+    )
+
+
+def _dedupe_paths(values: list[str | None]) -> list[Path]:
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for raw in values:
+        text = str(raw or "").strip()
+        if not text:
+            continue
+        path = Path(text).expanduser().resolve(strict=False)
+        if path in seen:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
+
+
+def collect_refiner_permission_targets(
+    db_path: Path,
+    *,
+    include_watched: bool,
+    include_temp: bool,
+    include_output: bool,
+) -> dict[str, list[Path]]:
+    targets: dict[str, list[Path]] = {"watched": [], "temp": [], "output": []}
+    resolved_db = db_path.expanduser().resolve(strict=False)
+    if not resolved_db.is_file():
+        return targets
+    try:
+        with sqlite3.connect(resolved_db) as conn:
+            table = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'refiner_path_settings'",
+            ).fetchone()
+            if table is None:
+                return targets
+            row = conn.execute(
+                """
+                SELECT
+                    refiner_watched_folder,
+                    refiner_work_folder,
+                    refiner_output_folder,
+                    refiner_tv_watched_folder,
+                    refiner_tv_work_folder,
+                    refiner_tv_output_folder
+                FROM refiner_path_settings
+                WHERE id = 1
+                """,
+            ).fetchone()
+    except sqlite3.Error:
+        return targets
+    if row is None:
+        return targets
+    watched_movie, temp_movie, output_movie, watched_tv, temp_tv, output_tv = row
+    if include_watched:
+        targets["watched"] = _dedupe_paths([watched_movie, watched_tv])
+    if include_temp:
+        targets["temp"] = _dedupe_paths([temp_movie, temp_tv])
+    if include_output:
+        targets["output"] = _dedupe_paths([output_movie, output_tv])
+    return targets
+
+
+def _chown_tree(root: Path, *, uid: int, gid: int) -> None:
+    if not hasattr(os, "chown"):
+        raise RuntimeError("Recursive ownership changes require POSIX os.chown support.")
+    for current_root, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current_root)
+        os.chown(current_path, uid, gid, follow_symlinks=False)
+        for name in dirnames:
+            path = current_path / name
+            if path.is_symlink():
+                continue
+            os.chown(path, uid, gid, follow_symlinks=False)
+        for name in filenames:
+            path = current_path / name
+            if path.is_symlink():
+                continue
+            os.chown(path, uid, gid, follow_symlinks=False)
+
+
+def _chmod_directories(root: Path, *, mode: int) -> None:
+    for current_root, dirnames, _filenames in os.walk(root, topdown=True, followlinks=False):
+        current_path = Path(current_root)
+        os.chmod(current_path, mode, follow_symlinks=False)
+        for name in dirnames:
+            path = current_path / name
+            if path.is_symlink():
+                continue
+            os.chmod(path, mode, follow_symlinks=False)
+
+
+def apply_refiner_permissions(
+    *,
+    db_path: Path,
+    plan: DockerOwnershipPlan,
+) -> list[str]:
+    messages: list[str] = []
+    include_watched = plan.chown_watched or plan.watched_dir_mode is not None
+    include_temp = plan.chown_temp or plan.temp_dir_mode is not None
+    include_output = plan.chown_output or plan.output_dir_mode is not None
+    targets = collect_refiner_permission_targets(
+        db_path,
+        include_watched=include_watched,
+        include_temp=include_temp,
+        include_output=include_output,
+    )
+    mode_map = {
+        "watched": plan.watched_dir_mode,
+        "temp": plan.temp_dir_mode,
+        "output": plan.output_dir_mode,
+    }
+    chown_map = {
+        "watched": plan.chown_watched,
+        "temp": plan.chown_temp,
+        "output": plan.chown_output,
+    }
+    for kind in ("watched", "temp", "output"):
+        for path in targets[kind]:
+            if not path.exists():
+                messages.append(f"{kind}: skipped missing path {path}")
+                continue
+            if not path.is_dir():
+                raise RuntimeError(f"{kind} path is not a directory: {path}")
+            if chown_map[kind]:
+                _chown_tree(path, uid=plan.puid, gid=plan.pgid)
+                messages.append(f"{kind}: updated ownership for {path}")
+            mode = mode_map[kind]
+            if mode is not None:
+                _chmod_directories(path, mode=mode)
+                messages.append(f"{kind}: applied directory mode {mode:o} to {path}")
+    return messages
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    targets = sub.add_parser("print-refiner-targets")
+    targets.add_argument("--db-path", required=True)
+    targets.add_argument("--include-watched", action="store_true")
+    targets.add_argument("--include-temp", action="store_true")
+    targets.add_argument("--include-output", action="store_true")
+
+    apply = sub.add_parser("apply-refiner-permissions")
+    apply.add_argument("--db-path", required=True)
+    apply.add_argument("--uid", required=True)
+    apply.add_argument("--gid", required=True)
+    apply.add_argument("--include-watched", action="store_true")
+    apply.add_argument("--include-temp", action="store_true")
+    apply.add_argument("--include-output", action="store_true")
+    apply.add_argument("--watched-dir-mode")
+    apply.add_argument("--temp-dir-mode")
+    apply.add_argument("--output-dir-mode")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    db_path = Path(args.db_path)
+    if args.command == "print-refiner-targets":
+        data = collect_refiner_permission_targets(
+            db_path,
+            include_watched=bool(args.include_watched),
+            include_temp=bool(args.include_temp),
+            include_output=bool(args.include_output),
+        )
+        print(
+            json.dumps(
+                {kind: [str(path) for path in paths] for kind, paths in data.items()},
+                separators=(",", ":"),
+            )
+        )
+        return 0
+
+    plan = DockerOwnershipPlan(
+        puid=_parse_non_negative_int(str(args.uid), name="--uid"),
+        pgid=_parse_non_negative_int(str(args.gid), name="--gid"),
+        chown_watched=bool(args.include_watched),
+        chown_temp=bool(args.include_temp),
+        chown_output=bool(args.include_output),
+        watched_dir_mode=_parse_directory_mode(args.watched_dir_mode, name="--watched-dir-mode"),
+        temp_dir_mode=_parse_directory_mode(args.temp_dir_mode, name="--temp-dir-mode"),
+        output_dir_mode=_parse_directory_mode(args.output_dir_mode, name="--output-dir-mode"),
+    )
+    for line in apply_refiner_permissions(db_path=db_path, plan=plan):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/backend/src/mediamop/platform/reconciliation/router.py
+++ b/apps/backend/src/mediamop/platform/reconciliation/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from mediamop.api.deps import DbSessionDep
+from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.reconciliation.service import build_reconciliation_report, repair_reconciliation_issue
@@ -51,7 +52,7 @@ def post_reconciliation_repair(
 
     record_activity_event(
         db,
-        event_type="system.reconciliation.repair",
+        event_type=C.SYSTEM_RECONCILIATION_REPAIR,
         module="system",
         title="System repair action completed" if result.get("applied") else "System repair action skipped",
         detail=f"{body.action}: {result.get('message', '')}",

--- a/apps/backend/src/mediamop/platform/suite_settings/release_catalog.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/release_catalog.py
@@ -1,0 +1,166 @@
+"""Canonical GitHub release metadata helpers for MediaMop updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+GH_OWNER = "jampat000"
+GH_REPO = "MediaMop"
+GH_REPO_SLUG = f"{GH_OWNER}/{GH_REPO}"
+GH_RELEASES_LATEST_URL = f"https://api.github.com/repos/{GH_REPO_SLUG}/releases/latest"
+GH_RELEASE_BY_TAG_URL_TEMPLATE = f"https://api.github.com/repos/{GH_REPO_SLUG}/releases/tags/{{tag}}"
+WINDOWS_INSTALLER_ASSET_NAME = "MediaMopSetup.exe"
+WINDOWS_INSTALLER_SHA256_ASSET_NAME = "MediaMopSetup.exe.sha256"
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubReleaseAsset:
+    name: str
+    api_url: str
+    browser_download_url: str
+    size_bytes: int
+    content_type: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubReleaseRecord:
+    tag_name: str
+    version: str
+    release_name: str | None
+    html_url: str | None
+    published_at: datetime | None
+    draft: bool
+    prerelease: bool
+    assets: tuple[GitHubReleaseAsset, ...]
+
+    def asset_named(self, name: str) -> GitHubReleaseAsset | None:
+        wanted = name.strip().lower()
+        for asset in self.assets:
+            if asset.name.strip().lower() == wanted:
+                return asset
+        return None
+
+
+def normalize_release_version(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    text = raw.strip()
+    if not text:
+        return None
+    return text.removeprefix("v") or None
+
+
+def tag_for_version(version: str) -> str:
+    normalized = normalize_release_version(version)
+    if not normalized:
+        raise ValueError("Release version is missing.")
+    return f"v{normalized}"
+
+
+def parse_version_key(raw: str | None) -> tuple[int, ...] | None:
+    normalized = normalize_release_version(raw)
+    if not normalized:
+        return None
+    parts: list[int] = []
+    for piece in normalized.split("."):
+        digits = "".join(ch for ch in piece if ch.isdigit())
+        if digits == "":
+            break
+        parts.append(int(digits))
+    return tuple(parts) if parts else None
+
+
+def release_headers(user_agent_version: str) -> dict[str, str]:
+    return {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"MediaMop/{user_agent_version}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _coerce_release_asset(payload: dict[str, Any]) -> GitHubReleaseAsset:
+    name = str(payload.get("name") or "").strip()
+    api_url = str(payload.get("url") or "").strip()
+    if not name or not api_url:
+        raise ValueError("Release asset metadata is incomplete.")
+    return GitHubReleaseAsset(
+        name=name,
+        api_url=api_url,
+        browser_download_url=str(payload.get("browser_download_url") or "").strip(),
+        size_bytes=int(payload.get("size") or 0),
+        content_type=(
+            str(payload.get("content_type") or "").strip() or None
+        ),
+    )
+
+
+def _coerce_release_payload(payload: dict[str, Any]) -> GitHubReleaseRecord:
+    if not isinstance(payload, dict):
+        raise ValueError("Release API returned an unexpected response.")
+    tag_name = str(payload.get("tag_name") or "").strip()
+    version = normalize_release_version(tag_name)
+    if not version:
+        raise ValueError("Release metadata is missing a valid tag name.")
+    published_at_raw = payload.get("published_at")
+    published_at = None
+    if isinstance(published_at_raw, str) and published_at_raw.strip():
+        published_at = datetime.fromisoformat(
+            published_at_raw.strip().replace("Z", "+00:00")
+        )
+    assets_raw = payload.get("assets")
+    assets: list[GitHubReleaseAsset] = []
+    if isinstance(assets_raw, list):
+        for item in assets_raw:
+            if isinstance(item, dict):
+                assets.append(_coerce_release_asset(item))
+    return GitHubReleaseRecord(
+        tag_name=tag_name,
+        version=version,
+        release_name=str(payload.get("name") or "").strip() or None,
+        html_url=str(payload.get("html_url") or "").strip() or None,
+        published_at=published_at,
+        draft=bool(payload.get("draft")),
+        prerelease=bool(payload.get("prerelease")),
+        assets=tuple(assets),
+    )
+
+
+def fetch_latest_release_record(*, user_agent_version: str) -> GitHubReleaseRecord:
+    with httpx.Client(
+        timeout=5.0,
+        headers=release_headers(user_agent_version),
+        follow_redirects=True,
+    ) as client:
+        response = client.get(GH_RELEASES_LATEST_URL)
+        response.raise_for_status()
+        return _coerce_release_payload(response.json())
+
+
+def fetch_release_record_by_version(
+    version: str,
+    *,
+    user_agent_version: str,
+) -> GitHubReleaseRecord:
+    tag = tag_for_version(version)
+    with httpx.Client(
+        timeout=5.0,
+        headers=release_headers(user_agent_version),
+        follow_redirects=True,
+    ) as client:
+        response = client.get(GH_RELEASE_BY_TAG_URL_TEMPLATE.format(tag=tag))
+        response.raise_for_status()
+        record = _coerce_release_payload(response.json())
+    if record.tag_name != tag:
+        raise ValueError(
+            f"Release tag mismatch for MediaMop update: expected {tag}, got {record.tag_name}."
+        )
+    if record.draft or record.prerelease:
+        raise ValueError(
+            f"MediaMop update {tag} is not a stable published release."
+        )
+    return record
+

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -20,6 +20,7 @@ from mediamop.platform.suite_settings.schemas import (
     ConfigurationBundleImportIn,
     SuiteConfigurationBackupItemOut,
     SuiteConfigurationBackupListOut,
+    SuiteUpdateDiagnosticsOut,
     SuiteLogCountsOut,
     SuiteLogEntryOut,
     SuiteLogsOut,
@@ -43,7 +44,11 @@ from mediamop.platform.suite_settings.suite_configuration_backup_service import 
     get_suite_configuration_backup_file_path,
     list_suite_configuration_backups,
 )
-from mediamop.platform.suite_settings.update_service import build_suite_update_status, start_suite_update_now
+from mediamop.platform.suite_settings.update_service import (
+    build_suite_update_diagnostics,
+    build_suite_update_status,
+    start_suite_update_now,
+)
 
 router = APIRouter(tags=["suite"])
 
@@ -176,6 +181,14 @@ def get_suite_update_status(_user: UserPublicDep, settings: SettingsDep) -> Suit
     """Read-only update check for the signed-in Settings page."""
 
     return build_suite_update_status(settings)
+
+
+@router.get("/suite/update-diagnostics", response_model=SuiteUpdateDiagnosticsOut)
+@router.get("/suite/settings/update-diagnostics", response_model=SuiteUpdateDiagnosticsOut)
+def get_suite_update_diagnostics(_user: RequireOperatorDep, settings: SettingsDep) -> SuiteUpdateDiagnosticsOut:
+    """Operator-facing updater diagnostics for Windows package troubleshooting."""
+
+    return build_suite_update_diagnostics(settings)
 
 
 @router.get("/suite/update-now")

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -180,6 +180,7 @@ class SuiteUpdateStatusOut(BaseModel):
     docker_update_command: str | None = None
     in_app_upgrade_supported: bool = False
     in_app_upgrade_summary: str | None = None
+    upgrade: "SuiteUpgradeProgressOut | None" = None
 
 
 class SuiteUpdateStartOut(BaseModel):
@@ -189,9 +190,55 @@ class SuiteUpdateStartOut(BaseModel):
 
     status: str = Field(min_length=1, description="started, manual_required, or unavailable")
     message: str = Field(min_length=1)
+    attempt_id: str | None = None
     target_version: str | None = None
     installer_path: str | None = None
     log_path: str | None = None
+
+
+class SuiteUpgradeProgressOut(BaseModel):
+    """Persisted updater progress mirrored from the local Windows updater service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    attempt_id: str | None = None
+    target_version: str | None = None
+    current_version_seen: str | None = None
+    downloaded_installer_path: str | None = None
+    installer_sha256: str | None = None
+    expected_sha256: str | None = None
+    installer_log_path: str | None = None
+    service_log_path: str | None = None
+    install_root: str | None = None
+    runtime_home: str | None = None
+    last_started_at: datetime | None = None
+    last_updated_at: datetime | None = None
+    last_completed_at: datetime | None = None
+    last_error: str | None = None
+    diagnostics: dict[str, Any] = Field(default_factory=dict)
+
+
+class SuiteUpdateDiagnosticsOut(BaseModel):
+    """Operator-facing updater diagnostic snapshot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    current_version: str = Field(min_length=1)
+    latest_version: str | None = None
+    install_type: str = Field(min_length=1)
+    install_root: str | None = None
+    runtime_home: str | None = None
+    updater_service_reachable: bool = False
+    updater_token_path_present: bool = False
+    installer_log_path: str | None = None
+    service_log_path: str | None = None
+    installer_log_tail: list[str] = Field(default_factory=list)
+    service_log_tail: list[str] = Field(default_factory=list)
+    running_processes: list[dict[str, Any]] = Field(default_factory=list)
+    installed_files: list[dict[str, Any]] = Field(default_factory=list)
+    upgrade: SuiteUpgradeProgressOut | None = None
 
 
 class SuiteUpdateStartIn(BaseModel):

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -1,32 +1,56 @@
-"""Release-check logic for the Settings page."""
+"""Release-check logic and Windows updater status mirroring for the Settings page."""
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import os
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import httpx
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.suite_settings.schemas import SuiteUpdateStartOut, SuiteUpdateStatusOut
-from mediamop.version import __version__
+from mediamop.platform.observability.diagnostics import sanitize_diagnostic_value
+from mediamop.platform.suite_settings.release_catalog import (
+    GH_REPO_SLUG,
+    WINDOWS_INSTALLER_ASSET_NAME,
+    fetch_latest_release_record,
+    normalize_release_version,
+    parse_version_key,
+)
+from mediamop.platform.suite_settings.schemas import (
+    SuiteUpdateDiagnosticsOut,
+    SuiteUpdateStartOut,
+    SuiteUpdateStatusOut,
+    SuiteUpgradeProgressOut,
+)
+from mediamop.version import __version__, resolve_packaged_version
 from mediamop.windows.updater_service import UPDATER_PORT
 
 logger = logging.getLogger(__name__)
 
-GH_REPO = "jampat000/MediaMop"
-GH_RELEASES_LATEST_URL = f"https://api.github.com/repos/{GH_REPO}/releases/latest"
 DOCKER_IMAGE = "ghcr.io/jampat000/mediamop"
-
 _WINDOWS_LEGACY_UPGRADE_SUMMARY = (
     "This Windows install does not have the MediaMop updater service yet. "
     "Remote in-app upgrade is not available until one newer installer has been run locally as administrator."
 )
 _WINDOWS_UPDATER_READY_SUMMARY = "Remote in-app upgrade is ready on this Windows install."
+_WINDOWS_UPDATER_UNREACHABLE_SUMMARY = (
+    "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service. "
+    "Ensure the MediaMop Updater service is running on this computer, then click Check again."
+)
+_REQUIRED_WINDOWS_FILES: tuple[tuple[str, str], ...] = (
+    ("MediaMop.exe", "MediaMop.exe"),
+    ("MediaMopServer.exe", "MediaMopServer.exe"),
+    ("MediaMopUpdater.exe", "MediaMopUpdater.exe"),
+    ("MediaMopUpdaterService.exe", "MediaMopUpdaterService.exe"),
+    ("MediaMopUpdaterService.xml", "MediaMopUpdaterService.xml"),
+    ("web-dist", "_internal\\web-dist\\index.html"),
+)
 
 
 def _detect_install_type() -> str:
@@ -38,49 +62,6 @@ def _detect_install_type() -> str:
     if getattr(sys, "frozen", False) and os.name == "nt":
         return "windows"
     return "source"
-
-
-def _parse_version(raw: str | None) -> tuple[int, ...] | None:
-    if not raw:
-        return None
-    text = raw.strip().lower().removeprefix("v")
-    if not text:
-        return None
-    parts: list[int] = []
-    for piece in text.split("."):
-        digits = "".join(ch for ch in piece if ch.isdigit())
-        if digits == "":
-            break
-        parts.append(int(digits))
-    return tuple(parts) if parts else None
-
-
-def _fetch_latest_release_payload() -> dict[str, Any]:
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "User-Agent": f"MediaMop/{__version__}",
-    }
-    with httpx.Client(timeout=5.0, headers=headers, follow_redirects=True) as client:
-        response = client.get(GH_RELEASES_LATEST_URL)
-        response.raise_for_status()
-        payload = response.json()
-        if not isinstance(payload, dict):
-            msg = "Release API returned an unexpected response."
-            raise ValueError(msg)
-        return payload
-
-
-def _find_windows_installer_asset(payload: dict[str, Any]) -> str | None:
-    assets = payload.get("assets")
-    if not isinstance(assets, list):
-        return None
-    for asset in assets:
-        if not isinstance(asset, dict):
-            continue
-        name = str(asset.get("name") or "").strip().lower()
-        if name == "mediamopsetup.exe":
-            return str(asset.get("browser_download_url") or "").strip() or None
-    return None
 
 
 def _runtime_home(settings: MediaMopSettings | None = None) -> Path:
@@ -111,7 +92,10 @@ def _updater_token_path(settings: MediaMopSettings | None = None) -> Path:
 
 def _updater_token_paths(settings: MediaMopSettings | None = None) -> list[Path]:
     paths: list[Path] = []
-    for candidate in (_install_root() / "updater.secret", _runtime_home(settings) / "updater.secret"):
+    for candidate in (
+        _install_root() / "updater.secret",
+        _runtime_home(settings) / "updater.secret",
+    ):
         if candidate not in paths:
             paths.append(candidate)
     return paths
@@ -140,14 +124,42 @@ def _updater_headers(settings: MediaMopSettings | None = None) -> dict[str, str]
     return {"X-MediaMop-Updater-Token": token}
 
 
-def _windows_updater_service_ready(settings: MediaMopSettings | None = None) -> bool:
-    ready, _summary = _windows_updater_service_state(settings)
-    return ready
+def _safe_response_json(response: httpx.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
 
 
-def _windows_updater_service_state(settings: MediaMopSettings | None = None) -> tuple[bool, str]:
-    if os.name != "nt":
-        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY
+def _coerce_upgrade_progress(payload: dict[str, Any] | None) -> SuiteUpgradeProgressOut | None:
+    if not payload:
+        return None
+    diagnostics = payload.get("diagnostics")
+    return SuiteUpgradeProgressOut(
+        phase=str(payload.get("phase") or "unknown"),
+        message=str(payload.get("message") or "Updater status unavailable."),
+        attempt_id=str(payload.get("attempt_id") or "").strip() or None,
+        target_version=normalize_release_version(str(payload.get("target_version") or "")),
+        current_version_seen=str(payload.get("current_version_seen") or "").strip() or None,
+        downloaded_installer_path=str(payload.get("downloaded_installer_path") or "").strip() or None,
+        installer_sha256=str(payload.get("installer_sha256") or "").strip() or None,
+        expected_sha256=str(payload.get("expected_sha256") or "").strip() or None,
+        installer_log_path=str(payload.get("installer_log_path") or "").strip() or None,
+        service_log_path=str(payload.get("service_log_path") or "").strip() or None,
+        install_root=str(payload.get("install_root") or "").strip() or None,
+        runtime_home=str(payload.get("runtime_home") or "").strip() or None,
+        last_started_at=payload.get("last_started_at"),
+        last_updated_at=payload.get("last_updated_at"),
+        last_completed_at=payload.get("last_completed_at"),
+        last_error=str(payload.get("last_error") or "").strip() or None,
+        diagnostics=diagnostics if isinstance(diagnostics, dict) else {},
+    )
+
+
+def _fetch_windows_updater_progress(
+    settings: MediaMopSettings | None = None,
+) -> tuple[bool, str, SuiteUpgradeProgressOut | None]:
     headers = _updater_headers(settings)
     if not headers:
         logger.warning(
@@ -155,89 +167,72 @@ def _windows_updater_service_state(settings: MediaMopSettings | None = None) -> 
             "Ensure the updater service has been installed by running the MediaMop installer as administrator.",
             _updater_token_path(settings),
         )
-        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY
+        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY, None
     try:
-        response = httpx.get(f"{_updater_base_url()}/api/v1/status", headers=headers, timeout=3.0)
-    except Exception:
-        return (
-            False,
-            "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service. "
-            "Ensure the MediaMop Updater service is running on this computer, then click Check again.",
+        response = httpx.get(
+            f"{_updater_base_url()}/api/v1/status",
+            headers=headers,
+            timeout=3.0,
         )
+    except Exception as exc:
+        logger.warning("MediaMop could not reach the local updater service: %s", exc)
+        return False, _WINDOWS_UPDATER_UNREACHABLE_SUMMARY, None
     if response.status_code == 200:
-        return True, _WINDOWS_UPDATER_READY_SUMMARY
+        return True, _WINDOWS_UPDATER_READY_SUMMARY, _coerce_upgrade_progress(_safe_response_json(response))
     if response.status_code in {401, 403}:
         return (
             False,
             "Remote in-app upgrade is unavailable because the local updater service token did not match this app "
             "install. Run the latest MediaMop installer locally once as administrator to repair updater pairing.",
+            None,
         )
     return (
         False,
         f"Remote in-app upgrade is unavailable because the local updater service returned HTTP {response.status_code}.",
+        _coerce_upgrade_progress(_safe_response_json(response)),
     )
 
 
-def _assert_safe_installer_url(installer_url: str) -> str:
-    parsed = urlparse(installer_url)
-    host = (parsed.hostname or "").lower()
-    if parsed.scheme != "https":
-        msg = "Installer download URL must use HTTPS."
-        raise ValueError(msg)
-    if host not in {
-        "github.com",
-        "objects.githubusercontent.com",
-        "release-assets.githubusercontent.com",
-    }:
-        msg = "Installer download URL must come from GitHub Releases."
-        raise ValueError(msg)
-    return installer_url
+def _windows_updater_service_ready(settings: MediaMopSettings | None = None) -> bool:
+    ready, _summary, _progress = _fetch_windows_updater_progress(settings)
+    return ready
 
 
 def _start_windows_updater_service_apply(
     settings: MediaMopSettings,
     *,
-    installer_url: str,
     target_version: str,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, str | None]:
     headers = _updater_headers(settings)
     if not headers:
-        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY
+        return False, _WINDOWS_LEGACY_UPGRADE_SUMMARY, None
     try:
         response = httpx.post(
             f"{_updater_base_url()}/api/v1/apply",
             headers=headers,
-            json={
-                "installer_url": _assert_safe_installer_url(installer_url),
-                "target_version": target_version,
-            },
+            json={"target_version": normalize_release_version(target_version)},
             timeout=10.0,
         )
     except Exception as exc:
-        return False, f"MediaMop could not reach the local updater service: {exc}"
+        return False, f"MediaMop could not reach the local updater service: {exc}", None
+    payload = _safe_response_json(response)
+    attempt_id = str(payload.get("attempt_id") or "").strip() or None
     if response.status_code != 200:
-        try:
-            payload = response.json()
-            detail = str(payload.get("detail") or "").strip()
-        except Exception:
-            detail = ""
-        return False, detail or "MediaMop could not start the local updater service request."
-    try:
-        payload = response.json()
-    except Exception:
-        return False, "MediaMop updater service returned an invalid response."
-    return bool(payload.get("accepted")), str(payload.get("message") or "").strip()
+        detail = str(payload.get("detail") or payload.get("message") or "").strip()
+        return False, detail or "MediaMop could not start the local updater service request.", attempt_id
+    return bool(payload.get("accepted")), str(payload.get("message") or "").strip(), attempt_id
 
 
-def build_suite_update_status(settings: MediaMopSettings | None = None) -> SuiteUpdateStatusOut:
-    install_type = _detect_install_type()
-    current_version = __version__ or "1.0.0"
-    windows_updater_ready = False
-    windows_upgrade_summary: str | None = None
-    if install_type == "windows":
-        windows_updater_ready, windows_upgrade_summary = _windows_updater_service_state(settings)
+def _build_release_status(
+    *,
+    current_version: str,
+    install_type: str,
+    windows_updater_ready: bool,
+    windows_upgrade_summary: str | None,
+    upgrade_progress: SuiteUpgradeProgressOut | None,
+) -> SuiteUpdateStatusOut:
     try:
-        payload = _fetch_latest_release_payload()
+        release = fetch_latest_release_record(user_agent_version=current_version)
     except httpx.HTTPStatusError as exc:
         if exc.response.status_code == 404:
             return SuiteUpdateStatusOut(
@@ -248,6 +243,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
                 docker_image=DOCKER_IMAGE if install_type == "docker" else None,
                 in_app_upgrade_supported=windows_updater_ready,
                 in_app_upgrade_summary=windows_upgrade_summary,
+                upgrade=upgrade_progress,
             )
         return SuiteUpdateStatusOut(
             current_version=current_version,
@@ -257,6 +253,7 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
             docker_image=DOCKER_IMAGE if install_type == "docker" else None,
             in_app_upgrade_supported=windows_updater_ready,
             in_app_upgrade_summary=windows_upgrade_summary,
+            upgrade=upgrade_progress,
         )
     except Exception:
         return SuiteUpdateStatusOut(
@@ -267,30 +264,27 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
             docker_image=DOCKER_IMAGE if install_type == "docker" else None,
             in_app_upgrade_supported=windows_updater_ready,
             in_app_upgrade_summary=windows_upgrade_summary,
+            upgrade=upgrade_progress,
         )
 
-    tag_name = str(payload.get("tag_name") or "").strip()
-    latest_version = tag_name.removeprefix("v") or None
-    latest_name = str(payload.get("name") or "").strip() or latest_version
-    release_url = str(payload.get("html_url") or "").strip() or None
-    published_at = payload.get("published_at")
-    windows_installer_url = _find_windows_installer_asset(payload)
+    current_parsed = parse_version_key(current_version)
+    latest_parsed = parse_version_key(release.version)
+    update_available = bool(
+        current_parsed and latest_parsed and latest_parsed > current_parsed
+    )
 
-    current_parsed = _parse_version(current_version)
-    latest_parsed = _parse_version(latest_version)
-    update_available = bool(current_parsed and latest_parsed and latest_parsed > current_parsed)
-
-    if latest_version is None:
+    if not release.version:
         status = "unavailable"
         summary = "Could not read the latest release version."
     elif update_available:
         status = "update_available"
-        summary = f"MediaMop {latest_version} is available."
+        summary = f"MediaMop {release.version} is available."
     else:
         status = "up_to_date"
         summary = f"This install is already on MediaMop {current_version}."
 
-    docker_tag = latest_version if latest_version else None
+    installer_asset = release.asset_named(WINDOWS_INSTALLER_ASSET_NAME)
+    docker_tag = release.version if release.version else None
     docker_update_command = None
     if install_type == "docker" and docker_tag:
         docker_update_command = "docker compose pull && docker compose up -d"
@@ -300,16 +294,40 @@ def build_suite_update_status(settings: MediaMopSettings | None = None) -> Suite
         install_type=install_type,
         status=status,
         summary=summary,
-        latest_version=latest_version,
-        latest_name=latest_name,
-        published_at=published_at,
-        release_url=release_url,
-        windows_installer_url=windows_installer_url,
+        latest_version=release.version,
+        latest_name=release.release_name or release.version,
+        published_at=release.published_at,
+        release_url=release.html_url,
+        windows_installer_url=installer_asset.browser_download_url if installer_asset else None,
         docker_image=DOCKER_IMAGE if install_type == "docker" else None,
         docker_tag=docker_tag,
         docker_update_command=docker_update_command,
         in_app_upgrade_supported=windows_updater_ready,
         in_app_upgrade_summary=windows_upgrade_summary,
+        upgrade=upgrade_progress,
+    )
+
+
+def build_suite_update_status(
+    settings: MediaMopSettings | None = None,
+) -> SuiteUpdateStatusOut:
+    install_type = _detect_install_type()
+    current_version = __version__ or "0.0.0"
+    windows_updater_ready = False
+    windows_upgrade_summary: str | None = None
+    upgrade_progress: SuiteUpgradeProgressOut | None = None
+    if install_type == "windows":
+        (
+            windows_updater_ready,
+            windows_upgrade_summary,
+            upgrade_progress,
+        ) = _fetch_windows_updater_progress(settings)
+    return _build_release_status(
+        current_version=current_version,
+        install_type=install_type,
+        windows_updater_ready=windows_updater_ready,
+        windows_upgrade_summary=windows_upgrade_summary,
+        upgrade_progress=upgrade_progress,
     )
 
 
@@ -323,39 +341,180 @@ def start_suite_update_now(settings: MediaMopSettings) -> SuiteUpdateStartOut:
             message="In-app upgrades are only available for the Windows desktop install. Docker/source installs must be updated outside the app.",
         )
 
-    payload = _fetch_latest_release_payload()
-    latest_version = str(payload.get("tag_name") or "").strip().removeprefix("v") or None
-    installer_url = _find_windows_installer_asset(payload)
-    current_parsed = _parse_version(__version__)
-    latest_parsed = _parse_version(latest_version)
-    if not installer_url or not current_parsed or not latest_parsed or latest_parsed <= current_parsed:
+    current_version = __version__ or "0.0.0"
+    release = fetch_latest_release_record(user_agent_version=current_version)
+    current_parsed = parse_version_key(current_version)
+    latest_parsed = parse_version_key(release.version)
+    if not latest_parsed or not current_parsed or latest_parsed <= current_parsed:
         return SuiteUpdateStartOut(
             status="unavailable",
             message="No newer Windows installer is available right now.",
-            target_version=latest_version,
+            target_version=release.version,
+            log_path=str(_runtime_home(settings) / "upgrades" / "updater-service.log"),
         )
 
-    upgrade_dir = Path(settings.mediamop_home) / "upgrades"
-    task_log_path = upgrade_dir / "updater-service.log"
-    started, detail = _start_windows_updater_service_apply(
+    started, detail, attempt_id = _start_windows_updater_service_apply(
         settings,
-        installer_url=installer_url,
-        target_version=latest_version,
+        target_version=release.version,
     )
+    log_path = str(_runtime_home(settings) / "upgrades" / "updater-service.log")
     if started:
         return SuiteUpdateStartOut(
             status="started",
-            message=(
-                detail
-                or "Upgrade started using the MediaMop updater service. MediaMop will close, install the update, "
-                "reopen, and this page should reconnect after the app is back."
-            ),
-            target_version=latest_version,
-            log_path=str(task_log_path),
+            message=detail or "Upgrade request accepted. MediaMop is preparing the update.",
+            attempt_id=attempt_id,
+            target_version=release.version,
+            log_path=log_path,
         )
     return SuiteUpdateStartOut(
         status="unavailable",
         message=detail or _WINDOWS_LEGACY_UPGRADE_SUMMARY,
-        target_version=latest_version,
-        log_path=str(task_log_path),
+        attempt_id=attempt_id,
+        target_version=release.version,
+        log_path=log_path,
+    )
+
+
+def _tail_lines(path: Path | None, *, limit: int = 20) -> list[str]:
+    if path is None or not path.is_file():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    trimmed = lines[-limit:]
+    return [
+        str(sanitize_diagnostic_value("log_line", line))[:1000]
+        for line in trimmed
+    ]
+
+
+def _sha256_for_path(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _windows_file_version(path: Path) -> str | None:
+    if os.name != "nt" or not path.is_file():
+        return None
+    script = (
+        "$item = Get-Item -LiteralPath $args[0]; "
+        "[string]$item.VersionInfo.FileVersion"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script, str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    value = (result.stdout or "").strip()
+    return value or None
+
+
+def _list_windows_processes() -> list[dict[str, Any]]:
+    if os.name != "nt":
+        return []
+    script = (
+        "$rows = Get-CimInstance Win32_Process | "
+        "Where-Object { $_.Name -like 'MediaMop*' -or $_.ExecutablePath -like '*MediaMop*' } | "
+        "Select-Object Name, ProcessId, ExecutablePath, CommandLine; "
+        "$rows | ConvertTo-Json -Compress"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        return [{"error": f"Could not enumerate MediaMop processes: {exc}"}]
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return [{"error": "Could not parse MediaMop process inventory."}]
+    rows = parsed if isinstance(parsed, list) else [parsed]
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        out.append(
+            {
+                "name": str(row.get("Name") or "").strip() or None,
+                "pid": row.get("ProcessId"),
+                "executable_path": str(row.get("ExecutablePath") or "").strip() or None,
+                "command_line": str(
+                    sanitize_diagnostic_value(
+                        "command_line",
+                        str(row.get("CommandLine") or "").strip(),
+                    )
+                )
+                or None,
+            }
+        )
+    return out
+
+
+def _installed_file_diagnostics(install_root: Path) -> list[dict[str, Any]]:
+    packaged_root = install_root / "_internal"
+    packaged_version = resolve_packaged_version(packaged_root)
+    items: list[dict[str, Any]] = []
+    for label, relative in _REQUIRED_WINDOWS_FILES:
+        path = install_root / relative
+        items.append(
+            {
+                "label": label,
+                "path": str(path),
+                "exists": path.exists(),
+                "sha256": _sha256_for_path(path) if path.is_file() else None,
+                "file_version": _windows_file_version(path),
+                "packaged_version": packaged_version if label == "MediaMopServer.exe" else None,
+            }
+        )
+    return items
+
+
+def build_suite_update_diagnostics(
+    settings: MediaMopSettings | None = None,
+) -> SuiteUpdateDiagnosticsOut:
+    status = build_suite_update_status(settings)
+    install_root = _install_root()
+    runtime_home = _runtime_home(settings)
+    installer_log_path = None
+    service_log_path = None
+    if status.upgrade is not None:
+        installer_log_path = status.upgrade.installer_log_path
+        service_log_path = status.upgrade.service_log_path
+    else:
+        default_upgrade_root = runtime_home / "upgrades"
+        installer_log_path = str(default_upgrade_root / "installer-latest.log")
+        service_log_path = str(default_upgrade_root / "updater-service.log")
+    return SuiteUpdateDiagnosticsOut(
+        current_version=status.current_version,
+        latest_version=status.latest_version,
+        install_type=status.install_type,
+        install_root=str(install_root),
+        runtime_home=str(runtime_home),
+        updater_service_reachable=bool(status.in_app_upgrade_supported),
+        updater_token_path_present=any(path.is_file() for path in _updater_token_paths(settings)),
+        installer_log_path=installer_log_path,
+        service_log_path=service_log_path,
+        installer_log_tail=_tail_lines(Path(installer_log_path) if installer_log_path else None),
+        service_log_tail=_tail_lines(Path(service_log_path) if service_log_path else None),
+        running_processes=_list_windows_processes(),
+        installed_files=_installed_file_diagnostics(install_root),
+        upgrade=status.upgrade,
     )

--- a/apps/backend/src/mediamop/version.py
+++ b/apps/backend/src/mediamop/version.py
@@ -30,8 +30,7 @@ def _packaged_resource_root() -> Path | None:
     return executable_dir
 
 
-def _packaged_dist_info_version() -> str | None:
-    root = _packaged_resource_root()
+def resolve_packaged_version(root: Path | None) -> str | None:
     if root is None or not root.is_dir():
         return None
 
@@ -43,6 +42,10 @@ def _packaged_dist_info_version() -> str | None:
     if not versions:
         return None
     return sorted(versions, key=_version_key)[-1]
+
+
+def _packaged_dist_info_version() -> str | None:
+    return resolve_packaged_version(_packaged_resource_root())
 
 
 def _source_tree_version() -> str | None:

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -25,6 +25,7 @@ import uvicorn
 from alembic import command
 from alembic.config import Config
 from mediamop.api.factory import create_app
+from mediamop.version import __version__
 
 _LOG_LOCK = threading.Lock()
 
@@ -342,6 +343,9 @@ def _run_server_mode(port: int) -> None:
 
 def main() -> None:
     try:
+        if "--version" in sys.argv:
+            print(__version__)
+            return
         if "--serve" in sys.argv:
             port = 8788
             if "--port" in sys.argv:

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -1,27 +1,72 @@
-"""Dedicated local Windows updater service for premium in-app upgrades."""
+"""Dedicated local Windows updater service for MediaMop in-app upgrades."""
 
 from __future__ import annotations
 
+import argparse
+import hashlib
 import json
 import os
+import re
 import secrets
+import socket
 import subprocess
 import sys
 import threading
+import time
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import urlparse
+from typing import Any
+from urllib.parse import urljoin, urlparse
 
 import httpx
 import uvicorn
 from fastapi import FastAPI, Header, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
-from mediamop.version import __version__
+from mediamop.platform.suite_settings.release_catalog import (
+    GH_REPO_SLUG,
+    WINDOWS_INSTALLER_ASSET_NAME,
+    WINDOWS_INSTALLER_SHA256_ASSET_NAME,
+    fetch_release_record_by_version,
+    normalize_release_version,
+)
+from mediamop.version import __version__, resolve_packaged_version
 
 UPDATER_PORT = 8791
 _STATE_LOCK = threading.Lock()
-_JOB_LOCK = threading.Lock()
+_APPLY_LOCK = threading.Lock()
+_RECONCILE_LOCK = threading.Lock()
+_ACTIVE_PHASES = {
+    "checking",
+    "downloading",
+    "verifying_download",
+    "installer_started",
+    "installer_running",
+    "restarting",
+    "verifying_install",
+}
+_RECOVERABLE_PHASES = {"installer_started", "installer_running", "restarting", "verifying_install"}
+_INSTALLER_WAIT_TIMEOUT_SECONDS = 90 * 60
+_VERIFY_INSTALL_TIMEOUT_SECONDS = 5 * 60
+_STALE_ATTEMPT_SECONDS = 30 * 60
+_BACKEND_POLL_INTERVAL_SECONDS = 2.0
+_MIN_INSTALLER_BYTES = 512 * 1024
+_SHA256_RE = re.compile(r"\b([0-9a-fA-F]{64})\b")
+_TRUSTED_RELEASE_DOWNLOAD_HOSTS = {
+    "github.com",
+    "objects.githubusercontent.com",
+    "release-assets.githubusercontent.com",
+}
+_REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+
+
+def _append_service_log(message: str) -> None:
+    path = _service_log_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{stamp}] {message}\n")
 
 
 def _runtime_home() -> Path:
@@ -54,7 +99,11 @@ def _state_path() -> Path:
     return _upgrade_root() / "updater-state.json"
 
 
-def _setup_log_path() -> Path:
+def _installer_log_path(attempt_id: str) -> Path:
+    return _upgrade_root() / f"installer-{attempt_id}.log"
+
+
+def _latest_installer_log_path() -> Path:
     return _upgrade_root() / "installer-latest.log"
 
 
@@ -62,9 +111,282 @@ def _service_log_path() -> Path:
     return _upgrade_root() / "updater-service.log"
 
 
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+def _parse_iso(raw: object) -> datetime | None:
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    try:
+        return datetime.fromisoformat(raw.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _state_timestamp(state: dict[str, object]) -> datetime | None:
+    return _parse_iso(state.get("last_updated_at")) or _parse_iso(state.get("last_started_at"))
+
+
+def _state_age_seconds(state: dict[str, object]) -> float | None:
+    stamp = _state_timestamp(state)
+    if stamp is None:
+        return None
+    return max(0.0, (datetime.now(UTC) - stamp).total_seconds())
+
+
+def _bool_env(name: str) -> bool:
+    return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _pid_is_running(pid: object) -> bool:
+    try:
+        numeric = int(pid)
+    except (TypeError, ValueError):
+        return False
+    if numeric <= 0:
+        return False
+    try:
+        os.kill(numeric, 0)
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _running_media_processes() -> list[dict[str, object]]:
+    script = (
+        "$rows = Get-CimInstance Win32_Process | "
+        "Where-Object { $_.Name -like 'MediaMop*' -or $_.ExecutablePath -like '*MediaMop*' } | "
+        "Select-Object Name, ProcessId, ExecutablePath, CommandLine; "
+        "$rows | ConvertTo-Json -Compress"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except Exception as exc:
+        return [{"error": f"Could not enumerate MediaMop processes: {exc}"}]
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return [{"error": "Could not parse MediaMop process inventory."}]
+    rows = parsed if isinstance(parsed, list) else [parsed]
+    out: list[dict[str, object]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        out.append(
+            {
+                "name": str(row.get("Name") or "").strip() or None,
+                "pid": row.get("ProcessId"),
+                "executable_path": str(row.get("ExecutablePath") or "").strip() or None,
+                "command_line": str(row.get("CommandLine") or "").strip() or None,
+            }
+        )
+    return out
+
+
+def _default_state() -> dict[str, object]:
+    return {
+        "phase": "idle",
+        "message": "Updater ready.",
+        "attempt_id": None,
+        "target_version": None,
+        "current_version_seen": __version__,
+        "downloaded_installer_path": None,
+        "installer_sha256": None,
+        "expected_sha256": None,
+        "installer_log_path": str(_latest_installer_log_path()),
+        "service_log_path": str(_service_log_path()),
+        "install_root": str(_install_root()),
+        "runtime_home": str(_runtime_home()),
+        "last_started_at": None,
+        "last_updated_at": None,
+        "last_completed_at": None,
+        "last_error": None,
+        "diagnostics": {},
+    }
+
+
+def _read_state_unlocked() -> dict[str, object]:
+    path = _state_path()
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _default_state()
+    except OSError as exc:
+        _append_service_log(f"Updater state read failed at {path}: {exc}")
+        return {
+            **_default_state(),
+            "phase": "state_corrupt",
+            "message": "Updater state file is unreadable.",
+            "last_error": f"Could not read updater state file: {exc}",
+            "last_completed_at": _iso_now(),
+        }
+    except json.JSONDecodeError as exc:
+        _append_service_log(f"Updater state parse failed at {path}: {exc}")
+        return {
+            **_default_state(),
+            "phase": "state_corrupt",
+            "message": "Updater state file is unreadable.",
+            "last_error": f"Could not parse updater state file: {exc}",
+            "last_completed_at": _iso_now(),
+        }
+    if not isinstance(raw, dict):
+        _append_service_log(f"Updater state parse failed at {path}: expected JSON object.")
+        return {
+            **_default_state(),
+            "phase": "state_corrupt",
+            "message": "Updater state file is unreadable.",
+            "last_error": "Could not parse updater state file: expected a JSON object.",
+            "last_completed_at": _iso_now(),
+        }
+    diagnostics = raw.get("diagnostics")
+    if not isinstance(diagnostics, dict):
+        raw["diagnostics"] = {}
+    state = {**_default_state(), **raw}
+    state["service_log_path"] = str(_service_log_path())
+    state["install_root"] = str(_install_root())
+    state["runtime_home"] = str(_runtime_home())
+    return state
+
+
+def _read_state() -> dict[str, object]:
+    with _STATE_LOCK:
+        return _read_state_unlocked()
+
+
+def _persist_state(state: dict[str, object]) -> dict[str, object]:
+    path = _state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state["service_log_path"] = str(_service_log_path())
+    state["install_root"] = str(_install_root())
+    state["runtime_home"] = str(_runtime_home())
+    state["last_updated_at"] = _iso_now()
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+    return state
+
+
+def _write_state(**updates: object) -> dict[str, object]:
+    with _STATE_LOCK:
+        state = _read_state_unlocked()
+        diagnostics_update = updates.pop("diagnostics", None)
+        if diagnostics_update is not None:
+            merged = dict(state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {})
+            if isinstance(diagnostics_update, dict):
+                merged.update(diagnostics_update)
+            else:
+                merged = {}
+            state["diagnostics"] = merged
+        state.update(updates)
+        return _persist_state(state)
+
+
+def _transition_state(phase: str, message: str, **updates: object) -> dict[str, object]:
+    previous_phase = str(_read_state().get("phase") or "unknown")
+    _append_service_log(f"Transition {previous_phase} -> {phase}: {message}")
+    return _write_state(phase=phase, message=message, **updates)
+
+
+def _fresh_attempt_state(target_version: str, attempt_id: str) -> dict[str, object]:
+    installer_log_path = _installer_log_path(attempt_id)
+    state = _default_state()
+    state.update(
+        {
+            "phase": "checking",
+            "message": "Upgrade request accepted. MediaMop is checking release metadata.",
+            "attempt_id": attempt_id,
+            "target_version": target_version,
+            "current_version_seen": __version__,
+            "downloaded_installer_path": None,
+            "installer_sha256": None,
+            "expected_sha256": None,
+            "installer_log_path": str(installer_log_path),
+            "last_started_at": _iso_now(),
+            "last_completed_at": None,
+            "last_error": None,
+            "diagnostics": {
+                "helper_pid": None,
+                "installer_pid": None,
+                "restarted_server_pid": None,
+                "release_tag": f"v{target_version}",
+            },
+        }
+    )
+    return state
+
+
+def _stable_or_active_attempt_exists(state: dict[str, object]) -> bool:
+    phase = str(state.get("phase") or "").strip().lower()
+    if phase not in _ACTIVE_PHASES:
+        return False
+    attempt_id = str(state.get("attempt_id") or "").strip()
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    helper_pid = diagnostics.get("helper_pid") if isinstance(diagnostics, dict) else None
+    installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
+    if _pid_is_running(helper_pid) or _pid_is_running(installer_pid):
+        return True
+    age = _state_age_seconds(state)
+    if age is None:
+        return bool(attempt_id)
+    return age < _STALE_ATTEMPT_SECONDS
+
+
+def _mark_failed(
+    *,
+    message: str,
+    last_error: str,
+    target_version: str | None = None,
+    current_version_seen: str | None = None,
+    diagnostics: dict[str, object] | None = None,
+) -> dict[str, object]:
+    _append_service_log(f"Upgrade failed: {last_error}")
+    return _transition_state(
+        "failed",
+        message,
+        target_version=target_version,
+        current_version_seen=current_version_seen,
+        last_completed_at=_iso_now(),
+        last_error=last_error,
+        diagnostics=diagnostics or {},
+    )
+
+
+def _harden_token_acl_windows(path: Path) -> None:
+    principals = ["SYSTEM", "Administrators", "INTERACTIVE"]
+    cmd = ["icacls", str(path), "/inheritance:r"]
+    for principal in principals:
+        cmd.extend(["/grant:r", f"{principal}:R"])
+    result = subprocess.run(
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        _append_service_log(
+            "Could not tighten updater.secret ACLs: "
+            f"rc={result.returncode} stdout={result.stdout.strip()} stderr={result.stderr.strip()}"
+        )
+
+
 def _write_private_token(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     if os.name == "nt":
         path.write_text(value, encoding="utf-8")
+        _harden_token_acl_windows(path)
         return
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
@@ -84,272 +406,644 @@ def _load_or_create_token() -> str:
     except OSError:
         token = ""
     if len(token) >= 32:
+        if os.name == "nt":
+            _harden_token_acl_windows(path)
         return token
-    path.parent.mkdir(parents=True, exist_ok=True)
     token = secrets.token_urlsafe(48)
     _write_private_token(path, token)
     return token
 
 
-def _iso_now() -> str:
-    return datetime.now(UTC).replace(microsecond=0).isoformat()
+def _validated_asset_download_url(url: str, *, version: str, asset_name: str) -> str:
+    normalized = normalize_release_version(version)
+    if not normalized:
+        raise ValueError("Release version is missing.")
+    parsed = urlparse(url)
+    expected_path = f"/{GH_REPO_SLUG}/releases/download/v{normalized}/{asset_name}"
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise ValueError(f"Release asset URL for {asset_name} was not a trusted GitHub Releases URL.")
+    if parsed.path != expected_path:
+        raise ValueError(
+            f"Release asset URL for {asset_name} did not match {GH_REPO_SLUG} tag v{normalized}."
+        )
+    if parsed.query or parsed.fragment:
+        raise ValueError(f"Release asset URL for {asset_name} included unexpected query or fragment data.")
+    return url
 
 
-def _default_state() -> dict[str, object]:
+def _release_download_headers() -> dict[str, str]:
     return {
-        "phase": "idle",
-        "message": "Updater ready.",
-        "target_version": None,
-        "installer_log_path": str(_setup_log_path()),
-        "last_started_at": None,
-        "last_completed_at": None,
-        "last_error": None,
+        "Accept": "application/octet-stream",
+        "User-Agent": f"MediaMopUpdater/{__version__}",
     }
 
 
-def _read_state() -> dict[str, object]:
-    path = _state_path()
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return _default_state()
-    except OSError as exc:
-        _append_service_log(f"Updater state read failed at {path}: {exc}")
-        return {
-            **_default_state(),
-            "phase": "state_corrupt",
-            "message": "Updater state file is unreadable.",
-            "last_error": f"Could not read updater state file: {exc}",
-        }
-    except json.JSONDecodeError as exc:
-        _append_service_log(f"Updater state parse failed at {path}: {exc}")
-        return {
-            **_default_state(),
-            "phase": "state_corrupt",
-            "message": "Updater state file is unreadable.",
-            "last_error": f"Could not parse updater state file: {exc}",
-        }
-    if not isinstance(raw, dict):
-        _append_service_log(f"Updater state parse failed at {path}: expected JSON object.")
-        return {
-            **_default_state(),
-            "phase": "state_corrupt",
-            "message": "Updater state file is unreadable.",
-            "last_error": "Could not parse updater state file: expected a JSON object.",
-        }
-    return {**_default_state(), **raw}
+def _download_text(url: str) -> str:
+    with httpx.Client(
+        timeout=60.0,
+        follow_redirects=False,
+        headers=_release_download_headers(),
+    ) as client:
+        current_url = url
+        for _ in range(6):
+            response = client.get(current_url)
+            if response.status_code in _REDIRECT_STATUS_CODES:
+                location = response.headers.get("location")
+                response.close()
+                current_url = _validated_redirect_target(current_url, location)
+                continue
+            response.raise_for_status()
+            return response.text
+    raise ValueError("Release asset download redirected too many times.")
 
 
-def _write_state(**updates: object) -> dict[str, object]:
-    with _STATE_LOCK:
-        state = _read_state()
-        state.update(updates)
-        path = _state_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".tmp")
-        tmp.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
-        tmp.replace(path)
-        return state
+def _parse_sha256_manifest(text: str) -> str | None:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if WINDOWS_INSTALLER_ASSET_NAME.lower() in stripped.lower():
+            match = _SHA256_RE.search(line)
+            if match:
+                return match.group(1).lower()
+    stripped_text = text.strip()
+    return stripped_text.lower() if _SHA256_RE.fullmatch(stripped_text) else None
 
 
-def _append_service_log(message: str) -> None:
-    path = _service_log_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    stamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(f"[{stamp}] {message}\n")
-
-
-def _reconcile_post_restart_state() -> None:
-    try:
-        state = _read_state()
-    except NotImplementedError:
-        return
-    phase = str(state.get("phase") or "").strip().lower()
-    if phase != "installer_running":
-        return
-    target_version = str(state.get("target_version") or "").strip()
-    if not target_version or target_version != __version__:
-        return
-    installer_log_path = str(state.get("installer_log_path") or _setup_log_path())
-    _append_service_log(
-        "Detected updater service restart after successful install; "
-        f"marking upgrade completed for {target_version}.",
-    )
-    _write_state(
-        phase="completed",
-        message=f"MediaMop {target_version} upgrade completed.",
-        target_version=target_version,
-        installer_log_path=installer_log_path,
-        last_completed_at=_iso_now(),
-        last_error=None,
-    )
-
-
-def _validate_installer_url(installer_url: str) -> str:
-    parsed = urlparse(installer_url)
-    host = (parsed.hostname or "").lower()
+def _validated_redirect_target(current_url: str, location: str | None) -> str:
+    if not location:
+        raise ValueError("Release asset download redirect was missing a location header.")
+    resolved = urljoin(current_url, location)
+    parsed = urlparse(resolved)
     if parsed.scheme != "https":
-        msg = "Installer download URL must use HTTPS."
-        raise ValueError(msg)
-    if host not in {
-        "github.com",
-        "objects.githubusercontent.com",
-        "release-assets.githubusercontent.com",
-    }:
-        msg = "Installer download URL must come from GitHub Releases."
-        raise ValueError(msg)
-    if not parsed.path.lower().endswith("/mediamopsetup.exe"):
-        msg = "Installer download URL must point to MediaMopSetup.exe."
-        raise ValueError(msg)
-    return installer_url
+        raise ValueError("Release asset download redirected to a non-HTTPS URL.")
+    if parsed.netloc.lower() not in _TRUSTED_RELEASE_DOWNLOAD_HOSTS:
+        raise ValueError(
+            f"Release asset download redirected to an untrusted host: {parsed.netloc}."
+        )
+    return resolved
 
 
-def _launch_installer_detached(installer_path: Path) -> subprocess.Popen[bytes]:
-    if os.name != "nt":
-        msg = "Windows only"
-        raise OSError(msg)
-    # Keep installer launch semantics aligned with Start-Process behavior.
-    # Aggressive detached flags can cause the installer to exit immediately
-    # on some hosts without producing a setup log.
-    create_new_process_group = 0x00000200
-    cmd = [
-        str(installer_path.resolve()),
-        "/VERYSILENT",
-        "/SUPPRESSMSGBOXES",
-        "/NORESTART",
-        "/CLOSEAPPLICATIONS",
-        "/RESTARTAPPLICATIONS",
-        f"/LOG={_setup_log_path()}",
-    ]
+def _open_trusted_download_stream(url: str) -> tuple[httpx.Client, httpx.Response]:
+    client = httpx.Client(
+        timeout=600.0,
+        follow_redirects=False,
+        headers=_release_download_headers(),
+    )
+    current_url = url
+    try:
+        for _ in range(6):
+            response = client.send(client.build_request("GET", current_url), stream=True)
+            if response.status_code in _REDIRECT_STATUS_CODES:
+                location = response.headers.get("location")
+                response.close()
+                current_url = _validated_redirect_target(current_url, location)
+                continue
+            response.raise_for_status()
+            return client, response
+    except Exception:
+        client.close()
+        raise
+    client.close()
+    raise ValueError("Release asset download redirected too many times.")
+
+
+def _download_installer(url: str, *, target_version: str, attempt_id: str) -> Path:
+    target = _upgrade_root() / f"MediaMopSetup-{target_version}-{attempt_id}.exe"
+    tmp = target.with_suffix(".download")
+    total = 0
+    client, response = _open_trusted_download_stream(url)
+    try:
+        with response:
+            tmp.parent.mkdir(parents=True, exist_ok=True)
+            with tmp.open("wb") as handle:
+                for chunk in response.iter_bytes():
+                    if not chunk:
+                        continue
+                    handle.write(chunk)
+                    total += len(chunk)
+    finally:
+        client.close()
+    if total < _MIN_INSTALLER_BYTES:
+        tmp.unlink(missing_ok=True)
+        raise ValueError("Downloaded installer is too small to be valid.")
+    tmp.replace(target)
+    return target
+
+
+def _sha256_for_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _verify_authenticode_signature(path: Path) -> tuple[bool, str]:
+    if not _bool_env("MEDIAMOP_UPDATER_REQUIRE_AUTHENTICODE"):
+        return True, "Authenticode verification not required."
+    script = (
+        "$signature = Get-AuthenticodeSignature -FilePath $args[0]; "
+        "$out = @{ Status = [string]$signature.Status; "
+        "StatusMessage = [string]$signature.StatusMessage; "
+        "Signer = [string]$signature.SignerCertificate.Subject }; "
+        "$out | ConvertTo-Json -Compress"
+    )
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", script, str(path)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    raw = (result.stdout or "").strip()
+    if result.returncode != 0 or not raw:
+        return False, f"Could not verify Authenticode signature: {result.stderr.strip() or 'unknown error'}"
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return False, "Could not parse Authenticode verification result."
+    status = str(payload.get("Status") or "").strip()
+    if status != "Valid":
+        return False, (
+            "Authenticode signature verification failed: "
+            f"{payload.get('StatusMessage') or status or 'unknown error'}"
+        )
+    return True, str(payload.get("Signer") or "Valid Authenticode signature")
+
+
+def _helper_command(attempt_id: str) -> list[str]:
+    if getattr(sys, "frozen", False):
+        return [str(Path(sys.executable).resolve()), "--run-upgrade-helper", attempt_id]
+    return [sys.executable, "-m", "mediamop.windows.updater_service", "--run-upgrade-helper", attempt_id]
+
+
+def _launch_helper(attempt_id: str) -> subprocess.Popen[bytes]:
+    creationflags = 0
+    for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_NO_WINDOW"):
+        creationflags |= int(getattr(subprocess, name, 0))
     return subprocess.Popen(
-        cmd,
+        _helper_command(attempt_id),
+        cwd=str(_install_root()),
         close_fds=True,
-        creationflags=create_new_process_group,
-        cwd=str(installer_path.parent),
+        creationflags=creationflags,
         stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
 
 
-def _download_installer(installer_url: str, target_version: str) -> Path:
-    target = _upgrade_root() / f"MediaMopSetup-{target_version}.exe"
-    tmp = target.with_suffix(".download")
-    headers = {
-        "Accept": "application/octet-stream",
-        "User-Agent": f"MediaMopUpdater/{__version__}",
-    }
-    total = 0
-    with httpx.stream("GET", installer_url, timeout=600.0, follow_redirects=True, headers=headers) as response:
-        response.raise_for_status()
-        tmp.parent.mkdir(parents=True, exist_ok=True)
-        with tmp.open("wb") as handle:
-            for chunk in response.iter_bytes():
-                if not chunk:
-                    continue
-                total += len(chunk)
-                handle.write(chunk)
-    if total < 512 * 1024:
-        tmp.unlink(missing_ok=True)
-        msg = "Downloaded installer is too small to be valid."
-        raise ValueError(msg)
-    tmp.replace(target)
-    return target
+def _launch_installer(installer_path: Path, *, installer_log_path: Path) -> subprocess.Popen[bytes]:
+    creationflags = 0
+    for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_NO_WINDOW"):
+        creationflags |= int(getattr(subprocess, name, 0))
+    cmd = [
+        str(installer_path.resolve()),
+        "/VERYSILENT",
+        "/SUPPRESSMSGBOXES",
+        "/NORESTART",
+        "/CLOSEAPPLICATIONS",
+        f"/LOG={installer_log_path}",
+    ]
+    return subprocess.Popen(
+        cmd,
+        cwd=str(installer_path.parent),
+        close_fds=True,
+        creationflags=creationflags,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
 
 
-def _apply_update_job(installer_url: str, target_version: str) -> None:
+def _copy_latest_installer_log(source: Path) -> None:
     try:
-        _append_service_log(f"Upgrade request accepted for {target_version}.")
-        installer_log_path = _setup_log_path()
-        installer_log_path.parent.mkdir(parents=True, exist_ok=True)
-        installer_log_path.unlink(missing_ok=True)
-        _write_state(
-            phase="downloading",
-            message=f"Downloading MediaMop {target_version}.",
-            target_version=target_version,
-            installer_log_path=str(installer_log_path),
-            last_started_at=_iso_now(),
-            last_error=None,
+        latest = _latest_installer_log_path()
+        latest.parent.mkdir(parents=True, exist_ok=True)
+        latest.write_text(source.read_text(encoding="utf-8", errors="replace"), encoding="utf-8")
+    except OSError as exc:
+        _append_service_log(f"Could not refresh latest installer log copy: {exc}")
+
+
+def _read_runtime_port() -> int:
+    path = _runtime_home() / "current-port.txt"
+    try:
+        raw = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return 8788
+    try:
+        port = int(raw)
+    except ValueError:
+        return 8788
+    return port if 1 <= port <= 65535 else 8788
+
+
+def _backend_urls(port: int) -> tuple[str, str]:
+    return (f"http://127.0.0.1:{port}/ready", f"http://127.0.0.1:{port}/openapi.json")
+
+
+def _probe_running_backend_version(port: int) -> tuple[bool, str | None, str | None]:
+    ready_url, openapi_url = _backend_urls(port)
+    try:
+        ready_response = httpx.get(ready_url, timeout=3.0)
+    except Exception as exc:
+        return False, None, f"Could not reach {ready_url}: {exc}"
+    if ready_response.status_code != 200:
+        return False, None, f"{ready_url} returned HTTP {ready_response.status_code}."
+    try:
+        version_response = httpx.get(openapi_url, timeout=3.0)
+        version_response.raise_for_status()
+        payload = version_response.json()
+    except Exception as exc:
+        return True, None, f"Could not read backend version from {openapi_url}: {exc}"
+    version_value = None
+    if isinstance(payload, dict):
+        info = payload.get("info")
+        if isinstance(info, dict):
+            version_value = str(info.get("version") or "").strip() or None
+    return True, version_value, None
+
+
+def _start_packaged_server(port: int) -> subprocess.Popen[bytes]:
+    install_root = _install_root()
+    server_exe = install_root / "MediaMopServer.exe"
+    if not server_exe.is_file():
+        raise FileNotFoundError(f"Bundled server host is missing: {server_exe}")
+    creationflags = 0
+    for name in ("DETACHED_PROCESS", "CREATE_NEW_PROCESS_GROUP", "CREATE_NO_WINDOW"):
+        creationflags |= int(getattr(subprocess, name, 0))
+    return subprocess.Popen(
+        [str(server_exe), "--serve", "--port", str(port)],
+        cwd=str(install_root),
+        close_fds=True,
+        creationflags=creationflags,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _required_install_paths(install_root: Path) -> list[tuple[str, Path]]:
+    return [
+        ("MediaMop.exe", install_root / "MediaMop.exe"),
+        ("MediaMopServer.exe", install_root / "MediaMopServer.exe"),
+        ("MediaMopUpdater.exe", install_root / "MediaMopUpdater.exe"),
+        ("MediaMopUpdaterService.exe", install_root / "MediaMopUpdaterService.exe"),
+        ("MediaMopUpdaterService.xml", install_root / "MediaMopUpdaterService.xml"),
+        ("web-dist", install_root / "_internal" / "web-dist" / "index.html"),
+    ]
+
+
+def _collect_install_diagnostics(target_version: str, *, port: int) -> dict[str, object]:
+    install_root = _install_root()
+    packaged_root = install_root / "_internal"
+    packaged_version = resolve_packaged_version(packaged_root)
+    required_files = []
+    missing_labels: list[str] = []
+    for label, path in _required_install_paths(install_root):
+        exists = path.exists()
+        required_files.append({"label": label, "path": str(path), "exists": exists})
+        if not exists:
+            missing_labels.append(label)
+    backend_ready, backend_version, backend_detail = _probe_running_backend_version(port)
+    return {
+        "required_files": required_files,
+        "missing_required_files": missing_labels,
+        "packaged_version": packaged_version,
+        "backend_port": port,
+        "backend_ready": backend_ready,
+        "backend_version": backend_version,
+        "backend_detail": backend_detail,
+        "running_processes": _running_media_processes(),
+        "target_version": target_version,
+    }
+
+
+def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
+    port = _read_runtime_port()
+    deadline = time.time() + _VERIFY_INSTALL_TIMEOUT_SECONDS
+    started_server_pid: int | None = None
+    last_diagnostics: dict[str, object] = _collect_install_diagnostics(target_version, port=port)
+    while time.time() < deadline:
+        diagnostics = _collect_install_diagnostics(target_version, port=port)
+        diagnostics["restarted_server_pid"] = started_server_pid
+        packaged_version = str(diagnostics.get("packaged_version") or "").strip() or None
+        backend_ready = bool(diagnostics.get("backend_ready"))
+        backend_version = str(diagnostics.get("backend_version") or "").strip() or None
+        missing_required = diagnostics.get("missing_required_files")
+        if packaged_version == target_version and not missing_required and backend_ready and backend_version == target_version:
+            return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
+        if packaged_version == target_version and not missing_required and started_server_pid is None and not backend_ready:
+            try:
+                process = _start_packaged_server(port)
+            except Exception as exc:
+                diagnostics["server_restart_error"] = str(exc)
+            else:
+                started_server_pid = process.pid
+                diagnostics["restarted_server_pid"] = process.pid
+                _append_service_log(f"Restarted packaged MediaMop server for upgrade verification (pid={process.pid}, port={port}).")
+        last_diagnostics = diagnostics
+        time.sleep(_BACKEND_POLL_INTERVAL_SECONDS)
+    backend_version = str(last_diagnostics.get("backend_version") or "").strip() or None
+    packaged_version = str(last_diagnostics.get("packaged_version") or "").strip() or None
+    if packaged_version != target_version:
+        reason = (
+            f"Installed package metadata still reports {packaged_version or 'unknown'} instead of {target_version}."
         )
-        installer_path = _download_installer(installer_url, target_version)
-        _append_service_log(f"Downloaded installer to {installer_path}.")
-        _write_state(
-            phase="installer_started",
-            message=f"Launching MediaMop {target_version} installer.",
-            target_version=target_version,
-            installer_log_path=str(installer_log_path),
-            last_error=None,
+    elif backend_version != target_version:
+        reason = f"Running backend still reports {backend_version or 'unknown'} instead of {target_version}."
+    else:
+        reason = "MediaMop did not become ready with the expected version in time."
+    return False, last_diagnostics, reason
+
+
+def _perform_upgrade_attempt(attempt_id: str) -> None:
+    state = _read_state()
+    if str(state.get("attempt_id") or "").strip() != attempt_id:
+        _append_service_log(f"Ignoring helper run for stale attempt {attempt_id}.")
+        return
+    target_version = normalize_release_version(str(state.get("target_version") or ""))
+    if not target_version:
+        _mark_failed(
+            message="Upgrade failed.",
+            last_error="Upgrade state did not include a target version.",
+            diagnostics={"attempt_id": attempt_id},
         )
-        process = _launch_installer_detached(installer_path)
-        _append_service_log(f"Installer launched (pid={process.pid}).")
-        _write_state(
-            phase="installer_running",
-            message=f"MediaMop {target_version} installer is running.",
+        return
+    installer_log = Path(str(state.get("installer_log_path") or _installer_log_path(attempt_id)))
+    installer_log.parent.mkdir(parents=True, exist_ok=True)
+    installer_log.unlink(missing_ok=True)
+    try:
+        _transition_state(
+            "checking",
+            "Upgrade request accepted. MediaMop is checking release metadata.",
             target_version=target_version,
-            installer_log_path=str(installer_log_path),
-            last_error=None,
+            diagnostics={"helper_pid": os.getpid(), "release_tag": f"v{target_version}"},
         )
-        exit_code = process.wait(timeout=3600)
+        release = fetch_release_record_by_version(target_version, user_agent_version=__version__)
+        installer_asset = release.asset_named(WINDOWS_INSTALLER_ASSET_NAME)
+        if installer_asset is None:
+            raise ValueError(f"Release v{target_version} does not include {WINDOWS_INSTALLER_ASSET_NAME}.")
+        installer_url = _validated_asset_download_url(
+            installer_asset.browser_download_url,
+            version=target_version,
+            asset_name=WINDOWS_INSTALLER_ASSET_NAME,
+        )
+        checksum_asset = release.asset_named(WINDOWS_INSTALLER_SHA256_ASSET_NAME)
+        expected_sha256 = None
+        if checksum_asset is not None:
+            checksum_url = _validated_asset_download_url(
+                checksum_asset.browser_download_url,
+                version=target_version,
+                asset_name=WINDOWS_INSTALLER_SHA256_ASSET_NAME,
+            )
+            checksum_text = _download_text(checksum_url)
+            expected_sha256 = _parse_sha256_manifest(checksum_text)
+        if not expected_sha256 and not _bool_env("MEDIAMOP_UPDATER_ALLOW_UNVERIFIED"):
+            raise ValueError(
+                "Release checksum manifest is missing or unreadable. Official in-app upgrades require "
+                f"{WINDOWS_INSTALLER_SHA256_ASSET_NAME}."
+            )
+
+        _transition_state(
+            "downloading",
+            "Upgrade request accepted. MediaMop is downloading the installer.",
+            target_version=target_version,
+            expected_sha256=expected_sha256,
+        )
+        installer_path = _download_installer(
+            installer_url,
+            target_version=target_version,
+            attempt_id=attempt_id,
+        )
+        _transition_state(
+            "verifying_download",
+            "Installer is being verified.",
+            target_version=target_version,
+            downloaded_installer_path=str(installer_path),
+            expected_sha256=expected_sha256,
+        )
+        installer_sha256 = _sha256_for_path(installer_path)
+        if expected_sha256 and installer_sha256.lower() != expected_sha256.lower():
+            raise ValueError(
+                f"Installer SHA-256 mismatch. Expected {expected_sha256}, got {installer_sha256}."
+            )
+        signature_ok, signature_detail = _verify_authenticode_signature(installer_path)
+        if not signature_ok:
+            raise ValueError(signature_detail)
+        _transition_state(
+            "installer_started",
+            "Installer is starting.",
+            target_version=target_version,
+            downloaded_installer_path=str(installer_path),
+            installer_sha256=installer_sha256,
+            expected_sha256=expected_sha256,
+            diagnostics={
+                "signature_detail": signature_detail,
+            },
+        )
+        process = _launch_installer(installer_path, installer_log_path=installer_log)
+        _transition_state(
+            "installer_running",
+            "Installer is running. MediaMop may temporarily disconnect.",
+            target_version=target_version,
+            diagnostics={
+                "installer_pid": process.pid,
+            },
+        )
+        if getattr(sys, "frozen", False) and os.name == "nt":
+            _append_service_log(
+                "Installer launched from packaged updater; helper will exit and let updater-service "
+                "reconciliation finish verification after installer/service restart."
+            )
+            return
+        exit_code = process.wait(timeout=_INSTALLER_WAIT_TIMEOUT_SECONDS)
+        _append_service_log(f"Installer process exited with code {exit_code}.")
         if exit_code != 0:
-            msg = f"Installer exited with code {exit_code}."
-            _append_service_log(msg)
-            _write_state(
-                phase="failed",
+            if installer_log.is_file():
+                _copy_latest_installer_log(installer_log)
+            _mark_failed(
                 message="Upgrade failed.",
+                last_error=f"Installer exited with code {exit_code}.",
                 target_version=target_version,
-                installer_log_path=str(installer_log_path),
-                last_completed_at=_iso_now(),
-                last_error=msg,
+                diagnostics={
+                    "installer_exit_code": exit_code,
+                },
             )
             return
-        if not installer_log_path.is_file():
-            msg = (
-                "Installer exited successfully but did not produce installer-latest.log. "
-                "Upgrade outcome cannot be verified."
-            )
-            _append_service_log(msg)
-            _write_state(
-                phase="failed",
+        if not installer_log.is_file():
+            _mark_failed(
                 message="Upgrade failed.",
+                last_error="Installer exited successfully but did not produce an installer log.",
                 target_version=target_version,
-                installer_log_path=str(installer_log_path),
-                last_completed_at=_iso_now(),
-                last_error=msg,
+                diagnostics={
+                    "installer_exit_code": exit_code,
+                },
             )
             return
-        _append_service_log("Installer completed successfully.")
-        _write_state(
-            phase="completed",
-            message=f"MediaMop {target_version} upgrade completed.",
+        _copy_latest_installer_log(installer_log)
+        _transition_state(
+            "restarting",
+            "MediaMop is reconnecting and verifying the installed version.",
             target_version=target_version,
-            installer_log_path=str(installer_log_path),
-            last_completed_at=_iso_now(),
-            last_error=None,
+            diagnostics={
+                "installer_exit_code": exit_code,
+            },
+        )
+        _transition_state(
+            "verifying_install",
+            "MediaMop is reconnecting and verifying the installed version.",
+            target_version=target_version,
+        )
+        verified, diagnostics, message = _verify_install(target_version)
+        if verified:
+            _transition_state(
+                "completed",
+                message,
+                target_version=target_version,
+                current_version_seen=target_version,
+                last_completed_at=_iso_now(),
+                last_error=None,
+                diagnostics=diagnostics,
+            )
+            return
+        _mark_failed(
+            message="Upgrade failed.",
+            last_error=message,
+            target_version=target_version,
+            current_version_seen=str(diagnostics.get("backend_version") or diagnostics.get("packaged_version") or __version__),
+            diagnostics=diagnostics,
         )
     except Exception as exc:
-        _append_service_log(f"Upgrade failed: {exc}")
-        _write_state(
-            phase="failed",
+        _mark_failed(
             message="Upgrade failed.",
-            target_version=target_version,
-            installer_log_path=str(_setup_log_path()),
-            last_completed_at=_iso_now(),
             last_error=str(exc),
+            target_version=target_version,
+            diagnostics={"helper_pid": os.getpid()},
+        )
+
+
+def _reconcile_attempt_worker(attempt_id: str) -> None:
+    try:
+        state = _read_state()
+        if str(state.get("attempt_id") or "").strip() != attempt_id:
+            return
+        phase = str(state.get("phase") or "").strip().lower()
+        if phase not in _RECOVERABLE_PHASES:
+            return
+        diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+        installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
+        if _pid_is_running(installer_pid):
+            deadline = time.time() + _INSTALLER_WAIT_TIMEOUT_SECONDS
+            while time.time() < deadline and _pid_is_running(installer_pid):
+                time.sleep(_BACKEND_POLL_INTERVAL_SECONDS)
+        target_version = normalize_release_version(str(state.get("target_version") or ""))
+        if not target_version:
+            _mark_failed(
+                message="Upgrade failed.",
+                last_error="Upgrade reconciliation could not find a target version.",
+                diagnostics={"attempt_id": attempt_id},
+            )
+            return
+        installer_log = Path(str(state.get("installer_log_path") or ""))
+        if not installer_log.is_file():
+            _mark_failed(
+                message="Upgrade failed.",
+                last_error="Installer exited but did not produce an installer log.",
+                target_version=target_version,
+                diagnostics={"reconciled_after_restart": True},
+            )
+            return
+        _copy_latest_installer_log(installer_log)
+        _transition_state(
+            "restarting",
+            "MediaMop is reconnecting and verifying the installed version.",
+            target_version=target_version,
+            diagnostics={"reconciled_after_restart": True},
+        )
+        _transition_state(
+            "verifying_install",
+            "MediaMop is reconnecting and verifying the installed version.",
+            target_version=target_version,
+            diagnostics={"reconciled_after_restart": True},
+        )
+        verified, diagnostics, message = _verify_install(target_version)
+        if verified:
+            _transition_state(
+                "completed",
+                message,
+                target_version=target_version,
+                current_version_seen=target_version,
+                last_completed_at=_iso_now(),
+                last_error=None,
+                diagnostics=diagnostics,
+            )
+            return
+        _mark_failed(
+            message="Upgrade failed.",
+            last_error=message,
+            target_version=target_version,
+            current_version_seen=str(diagnostics.get("backend_version") or diagnostics.get("packaged_version") or __version__),
+            diagnostics=diagnostics,
         )
     finally:
-        if _JOB_LOCK.locked():
-            _JOB_LOCK.release()
+        if _RECONCILE_LOCK.locked():
+            try:
+                _RECONCILE_LOCK.release()
+            except RuntimeError:
+                pass
+
+
+def _maybe_reconcile_pending_attempt() -> None:
+    state = _read_state()
+    phase = str(state.get("phase") or "").strip().lower()
+    if phase not in _ACTIVE_PHASES:
+        return
+    attempt_id = str(state.get("attempt_id") or "").strip()
+    if not attempt_id:
+        return
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    helper_pid = diagnostics.get("helper_pid") if isinstance(diagnostics, dict) else None
+    installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
+    if _pid_is_running(helper_pid):
+        return
+    age = _state_age_seconds(state)
+    if (
+        age is not None
+        and age >= _STALE_ATTEMPT_SECONDS
+        and not _pid_is_running(installer_pid)
+    ):
+        _mark_failed(
+            message="Upgrade failed.",
+            last_error=f"Upgrade attempt stalled during {phase}.",
+            target_version=str(state.get("target_version") or "").strip() or None,
+            diagnostics={
+                "stalled_phase": phase,
+                "state_age_seconds": age,
+            },
+        )
+        return
+    if phase in _RECOVERABLE_PHASES:
+        if _RECONCILE_LOCK.acquire(blocking=False):
+            thread = threading.Thread(
+                target=_reconcile_attempt_worker,
+                args=(attempt_id,),
+                daemon=True,
+                name="mediamop-updater-reconcile",
+            )
+            thread.start()
+        return
 
 
 class ApplyRequest(BaseModel):
-    installer_url: str = Field(min_length=1)
+    model_config = ConfigDict(extra="forbid")
+
     target_version: str = Field(min_length=1)
 
 
 def create_updater_app() -> FastAPI:
     app = FastAPI(title="MediaMop Updater Service", version=__version__)
-    _reconcile_post_restart_state()
+    _maybe_reconcile_pending_attempt()
     shared_token = _load_or_create_token()
 
     def _require_token(x_mediamop_updater_token: str | None = Header(default=None, alias="X-MediaMop-Updater-Token")) -> None:
@@ -358,15 +1052,18 @@ def create_updater_app() -> FastAPI:
 
     @app.get("/health")
     def health() -> dict[str, object]:
+        state = _read_state()
         return {
             "ok": True,
             "version": __version__,
-            "phase": _read_state().get("phase"),
+            "phase": state.get("phase"),
+            "attempt_id": state.get("attempt_id"),
         }
 
     @app.get("/api/v1/status")
     def status(x_mediamop_updater_token: str | None = Header(default=None, alias="X-MediaMop-Updater-Token")) -> dict[str, object]:
         _require_token(x_mediamop_updater_token)
+        _maybe_reconcile_pending_attempt()
         return _read_state()
 
     @app.post("/api/v1/apply")
@@ -377,41 +1074,49 @@ def create_updater_app() -> FastAPI:
         _require_token(x_mediamop_updater_token)
         if os.name != "nt":
             raise HTTPException(status_code=400, detail="Windows updater service can only run on Windows.")
-        try:
-            installer_url = _validate_installer_url(body.installer_url)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        if not _JOB_LOCK.acquire(blocking=False):
-            raise HTTPException(status_code=409, detail="A MediaMop upgrade is already in progress.")
-        thread = threading.Thread(
-            target=_apply_update_job,
-            args=(installer_url, body.target_version),
-            daemon=True,
-            name="mediamop-updater-apply",
-        )
-        try:
-            thread.start()
-        except Exception as exc:
-            _JOB_LOCK.release()
-            _append_service_log(f"Upgrade failed to start worker thread: {exc}")
-            _write_state(
-                phase="failed",
-                message="Upgrade failed before launch.",
-                target_version=body.target_version,
-                installer_log_path=str(_setup_log_path()),
-                last_completed_at=_iso_now(),
-                last_error=f"Failed to start updater worker thread: {exc}",
-            )
-            raise HTTPException(status_code=500, detail="Failed to start MediaMop updater worker.") from exc
-        return {
-            "accepted": True,
-            "message": "Upgrade started using the MediaMop updater service. MediaMop will close, install the update, and reopen.",
-        }
+        target_version = normalize_release_version(body.target_version)
+        if not target_version:
+            raise HTTPException(status_code=400, detail="Target version is missing.")
+        with _APPLY_LOCK:
+            current_state = _read_state()
+            if _stable_or_active_attempt_exists(current_state):
+                raise HTTPException(status_code=409, detail="A MediaMop upgrade is already in progress.")
+            attempt_id = uuid.uuid4().hex
+            with _STATE_LOCK:
+                _persist_state(_fresh_attempt_state(target_version, attempt_id))
+            try:
+                helper = _launch_helper(attempt_id)
+            except Exception as exc:
+                _mark_failed(
+                    message="Upgrade failed before launch.",
+                    last_error=f"Could not launch upgrade helper: {exc}",
+                    target_version=target_version,
+                    diagnostics={"attempt_id": attempt_id},
+                )
+                raise HTTPException(status_code=500, detail="Failed to start MediaMop upgrade helper.") from exc
+            _write_state(diagnostics={"helper_pid": helper.pid})
+            _append_service_log(f"Upgrade helper launched for {target_version} (attempt_id={attempt_id}, pid={helper.pid}).")
+            return {
+                "accepted": True,
+                "attempt_id": attempt_id,
+                "target_version": target_version,
+                "message": "Upgrade request accepted. MediaMop is checking release metadata.",
+            }
 
     return app
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--run-upgrade-helper", dest="attempt_id")
+    parser.add_argument("--version", action="store_true")
+    args, _extra = parser.parse_known_args(argv)
+    if args.version:
+        print(__version__)
+        return
+    if args.attempt_id:
+        _perform_upgrade_attempt(args.attempt_id)
+        return
     app = create_updater_app()
     port = int((os.environ.get("MEDIAMOP_UPDATER_PORT") or str(UPDATER_PORT)).strip())
     uvicorn.run(app, host="127.0.0.1", port=port, log_level="info", log_config=None)

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -15,7 +15,7 @@ import threading
 import time
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PosixPath, WindowsPath
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -69,17 +69,22 @@ def _append_service_log(message: str) -> None:
         handle.write(f"[{stamp}] {message}\n")
 
 
+def _host_path(raw: str | os.PathLike[str]) -> Path:
+    path_cls = WindowsPath if sys.platform == "win32" else PosixPath
+    return path_cls(os.fspath(raw))
+
+
 def _runtime_home() -> Path:
     raw = (os.environ.get("MEDIAMOP_HOME") or "").strip()
     if raw:
-        return Path(raw).expanduser().resolve()
+        return _host_path(raw).expanduser().resolve()
     program_data = (os.environ.get("PROGRAMDATA") or r"C:\ProgramData").strip()
-    return Path(program_data) / "MediaMop"
+    return _host_path(program_data) / "MediaMop"
 
 
 def _install_root() -> Path:
     if getattr(sys, "frozen", False) and os.name == "nt":
-        resolved = Path(sys.executable).resolve().parent
+        resolved = _host_path(sys.executable).resolve().parent
         _append_service_log(f"updater_service._install_root resolved to {resolved} (frozen)")
         return resolved
     resolved = _runtime_home()
@@ -574,7 +579,7 @@ def _verify_authenticode_signature(path: Path) -> tuple[bool, str]:
 
 def _helper_command(attempt_id: str) -> list[str]:
     if getattr(sys, "frozen", False):
-        return [str(Path(sys.executable).resolve()), "--run-upgrade-helper", attempt_id]
+        return [str(_host_path(sys.executable).resolve()), "--run-upgrade-helper", attempt_id]
     return [sys.executable, "-m", "mediamop.windows.updater_service", "--run-upgrade-helper", attempt_id]
 
 
@@ -770,7 +775,7 @@ def _perform_upgrade_attempt(attempt_id: str) -> None:
             diagnostics={"attempt_id": attempt_id},
         )
         return
-    installer_log = Path(str(state.get("installer_log_path") or _installer_log_path(attempt_id)))
+    installer_log = _host_path(str(state.get("installer_log_path") or _installer_log_path(attempt_id)))
     installer_log.parent.mkdir(parents=True, exist_ok=True)
     installer_log.unlink(missing_ok=True)
     try:
@@ -945,7 +950,7 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
                 diagnostics={"attempt_id": attempt_id},
             )
             return
-        installer_log = Path(str(state.get("installer_log_path") or ""))
+        installer_log = _host_path(str(state.get("installer_log_path") or ""))
         if not installer_log.is_file():
             _mark_failed(
                 message="Upgrade failed.",

--- a/apps/backend/tests/test_docker_onboarding_files.py
+++ b/apps/backend/tests/test_docker_onboarding_files.py
@@ -21,6 +21,10 @@ def test_docker_env_example_documents_required_and_recommended_values() -> None:
     assert "MEDIAMOP_CREDENTIALS_SECRET" in example
     assert "openssl rand -hex 32" in example
     assert "MEDIAMOP_HOME" in example
+    assert "MEDIAMOP_PUID" in example
+    assert "MEDIAMOP_PGID" in example
+    assert "MEDIAMOP_CHOWN_OUTPUT" in example
+    assert "MEDIAMOP_DIR_MODE_OUTPUT" in example
 
 
 def test_docker_entrypoint_generates_persistent_session_secret() -> None:
@@ -30,10 +34,13 @@ def test_docker_entrypoint_generates_persistent_session_secret() -> None:
     assert "session.secret" in entrypoint
     assert "export MEDIAMOP_SESSION_SECRET" in entrypoint
     assert "must be at least 32 characters" in entrypoint
+    assert "MEDIAMOP_PUID" in entrypoint
+    assert "MEDIAMOP_CHOWN_OUTPUT" in entrypoint
+    assert "gosu mediamop" in entrypoint
 
 
-def test_dockerfile_runs_as_non_root_user() -> None:
+def test_dockerfile_provisions_gosu_and_unprivileged_runtime_user() -> None:
     dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
 
     assert "useradd --system --uid 1000" in dockerfile
-    assert "USER mediamop" in dockerfile
+    assert "gosu" in dockerfile

--- a/apps/backend/tests/test_docker_runtime.py
+++ b/apps/backend/tests/test_docker_runtime.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from mediamop.platform.docker_runtime import (
+    collect_refiner_permission_targets,
+    load_docker_ownership_plan,
+)
+
+
+def _seed_refiner_path_settings(db_path: Path, *, root: Path) -> dict[str, Path]:
+    paths = {
+        "movies_watch": root / "movies-watch",
+        "movies_temp": root / "movies-temp",
+        "movies_out": root / "movies-out",
+        "tv_watch": root / "tv-watch",
+        "tv_temp": root / "tv-temp",
+        "tv_out": root / "tv-out",
+    }
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE refiner_path_settings (
+                id INTEGER PRIMARY KEY,
+                refiner_watched_folder TEXT,
+                refiner_work_folder TEXT,
+                refiner_output_folder TEXT NOT NULL DEFAULT '',
+                refiner_tv_watched_folder TEXT,
+                refiner_tv_work_folder TEXT,
+                refiner_tv_output_folder TEXT
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO refiner_path_settings (
+                id,
+                refiner_watched_folder,
+                refiner_work_folder,
+                refiner_output_folder,
+                refiner_tv_watched_folder,
+                refiner_tv_work_folder,
+                refiner_tv_output_folder
+            ) VALUES (1, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(paths["movies_watch"]),
+                str(paths["movies_temp"]),
+                str(paths["movies_out"]),
+                str(paths["tv_watch"]),
+                str(paths["tv_temp"]),
+                str(paths["tv_out"]),
+            ),
+        )
+        conn.commit()
+    return paths
+
+
+def test_load_docker_ownership_plan_accepts_alias_env_names() -> None:
+    plan = load_docker_ownership_plan(
+        {
+            "PUID": "1001",
+            "PGID": "1002",
+            "MEDIAMOP_CHOWN_OUTPUT": "true",
+            "MEDIAMOP_DIR_MODE_OUTPUT": "2775",
+        }
+    )
+
+    assert plan.puid == 1001
+    assert plan.pgid == 1002
+    assert plan.chown_output is True
+    assert plan.output_dir_mode == 0o2775
+
+
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("MEDIAMOP_PUID", "-1"),
+        ("MEDIAMOP_PGID", "abc"),
+        ("MEDIAMOP_CHOWN_OUTPUT", "sometimes"),
+        ("MEDIAMOP_DIR_MODE_OUTPUT", "27x5"),
+    ],
+)
+def test_load_docker_ownership_plan_rejects_invalid_values(
+    name: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValueError):
+        load_docker_ownership_plan({name: value})
+
+
+def test_collect_refiner_permission_targets_groups_movie_and_tv_paths(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "data" / "mediamop.sqlite3"
+    paths = _seed_refiner_path_settings(db_path, root=tmp_path / "mounted")
+
+    targets = collect_refiner_permission_targets(
+        db_path,
+        include_watched=True,
+        include_temp=True,
+        include_output=True,
+    )
+
+    assert [str(path) for path in targets["watched"]] == [
+        str(paths["movies_watch"].resolve(strict=False)),
+        str(paths["tv_watch"].resolve(strict=False)),
+    ]
+    assert [str(path) for path in targets["temp"]] == [
+        str(paths["movies_temp"].resolve(strict=False)),
+        str(paths["tv_temp"].resolve(strict=False)),
+    ]
+    assert [str(path) for path in targets["output"]] == [
+        str(paths["movies_out"].resolve(strict=False)),
+        str(paths["tv_out"].resolve(strict=False)),
+    ]
+
+
+def test_collect_refiner_permission_targets_is_empty_without_table(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "data" / "mediamop.sqlite3"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path):
+        pass
+
+    targets = collect_refiner_permission_targets(
+        db_path,
+        include_watched=True,
+        include_temp=True,
+        include_output=True,
+    )
+
+    assert targets == {"watched": [], "temp": [], "output": []}

--- a/apps/backend/tests/test_refiner_file_remux_pass_run.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_run.py
@@ -11,6 +11,7 @@ import pytest
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.refiner import refiner_file_remux_pass_run as runmod
+from mediamop.modules.refiner.refiner_remux_rules import PlannedTrack, RemuxPlan
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_file_remux_pass_visibility import (
     REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
@@ -113,6 +114,49 @@ def test_live_skips_when_no_remux_required_copies_to_output_and_deletes_release_
     assert r.get("source_folder_deleted") is True
     assert not mkv.exists()
     assert not release.exists()
+
+
+def test_live_result_keeps_removed_track_lists_for_activity_detail(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    media = tmp_path / "media"
+    media.mkdir()
+    release = media / "ReleaseTitle"
+    release.mkdir()
+    mkv = release / "one.mkv"
+    mkv.write_bytes(b"x" * 2000)
+    out = tmp_path / "out"
+    out.mkdir()
+
+    settings = replace(MediaMopSettings.load(), mediamop_home=str(home), refiner_watched_folder_min_file_age_seconds=0)
+    rt = _runtime(media=media, home=home, out=out)
+
+    monkeypatch.setattr(runmod, "ffprobe_json", lambda path, mediamop_home, **kwargs: _fake_probe())
+    monkeypatch.setattr(runmod, "resolve_ffprobe_ffmpeg", lambda *, mediamop_home: ("ffprobe-x", "ffmpeg-x"))
+    monkeypatch.setattr(
+        runmod,
+        "plan_remux",
+        lambda **_kwargs: RemuxPlan(
+            video_indices=[0],
+            audio=[PlannedTrack(input_index=1, lang_label="eng", kind="audio")],
+            subtitles=[],
+            removed_audio=["Director commentary", "Japanese stereo"],
+            removed_subtitles=["spa", "fre"],
+        ),
+    )
+    monkeypatch.setattr(runmod, "is_remux_required", lambda *_a, **_k: False)
+
+    r = runmod.run_refiner_file_remux_pass(
+        settings=settings,
+        path_runtime=rt,
+        relative_media_path="ReleaseTitle/one.mkv",
+    )
+    assert r["ok"] is True
+    assert r["removed_audio"] == ["Director commentary", "Japanese stereo"]
+    assert r["removed_subtitles"] == ["spa", "fre"]
 
 
 def test_live_skips_when_no_remux_required_replaces_existing_output_before_cleanup(

--- a/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
@@ -56,3 +56,19 @@ def test_remux_pass_result_to_activity_detail_is_valid_json() -> None:
         {"ok": True, "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN, "relative_media_path": "x.mkv"},
     )
     assert '"outcome":"live_output_written"' in detail
+
+
+def test_remux_pass_result_to_activity_detail_keeps_removed_track_lists_and_counts() -> None:
+    detail = remux_pass_result_to_activity_detail(
+        {
+            "ok": True,
+            "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN,
+            "relative_media_path": "movies/sample.mkv",
+            "removed_audio": ["eng commentary", "jpn stereo"],
+            "removed_subtitles": ["spa", "fre"],
+        },
+    )
+    assert '"removed_audio":["eng commentary","jpn stereo"]' in detail
+    assert '"removed_subtitles":["spa","fre"]' in detail
+    assert '"audio_removed":2' in detail
+    assert '"subtitles_removed":2' in detail

--- a/apps/backend/tests/test_release_catalog.py
+++ b/apps/backend/tests/test_release_catalog.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+
+from mediamop.platform.suite_settings import release_catalog
+
+
+def test_normalize_release_version_strips_v_prefix() -> None:
+    assert release_catalog.normalize_release_version("v2.0.8") == "2.0.8"
+    assert release_catalog.normalize_release_version("2.0.8") == "2.0.8"
+    assert release_catalog.tag_for_version("2.0.8") == "v2.0.8"
+
+
+def test_fetch_release_record_by_version_rejects_wrong_returned_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "tag_name": "v2.0.7",
+        "name": "MediaMop 2.0.7",
+        "html_url": "https://github.com/jampat000/MediaMop/releases/tag/v2.0.7",
+        "published_at": "2026-05-07T00:00:00Z",
+        "draft": False,
+        "prerelease": False,
+        "assets": [],
+    }
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class _Client:
+        def __enter__(self) -> "_Client":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def get(self, url: str) -> _Response:
+            return _Response()
+
+    monkeypatch.setattr(release_catalog.httpx, "Client", lambda **_kwargs: _Client())
+
+    with pytest.raises(ValueError, match="Release tag mismatch"):
+        release_catalog.fetch_release_record_by_version(
+            "2.0.8",
+            user_agent_version="2.0.7",
+        )
+
+
+def test_fetch_release_record_by_version_rejects_prerelease(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "tag_name": "v2.0.8",
+        "name": "MediaMop 2.0.8-rc1",
+        "html_url": "https://github.com/jampat000/MediaMop/releases/tag/v2.0.8",
+        "published_at": "2026-05-07T00:00:00Z",
+        "draft": False,
+        "prerelease": True,
+        "assets": [],
+    }
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return payload
+
+    class _Client:
+        def __enter__(self) -> "_Client":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def get(self, url: str) -> _Response:
+            return _Response()
+
+    monkeypatch.setattr(release_catalog.httpx, "Client", lambda **_kwargs: _Client())
+
+    with pytest.raises(ValueError, match="not a stable published release"):
+        release_catalog.fetch_release_record_by_version(
+            "2.0.8",
+            user_agent_version="2.0.7",
+        )

--- a/apps/backend/tests/test_subber_jobs_lane.py
+++ b/apps/backend/tests/test_subber_jobs_lane.py
@@ -121,3 +121,4 @@ def test_webhook_import_tv_runs_on_subber_lane_records_activity(session_factory)
         ).first()
         assert ev is not None
         assert ev.module == "subber"
+        assert json.loads(ev.detail or "{}")["media_scope"] == "tv"

--- a/apps/backend/tests/test_subber_upgrade_job_handler.py
+++ b/apps/backend/tests/test_subber_upgrade_job_handler.py
@@ -20,6 +20,8 @@ from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
 from mediamop.modules.subber.worker_loop import process_one_subber_job
+from mediamop.platform.activity import constants as C
+from mediamop.platform.activity.models import ActivityEvent
 
 import mediamop.modules.subber.subber_jobs_model  # noqa: F401
 import mediamop.modules.subber.subber_settings_model  # noqa: F401
@@ -116,6 +118,18 @@ def test_upgrade_handler_skips_when_subber_disabled(mock_dl, session_factory) ->
     t0 = datetime(2026, 1, 2, tzinfo=timezone.utc)
     process_one_subber_job(session_factory, lease_owner="u3", job_handlers=handlers, now=t0, lease_seconds=600)
     assert not mock_dl.called
+    with session_factory() as s:
+        ev = s.scalars(
+            select(ActivityEvent)
+            .where(ActivityEvent.event_type == C.SUBBER_SUBTITLE_UPGRADE_COMPLETED)
+            .order_by(ActivityEvent.id.desc()),
+        ).first()
+        assert ev is not None
+        detail = json.loads(ev.detail or "{}")
+        assert detail["result"] == "skipped"
+        assert detail["user_message"] == "Subtitle upgrade is turned off in Subber settings."
+        assert detail["attempted"] == 0
+        assert detail["upgraded"] == 0
 
 
 def test_upgrade_handler_runs_when_enabled_with_candidates(session_factory, tmp_path: Path) -> None:

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -15,6 +15,10 @@ from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.activity import constants as act_c
 from mediamop.platform.activity.models import ActivityEvent
 from mediamop.platform.activity.service import record_activity_event
+from mediamop.platform.suite_settings.release_catalog import (
+    GitHubReleaseAsset,
+    GitHubReleaseRecord,
+)
 from mediamop.platform.suite_settings.model import SuiteSettingsRow
 from mediamop.platform.suite_settings.service import apply_suite_settings_put
 from mediamop.platform.suite_settings.suite_configuration_backup_periodic import run_suite_configuration_backup_tick
@@ -26,6 +30,27 @@ from mediamop.platform.suite_settings.logs_retention_periodic import (
 from mediamop.platform.suite_settings.update_service import start_suite_update_now
 
 from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+
+
+def _release_record(version: str = "1.2.3") -> GitHubReleaseRecord:
+    return GitHubReleaseRecord(
+        tag_name=f"v{version}",
+        version=version,
+        release_name=f"MediaMop {version}",
+        html_url="https://example.com/release",
+        published_at=datetime(2026, 4, 23, tzinfo=UTC),
+        draft=False,
+        prerelease=False,
+        assets=(
+            GitHubReleaseAsset(
+                name="MediaMopSetup.exe",
+                api_url=f"https://api.github.com/repos/jampat000/MediaMop/releases/assets/{version.replace('.', '')}",
+                browser_download_url=f"https://github.com/jampat000/MediaMop/releases/download/v{version}/MediaMopSetup.exe",
+                size_bytes=123456789,
+                content_type="application/octet-stream",
+            ),
+        ),
+    )
 
 
 def _login_admin(client: TestClient) -> None:
@@ -287,50 +312,57 @@ def test_log_retention_does_not_prune_activity_history(client_with_admin: TestCl
 def test_suite_update_status_ok(client_with_admin: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     _login_admin(client_with_admin)
     monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
-        lambda: {
-            "tag_name": "v1.2.3",
-            "name": "MediaMop 1.2.3",
-            "html_url": "https://example.com/release",
-            "published_at": "2026-04-23T00:00:00Z",
-            "assets": [
-                {
-                    "name": "MediaMopSetup.exe",
-                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
-                }
-            ],
-        },
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("1.2.3"),
     )
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
-    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_updater_service_ready", lambda _settings=None: False)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_windows_updater_progress",
+        lambda _settings=None: (
+            True,
+            "Remote in-app upgrade is ready on this Windows install.",
+            None,
+        ),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._detect_install_type", lambda: "windows")
+
     r = client_with_admin.get("/api/v1/suite/update-status")
+
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["current_version"] == "1.0.0"
     assert body["latest_version"] == "1.2.3"
     assert body["status"] == "update_available"
-    assert body["in_app_upgrade_supported"] is False
+    assert body["in_app_upgrade_supported"] is True
 
 
 def test_suite_update_status_alias_ok(client_with_admin: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     _login_admin(client_with_admin)
     monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
-        lambda: {
-            "tag_name": "v1.2.3",
-            "name": "MediaMop 1.2.3",
-            "html_url": "https://example.com/release",
-            "published_at": "2026-04-23T00:00:00Z",
-            "assets": [],
-        },
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("1.2.3"),
     )
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
-    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_updater_service_ready", lambda _settings=None: False)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_windows_updater_progress",
+        lambda _settings=None: (
+            False,
+            "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service.",
+            {
+                "phase": "installer_running",
+                "message": "Installer is running. MediaMop may temporarily disconnect.",
+                "target_version": "1.2.3",
+            },
+        ),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._detect_install_type", lambda: "windows")
 
     r = client_with_admin.get("/api/v1/suite/settings/update-status")
 
     assert r.status_code == 200, r.text
-    assert r.json()["status"] == "update_available"
+    body = r.json()
+    assert body["status"] == "update_available"
+    assert body["upgrade"]["phase"] == "installer_running"
 
 
 def test_suite_update_now_get_redirects_back_to_settings(client_with_admin: TestClient) -> None:
@@ -342,6 +374,39 @@ def test_suite_update_now_get_redirects_back_to_settings(client_with_admin: Test
     assert r.headers["location"] == "/settings"
 
 
+def test_suite_update_diagnostics_requires_operator_and_returns_shape(
+    client_with_admin: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_admin)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.router.build_suite_update_diagnostics",
+        lambda _settings=None: {
+            "current_version": "2.0.7",
+            "latest_version": "2.0.8",
+            "install_type": "windows",
+            "install_root": "C:/Program Files/MediaMop",
+            "runtime_home": "C:/ProgramData/MediaMop",
+            "updater_service_reachable": True,
+            "updater_token_path_present": True,
+            "installer_log_path": "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+            "service_log_path": "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+            "installer_log_tail": [],
+            "service_log_tail": [],
+            "running_processes": [],
+            "installed_files": [],
+            "upgrade": None,
+        },
+    )
+
+    r = client_with_admin.get("/api/v1/suite/update-diagnostics")
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["install_type"] == "windows"
+    assert body["updater_service_reachable"] is True
+
+
 def test_suite_update_status_not_published_when_release_missing(
     client_with_admin: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -351,23 +416,24 @@ def test_suite_update_status_not_published_when_release_missing(
     request = httpx.Request("GET", "https://api.github.com/repos/jampat000/MediaMop/releases/latest")
     response = httpx.Response(404, request=request)
 
-    def _raise_not_found() -> None:
+    def _raise_not_found(**_kwargs) -> None:  # noqa: ANN003
         raise httpx.HTTPStatusError("not found", request=request, response=response)
 
     monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
         _raise_not_found,
     )
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
 
     r = client_with_admin.get("/api/v1/suite/update-status")
+
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["status"] == "not_published"
     assert "no public mediamop release is published yet" in body["summary"].lower()
 
 
-def test_suite_update_now_stages_windows_installer_when_task_missing(
+def test_suite_update_now_returns_unavailable_when_updater_service_is_not_ready(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -375,66 +441,22 @@ def test_suite_update_now_stages_windows_installer_when_task_missing(
     monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
     monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
-        lambda: {
-            "tag_name": "v1.2.3",
-            "assets": [
-                {
-                    "name": "MediaMopSetup.exe",
-                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
-                }
-            ],
-        },
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("1.2.3"),
     )
-
     monkeypatch.setattr(
         "mediamop.platform.suite_settings.update_service._start_windows_updater_service_apply",
-        lambda _settings, installer_url, target_version: (
+        lambda _settings, target_version: (
             False,
-            "Remote in-app upgrade is not available on this Windows install yet because the MediaMop updater service has not been installed.",
+            "Remote in-app upgrade is unavailable because the local updater service token did not match this app install.",
+            None,
         ),
     )
 
     out = start_suite_update_now(settings)
 
     assert out.status == "unavailable"
-    assert "updater service has not been installed" in out.message.lower()
-    assert out.installer_path is None
-    assert out.log_path == str(tmp_path / "upgrades" / "updater-service.log")
-
-
-def test_suite_update_now_reports_manual_when_task_missing(
-    tmp_path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    settings = replace(MediaMopSettings.load(), mediamop_home=str(tmp_path))
-    monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
-    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
-    monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
-        lambda: {
-            "tag_name": "v1.2.3",
-            "assets": [
-                {
-                    "name": "MediaMopSetup.exe",
-                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
-                }
-            ],
-        },
-    )
-
-    monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._start_windows_updater_service_apply",
-        lambda _settings, installer_url, target_version: (
-            False,
-            "Remote in-app upgrade is not available on this Windows install yet because the MediaMop updater service has not been installed.",
-        ),
-    )
-
-    out = start_suite_update_now(settings)
-
-    assert out.status == "unavailable"
-    assert "remote in-app upgrade is not available on this windows install yet" in out.message.lower()
+    assert "local updater service token did not match" in out.message.lower()
     assert out.installer_path is None
     assert out.log_path == str(tmp_path / "upgrades" / "updater-service.log")
 
@@ -447,28 +469,22 @@ def test_suite_update_now_uses_windows_updater_service_when_available(
     monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
     monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "1.0.0")
     monkeypatch.setattr(
-        "mediamop.platform.suite_settings.update_service._fetch_latest_release_payload",
-        lambda: {
-            "tag_name": "v1.2.3",
-            "assets": [
-                {
-                    "name": "MediaMopSetup.exe",
-                    "browser_download_url": "https://example.com/MediaMopSetup.exe",
-                }
-            ],
-        },
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("1.2.3"),
     )
     monkeypatch.setattr(
         "mediamop.platform.suite_settings.update_service._start_windows_updater_service_apply",
-        lambda _settings, installer_url, target_version: (
+        lambda _settings, target_version: (
             True,
-            "Upgrade started using the MediaMop updater service.",
+            "Upgrade request accepted. MediaMop is checking release metadata.",
+            "attempt-123",
         ),
     )
 
     out = start_suite_update_now(settings)
 
     assert out.status == "started"
+    assert out.attempt_id == "attempt-123"
     assert out.target_version == "1.2.3"
     assert out.log_path == str(tmp_path / "upgrades" / "updater-service.log")
 

--- a/apps/backend/tests/test_suite_update_service.py
+++ b/apps/backend/tests/test_suite_update_service.py
@@ -1,10 +1,36 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 
 from mediamop.platform.suite_settings import update_service
+from mediamop.platform.suite_settings.release_catalog import (
+    GitHubReleaseAsset,
+    GitHubReleaseRecord,
+)
+
+
+def _release_record(version: str = "2.0.8") -> GitHubReleaseRecord:
+    return GitHubReleaseRecord(
+        tag_name=f"v{version}",
+        version=version,
+        release_name=f"MediaMop {version}",
+        html_url="https://example.com/release",
+        published_at=datetime(2026, 5, 7, tzinfo=UTC),
+        draft=False,
+        prerelease=False,
+        assets=(
+            GitHubReleaseAsset(
+                name="MediaMopSetup.exe",
+                api_url="https://api.github.com/repos/jampat000/MediaMop/releases/assets/1",
+                browser_download_url=f"https://github.com/jampat000/MediaMop/releases/download/v{version}/MediaMopSetup.exe",
+                size_bytes=123456789,
+                content_type="application/octet-stream",
+            ),
+        ),
+    )
 
 
 def test_read_updater_token_uses_fallback_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -27,6 +53,14 @@ def test_windows_updater_service_ready_requires_authenticated_status(monkeypatch
     class _Resp:
         status_code = 200
 
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {
+                "phase": "installer_running",
+                "message": "Installer is running. MediaMop may temporarily disconnect.",
+                "target_version": "2.0.8",
+            }
+
     def _fake_get(url: str, *, headers: dict[str, str] | None = None, timeout: float | None = None) -> _Resp:
         observed["url"] = url
         observed["headers"] = headers
@@ -34,14 +68,18 @@ def test_windows_updater_service_ready_requires_authenticated_status(monkeypatch
         return _Resp()
 
     with monkeypatch.context() as scoped:
-        scoped.setattr("mediamop.platform.suite_settings.update_service.os.name", "nt", raising=False)
         scoped.setattr(
             "mediamop.platform.suite_settings.update_service._updater_headers",
             lambda _settings=None: {"X-MediaMop-Updater-Token": "token-value"},
         )
         scoped.setattr("mediamop.platform.suite_settings.update_service.httpx.get", _fake_get)
 
-        assert update_service._windows_updater_service_ready() is True
+        ready, summary, progress = update_service._fetch_windows_updater_progress()
+
+        assert ready is True
+        assert summary == "Remote in-app upgrade is ready on this Windows install."
+        assert progress is not None
+        assert progress.phase == "installer_running"
         assert observed["url"] == f"{update_service._updater_base_url()}/api/v1/status"
         assert observed["headers"] == {"X-MediaMop-Updater-Token": "token-value"}
         assert observed["timeout"] == 3.0
@@ -51,12 +89,205 @@ def test_windows_updater_service_ready_false_on_unauthorized(monkeypatch: pytest
     class _Resp:
         status_code = 401
 
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {}
+
     with monkeypatch.context() as scoped:
-        scoped.setattr("mediamop.platform.suite_settings.update_service.os.name", "nt", raising=False)
         scoped.setattr(
             "mediamop.platform.suite_settings.update_service._updater_headers",
             lambda _settings=None: {"X-MediaMop-Updater-Token": "bad-token"},
         )
         scoped.setattr("mediamop.platform.suite_settings.update_service.httpx.get", lambda *_args, **_kwargs: _Resp())
 
-        assert update_service._windows_updater_service_ready() is False
+        ready, summary, progress = update_service._fetch_windows_updater_progress()
+
+        assert ready is False
+        assert "token did not match" in summary.lower()
+        assert progress is None
+
+
+def test_start_windows_updater_service_apply_posts_target_version_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed: dict[str, object] = {}
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict[str, object]:
+            return {
+                "accepted": True,
+                "attempt_id": "attempt-123",
+                "message": "Upgrade request accepted. MediaMop is checking release metadata.",
+            }
+
+    def _fake_post(url: str, *, headers: dict[str, str] | None = None, json=None, timeout: float | None = None) -> _Resp:  # noqa: ANN001
+        observed["url"] = url
+        observed["headers"] = headers
+        observed["json"] = json
+        observed["timeout"] = timeout
+        return _Resp()
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(
+            "mediamop.platform.suite_settings.update_service._updater_headers",
+            lambda _settings=None: {"X-MediaMop-Updater-Token": "token-value"},
+        )
+        scoped.setattr("mediamop.platform.suite_settings.update_service.httpx.post", _fake_post)
+
+        started, message, attempt_id = update_service._start_windows_updater_service_apply(
+            object(),  # type: ignore[arg-type]
+            target_version="v2.0.8",
+        )
+
+        assert started is True
+        assert attempt_id == "attempt-123"
+        assert message == "Upgrade request accepted. MediaMop is checking release metadata."
+        assert observed["url"] == f"{update_service._updater_base_url()}/api/v1/apply"
+        assert observed["json"] == {"target_version": "2.0.8"}
+
+
+def test_build_suite_update_status_includes_upgrade_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("2.0.8"),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "2.0.7")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._detect_install_type", lambda: "windows")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_windows_updater_progress",
+        lambda _settings=None: (
+            True,
+            "Remote in-app upgrade is ready on this Windows install.",
+            update_service._coerce_upgrade_progress(
+                {
+                    "phase": "verifying_install",
+                    "message": "MediaMop is reconnecting and verifying the installed version.",
+                    "attempt_id": "attempt-123",
+                    "target_version": "2.0.8",
+                    "installer_log_path": "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+                }
+            ),
+        ),
+    )
+
+    status = update_service.build_suite_update_status()
+
+    assert status.status == "update_available"
+    assert status.latest_version == "2.0.8"
+    assert status.upgrade is not None
+    assert status.upgrade.phase == "verifying_install"
+    assert status.upgrade.attempt_id == "attempt-123"
+
+
+def test_start_suite_update_now_returns_attempt_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    settings = type("Settings", (), {"mediamop_home": str(tmp_path)})()
+    monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "2.0.7")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("2.0.8"),
+    )
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._start_windows_updater_service_apply",
+        lambda _settings, target_version: (
+            True,
+            "Upgrade request accepted. MediaMop is checking release metadata.",
+            "attempt-123",
+        ),
+    )
+
+    out = update_service.start_suite_update_now(settings)  # type: ignore[arg-type]
+
+    assert out.status == "started"
+    assert out.attempt_id == "attempt-123"
+    assert out.target_version == "2.0.8"
+    assert out.log_path == str(tmp_path / "upgrades" / "updater-service.log")
+
+
+def test_build_suite_update_diagnostics_reports_installed_files(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    install_root = tmp_path / "install"
+    runtime_home = tmp_path / "runtime"
+    internal = install_root / "_internal"
+    internal.mkdir(parents=True)
+    (internal / "mediamop_backend-2.0.8.dist-info").mkdir()
+    for relative in (
+        "MediaMop.exe",
+        "MediaMopServer.exe",
+        "MediaMopUpdater.exe",
+        "MediaMopUpdaterService.exe",
+        "MediaMopUpdaterService.xml",
+        "_internal/web-dist/index.html",
+    ):
+        path = install_root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("x", encoding="utf-8")
+
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._install_root", lambda: install_root)
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._runtime_home", lambda _settings=None: runtime_home)
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._updater_token_paths", lambda _settings=None: [])
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.build_suite_update_status",
+        lambda _settings=None: type(
+            "Status",
+            (),
+            {
+                "current_version": "2.0.7",
+                "latest_version": "2.0.8",
+                "install_type": "windows",
+                "in_app_upgrade_supported": True,
+                "upgrade": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._list_windows_processes", lambda: [])
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_file_version", lambda _path: None)
+
+    diagnostics = update_service.build_suite_update_diagnostics()
+
+    assert diagnostics.install_root == str(install_root)
+    assert diagnostics.runtime_home == str(runtime_home)
+    assert len(diagnostics.installed_files) == 6
+    assert diagnostics.installed_files[1]["packaged_version"] == "2.0.8"
+
+
+def test_build_suite_update_diagnostics_never_exposes_updater_token_value(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_root = tmp_path / "install"
+    runtime_home = tmp_path / "runtime"
+    token_path = runtime_home / "updater.secret"
+    secret_value = "super-secret-updater-token-value"
+    install_root.mkdir(parents=True)
+    runtime_home.mkdir(parents=True)
+    token_path.write_text(secret_value, encoding="utf-8")
+
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._install_root", lambda: install_root)
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._runtime_home", lambda _settings=None: runtime_home)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._updater_token_paths",
+        lambda _settings=None: [token_path],
+    )
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.build_suite_update_status",
+        lambda _settings=None: type(
+            "Status",
+            (),
+            {
+                "current_version": "2.0.7",
+                "latest_version": "2.0.8",
+                "install_type": "windows",
+                "in_app_upgrade_supported": True,
+                "upgrade": None,
+            },
+        )(),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._list_windows_processes", lambda: [])
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._windows_file_version", lambda _path: None)
+
+    diagnostics = update_service.build_suite_update_diagnostics()
+    payload = diagnostics.model_dump()
+
+    assert diagnostics.updater_token_path_present is True
+    assert secret_value not in str(payload)

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 
 from mediamop.windows import tray_app
 
@@ -71,7 +72,12 @@ def test_windows_installer_surfaces_firewall_rule_failures() -> None:
 
     assert "procedure InstallFirewallRule()" in text
     assert "profile=private,domain" in text
-    assert "MsgBox(" in text
+    assert "procedure ShowInstallNotice" in text
+    assert "SuppressibleMsgBox(" in text
+    assert re.search(r"(?<!Suppressible)MsgBox\(", text) is None
+    assert "TaskDialogMsgBox(" not in text
+    assert "SuppressibleTaskDialogMsgBox(" not in text
+    assert "WizardSilent" in text
     assert "Windows did not allow Setup to add the firewall rule" in text
     assert 'Filename: "{sys}\\netsh.exe"; Parameters: "advfirewall firewall add rule' not in text
 
@@ -88,9 +94,9 @@ def test_windows_installer_installs_dedicated_upgrade_task() -> None:
     assert 'Source: "{#RepoRoot}\\packaging\\windows\\vendor\\winsw\\WinSW-x64.exe"; DestDir: "{app}"; DestName: "MediaMopUpdaterService.exe"; Flags: ignoreversion' in text
     assert "function UpdaterServiceInstalled(): Boolean;" in text
     assert "procedure InstallUpdaterService();" in text
+    assert "procedure FailInstall" in text
     assert "MediaMopUpdaterService.exe" in text
     assert "Remote in-app upgrades depend on that service." in text
-    assert "RaiseException('MediaMop could not install the required Windows updater service.');" in text
     assert 'Filename: "{sys}\\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"' in text
     assert "<id>MediaMopUpdater</id>" in service_text
     assert "<name>MediaMop Updater</name>" in service_text
@@ -110,6 +116,7 @@ def test_windows_package_uses_dedicated_tray_icon_assets() -> None:
     assert "(str(TRAY_ICON_PNG), \"assets\")" in text
     assert "(str(TRAY_ICON_ICO), \"assets\")" in text
     assert "(str(THIRD_PARTY_NOTICES), \".\")" in text
+    assert 'copy_metadata("mediamop-backend")' in text
     assert "icon=str(TRAY_ICON_ICO)" in text
     assert 'name="MediaMopUpdater"' in text
     assert 'str(BACKEND / "src" / "mediamop" / "windows" / "updater_service.py")' in text
@@ -131,6 +138,23 @@ def test_windows_package_includes_ffmpeg_runtime_assets() -> None:
     assert "Ensure-WindowsServiceWrapper" in build_text
     assert "https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe" in build_text
     assert "05b82d46ad331cc16bdc00de5c6332c1ef818df8ceefcd49c726553209b3a0da" in build_text
+    assert "MEDIAMOP_BUILD_VERSION" in build_text
+    assert "$buildVersion.StartsWith(\"v\")" in build_text
+    assert "does not match backend project version" in build_text
+    assert "MediaMopServer.exe reports version" in build_text
+    assert "expected build version" in build_text
+    assert "MediaMopUpdater.exe reports version" in build_text
+
+
+def test_release_workflow_generates_checksum_and_uses_normalized_semver() -> None:
+    workflow = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "release.yml"
+    text = workflow.read_text(encoding="utf-8")
+
+    assert 'run: echo "plain=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"' in text
+    assert "MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}" in text
+    assert 'scripts/smoke-windows-package.ps1 -ExpectedVersion "${{ steps.version.outputs.plain }}"' in text
+    assert 'MediaMopSetup.exe.sha256' in text
+    assert "Get-AuthenticodeSignature" in text
 
 
 def test_packaged_server_binds_to_lan_interfaces() -> None:
@@ -145,3 +169,4 @@ def test_tray_double_click_opens_mediamop() -> None:
     source = Path(tray_app.__file__).read_text(encoding="utf-8")
 
     assert 'Item("Open MediaMop", self._handle_open, default=True)' in source
+    assert 'if "--version" in sys.argv:' in source

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -154,6 +154,9 @@ def test_release_workflow_generates_checksum_and_uses_normalized_semver() -> Non
     assert "MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}" in text
     assert 'scripts/smoke-windows-package.ps1 -ExpectedVersion "${{ steps.version.outputs.plain }}"' in text
     assert 'MediaMopSetup.exe.sha256' in text
+    assert 'id: codesign' in text
+    assert "steps.codesign.outputs.enabled == 'true'" in text
+    assert "if: ${{ secrets." not in text
     assert "Get-AuthenticodeSignature" in text
 
 

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-import threading
 from pathlib import Path
 
+import pytest
 from fastapi.testclient import TestClient
 
 from mediamop.windows import updater_service
@@ -13,78 +13,168 @@ def _configure_runtime_home(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setenv("MEDIAMOP_HOME", str(tmp_path))
 
 
-def test_apply_update_releases_lock_when_thread_start_fails(tmp_path: Path, monkeypatch) -> None:
+def _release_with_assets(
+    version: str,
+    asset_names: set[str] | None = None,
+):
+    names = asset_names or {
+        "MediaMopSetup.exe",
+        "MediaMopSetup.exe.sha256",
+    }
+
+    class _Release:
+        def asset_named(self, name: str):
+            if name not in names:
+                return None
+            return type(
+                "Asset",
+                (),
+                {
+                    "browser_download_url": f"https://github.com/jampat000/MediaMop/releases/download/v{version}/{name}",
+                },
+            )()
+
+    return _Release()
+
+
+def test_apply_update_rejects_legacy_installer_url_payload(tmp_path: Path, monkeypatch) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
-    monkeypatch.setattr(updater_service, "_JOB_LOCK", threading.Lock())
     with monkeypatch.context() as scoped:
         scoped.setattr(updater_service.os, "name", "nt")
         scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
-        scoped.setattr(updater_service, "_validate_installer_url", lambda url: url)
-
-        class _BrokenThread:
-            def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
-                pass
-
-            def start(self) -> None:
-                raise RuntimeError("thread start failed")
-
-        scoped.setattr(updater_service.threading, "Thread", _BrokenThread)
-
         app = updater_service.create_updater_app()
         with TestClient(app, raise_server_exceptions=False) as client:
             res = client.post(
                 "/api/v1/apply",
                 headers={"X-MediaMop-Updater-Token": "token"},
                 json={
-                    "installer_url": "https://github.com/jampat000/MediaMop/releases/download/v2.0.3/MediaMopSetup.exe",
-                    "target_version": "2.0.3",
+                    "installer_url": "https://github.com/jampat000/MediaMop/releases/download/v2.0.8/MediaMopSetup.exe",
+                    "target_version": "2.0.8",
                 },
             )
 
-        assert res.status_code == 500
-    assert updater_service._JOB_LOCK.locked() is False
+    assert res.status_code == 422
 
 
-def test_apply_update_job_marks_completed_when_installer_finishes_with_log(
+def test_apply_update_marks_failed_when_helper_launch_fails(tmp_path: Path, monkeypatch) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        scoped.setattr(updater_service, "_launch_helper", lambda _attempt_id: (_ for _ in ()).throw(RuntimeError("boom")))
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.post(
+                "/api/v1/apply",
+                headers={"X-MediaMop-Updater-Token": "token"},
+                json={"target_version": "2.0.8"},
+            )
+
+    state = updater_service._read_state()
+    assert res.status_code == 500
+    assert state["phase"] == "failed"
+    assert "Could not launch upgrade helper" in str(state["last_error"])
+
+
+def test_apply_update_starts_helper_and_returns_attempt_id(tmp_path: Path, monkeypatch) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+
+    class _Helper:
+        pid = 4321
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        scoped.setattr(updater_service, "_launch_helper", lambda _attempt_id: _Helper())
+        scoped.setattr(updater_service.uuid, "uuid4", lambda: type("Uuid", (), {"hex": "attempt-123"})())
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.post(
+                "/api/v1/apply",
+                headers={"X-MediaMop-Updater-Token": "token"},
+                json={"target_version": "v2.0.8"},
+            )
+
+    body = res.json()
+    state = updater_service._read_state()
+    assert res.status_code == 200
+    assert body["accepted"] is True
+    assert body["attempt_id"] == "attempt-123"
+    assert body["target_version"] == "2.0.8"
+    assert state["attempt_id"] == "attempt-123"
+    assert state["target_version"] == "2.0.8"
+    assert state["diagnostics"]["helper_pid"] == 4321
+
+
+def test_perform_upgrade_attempt_marks_completed_only_after_verified_version(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
     installer = tmp_path / "MediaMopSetup.exe"
     installer.write_bytes(b"installer")
-
-    def _download(_installer_url: str, _target_version: str) -> Path:
-        return installer
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
 
     class _DoneProcess:
-        pid = 4321
+        pid = 6789
 
         def wait(self, timeout: float) -> int:
-            updater_service._setup_log_path().write_text("installer log", encoding="utf-8")
+            Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
             return 0
 
-    monkeypatch.setattr(updater_service, "_download_installer", _download)
-    monkeypatch.setattr(updater_service, "_launch_installer_detached", lambda _path: _DoneProcess())
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: type(
+            "Release",
+            (),
+            {
+                "asset_named": lambda self, name: type(
+                    "Asset",
+                    (),
+                    {
+                        "browser_download_url": f"https://github.com/jampat000/MediaMop/releases/download/v{version}/{name}",
+                    },
+                )()
+                if name in {"MediaMopSetup.exe", "MediaMopSetup.exe.sha256"}
+                else None
+            },
+        )(),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _DoneProcess())
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda target_version: (
+            True,
+            {"backend_version": target_version, "packaged_version": target_version},
+            f"Upgrade completed. Running version: {target_version}.",
+        ),
+    )
 
-    updater_service._apply_update_job("https://example.invalid/MediaMopSetup.exe", "2.0.3")
+    updater_service._perform_upgrade_attempt(attempt_id)
     state = updater_service._read_state()
 
     assert state["phase"] == "completed"
-    assert state["target_version"] == "2.0.3"
+    assert state["target_version"] == "2.0.8"
+    assert state["current_version_seen"] == "2.0.8"
     assert state["last_error"] is None
-    assert state["installer_log_path"] == str(updater_service._setup_log_path())
 
 
-def test_apply_update_job_marks_failed_when_installer_log_missing(
+def test_perform_upgrade_attempt_marks_failed_when_installer_log_missing(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
     installer = tmp_path / "MediaMopSetup.exe"
     installer.write_bytes(b"installer")
-
-    def _download(_installer_url: str, _target_version: str) -> Path:
-        return installer
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
 
     class _DoneProcessNoLog:
         pid = 6789
@@ -92,15 +182,546 @@ def test_apply_update_job_marks_failed_when_installer_log_missing(
         def wait(self, timeout: float) -> int:
             return 0
 
-    monkeypatch.setattr(updater_service, "_download_installer", _download)
-    monkeypatch.setattr(updater_service, "_launch_installer_detached", lambda _path: _DoneProcessNoLog())
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: type(
+            "Release",
+            (),
+            {
+                "asset_named": lambda self, name: type(
+                    "Asset",
+                    (),
+                    {
+                        "browser_download_url": f"https://github.com/jampat000/MediaMop/releases/download/v{version}/{name}",
+                    },
+                )()
+                if name in {"MediaMopSetup.exe", "MediaMopSetup.exe.sha256"}
+                else None
+            },
+        )(),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _DoneProcessNoLog())
 
-    updater_service._apply_update_job("https://example.invalid/MediaMopSetup.exe", "2.0.3")
+    updater_service._perform_upgrade_attempt(attempt_id)
     state = updater_service._read_state()
 
     assert state["phase"] == "failed"
-    assert state["target_version"] == "2.0.3"
-    assert "did not produce installer-latest.log" in str(state["last_error"])
+    assert "did not produce an installer log" in str(state["last_error"]).lower()
+
+
+def test_perform_upgrade_attempt_marks_failed_when_version_does_not_change(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+
+    class _DoneProcess:
+        pid = 6789
+
+        def wait(self, timeout: float) -> int:
+            Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+            return 0
+
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: type(
+            "Release",
+            (),
+            {
+                "asset_named": lambda self, name: type(
+                    "Asset",
+                    (),
+                    {
+                        "browser_download_url": f"https://github.com/jampat000/MediaMop/releases/download/v{version}/{name}",
+                    },
+                )()
+                if name in {"MediaMopSetup.exe", "MediaMopSetup.exe.sha256"}
+                else None
+            },
+        )(),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _DoneProcess())
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda _target_version: (
+            False,
+            {"backend_version": "2.0.7", "packaged_version": "2.0.7"},
+            "Running backend still reports 2.0.7 instead of 2.0.8.",
+        ),
+    )
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "2.0.7 instead of 2.0.8" in str(state["last_error"])
+
+
+def test_perform_upgrade_attempt_marks_failed_when_installer_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+
+    class _FailedProcess:
+        pid = 6789
+
+        def wait(self, timeout: float) -> int:
+            Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+            return 5
+
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: _release_with_assets(version),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _FailedProcess())
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "installer exited with code 5" in str(state["last_error"]).lower()
+
+
+def test_perform_upgrade_attempt_requires_checksum_manifest_in_production(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+
+    monkeypatch.delenv("MEDIAMOP_UPDATER_ALLOW_UNVERIFIED", raising=False)
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: _release_with_assets(
+            version,
+            {"MediaMopSetup.exe"},
+        ),
+    )
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "require mediamopsetup.exe.sha256" in str(state["last_error"]).lower()
+
+
+def test_perform_upgrade_attempt_fails_on_sha256_mismatch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: _release_with_assets(version),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "b" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "sha-256 mismatch" in str(state["last_error"]).lower()
+
+
+def test_perform_upgrade_attempt_allows_missing_checksum_only_with_explicit_override(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+    monkeypatch.setenv("MEDIAMOP_UPDATER_ALLOW_UNVERIFIED", "true")
+
+    class _DoneProcess:
+        pid = 6789
+
+        def wait(self, timeout: float) -> int:
+            Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+            return 0
+
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: _release_with_assets(
+            version,
+            {"MediaMopSetup.exe"},
+        ),
+    )
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "b" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _DoneProcess())
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda target_version: (
+            True,
+            {"backend_version": target_version, "packaged_version": target_version},
+            f"Upgrade completed. Running version: {target_version}.",
+        ),
+    )
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["expected_sha256"] is None
+    assert state["installer_sha256"] == "b" * 64
+
+
+def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    attempt_id = "attempt-123"
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(updater_service._fresh_attempt_state("2.0.8", attempt_id))
+
+    class _LaunchedProcess:
+        pid = 6789
+
+    monkeypatch.setattr(
+        updater_service,
+        "fetch_release_record_by_version",
+        lambda version, user_agent_version: _release_with_assets(version),
+    )
+    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _LaunchedProcess())
+    monkeypatch.setattr(updater_service.sys, "frozen", True, raising=False)
+
+    updater_service._perform_upgrade_attempt(attempt_id)
+    launch_state = updater_service._read_state()
+
+    assert launch_state["phase"] == "installer_running"
+    assert launch_state["diagnostics"]["installer_pid"] == 6789
+
+    Path(launch_state["installer_log_path"]).write_text("installer log", encoding="utf-8")
+    updater_service._write_state(diagnostics={"helper_pid": None})
+    monkeypatch.setattr(updater_service, "_pid_is_running", lambda _pid: False)
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda target_version: (
+            True,
+            {"backend_version": target_version, "packaged_version": target_version},
+            f"Upgrade completed. Running version: {target_version}.",
+        ),
+    )
+
+    updater_service._reconcile_attempt_worker(attempt_id)
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["current_version_seen"] == "2.0.8"
+
+
+def test_apply_update_persists_state_before_launching_helper(tmp_path: Path, monkeypatch) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    observed: dict[str, object] = {}
+
+    class _Helper:
+        pid = 4321
+
+    def _launch_helper(attempt_id: str) -> _Helper:
+        state = updater_service._read_state()
+        observed["attempt_id"] = attempt_id
+        observed["phase"] = state["phase"]
+        observed["state_attempt_id"] = state["attempt_id"]
+        observed["target_version"] = state["target_version"]
+        return _Helper()
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        scoped.setattr(updater_service, "_launch_helper", _launch_helper)
+        scoped.setattr(updater_service.uuid, "uuid4", lambda: type("Uuid", (), {"hex": "attempt-123"})())
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.post(
+                "/api/v1/apply",
+                headers={"X-MediaMop-Updater-Token": "token"},
+                json={"target_version": "2.0.8"},
+            )
+
+    assert res.status_code == 200
+    assert observed == {
+        "attempt_id": "attempt-123",
+        "phase": "checking",
+        "state_attempt_id": "attempt-123",
+        "target_version": "2.0.8",
+    }
+
+
+def test_maybe_reconcile_pending_attempt_marks_stale_attempt_failed(tmp_path: Path, monkeypatch) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    state_path = updater_service._state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "phase": "downloading",
+                "attempt_id": "attempt-123",
+                "target_version": "2.0.8",
+                "last_started_at": "2026-05-06T00:00:00+00:00",
+                "last_updated_at": "2026-05-06T00:00:00+00:00",
+                "diagnostics": {"helper_pid": None, "installer_pid": None},
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(updater_service, "_state_age_seconds", lambda _state: updater_service._STALE_ATTEMPT_SECONDS + 5)
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "stalled during downloading" in str(state["last_error"]).lower()
+
+
+@pytest.mark.parametrize("phase", ["installer_running", "restarting", "verifying_install"])
+def test_maybe_reconcile_pending_attempt_resumes_verification_for_recoverable_phases(
+    tmp_path: Path,
+    monkeypatch,
+    phase: str,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+            "phase": phase,
+            "message": "waiting",
+            "diagnostics": {"helper_pid": None, "installer_pid": None},
+        }
+    )
+    Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+
+    class _ImmediateThread:
+        def __init__(self, *, target, args, daemon, name) -> None:
+            self._target = target
+            self._args = args
+
+        def start(self) -> None:
+            self._target(*self._args)
+
+    monkeypatch.setattr(updater_service, "_state_age_seconds", lambda _state: 5)
+    monkeypatch.setattr(updater_service, "_pid_is_running", lambda _pid: False)
+    monkeypatch.setattr(updater_service.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda target_version: (
+            True,
+            {"backend_version": target_version, "packaged_version": target_version},
+            f"Upgrade completed. Running version: {target_version}.",
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["diagnostics"]["reconciled_after_restart"] is True
+
+
+@pytest.mark.parametrize("phase", ["installer_running", "restarting", "verifying_install"])
+def test_maybe_reconcile_pending_attempt_fails_stale_recoverable_phases(
+    tmp_path: Path,
+    monkeypatch,
+    phase: str,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+            "phase": phase,
+            "message": "waiting",
+            "diagnostics": {"helper_pid": None, "installer_pid": None},
+        }
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_state_age_seconds",
+        lambda _state: updater_service._STALE_ATTEMPT_SECONDS + 5,
+    )
+    monkeypatch.setattr(updater_service, "_pid_is_running", lambda _pid: False)
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert f"stalled during {phase}" in str(state["last_error"]).lower()
+
+
+def test_parse_sha256_manifest_prefers_installer_line() -> None:
+    manifest = "\n".join(
+        [
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  something-else.exe",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  MediaMopSetup.exe",
+        ]
+    )
+
+    assert updater_service._parse_sha256_manifest(manifest) == "a" * 64
+
+
+def test_validated_asset_download_url_rejects_wrong_tag() -> None:
+    try:
+        updater_service._validated_asset_download_url(
+            "https://github.com/jampat000/MediaMop/releases/download/v2.0.7/MediaMopSetup.exe",
+            version="2.0.8",
+            asset_name="MediaMopSetup.exe",
+        )
+    except ValueError as exc:
+        assert "did not match" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+@pytest.mark.parametrize(
+    ("url", "asset_name", "expected"),
+    [
+        (
+            "https://github.com/other/MediaMop/releases/download/v2.0.8/MediaMopSetup.exe",
+            "MediaMopSetup.exe",
+            "did not match",
+        ),
+        (
+            "https://github.com/jampat000/OtherRepo/releases/download/v2.0.8/MediaMopSetup.exe",
+            "MediaMopSetup.exe",
+            "did not match",
+        ),
+        (
+            "https://github.com/jampat000/MediaMop/releases/download/v2.0.8/OtherSetup.exe",
+            "MediaMopSetup.exe",
+            "did not match",
+        ),
+    ],
+)
+def test_validated_asset_download_url_rejects_wrong_owner_repo_or_asset_name(
+    url: str,
+    asset_name: str,
+    expected: str,
+) -> None:
+    with pytest.raises(ValueError, match=expected):
+        updater_service._validated_asset_download_url(
+            url,
+            version="2.0.8",
+            asset_name=asset_name,
+        )
+
+
+def test_validated_redirect_target_rejects_untrusted_host() -> None:
+    with pytest.raises(ValueError, match="untrusted host"):
+        updater_service._validated_redirect_target(
+            "https://github.com/jampat000/MediaMop/releases/download/v2.0.8/MediaMopSetup.exe",
+            "https://example.com/MediaMopSetup.exe",
+        )
+
+
+def test_verify_authenticode_signature_is_optional_by_default(tmp_path: Path, monkeypatch) -> None:
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    monkeypatch.delenv("MEDIAMOP_UPDATER_REQUIRE_AUTHENTICODE", raising=False)
+
+    ok, detail = updater_service._verify_authenticode_signature(installer)
+
+    assert ok is True
+    assert detail == "Authenticode verification not required."
+
+
+def test_verify_authenticode_signature_requires_valid_signature_when_enabled(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    installer = tmp_path / "MediaMopSetup.exe"
+    installer.write_bytes(b"installer")
+    monkeypatch.setenv("MEDIAMOP_UPDATER_REQUIRE_AUTHENTICODE", "true")
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001
+        return type(
+            "Result",
+            (),
+            {
+                "returncode": 0,
+                "stdout": '{"Status":"UnknownError","StatusMessage":"bad","Signer":""}',
+                "stderr": "",
+            },
+        )()
+
+    monkeypatch.setattr(updater_service.subprocess, "run", _fake_run)
+
+    ok, detail = updater_service._verify_authenticode_signature(installer)
+
+    assert ok is False
+    assert "Authenticode signature verification failed" in detail
+
+
+def test_harden_token_acl_windows_uses_icacls(tmp_path: Path, monkeypatch) -> None:
+    token_path = tmp_path / "updater.secret"
+    token_path.write_text("token", encoding="utf-8")
+    observed: dict[str, object] = {}
+
+    def _fake_run(cmd, **kwargs):  # noqa: ANN001
+        observed["cmd"] = cmd
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(updater_service.subprocess, "run", _fake_run)
+
+    updater_service._harden_token_acl_windows(token_path)
+
+    assert observed["cmd"] == [
+        "icacls",
+        str(token_path),
+        "/inheritance:r",
+        "/grant:r",
+        "SYSTEM:R",
+        "/grant:r",
+        "Administrators:R",
+        "/grant:r",
+        "INTERACTIVE:R",
+    ]
 
 
 def test_read_state_surfaces_state_corruption(tmp_path: Path, monkeypatch) -> None:
@@ -113,19 +734,3 @@ def test_read_state_surfaces_state_corruption(tmp_path: Path, monkeypatch) -> No
 
     assert state["phase"] == "state_corrupt"
     assert "Could not parse updater state file" in str(state["last_error"])
-
-
-def test_read_state_merges_valid_json(tmp_path: Path, monkeypatch) -> None:
-    _configure_runtime_home(tmp_path, monkeypatch)
-    state_path = updater_service._state_path()
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text(
-        json.dumps({"phase": "installer_running", "target_version": "2.0.3"}),
-        encoding="utf-8",
-    )
-
-    state = updater_service._read_state()
-
-    assert state["phase"] == "installer_running"
-    assert state["target_version"] == "2.0.3"
-    assert state["installer_log_path"] == str(updater_service._setup_log_path())

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -420,20 +420,22 @@ def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
     class _LaunchedProcess:
         pid = 6789
 
-    monkeypatch.setattr(
-        updater_service,
-        "fetch_release_record_by_version",
-        lambda version, user_agent_version: _release_with_assets(version),
-    )
-    monkeypatch.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
-    monkeypatch.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
-    monkeypatch.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
-    monkeypatch.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
-    monkeypatch.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _LaunchedProcess())
-    monkeypatch.setattr(updater_service.sys, "frozen", True, raising=False)
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(
+            updater_service,
+            "fetch_release_record_by_version",
+            lambda version, user_agent_version: _release_with_assets(version),
+        )
+        scoped.setattr(updater_service, "_download_text", lambda _url: "a" * 64 + "  MediaMopSetup.exe")
+        scoped.setattr(updater_service, "_download_installer", lambda _url, target_version, attempt_id: installer)
+        scoped.setattr(updater_service, "_sha256_for_path", lambda _path: "a" * 64)
+        scoped.setattr(updater_service, "_verify_authenticode_signature", lambda _path: (True, "not required"))
+        scoped.setattr(updater_service, "_launch_installer", lambda _path, installer_log_path: _LaunchedProcess())
+        scoped.setattr(updater_service.sys, "frozen", True, raising=False)
 
-    updater_service._perform_upgrade_attempt(attempt_id)
-    launch_state = updater_service._read_state()
+        updater_service._perform_upgrade_attempt(attempt_id)
+        launch_state = updater_service._read_state()
 
     assert launch_state["phase"] == "installer_running"
     assert launch_state["diagnostics"]["installer_pid"] == 6789

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.0.7",
+  "version": "2.1.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -12,6 +12,7 @@ import {
 import { useLogoutMutation } from "../lib/auth/queries";
 import { useDashboardStatusQuery } from "../lib/dashboard/queries";
 import { useSuiteSettingsQuery } from "../lib/suite/queries";
+import { SUPPORT_URL } from "../lib/support";
 import {
   persistAppTheme,
   readStoredAppTheme,
@@ -96,6 +97,28 @@ export function AppShell() {
               title="Installed MediaMop version reported by the running server"
             >
               {appVersion ? `Version ${appVersion}` : "Version checking..."}
+            </div>
+            <div className="mm-sidebar-support" data-testid="sidebar-support">
+              <p className="mm-sidebar-support-title">Support MediaMop</p>
+              <p className="mm-sidebar-support-copy">
+                MediaMop is free to use. If it saves you time, you can support
+                development and help keep updates coming.
+              </p>
+              <p className="mm-sidebar-support-note">
+                Supporter licence (optional, future): this space is reserved
+                for future supporter acknowledgement details. There are no
+                licence checks or feature limits in this release.
+              </p>
+              {SUPPORT_URL ? (
+                <a
+                  href={SUPPORT_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mm-sidebar-support-link"
+                >
+                  Support MediaMop
+                </a>
+              ) : null}
             </div>
             <button
               type="button"

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -105,9 +105,9 @@ export function AppShell() {
                 development and help keep updates coming.
               </p>
               <p className="mm-sidebar-support-note">
-                Supporter licence (optional, future): this space is reserved
-                for future supporter acknowledgement details. There are no
-                licence checks or feature limits in this release.
+                Supporter licence (optional, future): this space is reserved for
+                future supporter acknowledgement details. There are no licence
+                checks or feature limits in this release.
               </p>
               {SUPPORT_URL ? (
                 <a

--- a/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
+++ b/apps/web/src/lib/activity/refiner-file-remux-pass-detail.test.tsx
@@ -19,6 +19,8 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
       audio_after: "A after",
       subs_before: "S before",
       subs_after: "S after",
+      removed_audio: ["Director commentary", "Japanese stereo"],
+      removed_subtitles: ["spa", "fre"],
       after_track_lines_meaning: "Planned only.",
       remux_required: true,
       ffmpeg_argv: ["/bin/ffmpeg", "-i", "a.mkv", "out.mkv"],
@@ -35,6 +37,10 @@ describe("RefinerFileRemuxPassActivityDetail", () => {
     expect(screen.getByText("/data/movies/a.mkv")).toBeInTheDocument();
     expect(screen.getByText("Audio in file")).toBeInTheDocument();
     expect(screen.getByText("A before")).toBeInTheDocument();
+    expect(screen.getByText("Director commentary")).toBeInTheDocument();
+    expect(screen.getByText("Japanese stereo")).toBeInTheDocument();
+    expect(screen.getByText("spa")).toBeInTheDocument();
+    expect(screen.queryByText("None removed")).not.toBeInTheDocument();
     expect(screen.getByText(/ffmpeg command line/i)).toBeInTheDocument();
   });
 

--- a/apps/web/src/lib/suite/queries.ts
+++ b/apps/web/src/lib/suite/queries.ts
@@ -50,12 +50,16 @@ export function useSuiteConfigurationBackupsQuery(enabled: boolean) {
   });
 }
 
-export function useSuiteUpdateStatusQuery(enabled = true) {
+export function useSuiteUpdateStatusQuery(
+  enabled = true,
+  refetchInterval: number | false = false,
+) {
   return useQuery({
     queryKey: suiteUpdateStatusQueryKey,
     queryFn: () => fetchSuiteUpdateStatus(),
     enabled,
-    staleTime: 60_000,
+    staleTime: enabled && refetchInterval ? 0 : 60_000,
+    refetchInterval,
     retry: false,
   });
 }

--- a/apps/web/src/lib/suite/suite-settings-api.ts
+++ b/apps/web/src/lib/suite/suite-settings-api.ts
@@ -28,8 +28,13 @@ export const suiteUpdateNowPaths = [
   "/api/v1/suite/update-now",
   "/api/v1/suite/settings/update-now",
 ] as const;
+export const suiteUpdateDiagnosticsPaths = [
+  "/api/v1/suite/update-diagnostics",
+  "/api/v1/suite/settings/update-diagnostics",
+] as const;
 export const suiteUpdateStatusPath = () => suiteUpdateStatusPaths[0];
 export const suiteUpdateNowPath = () => suiteUpdateNowPaths[0];
+export const suiteUpdateDiagnosticsPath = () => suiteUpdateDiagnosticsPaths[0];
 export const suiteLogsPath = () => "/api/v1/suite/logs";
 export const suiteMetricsPath = () => "/api/v1/suite/metrics";
 export const suiteOperationalHistoryResetPath = () =>

--- a/apps/web/src/lib/suite/types.ts
+++ b/apps/web/src/lib/suite/types.ts
@@ -72,14 +72,36 @@ export type SuiteUpdateStatusOut = {
   docker_update_command?: string | null;
   in_app_upgrade_supported?: boolean;
   in_app_upgrade_summary?: string | null;
+  upgrade?: SuiteUpgradeProgressOut | null;
 };
 
 export type SuiteUpdateStartOut = {
   status: "started" | "manual_required" | "unavailable" | string;
   message: string;
+  attempt_id?: string | null;
   target_version?: string | null;
   installer_path?: string | null;
   log_path?: string | null;
+};
+
+export type SuiteUpgradeProgressOut = {
+  phase: string;
+  message: string;
+  attempt_id?: string | null;
+  target_version?: string | null;
+  current_version_seen?: string | null;
+  downloaded_installer_path?: string | null;
+  installer_sha256?: string | null;
+  expected_sha256?: string | null;
+  installer_log_path?: string | null;
+  service_log_path?: string | null;
+  install_root?: string | null;
+  runtime_home?: string | null;
+  last_started_at?: string | null;
+  last_updated_at?: string | null;
+  last_completed_at?: string | null;
+  last_error?: string | null;
+  diagnostics?: Record<string, unknown>;
 };
 
 export type SuiteOperationalHistoryResetOut = {

--- a/apps/web/src/lib/support.test.ts
+++ b/apps/web/src/lib/support.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeSupportUrl, shouldShowSupportPlaceholder } from "./support";
+import {
+  normalizeSupportUrl,
+  shouldShowSupportCard,
+  shouldShowSupportPlaceholder,
+} from "./support";
 
 describe("support helpers", () => {
   it("accepts http and https URLs", () => {
@@ -24,5 +28,13 @@ describe("support helpers", () => {
     expect(
       shouldShowSupportPlaceholder(true, "https://github.com/sponsors/example"),
     ).toBe(false);
+  });
+
+  it("only shows the support card in production when URL is valid", () => {
+    expect(shouldShowSupportCard(false, null)).toBe(false);
+    expect(
+      shouldShowSupportCard(false, "https://github.com/sponsors/example"),
+    ).toBe(true);
+    expect(shouldShowSupportCard(true, null)).toBe(true);
   });
 });

--- a/apps/web/src/lib/support.ts
+++ b/apps/web/src/lib/support.ts
@@ -23,10 +23,21 @@ export function shouldShowSupportPlaceholder(
   return isDev && supportUrl === null;
 }
 
+export function shouldShowSupportCard(
+  isDev: boolean,
+  supportUrl: string | null,
+): boolean {
+  return supportUrl !== null || shouldShowSupportPlaceholder(isDev, supportUrl);
+}
+
 export const SUPPORT_URL = normalizeSupportUrl(
   import.meta.env.VITE_SUPPORT_URL,
 );
 export const SHOW_SUPPORT_URL_PLACEHOLDER = shouldShowSupportPlaceholder(
+  import.meta.env.DEV,
+  SUPPORT_URL,
+);
+export const SHOW_SUPPORT_CARD = shouldShowSupportCard(
   import.meta.env.DEV,
   SUPPORT_URL,
 );

--- a/apps/web/src/pages/activity/activity-page.test.tsx
+++ b/apps/web/src/pages/activity/activity-page.test.tsx
@@ -94,4 +94,68 @@ describe("ActivityPage", () => {
     const options = within(select.closest("label")!).getAllByRole("option");
     expect(options.map((option) => option.textContent)).toContain("System");
   });
+
+  it("renders skipped subtitle upgrades as warning activity, not success", () => {
+    useActivityRecentQuery.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        items: [
+          {
+            id: 1,
+            created_at: "2026-05-07T00:00:00Z",
+            event_type: "subber.subtitle_upgrade_completed",
+            module: "subber",
+            title: "Subtitle upgrade skipped because it is turned off",
+            detail:
+              '{"result":"skipped","user_message":"Subtitle upgrade is turned off in Subber settings.","counts":{"checked":0,"upgraded":0,"skipped":0},"attempted":0,"upgraded":0}',
+          },
+        ],
+        total: 1,
+        system_events: 0,
+      },
+    });
+
+    render(<ActivityPage />);
+
+    expect(screen.getByText("Subtitle upgrade skipped")).toBeInTheDocument();
+    expect(screen.getByText("Upgrade skipped")).toBeInTheDocument();
+    expect(
+      screen.getByText("Subtitle upgrade is turned off in Subber settings."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Result")).toBeInTheDocument();
+  });
+
+  it("renders explicit labels for system repair activity", () => {
+    useActivityRecentQuery.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        items: [
+          {
+            id: 2,
+            created_at: "2026-05-07T00:10:00Z",
+            event_type: "system.reconciliation.repair",
+            module: "system",
+            title: "System repair action completed",
+            detail:
+              "remove_refiner_temp_artifact: Removed the Refiner temp artifact.",
+          },
+        ],
+        total: 1,
+        system_events: 1,
+      },
+    });
+
+    render(<ActivityPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "System repair finished" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "remove_refiner_temp_artifact: Removed the Refiner temp artifact.",
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/activity/activity-page.tsx
+++ b/apps/web/src/pages/activity/activity-page.tsx
@@ -61,6 +61,7 @@ const EVENT_LABELS: Record<string, string> = {
   "auth.bootstrap_succeeded": "First admin created",
   "auth.bootstrap_denied": "First-time setup blocked",
   "auth.password_changed": "Password changed",
+  "system.reconciliation.repair": "System repair finished",
   "arr_library.connection_test_succeeded": "Connection check finished",
   "arr_library.connection_test_failed": "Connection check failed",
   "refiner.supplied_payload_evaluation_completed":
@@ -262,12 +263,30 @@ function normalizeSubberSummary(ev: ActivityEventItem): ActivityDisplay | null {
   }
 
   if (ev.event_type === "subber.subtitle_upgrade_completed") {
+    const result = asString(parsed?.result);
+    const userMessage = asString(parsed?.user_message);
+    const nextAction = asString(parsed?.next_action);
     return {
-      title: "Subtitle upgrade finished",
+      title:
+        result === "skipped"
+          ? "Subtitle upgrade skipped"
+          : result === "failed"
+            ? "Subtitle upgrade failed"
+            : "Subtitle upgrade finished",
       summary: "Subtitle upgrade result",
-      detail: ev.detail,
-      chip: "Upgrade complete",
-      tone: "success",
+      detail: userMessage ?? nextAction ?? ev.detail,
+      chip:
+        result === "skipped"
+          ? "Upgrade skipped"
+          : result === "failed"
+            ? "Upgrade failed"
+            : "Upgrade complete",
+      tone:
+        result === "skipped"
+          ? "warning"
+          : result === "failed"
+            ? "error"
+            : "success",
       compact: true,
     };
   }
@@ -786,16 +805,58 @@ function StructuredActivityDetails({ ev }: { ev: ActivityEventItem }) {
   }
 
   if (ev.event_type === "subber.subtitle_upgrade_completed") {
+    const result = asString(parsed.result);
+    const counts =
+      parsed.counts && typeof parsed.counts === "object"
+        ? (parsed.counts as ParsedDetail)
+        : null;
+    const skipped = asNumber(counts?.skipped);
     return (
-      <div className="grid gap-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3 sm:grid-cols-2">
-        <StructuredMetric
-          label="Checked"
-          value={asNumber(parsed.attempted) ?? 0}
-        />
-        <StructuredMetric
-          label="Upgraded"
-          value={asNumber(parsed.upgraded) ?? 0}
-        />
+      <div className="space-y-3 rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          <StructuredMetric
+            label="Result"
+            value={
+              result === "skipped"
+                ? "Skipped"
+                : result === "failed"
+                  ? "Failed"
+                  : "Completed"
+            }
+          />
+          <StructuredMetric
+            label="Checked"
+            value={asNumber(parsed.attempted) ?? 0}
+          />
+          <StructuredMetric
+            label="Upgraded"
+            value={asNumber(parsed.upgraded) ?? 0}
+          />
+          {skipped != null ? (
+            <StructuredMetric label="Skipped" value={skipped} />
+          ) : null}
+        </div>
+        {asString(parsed.user_message) ? (
+          <p className="text-sm text-[var(--mm-text2)]">
+            {asString(parsed.user_message)}
+          </p>
+        ) : null}
+        {asString(parsed.next_action) ? (
+          <p className="text-sm text-amber-100">
+            {asString(parsed.next_action)}
+          </p>
+        ) : null}
+        {asString(parsed.error) ? (
+          <p className="text-sm text-red-200">{asString(parsed.error)}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (ev.event_type === "system.reconciliation.repair") {
+    return (
+      <div className="rounded-md border border-[var(--mm-border)] bg-black/10 p-3">
+        <p className="text-sm leading-6 text-[var(--mm-text2)]">{ev.detail}</p>
       </div>
     );
   }

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -57,6 +57,21 @@ const minimalUpdateStatus: SuiteUpdateStatusOut = {
   in_app_upgrade_summary: null,
 };
 
+const windowsUpdateAvailableStatus: SuiteUpdateStatusOut = {
+  ...minimalUpdateStatus,
+  current_version: "2.0.7",
+  install_type: "windows",
+  status: "update_available",
+  summary: "MediaMop 2.0.8 is available.",
+  latest_version: "2.0.8",
+  latest_name: "MediaMop 2.0.8",
+  windows_installer_url:
+    "https://github.com/jampat000/MediaMop/releases/download/v2.0.8/MediaMopSetup.exe",
+  in_app_upgrade_supported: true,
+  in_app_upgrade_summary:
+    "Remote in-app upgrade is ready on this Windows install.",
+};
+
 const minimalSecurity: SuiteSecurityOverviewOut = {
   session_signing_configured: true,
   sign_in_cookie_https_only: false,
@@ -148,6 +163,7 @@ function renderSettings(
 
 describe("SettingsPage (suite settings)", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     localStorage.removeItem(DISPLAY_DENSITY_STORAGE_KEY);
     document.documentElement.removeAttribute("data-mm-density");
   });
@@ -161,7 +177,7 @@ describe("SettingsPage (suite settings)", () => {
     expect(screen.getByTestId("suite-settings-global")).toBeTruthy();
   });
 
-  it("shows support copy and avoids a broken support button when no URL is configured", () => {
+  it("shows development support guidance without a button when URL is missing", () => {
     renderSettings(operatorMe);
     expect(screen.getByTestId("suite-settings-support")).toBeInTheDocument();
     expect(
@@ -169,9 +185,12 @@ describe("SettingsPage (suite settings)", () => {
         "MediaMop is free to use. If it saves you time, you can support development and help keep updates coming.",
       ),
     ).toBeInTheDocument();
+    expect(screen.getByText(/Development note: set/i)).toBeInTheDocument();
+    expect(screen.getByText("VITE_SUPPORT_URL")).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Support MediaMop" }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/supporter licence/i)).not.toBeInTheDocument();
   });
 
   it("hides save for viewers", () => {
@@ -368,6 +387,224 @@ describe("SettingsPage (suite settings)", () => {
     expect(
       screen.getByText(/could not reach the local updater service/i),
     ).toBeInTheDocument();
+  });
+
+  it("shows reconnecting state instead of blind refresh during upgrade polling disconnects", async () => {
+    vi.spyOn(suiteSettingsApi, "startSuiteUpdateNow").mockResolvedValue({
+      status: "started",
+      message:
+        "Upgrade request accepted. MediaMop is checking release metadata.",
+      attempt_id: "attempt-123",
+      target_version: "2.0.8",
+      log_path: "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+    });
+    vi.spyOn(suiteSettingsApi, "fetchSuiteUpdateStatus").mockRejectedValue(
+      new Error("network down"),
+    );
+
+    renderSettings(operatorMe, { updateStatus: windowsUpdateAvailableStatus });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade now" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Reconnecting")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "MediaMop is reconnecting and verifying the installed version.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("treats update-now as accepted work, not completed success", async () => {
+    vi.spyOn(suiteSettingsApi, "startSuiteUpdateNow").mockResolvedValue({
+      status: "started",
+      message:
+        "Upgrade request accepted. MediaMop is checking release metadata.",
+      attempt_id: "attempt-123",
+      target_version: "2.0.8",
+      log_path: "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+    });
+    vi.spyOn(suiteSettingsApi, "fetchSuiteUpdateStatus").mockResolvedValue({
+      ...windowsUpdateAvailableStatus,
+      upgrade: {
+        phase: "downloading",
+        message: "Upgrade request accepted. MediaMop is downloading the installer.",
+        attempt_id: "attempt-123",
+        target_version: "2.0.8",
+      },
+    });
+
+    renderSettings(operatorMe, { updateStatus: windowsUpdateAvailableStatus });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade now" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Downloading")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Upgrade request accepted. MediaMop is downloading the installer.",
+        ),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/Upgrade completed\. Running version:/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the verifying installer phase from real progress", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "verifying_download",
+          message: "Installer is being verified.",
+          attempt_id: "attempt-123",
+          target_version: "2.0.8",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(screen.getByText("Verifying installer")).toBeInTheDocument();
+    expect(screen.getByText("Installer is being verified.")).toBeInTheDocument();
+  });
+
+  it("shows the installer running phase from real progress", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "installer_running",
+          message: "Installer is running. MediaMop may temporarily disconnect.",
+          attempt_id: "attempt-123",
+          target_version: "2.0.8",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(screen.getByText("Installer running")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Installer is running. MediaMop may temporarily disconnect.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not treat completed phase as success until the running version matches the target", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          target_version: "2.0.8",
+          installer_log_path:
+            "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.getByText("Verifying installed version"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Upgrade reported completed, but the running version has not been confirmed yet.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Completed")).not.toBeInTheDocument();
+  });
+
+  it("shows completed only after the running version matches the target", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        current_version: "2.0.8",
+        status: "up_to_date",
+        summary: "This install is already on MediaMop 2.0.8.",
+        upgrade: {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          target_version: "2.0.8",
+          installer_log_path:
+            "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+          service_log_path:
+            "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.getByText("Upgrade completed. Running version: 2.0.8."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows failed upgrade diagnostics with log paths", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "failed",
+          message: "Upgrade failed.",
+          target_version: "2.0.8",
+          last_error: "Running backend still reports 2.0.7 instead of 2.0.8.",
+          installer_log_path:
+            "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+          service_log_path:
+            "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.getByText(
+        "Upgrade failed: Running backend still reports 2.0.7 instead of 2.0.8.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Installer log: C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Service log: C:/ProgramData/MediaMop/upgrades/updater-service.log",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open updater diagnostics" }),
+    ).toHaveAttribute("href", "/api/v1/suite/update-diagnostics");
+  });
+
+  it("fails the upgrade UI when version verification times out with the old version still running", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "verifying_install",
+          message: "MediaMop is reconnecting and verifying the installed version.",
+          attempt_id: "attempt-123",
+          target_version: "2.0.8",
+          current_version_seen: "2.0.7",
+          last_started_at: new Date(
+            Date.now() - 9 * 60 * 1000,
+          ).toISOString(),
+          installer_log_path:
+            "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
+          service_log_path:
+            "C:/ProgramData/MediaMop/upgrades/updater-service.log",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.getAllByText(
+        "Upgrade failed: MediaMop did not verify version 2.0.8 within 8 minutes. The running app still reports 2.0.7.",
+      ),
+    ).toHaveLength(2);
+    expect(screen.getByText("Phase: verification_timeout")).toBeInTheDocument();
+    expect(screen.getByText("Attempt ID: attempt-123")).toBeInTheDocument();
+    expect(screen.getByText("Current version seen: 2.0.7")).toBeInTheDocument();
   });
 
   it("shows change password only on Security tab", () => {

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -429,7 +429,8 @@ describe("SettingsPage (suite settings)", () => {
       ...windowsUpdateAvailableStatus,
       upgrade: {
         phase: "downloading",
-        message: "Upgrade request accepted. MediaMop is downloading the installer.",
+        message:
+          "Upgrade request accepted. MediaMop is downloading the installer.",
         attempt_id: "attempt-123",
         target_version: "2.0.8",
       },
@@ -466,7 +467,9 @@ describe("SettingsPage (suite settings)", () => {
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
     expect(screen.getByText("Verifying installer")).toBeInTheDocument();
-    expect(screen.getByText("Installer is being verified.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Installer is being verified."),
+    ).toBeInTheDocument();
   });
 
   it("shows the installer running phase from real progress", () => {
@@ -504,9 +507,7 @@ describe("SettingsPage (suite settings)", () => {
       },
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
-    expect(
-      screen.getByText("Verifying installed version"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Verifying installed version")).toBeInTheDocument();
     expect(
       screen.getByText(
         "Upgrade reported completed, but the running version has not been confirmed yet.",
@@ -582,13 +583,12 @@ describe("SettingsPage (suite settings)", () => {
         ...windowsUpdateAvailableStatus,
         upgrade: {
           phase: "verifying_install",
-          message: "MediaMop is reconnecting and verifying the installed version.",
+          message:
+            "MediaMop is reconnecting and verifying the installed version.",
           attempt_id: "attempt-123",
           target_version: "2.0.8",
           current_version_seen: "2.0.7",
-          last_started_at: new Date(
-            Date.now() - 9 * 60 * 1000,
-          ).toISOString(),
+          last_started_at: new Date(Date.now() - 9 * 60 * 1000).toISOString(),
           installer_log_path:
             "C:/ProgramData/MediaMop/upgrades/installer-attempt-123.log",
           service_log_path:

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -408,8 +408,7 @@ function describeUpgradeProgress(
       }
       return {
         label: "Verifying installed version",
-        body:
-          "Upgrade reported completed, but the running version has not been confirmed yet.",
+        body: "Upgrade reported completed, but the running version has not been confirmed yet.",
       };
     case "failed":
       return {
@@ -662,8 +661,11 @@ export function SettingsPage() {
       });
       return;
     }
-    const targetVersion =
-      (progress?.target_version || upgradeMonitor.targetVersion || "").trim();
+    const targetVersion = (
+      progress?.target_version ||
+      upgradeMonitor.targetVersion ||
+      ""
+    ).trim();
     if (
       targetVersion &&
       updateStatusQ.data.current_version === targetVersion &&
@@ -949,8 +951,11 @@ export function SettingsPage() {
         setUpgradePollActive(true);
         setUpgradeMonitor({
           attemptId: result.attempt_id ?? null,
-          targetVersion:
-            (result.target_version || updateStatusQ.data?.latest_version || "").trim(),
+          targetVersion: (
+            result.target_version ||
+            updateStatusQ.data?.latest_version ||
+            ""
+          ).trim(),
           disconnects: 0,
           active: true,
           startedAtMs: Date.now(),
@@ -1426,14 +1431,14 @@ export function SettingsPage() {
                           Support MediaMop
                         </h3>
                         <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                          MediaMop is free to use. If it saves you time, you
-                          can support development and help keep updates coming.
+                          MediaMop is free to use. If it saves you time, you can
+                          support development and help keep updates coming.
                         </p>
                       </div>
                       {SHOW_SUPPORT_URL_PLACEHOLDER ? (
                         <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
-                          Development note: set <code>VITE_SUPPORT_URL</code>{" "}
-                          to show the support button.
+                          Development note: set <code>VITE_SUPPORT_URL</code> to
+                          show the support button.
                         </p>
                       ) : null}
                     </div>
@@ -1972,7 +1977,8 @@ export function SettingsPage() {
                           ) : null}
                           {activeUpgradeProgress?.service_log_path ? (
                             <p>
-                              Service log: {activeUpgradeProgress.service_log_path}
+                              Service log:{" "}
+                              {activeUpgradeProgress.service_log_path}
                             </p>
                           ) : null}
                           {(activeUpgradeProgress?.phase === "failed" ||

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../lib/ui/mm-module-tab-blurb";
 import {
   suiteConfigurationBackupsQueryKey,
+  suiteUpdateStatusQueryKey,
   useSuiteConfigurationBackupsQuery,
   useSuiteLogsQuery,
   useSuiteMetricsQuery,
@@ -40,11 +41,14 @@ import {
 import type {
   SuiteLogEntry,
   SuiteSettingsPutBody,
+  SuiteUpdateStatusOut,
+  SuiteUpgradeProgressOut,
 } from "../../lib/suite/types";
 import {
   fetchConfigurationBundle,
   fetchStoredConfigurationBackupBlob,
   putConfigurationBundle,
+  suiteUpdateDiagnosticsPath,
   type ConfigurationBundle,
 } from "../../lib/suite/suite-settings-api";
 import {
@@ -53,7 +57,11 @@ import {
   type DisplayDensity,
 } from "../../lib/ui/display-density";
 import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
-import { SHOW_SUPPORT_URL_PLACEHOLDER, SUPPORT_URL } from "../../lib/support";
+import {
+  SHOW_SUPPORT_CARD,
+  SHOW_SUPPORT_URL_PLACEHOLDER,
+  SUPPORT_URL,
+} from "../../lib/support";
 
 function canEditSuiteGlobal(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
@@ -90,8 +98,41 @@ const SUITE_SETTINGS_PREMIUM_PANEL_CLASS =
 const SUITE_SETTINGS_PREMIUM_TILE_CLASS =
   "rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/80 px-4 py-3 shadow-[var(--mm-shadow-card-inner)]";
 const CONFIGURATION_BACKUP_INTERVAL_HOURS = [6, 12, 24, 48, 72, 168] as const;
+const UPGRADE_VERIFICATION_TIMEOUT_MS = 8 * 60_000;
+
+type UpgradeMonitor = {
+  attemptId: string | null;
+  targetVersion: string;
+  disconnects: number;
+  active: boolean;
+  startedAtMs: number;
+  timedOutReason: string | null;
+};
+
+type UpgradeNotice = {
+  tone: "info" | "success" | "error";
+  text: string;
+};
 
 type LogLevelFilter = "" | "INFO" | "WARNING" | "ERROR";
+
+function parseUpgradeTime(raw: string | null | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function upgradeNoticeClass(tone: UpgradeNotice["tone"]): string {
+  if (tone === "error") {
+    return "rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200";
+  }
+  if (tone === "success") {
+    return "rounded-md border border-emerald-500/30 bg-emerald-950/20 px-3 py-2 text-sm text-emerald-200";
+  }
+  return "rounded-md border border-amber-400/25 bg-amber-400/[0.06] px-3 py-2 text-sm text-[var(--mm-text2)]";
+}
 
 function formatBackupBytes(n: number): string {
   if (n < 1024) {
@@ -255,6 +296,136 @@ function requestIssueSummary(
   return { value: "No request issues", detail };
 }
 
+function isUpgradeActivePhase(phase: string | null | undefined): boolean {
+  return (
+    phase === "checking" ||
+    phase === "downloading" ||
+    phase === "verifying_download" ||
+    phase === "installer_started" ||
+    phase === "installer_running" ||
+    phase === "restarting" ||
+    phase === "verifying_install"
+  );
+}
+
+function upgradePhaseTone(
+  status: SuiteUpdateStatusOut | undefined,
+  progress: SuiteUpgradeProgressOut | null | undefined,
+  monitor: UpgradeMonitor | null,
+): string {
+  if (monitor?.timedOutReason || progress?.phase === "failed") {
+    return "border-red-500/40 bg-red-950/25";
+  }
+  if (
+    progress?.phase === "completed" &&
+    progress.target_version &&
+    status?.current_version === progress.target_version
+  ) {
+    return "border-emerald-500/30 bg-emerald-950/20";
+  }
+  return "border-amber-400/25 bg-amber-400/[0.06]";
+}
+
+function describeUpgradeProgress(
+  status: SuiteUpdateStatusOut | undefined,
+  progress: SuiteUpgradeProgressOut | null | undefined,
+  monitor: UpgradeMonitor | null,
+  disconnected: boolean,
+): { label: string; body: string } | null {
+  if (monitor?.timedOutReason) {
+    return {
+      label: "Failed",
+      body: monitor.timedOutReason,
+    };
+  }
+  if (disconnected && monitor?.active) {
+    return {
+      label: "Reconnecting",
+      body: "MediaMop is reconnecting and verifying the installed version.",
+    };
+  }
+  if (!progress) {
+    if (!monitor?.active) {
+      return null;
+    }
+    return {
+      label: "Waiting",
+      body: "Upgrade request accepted. MediaMop is checking release metadata.",
+    };
+  }
+  switch (progress.phase) {
+    case "checking":
+      return {
+        label: "Checking release",
+        body:
+          progress.message ||
+          "Upgrade request accepted. MediaMop is checking release metadata.",
+      };
+    case "downloading":
+      return {
+        label: "Downloading",
+        body:
+          progress.message ||
+          "Upgrade request accepted. MediaMop is downloading the installer.",
+      };
+    case "verifying_download":
+      return {
+        label: "Verifying installer",
+        body: progress.message || "Installer is being verified.",
+      };
+    case "installer_started":
+      return {
+        label: "Starting installer",
+        body: progress.message || "Installer is starting.",
+      };
+    case "installer_running":
+      return {
+        label: "Installer running",
+        body:
+          progress.message ||
+          "Installer is running. MediaMop may temporarily disconnect.",
+      };
+    case "restarting":
+    case "verifying_install":
+      return {
+        label: "Verifying installed version",
+        body:
+          progress.message ||
+          "MediaMop is reconnecting and verifying the installed version.",
+      };
+    case "completed":
+      if (
+        status &&
+        progress.target_version &&
+        status.current_version === progress.target_version
+      ) {
+        return {
+          label: "Completed",
+          body:
+            progress.message ||
+            `Upgrade completed. Running version: ${status.current_version}.`,
+        };
+      }
+      return {
+        label: "Verifying installed version",
+        body:
+          "Upgrade reported completed, but the running version has not been confirmed yet.",
+      };
+    case "failed":
+      return {
+        label: "Failed",
+        body: progress.last_error
+          ? `Upgrade failed: ${progress.last_error}`
+          : progress.message || "Upgrade failed.",
+      };
+    default:
+      return {
+        label: "Upgrade status",
+        body: progress.message || "Updater status is available.",
+      };
+  }
+}
+
 /** Settings: General (timezone, display density, configuration export), Security, Logs (retention + recent events). */
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -289,7 +460,13 @@ export function SettingsPage() {
   const [backupBusy, setBackupBusy] = useState(false);
   const [backupMsg, setBackupMsg] = useState<string | null>(null);
   const [backupErr, setBackupErr] = useState<string | null>(null);
-  const [upgradeMsg, setUpgradeMsg] = useState<string | null>(null);
+  const [upgradeNotice, setUpgradeNotice] = useState<UpgradeNotice | null>(
+    null,
+  );
+  const [upgradeMonitor, setUpgradeMonitor] = useState<UpgradeMonitor | null>(
+    null,
+  );
+  const [upgradePollActive, setUpgradePollActive] = useState(false);
   const [resetHistoryMsg, setResetHistoryMsg] = useState<string | null>(null);
   const [resetHistoryConfirm, setResetHistoryConfirm] = useState("");
   const [configurationBackupEnabled, setConfigurationBackupEnabled] =
@@ -337,8 +514,13 @@ export function SettingsPage() {
   const backupsQ = useSuiteConfigurationBackupsQuery(
     editable && tab === "backup" && Boolean(settingsQ.data),
   );
+  const upgradePollingMs =
+    tab === "upgrade" && (upgradeMonitor?.active || upgradePollActive)
+      ? Math.min(10_000, 1500 * ((upgradeMonitor?.disconnects ?? 0) + 1))
+      : false;
   const updateStatusQ = useSuiteUpdateStatusQuery(
     tab === "upgrade" && Boolean(settingsQ.data),
+    upgradePollingMs,
   );
   const logsQ = useSuiteLogsQuery(
     {
@@ -384,6 +566,164 @@ export function SettingsPage() {
     (updateStatusQ.data.in_app_upgrade_summary || "")
       .toLowerCase()
       .includes("does not have the mediamop updater service yet");
+  const activeUpgradeProgress = updateStatusQ.data?.upgrade;
+  const upgradeConnectionLost =
+    Boolean(upgradeMonitor?.active) && updateStatusQ.isError;
+  const upgradeProgressSummary = describeUpgradeProgress(
+    updateStatusQ.data,
+    activeUpgradeProgress,
+    upgradeMonitor,
+    upgradeConnectionLost,
+  );
+  const upgradeInProgress =
+    !upgradeMonitor?.timedOutReason &&
+    (Boolean(upgradeMonitor?.active) ||
+      isUpgradeActivePhase(activeUpgradeProgress?.phase));
+
+  useEffect(() => {
+    if (isUpgradeActivePhase(activeUpgradeProgress?.phase)) {
+      setUpgradePollActive(true);
+      return;
+    }
+    if (!upgradeMonitor?.active) {
+      setUpgradePollActive(false);
+    }
+  }, [activeUpgradeProgress?.phase, upgradeMonitor?.active]);
+
+  useEffect(() => {
+    if (!updateStatusQ.data?.upgrade) {
+      return;
+    }
+    const progress = updateStatusQ.data.upgrade;
+    if (!isUpgradeActivePhase(progress.phase)) {
+      return;
+    }
+    setUpgradeMonitor((current) => {
+      if (
+        current?.active &&
+        current.attemptId === (progress.attempt_id ?? null) &&
+        current.targetVersion === (progress.target_version || "").trim()
+      ) {
+        return current;
+      }
+      return {
+        attemptId: progress.attempt_id ?? null,
+        targetVersion: (progress.target_version || "").trim(),
+        disconnects: 0,
+        active: true,
+        startedAtMs:
+          parseUpgradeTime(progress.last_started_at) ??
+          parseUpgradeTime(progress.last_updated_at) ??
+          Date.now(),
+        timedOutReason: null,
+      };
+    });
+  }, [updateStatusQ.data]);
+
+  useEffect(() => {
+    if (!upgradeMonitor?.active || updateStatusQ.errorUpdatedAt === 0) {
+      return;
+    }
+    setUpgradeMonitor((current) => {
+      if (!current?.active) {
+        return current;
+      }
+      return {
+        ...current,
+        disconnects: Math.min(current.disconnects + 1, 6),
+      };
+    });
+  }, [upgradeMonitor?.active, updateStatusQ.errorUpdatedAt]);
+
+  useEffect(() => {
+    if (!upgradeMonitor || !updateStatusQ.data) {
+      return;
+    }
+    const progress = updateStatusQ.data.upgrade;
+    setUpgradeMonitor((current) => {
+      if (!current?.active) {
+        return current;
+      }
+      if (current.disconnects === 0) {
+        return current;
+      }
+      return { ...current, disconnects: 0 };
+    });
+    if (progress?.phase === "failed") {
+      setUpgradePollActive(false);
+      setUpgradeMonitor((current) =>
+        current ? { ...current, active: false, timedOutReason: null } : current,
+      );
+      setUpgradeNotice({
+        tone: "error",
+        text: progress.last_error
+          ? `Upgrade failed: ${progress.last_error}`
+          : progress.message || "Upgrade failed.",
+      });
+      return;
+    }
+    const targetVersion =
+      (progress?.target_version || upgradeMonitor.targetVersion || "").trim();
+    if (
+      targetVersion &&
+      updateStatusQ.data.current_version === targetVersion &&
+      (progress?.phase === "completed" || !progress)
+    ) {
+      setUpgradePollActive(false);
+      setUpgradeMonitor((current) =>
+        current ? { ...current, active: false, timedOutReason: null } : current,
+      );
+      setUpgradeNotice({
+        tone: "success",
+        text:
+          progress?.message ||
+          `Upgrade completed. Running version: ${updateStatusQ.data.current_version}.`,
+      });
+    }
+  }, [upgradeMonitor, updateStatusQ.data]);
+
+  useEffect(() => {
+    if (!upgradeMonitor?.active) {
+      return;
+    }
+    const targetVersion = upgradeMonitor.targetVersion.trim();
+    if (!targetVersion || !updateStatusQ.data) {
+      return;
+    }
+    if (updateStatusQ.data.current_version === targetVersion) {
+      return;
+    }
+    const elapsed = Date.now() - upgradeMonitor.startedAtMs;
+    if (elapsed < UPGRADE_VERIFICATION_TIMEOUT_MS) {
+      return;
+    }
+    const currentVersionSeen =
+      activeUpgradeProgress?.current_version_seen ||
+      updateStatusQ.data.current_version ||
+      "unknown";
+    const reason =
+      `Upgrade failed: MediaMop did not verify version ${targetVersion} within ${Math.floor(UPGRADE_VERIFICATION_TIMEOUT_MS / 60_000)} minutes. ` +
+      `The running app still reports ${currentVersionSeen}.`;
+    setUpgradePollActive(false);
+    setUpgradeMonitor((current) =>
+      current
+        ? {
+            ...current,
+            active: false,
+            timedOutReason: reason,
+          }
+        : current,
+    );
+    setUpgradeNotice({
+      tone: "error",
+      text: reason,
+    });
+  }, [
+    activeUpgradeProgress?.current_version_seen,
+    activeUpgradeProgress?.phase,
+    updateStatusQ.data,
+    upgradeMonitor,
+  ]);
 
   const loadingAny = settingsQ.isPending || me.isPending;
 
@@ -602,17 +942,30 @@ export function SettingsPage() {
   }
 
   async function handleUpgradeNow() {
-    setUpgradeMsg(null);
+    setUpgradeNotice(null);
     try {
       const result = await updateNow.mutateAsync();
-      setUpgradeMsg(result.message);
       if (result.status === "started") {
-        window.setTimeout(() => {
-          window.location.assign("/settings");
-        }, 30_000);
+        setUpgradePollActive(true);
+        setUpgradeMonitor({
+          attemptId: result.attempt_id ?? null,
+          targetVersion:
+            (result.target_version || updateStatusQ.data?.latest_version || "").trim(),
+          disconnects: 0,
+          active: true,
+          startedAtMs: Date.now(),
+          timedOutReason: null,
+        });
+        await queryClient.invalidateQueries({
+          queryKey: suiteUpdateStatusQueryKey,
+        });
       } else {
+        setUpgradeNotice({
+          tone: "info",
+          text: result.message,
+        });
         void queryClient.invalidateQueries({
-          queryKey: ["suite", "update-status"],
+          queryKey: suiteUpdateStatusQueryKey,
         });
       }
     } catch {
@@ -1058,54 +1411,50 @@ export function SettingsPage() {
                     </div>
                   </fieldset>
                 </section>
-                <section
-                  className={SUITE_SETTINGS_DASH_CARD_CLASS}
-                  data-testid="suite-settings-support"
-                  aria-labelledby="suite-settings-support-heading"
-                >
-                  <div className="mm-card-action-body">
-                    <div>
-                      <h3
-                        id="suite-settings-support-heading"
-                        className="text-base font-semibold text-[var(--mm-text1)]"
-                      >
-                        Support MediaMop
-                      </h3>
-                      <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                        MediaMop is free to use. If it saves you time, you can
-                        support development and help keep updates coming.
-                      </p>
+                {SHOW_SUPPORT_CARD ? (
+                  <section
+                    className={SUITE_SETTINGS_DASH_CARD_CLASS}
+                    data-testid="suite-settings-support"
+                    aria-labelledby="suite-settings-support-heading"
+                  >
+                    <div className="mm-card-action-body">
+                      <div>
+                        <h3
+                          id="suite-settings-support-heading"
+                          className="text-base font-semibold text-[var(--mm-text1)]"
+                        >
+                          Support MediaMop
+                        </h3>
+                        <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                          MediaMop is free to use. If it saves you time, you
+                          can support development and help keep updates coming.
+                        </p>
+                      </div>
+                      {SHOW_SUPPORT_URL_PLACEHOLDER ? (
+                        <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
+                          Development note: set <code>VITE_SUPPORT_URL</code>{" "}
+                          to show the support button.
+                        </p>
+                      ) : null}
                     </div>
-                    <p className="text-sm text-[var(--mm-text3)]">
-                      Supporter licence (optional, future): this space is
-                      reserved for future supporter acknowledgement details.
-                      There are no licence checks or feature limits in this
-                      release.
-                    </p>
-                    {SHOW_SUPPORT_URL_PLACEHOLDER ? (
-                      <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
-                        Development note: set <code>VITE_SUPPORT_URL</code> to
-                        show the support button.
-                      </p>
-                    ) : null}
-                  </div>
-                  <div className="mm-card-action-footer">
-                    {SUPPORT_URL ? (
-                      <a
-                        href={SUPPORT_URL}
-                        target="_blank"
-                        rel="noreferrer"
-                        className={mmActionButtonClass({
-                          variant: "secondary",
-                          disabled: false,
-                        })}
-                        data-testid="suite-settings-support-button"
-                      >
-                        Support MediaMop
-                      </a>
-                    ) : null}
-                  </div>
-                </section>
+                    <div className="mm-card-action-footer">
+                      {SUPPORT_URL ? (
+                        <a
+                          href={SUPPORT_URL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className={mmActionButtonClass({
+                            variant: "secondary",
+                            disabled: false,
+                          })}
+                          data-testid="suite-settings-support-button"
+                        >
+                          Support MediaMop
+                        </a>
+                      ) : null}
+                    </div>
+                  </section>
+                ) : null}
               </div>
             </div>
           </div>
@@ -1430,15 +1779,33 @@ export function SettingsPage() {
                 <p className="text-sm text-[var(--mm-text3)]">
                   Checking for updates…
                 </p>
-              ) : updateStatusQ.isError || !updateStatusQ.data ? (
-                <p
-                  className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
-                  role="alert"
-                >
-                  {updateStatusQ.error instanceof Error
-                    ? updateStatusQ.error.message
-                    : "Could not check for updates right now."}
-                </p>
+              ) : !updateStatusQ.data ? (
+                upgradeConnectionLost ? (
+                  <div
+                    className={`rounded-lg border px-3 py-3 ${upgradePhaseTone(
+                      undefined,
+                      null,
+                      upgradeMonitor,
+                    )}`}
+                  >
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
+                      Reconnecting
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-[var(--mm-text2)]">
+                      MediaMop is reconnecting and verifying the installed
+                      version.
+                    </p>
+                  </div>
+                ) : (
+                  <p
+                    className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                    role="alert"
+                  >
+                    {updateStatusQ.error instanceof Error
+                      ? updateStatusQ.error.message
+                      : "Could not check for updates right now."}
+                  </p>
+                )
               ) : (
                 <>
                   <div
@@ -1519,9 +1886,9 @@ export function SettingsPage() {
                     updateStatusQ.data.status === "update_available" ? (
                       updateStatusQ.data.in_app_upgrade_supported ? (
                         <p className="text-sm leading-6 text-[var(--mm-text2)]">
-                          Upgrade now downloads the installer, closes MediaMop,
-                          installs the update, reopens the app, and refreshes
-                          this page after the server comes back.
+                          Upgrade now downloads the trusted installer, verifies
+                          it, runs the installer, and waits for MediaMop to
+                          reconnect and prove the running version changed.
                         </p>
                       ) : (
                         <p className="text-sm leading-6 text-[var(--mm-text2)]">
@@ -1543,6 +1910,87 @@ export function SettingsPage() {
                     ) : null}
                   </div>
 
+                  {upgradeProgressSummary ? (
+                    <div
+                      className={`rounded-lg border px-3 py-3 ${upgradePhaseTone(
+                        updateStatusQ.data,
+                        activeUpgradeProgress,
+                        upgradeMonitor,
+                      )}`}
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[var(--mm-gold)]">
+                            {upgradeProgressSummary.label}
+                          </p>
+                          <p className="mt-1 text-sm leading-6 text-[var(--mm-text2)]">
+                            {upgradeProgressSummary.body}
+                          </p>
+                        </div>
+                        {activeUpgradeProgress?.target_version ? (
+                          <span className="rounded-full border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-2.5 py-1 text-xs font-medium text-[var(--mm-text2)]">
+                            Target {activeUpgradeProgress.target_version}
+                          </span>
+                        ) : null}
+                      </div>
+                      {activeUpgradeProgress?.attempt_id ||
+                      upgradeMonitor?.attemptId ||
+                      activeUpgradeProgress?.current_version_seen ||
+                      updateStatusQ.data.current_version ||
+                      activeUpgradeProgress?.installer_log_path ||
+                      activeUpgradeProgress?.service_log_path ||
+                      activeUpgradeProgress?.phase === "failed" ||
+                      Boolean(upgradeMonitor?.timedOutReason) ? (
+                        <div className="mt-3 space-y-1 text-xs text-[var(--mm-text3)]">
+                          {activeUpgradeProgress?.attempt_id ||
+                          upgradeMonitor?.attemptId ? (
+                            <p>
+                              Attempt ID:{" "}
+                              {activeUpgradeProgress?.attempt_id ||
+                                upgradeMonitor?.attemptId}
+                            </p>
+                          ) : null}
+                          <p>
+                            Phase:{" "}
+                            {upgradeMonitor?.timedOutReason
+                              ? "verification_timeout"
+                              : activeUpgradeProgress?.phase || "unknown"}
+                          </p>
+                          {activeUpgradeProgress?.current_version_seen ||
+                          updateStatusQ.data.current_version ? (
+                            <p>
+                              Current version seen:{" "}
+                              {activeUpgradeProgress?.current_version_seen ||
+                                updateStatusQ.data.current_version}
+                            </p>
+                          ) : null}
+                          {activeUpgradeProgress?.installer_log_path ? (
+                            <p>
+                              Installer log:{" "}
+                              {activeUpgradeProgress.installer_log_path}
+                            </p>
+                          ) : null}
+                          {activeUpgradeProgress?.service_log_path ? (
+                            <p>
+                              Service log: {activeUpgradeProgress.service_log_path}
+                            </p>
+                          ) : null}
+                          {(activeUpgradeProgress?.phase === "failed" ||
+                            upgradeMonitor?.timedOutReason) && (
+                            <a
+                              className="text-[var(--mm-link)] underline-offset-2 hover:underline"
+                              href={suiteUpdateDiagnosticsPath()}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Open updater diagnostics
+                            </a>
+                          )}
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+
                   <div className="mt-auto flex flex-wrap gap-2 border-t border-[var(--mm-border)] pt-4">
                     <button
                       type="button"
@@ -1557,20 +2005,21 @@ export function SettingsPage() {
                     </button>
                     {updateStatusQ.data.install_type === "windows" &&
                     updateStatusQ.data.status === "update_available" &&
-                    updateStatusQ.data.in_app_upgrade_supported &&
-                    updateStatusQ.data.windows_installer_url ? (
+                    updateStatusQ.data.in_app_upgrade_supported ? (
                       <button
                         type="button"
                         className={mmActionButtonClass({
                           variant: "primary",
-                          disabled: updateNow.isPending,
+                          disabled: updateNow.isPending || upgradeInProgress,
                         })}
-                        disabled={updateNow.isPending}
+                        disabled={updateNow.isPending || upgradeInProgress}
                         onClick={() => void handleUpgradeNow()}
                       >
                         {updateNow.isPending
                           ? "Starting upgrade…"
-                          : "Upgrade now"}
+                          : upgradeInProgress
+                            ? "Upgrade in progressâ€¦"
+                            : "Upgrade now"}
                       </button>
                     ) : null}
                     {updateStatusQ.data.windows_installer_url ? (
@@ -1600,9 +2049,9 @@ export function SettingsPage() {
                       </a>
                     ) : null}
                   </div>
-                  {upgradeMsg ? (
-                    <p className="rounded-md border border-emerald-500/30 bg-emerald-950/20 px-3 py-2 text-sm text-emerald-200">
-                      {upgradeMsg}
+                  {upgradeNotice ? (
+                    <p className={upgradeNoticeClass(upgradeNotice.tone)}>
+                      {upgradeNotice.text}
                     </p>
                   ) : null}
                   {updateNow.isError ? (

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -374,6 +374,56 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   opacity: 0.9;
 }
 
+.mm-sidebar-support {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.055);
+}
+
+.mm-sidebar-support-title {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mm-text1);
+}
+
+.mm-sidebar-support-copy {
+  margin: 6px 0 0;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  color: var(--mm-text2);
+}
+
+.mm-sidebar-support-note {
+  margin: 6px 0 0;
+  font-size: 0.71875rem;
+  line-height: 1.45;
+  color: var(--mm-text3);
+}
+
+.mm-sidebar-support-link {
+  display: inline-flex;
+  margin-top: 8px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: var(--mm-gold);
+  text-decoration: none;
+}
+
+.mm-sidebar-support-link:hover {
+  color: var(--mm-accent-bright);
+  text-decoration: underline;
+}
+
+.mm-sidebar-support-link:focus-visible {
+  outline: 2px solid var(--mm-accent-ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .mm-sidebar-signout {
   display: inline-flex;
   align-self: stretch;

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,17 @@ services:
       - "8788:8788"
     environment:
       MEDIAMOP_HOME: ${MEDIAMOP_HOME:-/data/mediamop}
+      # Optional UID/GID remap for the runtime account inside the container.
+      # MEDIAMOP_PUID: ${MEDIAMOP_PUID:-1000}
+      # MEDIAMOP_PGID: ${MEDIAMOP_PGID:-1000}
+      # Optional Refiner path ownership policies for configured watched/work/output folders.
+      # MEDIAMOP_CHOWN_WATCHED: ${MEDIAMOP_CHOWN_WATCHED:-false}
+      # MEDIAMOP_CHOWN_TEMP: ${MEDIAMOP_CHOWN_TEMP:-false}
+      # MEDIAMOP_CHOWN_OUTPUT: ${MEDIAMOP_CHOWN_OUTPUT:-false}
+      # Optional directory-only modes (octal) applied recursively to configured folders.
+      # MEDIAMOP_DIR_MODE_WATCHED: ${MEDIAMOP_DIR_MODE_WATCHED:-}
+      # MEDIAMOP_DIR_MODE_TEMP: ${MEDIAMOP_DIR_MODE_TEMP:-}
+      # MEDIAMOP_DIR_MODE_OUTPUT: ${MEDIAMOP_DIR_MODE_OUTPUT:-}
       # Optional. If omitted, the container generates and persists /data/mediamop/session.secret.
       # To provide your own value, generate one with: openssl rand -hex 32
       # MEDIAMOP_SESSION_SECRET: ${MEDIAMOP_SESSION_SECRET}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -16,6 +16,23 @@
 # Persistent data root inside the container. The default compose volume maps this path.
 # MEDIAMOP_HOME=/data/mediamop
 
+# Optional runtime UID/GID remap for the mediamop user inside the container.
+# Aliases PUID / PGID are also accepted.
+# MEDIAMOP_PUID=1000
+# MEDIAMOP_PGID=1000
+
+# Optional Refiner folder ownership policies. Leave these false unless you want the
+# container to recursively chown configured watched/work/output folders at startup.
+# MEDIAMOP_CHOWN_WATCHED=false
+# MEDIAMOP_CHOWN_TEMP=false
+# MEDIAMOP_CHOWN_OUTPUT=false
+
+# Optional directory-only modes applied recursively to configured watched/work/output folders.
+# Example: setgid-friendly output tree for shared media directories.
+# MEDIAMOP_DIR_MODE_WATCHED=
+# MEDIAMOP_DIR_MODE_TEMP=
+# MEDIAMOP_DIR_MODE_OUTPUT=2775
+
 # Optional image override.
 # MEDIAMOP_DOCKER_IMAGE=ghcr.io/jampat000/mediamop:latest
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,6 +50,62 @@ and run `docker compose --env-file .env.mediamop up -d`.
 - `MEDIAMOP_SESSION_COOKIE_SECURE=false` is the default in the image so plain `http://localhost` works
 - set `MEDIAMOP_SESSION_COOKIE_SECURE=true` only when all browser traffic is HTTPS
 
+## Docker ownership controls
+
+The container starts as `root`, reconciles optional filesystem ownership, then launches
+MediaMop as the unprivileged `mediamop` user. This keeps the app itself non-root while
+allowing host-mounted media paths to be aligned with your NAS or Docker user strategy.
+
+Available environment variables:
+
+- `MEDIAMOP_PUID` / `PUID`
+- `MEDIAMOP_PGID` / `PGID`
+- `MEDIAMOP_CHOWN_WATCHED`
+- `MEDIAMOP_CHOWN_TEMP`
+- `MEDIAMOP_CHOWN_OUTPUT`
+- `MEDIAMOP_DIR_MODE_WATCHED`
+- `MEDIAMOP_DIR_MODE_TEMP`
+- `MEDIAMOP_DIR_MODE_OUTPUT`
+
+Defaults:
+
+- `MEDIAMOP_PUID=1000`
+- `MEDIAMOP_PGID=1000`
+- all `MEDIAMOP_CHOWN_*` flags default to `false`
+- directory modes are unset unless you opt in
+
+The `MEDIAMOP_CHOWN_*` flags recursively chown the configured Refiner folders stored in
+MediaMop settings:
+
+- watched = Movies/TV watched folders
+- temp = Movies/TV work folders
+- output = Movies/TV output folders
+
+The `MEDIAMOP_DIR_MODE_*` values are optional octal directory modes such as `2775`. When
+set, they are applied recursively to directories only for the selected folder category.
+
+Example:
+
+```bash
+docker run --rm \
+  -p 8788:8788 \
+  -v mediamop-data:/data/mediamop \
+  -e MEDIAMOP_PUID=1001 \
+  -e MEDIAMOP_PGID=1001 \
+  -e MEDIAMOP_CHOWN_OUTPUT=true \
+  -e MEDIAMOP_DIR_MODE_OUTPUT=2775 \
+  ghcr.io/jampat000/mediamop:latest
+```
+
+Migration note:
+
+- Existing containers keep working with no env changes.
+- If your output or work folders are bind-mounted from the host and MediaMop cannot write to them,
+  set `MEDIAMOP_PUID` / `MEDIAMOP_PGID` to the host owner and enable the matching `MEDIAMOP_CHOWN_*`
+  flag for the folder category you want MediaMop to manage.
+- Leave `MEDIAMOP_CHOWN_WATCHED=false` unless you explicitly want MediaMop to take ownership of
+  your watched/download folders.
+
 ## Health
 
 The image exposes `GET /health` and includes a Docker `HEALTHCHECK`.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,170 @@
 set -e
 
 export MEDIAMOP_HOME="${MEDIAMOP_HOME:-/data/mediamop}"
+MEDIAMOP_PUID="${MEDIAMOP_PUID:-${PUID:-1000}}"
+MEDIAMOP_PGID="${MEDIAMOP_PGID:-${PGID:-1000}}"
+MEDIAMOP_CHOWN_WATCHED="${MEDIAMOP_CHOWN_WATCHED:-false}"
+MEDIAMOP_CHOWN_TEMP="${MEDIAMOP_CHOWN_TEMP:-false}"
+MEDIAMOP_CHOWN_OUTPUT="${MEDIAMOP_CHOWN_OUTPUT:-false}"
+MEDIAMOP_DIR_MODE_WATCHED="${MEDIAMOP_DIR_MODE_WATCHED:-}"
+MEDIAMOP_DIR_MODE_TEMP="${MEDIAMOP_DIR_MODE_TEMP:-}"
+MEDIAMOP_DIR_MODE_OUTPUT="${MEDIAMOP_DIR_MODE_OUTPUT:-}"
+
+log_info() {
+  echo "info: $*" >&2
+}
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+validate_uint() {
+  value="$1"
+  name="$2"
+  case "$value" in
+    ""|*[!0-9]*)
+      fail "$name must be a non-negative integer."
+      ;;
+  esac
+}
+
+validate_boolish() {
+  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  name="$2"
+  case "$value" in
+    ""|0|1|true|false|yes|no|on|off)
+      ;;
+    *)
+      fail "$name must be one of: true/false, 1/0, yes/no, on/off."
+      ;;
+  esac
+}
+
+validate_dir_mode() {
+  value="$1"
+  name="$2"
+  if [ -z "$value" ]; then
+    return
+  fi
+  case "$value" in
+    *[!0-7]*)
+      fail "$name must be an octal directory mode such as 775 or 2775."
+      ;;
+  esac
+  case "${#value}" in
+    3|4)
+      ;;
+    *)
+      fail "$name must be an octal directory mode such as 775 or 2775."
+      ;;
+  esac
+}
+
+bool_enabled() {
+  value="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in
+    1|true|yes|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+resolve_db_path() {
+  if [ -n "${MEDIAMOP_DB_PATH:-}" ]; then
+    case "$MEDIAMOP_DB_PATH" in
+      /*) printf '%s\n' "$MEDIAMOP_DB_PATH" ;;
+      *) printf '%s/%s\n' "$MEDIAMOP_HOME" "$MEDIAMOP_DB_PATH" ;;
+    esac
+    return
+  fi
+  printf '%s/data/mediamop.sqlite3\n' "$MEDIAMOP_HOME"
+}
+
+update_runtime_identity() {
+  current_gid="$(getent group mediamop | cut -d: -f3)"
+  current_uid="$(id -u mediamop)"
+  if [ "$current_gid" != "$MEDIAMOP_PGID" ]; then
+    log_info "Updating mediamop group id to $MEDIAMOP_PGID"
+    groupmod -o -g "$MEDIAMOP_PGID" mediamop
+  fi
+  if [ "$current_uid" != "$MEDIAMOP_PUID" ]; then
+    log_info "Updating mediamop user id to $MEDIAMOP_PUID"
+    usermod -o -u "$MEDIAMOP_PUID" -g "$MEDIAMOP_PGID" mediamop
+  fi
+}
+
+ensure_runtime_home_ownership() {
+  mkdir -p "$MEDIAMOP_HOME"
+  chown -R mediamop:mediamop "$MEDIAMOP_HOME" /opt/mediamop /home/mediamop
+}
+
+apply_refiner_permissions() {
+  include_watched=0
+  include_temp=0
+  include_output=0
+  if bool_enabled "$MEDIAMOP_CHOWN_WATCHED" || [ -n "$MEDIAMOP_DIR_MODE_WATCHED" ]; then
+    include_watched=1
+  fi
+  if bool_enabled "$MEDIAMOP_CHOWN_TEMP" || [ -n "$MEDIAMOP_DIR_MODE_TEMP" ]; then
+    include_temp=1
+  fi
+  if bool_enabled "$MEDIAMOP_CHOWN_OUTPUT" || [ -n "$MEDIAMOP_DIR_MODE_OUTPUT" ]; then
+    include_output=1
+  fi
+
+  if [ "$include_watched" -eq 0 ] &&
+     [ "$include_temp" -eq 0 ] &&
+     [ "$include_output" -eq 0 ]; then
+    return
+  fi
+
+  db_path="$(resolve_db_path)"
+  set -- /opt/mediamop/.venv/bin/python -m mediamop.platform.docker_runtime apply-refiner-permissions \
+    --db-path "$db_path" \
+    --uid "$MEDIAMOP_PUID" \
+    --gid "$MEDIAMOP_PGID"
+
+  if [ "$include_watched" -eq 1 ]; then
+    set -- "$@" --include-watched
+  fi
+  if [ "$include_temp" -eq 1 ]; then
+    set -- "$@" --include-temp
+  fi
+  if [ "$include_output" -eq 1 ]; then
+    set -- "$@" --include-output
+  fi
+  if [ -n "$MEDIAMOP_DIR_MODE_WATCHED" ]; then
+    set -- "$@" --watched-dir-mode "$MEDIAMOP_DIR_MODE_WATCHED"
+  fi
+  if [ -n "$MEDIAMOP_DIR_MODE_TEMP" ]; then
+    set -- "$@" --temp-dir-mode "$MEDIAMOP_DIR_MODE_TEMP"
+  fi
+  if [ -n "$MEDIAMOP_DIR_MODE_OUTPUT" ]; then
+    set -- "$@" --output-dir-mode "$MEDIAMOP_DIR_MODE_OUTPUT"
+  fi
+
+  log_info "Applying optional Refiner path ownership policy"
+  "$@"
+}
+
+run_app() {
+  cd /opt/mediamop/apps/backend
+  alembic upgrade head
+  exec uvicorn mediamop.api.main:app --host 0.0.0.0 --port "${PORT:-8788}"
+}
+
+validate_uint "$MEDIAMOP_PUID" "MEDIAMOP_PUID"
+validate_uint "$MEDIAMOP_PGID" "MEDIAMOP_PGID"
+validate_boolish "$MEDIAMOP_CHOWN_WATCHED" "MEDIAMOP_CHOWN_WATCHED"
+validate_boolish "$MEDIAMOP_CHOWN_TEMP" "MEDIAMOP_CHOWN_TEMP"
+validate_boolish "$MEDIAMOP_CHOWN_OUTPUT" "MEDIAMOP_CHOWN_OUTPUT"
+validate_dir_mode "$MEDIAMOP_DIR_MODE_WATCHED" "MEDIAMOP_DIR_MODE_WATCHED"
+validate_dir_mode "$MEDIAMOP_DIR_MODE_TEMP" "MEDIAMOP_DIR_MODE_TEMP"
+validate_dir_mode "$MEDIAMOP_DIR_MODE_OUTPUT" "MEDIAMOP_DIR_MODE_OUTPUT"
 mkdir -p "$MEDIAMOP_HOME"
 
 generate_secret() {
@@ -19,17 +183,26 @@ if [ -z "${MEDIAMOP_SESSION_SECRET:-}" ]; then
     MEDIAMOP_SESSION_SECRET="$(generate_secret)"
     umask 077
     printf '%s\n' "$MEDIAMOP_SESSION_SECRET" > "$secret_file"
-    echo "info: generated MEDIAMOP_SESSION_SECRET at $secret_file" >&2
+    log_info "generated MEDIAMOP_SESSION_SECRET at $secret_file"
   fi
   export MEDIAMOP_SESSION_SECRET
 fi
 
 # Fernet-backed features and session signing expect adequate entropy.
 if [ "${#MEDIAMOP_SESSION_SECRET}" -lt 32 ]; then
-  echo "error: MEDIAMOP_SESSION_SECRET must be at least 32 characters (try: openssl rand -hex 32)" >&2
-  exit 1
+  fail "MEDIAMOP_SESSION_SECRET must be at least 32 characters (try: openssl rand -hex 32)"
 fi
 
-cd /opt/mediamop/apps/backend
-alembic upgrade head
-exec uvicorn mediamop.api.main:app --host 0.0.0.0 --port "${PORT:-8788}"
+if [ "$(id -u)" -eq 0 ]; then
+  update_runtime_identity
+  ensure_runtime_home_ownership
+  if [ -f "$MEDIAMOP_HOME/session.secret" ]; then
+    chown mediamop:mediamop "$MEDIAMOP_HOME/session.secret"
+  fi
+  gosu mediamop sh -c 'cd /opt/mediamop/apps/backend && alembic upgrade head'
+  apply_refiner_permissions
+  cd /opt/mediamop/apps/backend
+  exec gosu mediamop uvicorn mediamop.api.main:app --host 0.0.0.0 --port "${PORT:-8788}"
+fi
+
+run_app

--- a/docs/release-notes/v2.1.0.md
+++ b/docs/release-notes/v2.1.0.md
@@ -1,0 +1,32 @@
+# MediaMop v2.1.0
+
+Date: 2026-05-07
+
+This release focuses on making upgrades more reliable, improving activity history accuracy, and giving Docker operators better control over file ownership.
+
+## What Changed
+
+- Windows in-app upgrades now track real progress instead of showing a blind success state.
+- Activity history now reports Refiner removals and Subber outcomes more accurately.
+- Docker installs can now run with explicit UID/GID ownership and path permission controls.
+
+## Fixes And Stability
+
+- Windows upgrade verification now survives updater-service restarts during install and only completes after the running version matches the target version.
+- Refiner activity details no longer show `None removed` when audio or subtitle tracks were actually removed.
+- Activity feed events now stay in sync with the backend contract, including subtitle upgrade outcomes and reconciliation repair entries.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- Docker operators can now set `MEDIAMOP_PUID` / `MEDIAMOP_PGID` plus watched/temp/output ownership controls if the container should not write as root.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.1.0`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.0.7...v2.1.0

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.0.7"
+  #define AppVersion "2.1.0"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -72,10 +72,26 @@ Filename: "{app}\MediaMopUpdaterService.exe"; Parameters: "uninstall"; Flags: ru
 Filename: "{sys}\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"; Flags: runhidden waituntilterminated
 
 [Code]
+procedure ShowInstallNotice(MessageText: String);
+begin
+  Log(MessageText);
+  if not WizardSilent then
+    SuppressibleMsgBox(MessageText, mbInformation, MB_OK, IDOK);
+end;
+
+procedure FailInstall(MessageText: String);
+begin
+  Log(MessageText);
+  if not WizardSilent then
+    SuppressibleMsgBox(MessageText, mbCriticalError, MB_OK, IDOK);
+  RaiseException(MessageText);
+end;
+
 procedure StopMediaMopProcess(ProcessName: String);
 var
   ResultCode: Integer;
 begin
+  Log('Stopping process ' + ProcessName + ' before upgrade.');
   Exec(
     ExpandConstant('{sys}\taskkill.exe'),
     '/F /T /IM "' + ProcessName + '"',
@@ -84,6 +100,7 @@ begin
     ewWaitUntilTerminated,
     ResultCode
   );
+  Log('taskkill for ' + ProcessName + ' returned ' + IntToStr(ResultCode) + '.');
 end;
 
 procedure StopUpdaterServiceBeforeFileCopy;
@@ -93,7 +110,11 @@ var
 begin
   WrapperPath := ExpandConstant('{app}\MediaMopUpdaterService.exe');
   if FileExists(WrapperPath) then
+  begin
+    Log('Stopping updater service before file copy using ' + WrapperPath + '.');
     Exec(WrapperPath, 'stop', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, ResultCode);
+    Log('Updater service stop before file copy returned ' + IntToStr(ResultCode) + '.');
+  end;
 end;
 
 function QueryProcessRunning(ProcessName: String): Boolean;
@@ -137,6 +158,7 @@ end;
 
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
+  Log('PrepareToInstall: stopping MediaMop processes and updater service.');
   StopUpdaterServiceBeforeFileCopy();
   StopMediaMopProcess('MediaMop.exe');
   StopMediaMopProcess('MediaMopServer.exe');
@@ -149,6 +171,7 @@ var
   ResultCode: Integer;
   AddOk: Boolean;
 begin
+  Log('Refreshing MediaMop Windows Firewall rule.');
   Exec(
     ExpandConstant('{sys}\netsh.exe'),
     'advfirewall firewall delete rule name="MediaMop Server"',
@@ -170,11 +193,9 @@ begin
 
   if (not AddOk) or (ResultCode <> 0) then
   begin
-    MsgBox(
+    ShowInstallNotice(
       'MediaMop was installed, but Windows did not allow Setup to add the firewall rule for LAN access.' + #13#10 + #13#10 +
-      'Local access will still work. To open MediaMop from another device, allow MediaMopServer.exe through Windows Firewall for your current network profile.',
-      mbInformation,
-      MB_OK
+      'Local access will still work. To open MediaMop from another device, allow MediaMopServer.exe through Windows Firewall for your current network profile.'
     );
   end;
 end;
@@ -183,6 +204,7 @@ function UpdaterServiceInstalled(): Boolean;
 var
   ResultCode: Integer;
 begin
+  Log('Checking updater service status.');
   Result := Exec(
     ExpandConstant('{app}\MediaMopUpdaterService.exe'),
     'status',
@@ -204,6 +226,7 @@ begin
   InstallOk := True;
   StartOk := True;
 
+  Log('Stopping existing updater service before reinstall.');
   Exec(
     WrapperPath,
     'stop',
@@ -212,6 +235,8 @@ begin
     ewWaitUntilTerminated,
     ResultCode
   );
+  Log('Updater service stop returned ' + IntToStr(ResultCode) + '.');
+  Log('Uninstalling existing updater service before reinstall.');
   Exec(
     WrapperPath,
     'uninstall',
@@ -220,7 +245,9 @@ begin
     ewWaitUntilTerminated,
     ResultCode
   );
+  Log('Updater service uninstall returned ' + IntToStr(ResultCode) + '.');
 
+  Log('Installing updater service.');
   InstallOk := Exec(
     WrapperPath,
     'install',
@@ -231,15 +258,13 @@ begin
   ) and (ResultCode = 0);
   if not InstallOk then
   begin
-    MsgBox(
+    FailInstall(
       'MediaMop could not install the required Windows updater service.' + #13#10 + #13#10 +
-      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.',
-      mbCriticalError,
-      MB_OK
+      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.'
     );
-    RaiseException('MediaMop could not install the required Windows updater service.');
   end;
 
+  Log('Starting updater service.');
   StartOk := Exec(
     WrapperPath,
     'start',
@@ -250,24 +275,19 @@ begin
   ) and (ResultCode = 0);
   if not StartOk then
   begin
-    MsgBox(
+    FailInstall(
       'MediaMop could not install the required Windows updater service.' + #13#10 + #13#10 +
-      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.',
-      mbCriticalError,
-      MB_OK
+      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.'
     );
-    RaiseException('MediaMop could not install the required Windows updater service.');
   end;
 
+  Log('Verifying updater service status after reinstall.');
   if not UpdaterServiceInstalled() then
   begin
-    MsgBox(
+    FailInstall(
       'MediaMop could not install the required Windows updater service.' + #13#10 + #13#10 +
-      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.',
-      mbCriticalError,
-      MB_OK
+      'Remote in-app upgrades depend on that service. Fix the Windows service installation issue and run this installer again as administrator.'
     );
-    RaiseException('MediaMop could not install the required Windows updater service.');
   end;
 end;
 
@@ -275,7 +295,9 @@ procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
+    Log('Post-install step started.');
     InstallFirewallRule();
     InstallUpdaterService();
+    Log('Post-install step completed.');
   end;
 end;

--- a/packaging/windows/build.ps1
+++ b/packaging/windows/build.ps1
@@ -194,6 +194,12 @@ $buildVersion = if ($env:MEDIAMOP_BUILD_VERSION) {
 } else {
   $backendProjectVersion
 }
+if ($buildVersion.StartsWith("v")) {
+  $buildVersion = $buildVersion.Substring(1)
+}
+if ($buildVersion -ne $backendProjectVersion) {
+  throw "MEDIAMOP_BUILD_VERSION '$buildVersion' does not match backend project version '$backendProjectVersion'."
+}
 
 if (-not (Test-Path $py)) {
   $systemPython = Resolve-SystemPython
@@ -287,6 +293,31 @@ try {
   Invoke-Native -FilePath $py -ArgumentList @("-m", "PyInstaller", "--noconfirm", "--clean", "--distpath", $distRoot, "--workpath", (Join-Path $distRoot "build"), $specPath)
 } finally {
   Pop-Location
+}
+
+$packageDir = Join-Path $distRoot "MediaMop"
+$serverExe = Join-Path $packageDir "MediaMopServer.exe"
+$updaterExe = Join-Path $packageDir "MediaMopUpdater.exe"
+$updaterServiceXml = Join-Path $packageDir "MediaMopUpdaterService.xml"
+$updaterServiceExe = Join-Path $packageDir "MediaMopUpdaterService.exe"
+
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot "MediaMopUpdaterService.xml") -Destination $updaterServiceXml -Force
+Copy-Item -LiteralPath (Join-Path $winswVendorDir "WinSW-x64.exe") -Destination $updaterServiceExe -Force
+
+foreach ($exePath in @($serverExe, $updaterExe)) {
+  if (-not (Test-Path -LiteralPath $exePath)) {
+    throw "Expected packaged executable was not found: $exePath"
+  }
+}
+
+$serverVersion = (& $serverExe --version).Trim()
+if ($serverVersion -ne $buildVersion) {
+  throw "Packaged MediaMopServer.exe reports version '$serverVersion' but expected build version is '$buildVersion'."
+}
+
+$updaterVersion = (& $updaterExe --version).Trim()
+if ($updaterVersion -ne $buildVersion) {
+  throw "Packaged MediaMopUpdater.exe reports version '$updaterVersion' but expected build version is '$buildVersion'."
 }
 
 if (-not $SkipInstaller) {

--- a/packaging/windows/mediamop-tray.spec
+++ b/packaging/windows/mediamop-tray.spec
@@ -1,7 +1,7 @@
 # -*- mode: python ; coding: utf-8 -*-
 from pathlib import Path
 
-from PyInstaller.utils.hooks import collect_submodules
+from PyInstaller.utils.hooks import collect_submodules, copy_metadata
 
 ROOT = Path.cwd()
 BACKEND = ROOT / "apps" / "backend"
@@ -22,6 +22,7 @@ datas = [
     (str(TRAY_ICON_ICO), "assets"),
     (str(THIRD_PARTY_NOTICES), "."),
 ]
+datas += copy_metadata("mediamop-backend")
 if FFMPEG_VENDOR.is_dir():
     datas.append((str(FFMPEG_VENDOR), "bin/ffmpeg"))
 

--- a/scripts/smoke-windows-package.ps1
+++ b/scripts/smoke-windows-package.ps1
@@ -1,6 +1,7 @@
 param(
   [string]$PackageDir = "",
-  [int]$Port = 8799
+  [int]$Port = 8799,
+  [string]$ExpectedVersion = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -10,15 +11,36 @@ if (-not $PackageDir) {
   $PackageDir = Join-Path $repoRoot "dist\windows\MediaMop"
 }
 $packagePath = (Resolve-Path -LiteralPath $PackageDir).Path
+$backendPyproject = Join-Path $repoRoot "apps\backend\pyproject.toml"
+if (-not $ExpectedVersion) {
+  $ExpectedVersion = ((Get-Content -Path $backendPyproject) | Where-Object { $_ -match '^version = ' } | Select-Object -First 1).Split('"')[1]
+}
+$trayExe = Join-Path $packagePath "MediaMop.exe"
 $serverExe = Join-Path $packagePath "MediaMopServer.exe"
+$updaterExe = Join-Path $packagePath "MediaMopUpdater.exe"
+$updaterServiceExe = Join-Path $packagePath "MediaMopUpdaterService.exe"
+$updaterServiceXml = Join-Path $packagePath "MediaMopUpdaterService.xml"
+$internalRoot = Join-Path $packagePath "_internal"
 $webIndex = Join-Path $packagePath "_internal\web-dist\index.html"
 $trayIcon = Join-Path $packagePath "_internal\assets\mediamop-tray-icon.png"
 $alembicIni = Join-Path $packagePath "_internal\alembic.ini"
 $ffmpegExe = Join-Path $packagePath "_internal\bin\ffmpeg\ffmpeg.exe"
 $ffprobeExe = Join-Path $packagePath "_internal\bin\ffmpeg\ffprobe.exe"
 
+if (-not (Test-Path -LiteralPath $trayExe)) {
+  throw "Packaged tray executable not found: $trayExe"
+}
 if (-not (Test-Path -LiteralPath $serverExe)) {
   throw "Packaged server executable not found: $serverExe"
+}
+if (-not (Test-Path -LiteralPath $updaterExe)) {
+  throw "Packaged updater executable not found: $updaterExe"
+}
+if (-not (Test-Path -LiteralPath $updaterServiceExe)) {
+  throw "Packaged updater service wrapper not found: $updaterServiceExe"
+}
+if (-not (Test-Path -LiteralPath $updaterServiceXml)) {
+  throw "Packaged updater service XML not found: $updaterServiceXml"
 }
 if (-not (Test-Path -LiteralPath $webIndex)) {
   throw "Packaged web index not found: $webIndex"
@@ -35,9 +57,23 @@ if (-not (Test-Path -LiteralPath $ffmpegExe)) {
 if (-not (Test-Path -LiteralPath $ffprobeExe)) {
   throw "Packaged ffprobe executable not found: $ffprobeExe"
 }
+$distInfoDirs = Get-ChildItem -Path $internalRoot -Directory -Filter "mediamop_backend-*.dist-info" -ErrorAction SilentlyContinue
+if (-not $distInfoDirs -or $distInfoDirs.Count -eq 0) {
+  throw "Packaged backend dist-info metadata was not found in $internalRoot"
+}
 $indexText = Get-Content -LiteralPath $webIndex -Raw
 if ($indexText -notmatch "MediaMop") {
   throw "Packaged web index does not look like MediaMop."
+}
+
+$serverVersion = (& $serverExe --version).Trim()
+if ($serverVersion -ne $ExpectedVersion) {
+  throw "Packaged MediaMopServer.exe reports version '$serverVersion' but expected '$ExpectedVersion'."
+}
+
+$updaterVersion = (& $updaterExe --version).Trim()
+if ($updaterVersion -ne $ExpectedVersion) {
+  throw "Packaged MediaMopUpdater.exe reports version '$updaterVersion' but expected '$ExpectedVersion'."
 }
 
 $runtimeHome = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-package-smoke-" + [System.Guid]::NewGuid().ToString("N"))
@@ -67,16 +103,22 @@ try {
     -WindowStyle Hidden `
     -PassThru
 
-  $healthUrl = "http://127.0.0.1:$Port/health"
-  $deadline = (Get-Date).AddSeconds(45)
+  $readyUrl = "http://127.0.0.1:$Port/ready"
+  $openApiUrl = "http://127.0.0.1:$Port/openapi.json"
+  $deadline = (Get-Date).AddSeconds(60)
   do {
     if ($proc.HasExited) {
       throw "Packaged MediaMop server exited early with code $($proc.ExitCode)."
     }
     try {
-      $response = Invoke-RestMethod -Uri $healthUrl -Method Get -TimeoutSec 2
-      if ($response.status -eq "ok") {
-        Write-Host "Packaged MediaMop server health check passed on $healthUrl"
+      $ready = Invoke-RestMethod -Uri $readyUrl -Method Get -TimeoutSec 2
+      if ($ready.ready -eq $true) {
+        $openApi = Invoke-RestMethod -Uri $openApiUrl -Method Get -TimeoutSec 2
+        $reportedVersion = [string]$openApi.info.version
+        if ($reportedVersion -ne $ExpectedVersion) {
+          throw "Packaged MediaMop server reported version '$reportedVersion' but expected '$ExpectedVersion'."
+        }
+        Write-Host "Packaged MediaMop server readiness and version checks passed on $readyUrl"
         exit 0
       }
     } catch {
@@ -84,7 +126,7 @@ try {
     }
   } while ((Get-Date) -lt $deadline)
 
-  throw "Packaged MediaMop server did not become healthy at $healthUrl."
+  throw "Packaged MediaMop server did not become ready at $readyUrl."
 } catch {
   Write-Host "Packaged server smoke failed."
   if (Test-Path -LiteralPath $stdout) {


### PR DESCRIPTION
## Summary
- finalize the Windows updater lifecycle and release-path hardening
- fix remaining activity feed/detail fidelity issues
- add Docker runtime ownership controls for watched/temp/output paths
- repair the release workflow code-sign gating so branch workflow parsing is valid

## Closes
- #173
- #174
- #175
- #176

## Validation
- apps/backend: pytest -q, ruff check src tests, mypy src/mediamop
- apps/web: npm run lint, npm run test -- --run, npm run build
- Windows packaging: packaging/windows/build.ps1 -SkipWebBuild, scripts/smoke-windows-package.ps1 -ExpectedVersion 2.0.7
- Focused Docker/runtime and activity regression tests
