### PR TITLE
Release prep 2.1.1: harden Windows upgrade relaunch

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.0"
+version = "2.1.1"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -197,12 +197,13 @@ def _load_icon(resource_root: Path) -> Any:
 
 
 class _MediaMopTrayApp:
-    def __init__(self) -> None:
+    def __init__(self, *, open_browser_on_ready: bool = True) -> None:
         self._resource_root = _resource_root()
         self._runtime_home = _runtime_home()
         self._runtime_home.mkdir(parents=True, exist_ok=True)
         self._log_path = self._runtime_home / "tray-host.log"
         self._port = _find_free_port(8788)
+        self._open_browser_on_ready = open_browser_on_ready
         self._log(f"Starting tray host. resource_root={self._resource_root} runtime_home={self._runtime_home}")
         _prepare_environment(self._resource_root, self._runtime_home)
         (self._runtime_home / "current-port.txt").write_text(str(self._port), encoding="utf-8")
@@ -285,7 +286,10 @@ class _MediaMopTrayApp:
             lan = _lan_urls(self._port)
             if lan:
                 self._log("MediaMop LAN URLs: " + ", ".join(lan))
-            _open_browser(self._port)
+            if self._open_browser_on_ready:
+                _open_browser(self._port)
+            else:
+                self._log("Skipping browser auto-open because tray host was launched in no-browser mode.")
             self._icon = self._create_icon()
 
             def _watch_server_process() -> None:
@@ -355,7 +359,8 @@ def main() -> None:
                 port = int(sys.argv[idx + 1])
             _run_server_mode(port)
             return
-        app = _MediaMopTrayApp()
+        no_browser = "--no-browser" in sys.argv
+        app = _MediaMopTrayApp(open_browser_on_ready=not no_browser)
         app.run()
     except Exception:
         _append_fallback_log("Fatal startup error:\n" + traceback.format_exc())

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -160,6 +160,129 @@ def _pid_is_running(pid: object) -> bool:
     return True
 
 
+def _active_interactive_session_id() -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    class _WtsSessionInfo(ctypes.Structure):
+        _fields_ = [
+            ("SessionId", wintypes.DWORD),
+            ("pWinStationName", wintypes.LPWSTR),
+            ("State", wintypes.DWORD),
+        ]
+
+    wtsapi32 = ctypes.WinDLL("wtsapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    session_info = ctypes.POINTER(_WtsSessionInfo)()
+    count = wintypes.DWORD()
+    if not wtsapi32.WTSEnumerateSessionsW(0, 0, 1, ctypes.byref(session_info), ctypes.byref(count)):
+        raise OSError(ctypes.get_last_error(), "Could not enumerate Windows Terminal Services sessions.")
+    try:
+        for index in range(int(count.value)):
+            row = session_info[index]
+            if int(row.State) == 0:
+                return int(row.SessionId)
+    finally:
+        wtsapi32.WTSFreeMemory(session_info)
+    active_session = wintypes.DWORD(kernel32.WTSGetActiveConsoleSessionId())
+    if active_session.value != 0xFFFFFFFF:
+        return int(active_session.value)
+    raise RuntimeError("No active interactive Windows session was available for MediaMop relaunch.")
+
+
+def _launch_process_in_active_session(
+    executable: Path,
+    *,
+    args: list[str] | None = None,
+    cwd: Path | None = None,
+) -> int:
+    import ctypes
+    from ctypes import wintypes
+
+    if os.name != "nt":
+        raise RuntimeError("Active-session process launch is only supported on Windows.")
+
+    class _StartupInfo(ctypes.Structure):
+        _fields_ = [
+            ("cb", wintypes.DWORD),
+            ("lpReserved", wintypes.LPWSTR),
+            ("lpDesktop", wintypes.LPWSTR),
+            ("lpTitle", wintypes.LPWSTR),
+            ("dwX", wintypes.DWORD),
+            ("dwY", wintypes.DWORD),
+            ("dwXSize", wintypes.DWORD),
+            ("dwYSize", wintypes.DWORD),
+            ("dwXCountChars", wintypes.DWORD),
+            ("dwYCountChars", wintypes.DWORD),
+            ("dwFillAttribute", wintypes.DWORD),
+            ("dwFlags", wintypes.DWORD),
+            ("wShowWindow", wintypes.WORD),
+            ("cbReserved2", wintypes.WORD),
+            ("lpReserved2", ctypes.POINTER(ctypes.c_byte)),
+            ("hStdInput", wintypes.HANDLE),
+            ("hStdOutput", wintypes.HANDLE),
+            ("hStdError", wintypes.HANDLE),
+        ]
+
+    class _ProcessInformation(ctypes.Structure):
+        _fields_ = [
+            ("hProcess", wintypes.HANDLE),
+            ("hThread", wintypes.HANDLE),
+            ("dwProcessId", wintypes.DWORD),
+            ("dwThreadId", wintypes.DWORD),
+        ]
+
+    wtsapi32 = ctypes.WinDLL("wtsapi32", use_last_error=True)
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    userenv = ctypes.WinDLL("userenv", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    session_id = _active_interactive_session_id()
+    user_token = wintypes.HANDLE()
+    if not wtsapi32.WTSQueryUserToken(session_id, ctypes.byref(user_token)):
+        raise OSError(ctypes.get_last_error(), f"Could not acquire the token for interactive session {session_id}.")
+
+    environment = ctypes.c_void_p()
+    process_info = _ProcessInformation()
+    try:
+        if not userenv.CreateEnvironmentBlock(ctypes.byref(environment), user_token, False):
+            raise OSError(ctypes.get_last_error(), "Could not create the environment block for interactive relaunch.")
+
+        startup_info = _StartupInfo()
+        startup_info.cb = ctypes.sizeof(_StartupInfo)
+        startup_info.lpDesktop = "winsta0\\default"
+        command = [str(executable.resolve()), *(args or [])]
+        command_line = subprocess.list2cmdline(command)
+        creationflags = int(getattr(subprocess, "CREATE_UNICODE_ENVIRONMENT", 0)) | int(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        )
+        if not advapi32.CreateProcessAsUserW(
+            user_token,
+            None,
+            command_line,
+            None,
+            None,
+            False,
+            creationflags,
+            environment,
+            str((cwd or executable.parent).resolve()),
+            ctypes.byref(startup_info),
+            ctypes.byref(process_info),
+        ):
+            raise OSError(ctypes.get_last_error(), "Could not relaunch MediaMop in the active Windows session.")
+        return int(process_info.dwProcessId)
+    finally:
+        if process_info.hThread:
+            kernel32.CloseHandle(process_info.hThread)
+        if process_info.hProcess:
+            kernel32.CloseHandle(process_info.hProcess)
+        if environment:
+            userenv.DestroyEnvironmentBlock(environment)
+        if user_token:
+            kernel32.CloseHandle(user_token)
+
+
 def _running_media_processes() -> list[dict[str, object]]:
     script = (
         "$rows = Get-CimInstance Win32_Process | "
@@ -198,6 +321,30 @@ def _running_media_processes() -> list[dict[str, object]]:
             }
         )
     return out
+
+
+def _media_process_flags(processes: list[dict[str, object]]) -> dict[str, bool]:
+    tray_running = False
+    server_running = False
+    updater_running = False
+    for row in processes:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "").strip().lower()
+        command_line = str(row.get("command_line") or "").strip().lower()
+        executable_path = str(row.get("executable_path") or "").strip().lower()
+        normalized = name or Path(executable_path).name.lower()
+        if normalized == "mediamop.exe":
+            tray_running = True
+        elif normalized == "mediamopserver.exe" or "--serve" in command_line:
+            server_running = True
+        elif normalized in {"mediamopupdater.exe", "mediamopupdaterservice.exe"}:
+            updater_running = True
+    return {
+        "tray_running": tray_running,
+        "server_running": server_running,
+        "updater_running": updater_running,
+    }
 
 
 def _default_state() -> dict[str, object]:
@@ -688,6 +835,15 @@ def _start_packaged_server(port: int) -> subprocess.Popen[bytes]:
     )
 
 
+def _start_packaged_tray_in_active_session(*, open_browser: bool = False) -> int:
+    install_root = _install_root()
+    tray_exe = install_root / "MediaMop.exe"
+    if not tray_exe.is_file():
+        raise FileNotFoundError(f"Bundled tray host is missing: {tray_exe}")
+    args = [] if open_browser else ["--no-browser"]
+    return _launch_process_in_active_session(tray_exe, args=args, cwd=install_root)
+
+
 def _required_install_paths(install_root: Path) -> list[tuple[str, Path]]:
     return [
         ("MediaMop.exe", install_root / "MediaMop.exe"),
@@ -711,6 +867,7 @@ def _collect_install_diagnostics(target_version: str, *, port: int) -> dict[str,
         if not exists:
             missing_labels.append(label)
     backend_ready, backend_version, backend_detail = _probe_running_backend_version(port)
+    running_processes = _running_media_processes()
     return {
         "required_files": required_files,
         "missing_required_files": missing_labels,
@@ -719,7 +876,8 @@ def _collect_install_diagnostics(target_version: str, *, port: int) -> dict[str,
         "backend_ready": backend_ready,
         "backend_version": backend_version,
         "backend_detail": backend_detail,
-        "running_processes": _running_media_processes(),
+        "running_processes": running_processes,
+        **_media_process_flags(running_processes),
         "target_version": target_version,
     }
 
@@ -728,25 +886,70 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
     port = _read_runtime_port()
     deadline = time.time() + _VERIFY_INSTALL_TIMEOUT_SECONDS
     started_server_pid: int | None = None
+    restarted_tray_pid: int | None = None
+    tray_relaunch_attempted = False
+    tray_relaunch_started_at: float | None = None
+    tray_restart_error: str | None = None
+    server_restart_error: str | None = None
     last_diagnostics: dict[str, object] = _collect_install_diagnostics(target_version, port=port)
     while time.time() < deadline:
         diagnostics = _collect_install_diagnostics(target_version, port=port)
         diagnostics["restarted_server_pid"] = started_server_pid
+        diagnostics["restarted_tray_pid"] = restarted_tray_pid
+        diagnostics["tray_relaunch_attempted"] = tray_relaunch_attempted
+        if tray_restart_error:
+            diagnostics["tray_restart_error"] = tray_restart_error
+        if server_restart_error:
+            diagnostics["server_restart_error"] = server_restart_error
         packaged_version = str(diagnostics.get("packaged_version") or "").strip() or None
         backend_ready = bool(diagnostics.get("backend_ready"))
         backend_version = str(diagnostics.get("backend_version") or "").strip() or None
         missing_required = diagnostics.get("missing_required_files")
         if packaged_version == target_version and not missing_required and backend_ready and backend_version == target_version:
             return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
-        if packaged_version == target_version and not missing_required and started_server_pid is None and not backend_ready:
-            try:
-                process = _start_packaged_server(port)
-            except Exception as exc:
-                diagnostics["server_restart_error"] = str(exc)
-            else:
-                started_server_pid = process.pid
-                diagnostics["restarted_server_pid"] = process.pid
-                _append_service_log(f"Restarted packaged MediaMop server for upgrade verification (pid={process.pid}, port={port}).")
+        if packaged_version == target_version and not missing_required and not backend_ready:
+            if not tray_relaunch_attempted:
+                tray_relaunch_attempted = True
+                tray_relaunch_started_at = time.time()
+                try:
+                    restarted_tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
+                except Exception as exc:
+                    tray_restart_error = str(exc)
+                    diagnostics["tray_restart_error"] = tray_restart_error
+                    _append_service_log(
+                        "Could not relaunch packaged MediaMop tray host in the active session: "
+                        f"{exc}"
+                    )
+                else:
+                    diagnostics["restarted_tray_pid"] = restarted_tray_pid
+                    _append_service_log(
+                        "Relaunched packaged MediaMop tray host for upgrade verification "
+                        f"(pid={restarted_tray_pid}, port={port})."
+                    )
+            should_fallback_to_server = (
+                started_server_pid is None
+                and (
+                    restarted_tray_pid is None
+                    or (
+                        tray_relaunch_started_at is not None
+                        and time.time() - tray_relaunch_started_at >= 15.0
+                        and not bool(diagnostics.get("tray_running"))
+                    )
+                )
+            )
+            if should_fallback_to_server:
+                try:
+                    process = _start_packaged_server(port)
+                except Exception as exc:
+                    server_restart_error = str(exc)
+                    diagnostics["server_restart_error"] = server_restart_error
+                else:
+                    started_server_pid = process.pid
+                    diagnostics["restarted_server_pid"] = process.pid
+                    _append_service_log(
+                        "Restarted packaged MediaMop server for upgrade verification "
+                        f"(pid={process.pid}, port={port})."
+                    )
         last_diagnostics = diagnostics
         time.sleep(_BACKEND_POLL_INTERVAL_SECONDS)
     backend_version = str(last_diagnostics.get("backend_version") or "").strip() or None
@@ -857,9 +1060,10 @@ def _perform_upgrade_attempt(attempt_id: str) -> None:
             },
         )
         if getattr(sys, "frozen", False) and os.name == "nt":
+            _write_state(diagnostics={"helper_pid": None})
             _append_service_log(
                 "Installer launched from packaged updater; helper will exit and let updater-service "
-                "reconciliation finish verification after installer/service restart."
+                "reconciliation relaunch MediaMop and finish verification after installer/service restart."
             )
             return
         exit_code = process.wait(timeout=_INSTALLER_WAIT_TIMEOUT_SECONDS)
@@ -942,6 +1146,17 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
             deadline = time.time() + _INSTALLER_WAIT_TIMEOUT_SECONDS
             while time.time() < deadline and _pid_is_running(installer_pid):
                 time.sleep(_BACKEND_POLL_INTERVAL_SECONDS)
+            if _pid_is_running(installer_pid):
+                _mark_failed(
+                    message="Upgrade failed.",
+                    last_error="Installer did not exit before the reconciliation timeout elapsed.",
+                    target_version=str(state.get("target_version") or "").strip() or None,
+                    diagnostics={
+                        "reconciled_after_restart": True,
+                        "installer_pid": installer_pid,
+                    },
+                )
+                return
         target_version = normalize_release_version(str(state.get("target_version") or ""))
         if not target_version:
             _mark_failed(

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -82,6 +82,19 @@ def test_windows_installer_surfaces_firewall_rule_failures() -> None:
     assert 'Filename: "{sys}\\netsh.exe"; Parameters: "advfirewall firewall add rule' not in text
 
 
+def test_windows_installer_uses_explicit_interactive_launch_check() -> None:
+    installer = Path(__file__).resolve().parents[3] / "packaging" / "windows" / "MediaMop.iss"
+    text = installer.read_text(encoding="utf-8")
+
+    assert "function ShouldLaunchMediaMopAfterInstall(): Boolean;" in text
+    assert (
+        'Filename: "{app}\\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall; '
+        "Check: ShouldLaunchMediaMopAfterInstall"
+    ) in text
+    assert "skipifsilent" not in text
+    assert "updater-service relaunch handles post-upgrade startup" in text
+
+
 def test_windows_installer_installs_dedicated_upgrade_task() -> None:
     repo = Path(__file__).resolve().parents[3]
     installer = repo / "packaging" / "windows" / "MediaMop.iss"
@@ -173,3 +186,5 @@ def test_tray_double_click_opens_mediamop() -> None:
 
     assert 'Item("Open MediaMop", self._handle_open, default=True)' in source
     assert 'if "--version" in sys.argv:' in source
+    assert '"--no-browser" in sys.argv' in source
+    assert "open_browser_on_ready=not no_browser" in source

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -407,6 +407,134 @@ def test_perform_upgrade_attempt_allows_missing_checksum_only_with_explicit_over
     assert state["installer_sha256"] == "b" * 64
 
 
+def test_verify_install_relaunches_tray_before_marking_upgrade_complete(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    target_version = "2.0.8"
+    observed = {"tray_calls": 0, "server_calls": 0}
+    diagnostics_iter = iter(
+        [
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": False,
+                "backend_version": None,
+                "tray_running": False,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": False,
+                "backend_version": None,
+                "tray_running": False,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "backend_version": target_version,
+                "tray_running": True,
+            },
+        ]
+    )
+    clock = iter(range(1000))
+
+    monkeypatch.setattr(updater_service, "_read_runtime_port", lambda: 8788)
+    monkeypatch.setattr(
+        updater_service,
+        "_collect_install_diagnostics",
+        lambda _target_version, *, port: next(diagnostics_iter),
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_tray_in_active_session",
+        lambda *, open_browser=False: observed.__setitem__("tray_calls", observed["tray_calls"] + 1) or 4321,
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_server",
+        lambda _port: observed.__setitem__("server_calls", observed["server_calls"] + 1),
+    )
+    monkeypatch.setattr(updater_service.time, "time", lambda: float(next(clock)))
+    monkeypatch.setattr(updater_service.time, "sleep", lambda _seconds: None)
+
+    verified, diagnostics, message = updater_service._verify_install(target_version)
+
+    assert verified is True
+    assert message == f"Upgrade completed. Running version: {target_version}."
+    assert observed["tray_calls"] == 1
+    assert observed["server_calls"] == 0
+    assert diagnostics["restarted_tray_pid"] == 4321
+    assert diagnostics["tray_relaunch_attempted"] is True
+
+
+def test_verify_install_falls_back_to_server_when_tray_relaunch_is_unavailable(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    target_version = "2.0.8"
+    observed = {"server_calls": 0}
+    diagnostics_iter = iter(
+        [
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": False,
+                "backend_version": None,
+                "tray_running": False,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": False,
+                "backend_version": None,
+                "tray_running": False,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "backend_version": target_version,
+                "tray_running": False,
+            },
+        ]
+    )
+    clock = iter(range(1000))
+
+    class _ServerProcess:
+        pid = 5566
+
+    monkeypatch.setattr(updater_service, "_read_runtime_port", lambda: 8788)
+    monkeypatch.setattr(
+        updater_service,
+        "_collect_install_diagnostics",
+        lambda _target_version, *, port: next(diagnostics_iter),
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_tray_in_active_session",
+        lambda *, open_browser=False: (_ for _ in ()).throw(RuntimeError("no interactive session")),
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_server",
+        lambda _port: observed.__setitem__("server_calls", observed["server_calls"] + 1) or _ServerProcess(),
+    )
+    monkeypatch.setattr(updater_service.time, "time", lambda: float(next(clock)))
+    monkeypatch.setattr(updater_service.time, "sleep", lambda _seconds: None)
+
+    verified, diagnostics, message = updater_service._verify_install(target_version)
+
+    assert verified is True
+    assert message == f"Upgrade completed. Running version: {target_version}."
+    assert observed["server_calls"] == 1
+    assert diagnostics["restarted_server_pid"] == 5566
+    assert diagnostics["tray_restart_error"] == "no interactive session"
+
+
 def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
     tmp_path: Path,
     monkeypatch,
@@ -439,6 +567,7 @@ def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
 
     assert launch_state["phase"] == "installer_running"
     assert launch_state["diagnostics"]["installer_pid"] == 6789
+    assert launch_state["diagnostics"]["helper_pid"] is None
 
     Path(launch_state["installer_log_path"]).write_text("installer log", encoding="utf-8")
     updater_service._write_state(diagnostics={"helper_pid": None})
@@ -458,6 +587,31 @@ def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
 
     assert state["phase"] == "completed"
     assert state["current_version_seen"] == "2.0.8"
+
+
+def test_reconcile_attempt_worker_fails_when_installer_does_not_exit_in_time(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+            "phase": "installer_running",
+            "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+        }
+    )
+    clock = iter([0.0, float(updater_service._INSTALLER_WAIT_TIMEOUT_SECONDS + 1)])
+
+    monkeypatch.setattr(updater_service.time, "time", lambda: next(clock))
+    monkeypatch.setattr(updater_service.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(updater_service, "_pid_is_running", lambda pid: pid == 6789)
+
+    updater_service._reconcile_attempt_worker("attempt-123")
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "reconciliation timeout elapsed" in str(state["last_error"]).lower()
 
 
 def test_apply_update_persists_state_before_launching_helper(tmp_path: Path, monkeypatch) -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/layouts/app-shell.test.tsx
+++ b/apps/web/src/layouts/app-shell.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppShell } from "./app-shell";
+
+const logoutMutate = vi.fn();
+
+vi.mock("../lib/auth/queries", () => ({
+  useLogoutMutation: () => ({
+    mutate: logoutMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../lib/dashboard/queries", () => ({
+  useDashboardStatusQuery: () => ({
+    data: {
+      system: {
+        api_version: "2.1.1",
+      },
+    },
+  }),
+}));
+
+vi.mock("../lib/suite/queries", () => ({
+  useSuiteSettingsQuery: () => ({
+    data: {
+      product_display_name: "MediaMop",
+    },
+  }),
+}));
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    logoutMutate.mockReset();
+  });
+
+  it("keeps only the version and sign-out controls in the sidebar footer", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<AppShell />}>
+            <Route index element={<div>Dashboard</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Version 2.1.1")).toBeInTheDocument();
+    expect(screen.getByTestId("sign-out")).toBeInTheDocument();
+    expect(screen.queryByTestId("sidebar-support")).not.toBeInTheDocument();
+    expect(screen.queryByText("Support MediaMop")).not.toBeInTheDocument();
+    expect(screen.queryByText(/supporter licence/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/licence checks/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/feature limits/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -12,7 +12,6 @@ import {
 import { useLogoutMutation } from "../lib/auth/queries";
 import { useDashboardStatusQuery } from "../lib/dashboard/queries";
 import { useSuiteSettingsQuery } from "../lib/suite/queries";
-import { SUPPORT_URL } from "../lib/support";
 import {
   persistAppTheme,
   readStoredAppTheme,
@@ -97,28 +96,6 @@ export function AppShell() {
               title="Installed MediaMop version reported by the running server"
             >
               {appVersion ? `Version ${appVersion}` : "Version checking..."}
-            </div>
-            <div className="mm-sidebar-support" data-testid="sidebar-support">
-              <p className="mm-sidebar-support-title">Support MediaMop</p>
-              <p className="mm-sidebar-support-copy">
-                MediaMop is free to use. If it saves you time, you can support
-                development and help keep updates coming.
-              </p>
-              <p className="mm-sidebar-support-note">
-                Supporter licence (optional, future): this space is reserved for
-                future supporter acknowledgement details. There are no licence
-                checks or feature limits in this release.
-              </p>
-              {SUPPORT_URL ? (
-                <a
-                  href={SUPPORT_URL}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mm-sidebar-support-link"
-                >
-                  Support MediaMop
-                </a>
-              ) : null}
             </div>
             <button
               type="button"

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DISPLAY_DENSITY_STORAGE_KEY } from "../../lib/ui/display-density";
 import type { CurrentSession, UserPublic } from "../../lib/api/types";
 import { qk } from "../../lib/auth/queries";
@@ -161,11 +161,66 @@ function renderSettings(
   return render(wrap(<SettingsPage />, qc));
 }
 
+async function renderSettingsWithSupportConfig(
+  me: UserPublic,
+  supportConfig: {
+    showCard: boolean;
+    showPlaceholder: boolean;
+    supportUrl: string | null;
+  },
+  overrides?: { updateStatus?: SuiteUpdateStatusOut },
+) {
+  vi.resetModules();
+  vi.doMock("../../lib/support", () => ({
+    SHOW_SUPPORT_CARD: supportConfig.showCard,
+    SHOW_SUPPORT_URL_PLACEHOLDER: supportConfig.showPlaceholder,
+    SUPPORT_URL: supportConfig.supportUrl,
+  }));
+
+  const { SettingsPage: SettingsPageWithMockedSupport } =
+    await import("./settings-page");
+
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  qc.setQueryData(suiteSettingsQueryKey, minimalSuiteSettings);
+  qc.setQueryData(suiteSecurityOverviewQueryKey, minimalSecurity);
+  qc.setQueryData(qk.me, me);
+  qc.setQueryData(qk.session, minimalCurrentSession);
+  qc.setQueryData(suiteConfigurationBackupsQueryKey, {
+    directory: "C:/MediaMop/backups/suite-configuration",
+    items: [],
+  });
+  qc.setQueryData(
+    suiteUpdateStatusQueryKey,
+    overrides?.updateStatus ?? minimalUpdateStatus,
+  );
+  qc.setQueryData(
+    [
+      ...suiteLogsQueryKey,
+      {
+        level: undefined,
+        search: undefined,
+        has_exception: undefined,
+        limit: 100,
+      },
+    ],
+    minimalLogs,
+  );
+  qc.setQueryData(suiteMetricsQueryKey, minimalMetrics);
+  return render(wrap(<SettingsPageWithMockedSupport />, qc));
+}
+
 describe("SettingsPage (suite settings)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     localStorage.removeItem(DISPLAY_DENSITY_STORAGE_KEY);
     document.documentElement.removeAttribute("data-mm-density");
+  });
+
+  afterEach(() => {
+    vi.doUnmock("../../lib/support");
+    vi.resetModules();
   });
 
   it("does not mention Sonarr or Radarr on the central Settings page", () => {
@@ -177,12 +232,19 @@ describe("SettingsPage (suite settings)", () => {
     expect(screen.getByTestId("suite-settings-global")).toBeTruthy();
   });
 
-  it("shows development support guidance without a button when URL is missing", () => {
+  it("shows development support guidance inside the Support tab without a button when URL is missing", () => {
     renderSettings(operatorMe);
+    expect(
+      screen.queryByTestId("suite-settings-support"),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "Support" }));
     expect(screen.getByTestId("suite-settings-support")).toBeInTheDocument();
     expect(
+      screen.getByText("MediaMop is free to use. Support is optional."),
+    ).toBeInTheDocument();
+    expect(
       screen.getByText(
-        "MediaMop is free to use. If it saves you time, you can support development and help keep updates coming.",
+        "If MediaMop saves you time or helps keep your library cleaner, you can support ongoing development.",
       ),
     ).toBeInTheDocument();
     expect(screen.getByText(/Development note: set/i)).toBeInTheDocument();
@@ -190,6 +252,52 @@ describe("SettingsPage (suite settings)", () => {
     expect(
       screen.queryByRole("link", { name: "Support MediaMop" }),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText(/supporter licence/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the Support settings destination and button when a valid support URL is configured", async () => {
+    await renderSettingsWithSupportConfig(operatorMe, {
+      showCard: true,
+      showPlaceholder: false,
+      supportUrl: "https://example.com/support",
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "Support" }));
+
+    expect(screen.getByTestId("suite-settings-support")).toBeInTheDocument();
+    expect(
+      screen.getByText("MediaMop is free to use. Support is optional."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "If MediaMop saves you time or helps keep your library cleaner, you can support ongoing development.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Support MediaMop" }),
+    ).toHaveAttribute("href", "https://example.com/support");
+    expect(screen.queryByText("VITE_SUPPORT_URL")).not.toBeInTheDocument();
+    expect(screen.queryByText(/supporter licence/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/feature limits/i)).not.toBeInTheDocument();
+  });
+
+  it("hides the Support settings destination in production when the support URL is missing or invalid", async () => {
+    await renderSettingsWithSupportConfig(operatorMe, {
+      showCard: false,
+      showPlaceholder: false,
+      supportUrl: null,
+    });
+
+    expect(
+      screen.queryByRole("tab", { name: "Support" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-support"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Support MediaMop" }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("VITE_SUPPORT_URL")).not.toBeInTheDocument();
     expect(screen.queryByText(/supporter licence/i)).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -67,7 +67,7 @@ function canEditSuiteGlobal(role: string | undefined): boolean {
   return role === "operator" || role === "admin";
 }
 
-type TabId = "general" | "backup" | "upgrade" | "security" | "logs";
+type TabId = "general" | "backup" | "upgrade" | "security" | "logs" | "support";
 
 const SUITE_PASSWORD_FIELD_CLASS =
   "mm-input w-full min-w-0 flex-1 text-sm tracking-normal text-[var(--mm-text)]";
@@ -996,6 +996,7 @@ export function SettingsPage() {
   const runtimeRequestIssues = requestIssueSummary(
     runtimeMetrics?.status_counts,
   );
+  const showSupportTab = SHOW_SUPPORT_CARD;
 
   return (
     <div className="mm-page" data-testid="suite-settings-page">
@@ -1059,6 +1060,17 @@ export function SettingsPage() {
           >
             Logs
           </button>
+          {showSupportTab ? (
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "support"}
+              className={tabButtonClass(tab === "support")}
+              onClick={() => setTab("support")}
+            >
+              Support
+            </button>
+          ) : null}
         </div>
 
         {tab === "general" ? (
@@ -1416,50 +1428,6 @@ export function SettingsPage() {
                     </div>
                   </fieldset>
                 </section>
-                {SHOW_SUPPORT_CARD ? (
-                  <section
-                    className={SUITE_SETTINGS_DASH_CARD_CLASS}
-                    data-testid="suite-settings-support"
-                    aria-labelledby="suite-settings-support-heading"
-                  >
-                    <div className="mm-card-action-body">
-                      <div>
-                        <h3
-                          id="suite-settings-support-heading"
-                          className="text-base font-semibold text-[var(--mm-text1)]"
-                        >
-                          Support MediaMop
-                        </h3>
-                        <p className="mt-1 text-sm text-[var(--mm-text2)]">
-                          MediaMop is free to use. If it saves you time, you can
-                          support development and help keep updates coming.
-                        </p>
-                      </div>
-                      {SHOW_SUPPORT_URL_PLACEHOLDER ? (
-                        <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
-                          Development note: set <code>VITE_SUPPORT_URL</code> to
-                          show the support button.
-                        </p>
-                      ) : null}
-                    </div>
-                    <div className="mm-card-action-footer">
-                      {SUPPORT_URL ? (
-                        <a
-                          href={SUPPORT_URL}
-                          target="_blank"
-                          rel="noreferrer"
-                          className={mmActionButtonClass({
-                            variant: "secondary",
-                            disabled: false,
-                          })}
-                          data-testid="suite-settings-support-button"
-                        >
-                          Support MediaMop
-                        </a>
-                      ) : null}
-                    </div>
-                  </section>
-                ) : null}
               </div>
             </div>
           </div>
@@ -2329,6 +2297,64 @@ export function SettingsPage() {
                   {changePassword.isPending ? "Saving…" : "Change password"}
                 </button>
               </div>
+            </section>
+          </div>
+        ) : tab === "support" ? (
+          <div
+            data-testid="suite-settings-support-tab"
+            className="mm-bubble-stack"
+          >
+            <div className={mmModuleTabBlurbBandClass}>
+              <p className={mmModuleTabBlurbTextClass}>
+                Optional support details for MediaMop. Core app features remain
+                fully usable without any support flow.
+              </p>
+            </div>
+
+            <section
+              className={SUITE_SETTINGS_DASH_CARD_CLASS}
+              data-testid="suite-settings-support"
+              aria-labelledby="suite-settings-support-heading"
+            >
+              <div className="mm-card-action-body">
+                <div className="space-y-3">
+                  <h3
+                    id="suite-settings-support-heading"
+                    className="text-base font-semibold text-[var(--mm-text1)]"
+                  >
+                    Support MediaMop
+                  </h3>
+                  <div className="space-y-2 text-sm text-[var(--mm-text2)]">
+                    <p>MediaMop is free to use. Support is optional.</p>
+                    <p>
+                      If MediaMop saves you time or helps keep your library
+                      cleaner, you can support ongoing development.
+                    </p>
+                  </div>
+                </div>
+                {SHOW_SUPPORT_URL_PLACEHOLDER ? (
+                  <p className="rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 text-xs text-[var(--mm-text3)]">
+                    Development note: set <code>VITE_SUPPORT_URL</code> to show
+                    the support button.
+                  </p>
+                ) : null}
+              </div>
+              {SUPPORT_URL ? (
+                <div className="mm-card-action-footer">
+                  <a
+                    href={SUPPORT_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={mmActionButtonClass({
+                      variant: "secondary",
+                      disabled: false,
+                    })}
+                    data-testid="suite-settings-support-button"
+                  >
+                    Support MediaMop
+                  </a>
+                </div>
+              ) : null}
             </section>
           </div>
         ) : (

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -374,56 +374,6 @@ html[data-mm-theme="light"] .mm-theme-toggle {
   opacity: 0.9;
 }
 
-.mm-sidebar-support {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.055);
-}
-
-.mm-sidebar-support-title {
-  margin: 0;
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--mm-text1);
-}
-
-.mm-sidebar-support-copy {
-  margin: 6px 0 0;
-  font-size: 0.75rem;
-  line-height: 1.45;
-  color: var(--mm-text2);
-}
-
-.mm-sidebar-support-note {
-  margin: 6px 0 0;
-  font-size: 0.71875rem;
-  line-height: 1.45;
-  color: var(--mm-text3);
-}
-
-.mm-sidebar-support-link {
-  display: inline-flex;
-  margin-top: 8px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  color: var(--mm-gold);
-  text-decoration: none;
-}
-
-.mm-sidebar-support-link:hover {
-  color: var(--mm-accent-bright);
-  text-decoration: underline;
-}
-
-.mm-sidebar-support-link:focus-visible {
-  outline: 2px solid var(--mm-accent-ring);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
 .mm-sidebar-signout {
   display: inline-flex;
   align-self: stretch;

--- a/docs/release-notes/v2.1.1.md
+++ b/docs/release-notes/v2.1.1.md
@@ -1,0 +1,32 @@
+# MediaMop v2.1.1
+
+Date: 2026-05-07
+
+This release focuses on making Windows in-app upgrades restart cleanly after a silent install and keeping upgrade status truthful until the new version is actually running.
+
+## What Changed
+
+- Windows in-app upgrades now relaunch MediaMop explicitly after the installer finishes instead of depending on the installer's interactive launch step.
+- Settings keeps the optional support link inside a dedicated Support area instead of showing support copy in the global sidebar.
+- Upgrade progress stays visible while MediaMop reconnects and verifies the installed version.
+
+## Fixes And Stability
+
+- Silent upgrades no longer stop at a completed installer while leaving the app closed or half-restarted.
+- Upgrade verification now waits for the backend to come back on the target version before reporting completion.
+- If the tray app cannot be relaunched in an active user session, MediaMop now falls back to restarting the backend and continues verification from there.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- This release improves post-install relaunch behavior for remote in-app upgrades, but the updater still needs a valid interactive Windows session if it is expected to bring the tray app back automatically.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.1.1`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.1.0...v2.1.1

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.1.0"
+  #define AppVersion "2.1.1"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.
@@ -63,7 +63,7 @@ Name: "{commondesktop}\MediaMop"; Filename: "{app}\{#ExeName}"; Tasks: desktopic
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "MediaMop"; ValueData: """{app}\{#ExeName}"""; Flags: uninsdeletevalue; Tasks: startup
 
 [Run]
-Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\{#ExeName}"; Description: "Launch MediaMop"; Flags: nowait postinstall; Check: ShouldLaunchMediaMopAfterInstall
 
 [UninstallRun]
 Filename: "{sys}\netsh.exe"; Parameters: "advfirewall firewall delete rule name=""MediaMop Server"""; Flags: runhidden waituntilterminated
@@ -72,6 +72,13 @@ Filename: "{app}\MediaMopUpdaterService.exe"; Parameters: "uninstall"; Flags: ru
 Filename: "{sys}\schtasks.exe"; Parameters: "/Delete /TN ""MediaMop Upgrade"" /F"; Flags: runhidden waituntilterminated
 
 [Code]
+function ShouldLaunchMediaMopAfterInstall(): Boolean;
+begin
+  Result := not WizardSilent;
+  if not Result then
+    Log('Skipping [Run] MediaMop launch because this install is silent; updater-service relaunch handles post-upgrade startup.');
+end;
+
 procedure ShowInstallNotice(MessageText: String);
 begin
   Log(MessageText);


### PR DESCRIPTION
## Summary
- make silent Windows upgrades relaunch MediaMop explicitly instead of relying on the installer's interactive [Run] path
- keep upgrade verification running until the backend comes back on the target version and add coverage for the relaunch/reconciliation paths
- move optional support UI into Settings, bump versions to 2.1.1, and add release notes

## Validation
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m pytest -q
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m ruff check src tests
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m mypy src/mediamop
- node scripts/check-agent-docs.mjs
- cd apps/web && npm run ci
- .\\apps\\backend\\.venv\\Scripts\\python.exe -m pytest tests/e2e/mediamop -q --tb=short
- powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
- powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1 -ExpectedVersion 2.1.1