### PR TITLE
Fix Windows updater stale state and prepare 2.1.2

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.1"
+version = "2.1.2"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -202,7 +202,12 @@ class SuiteUpgradeProgressOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     phase: str = Field(min_length=1)
+    raw_phase: str | None = None
     message: str = Field(min_length=1)
+    is_active: bool = False
+    is_stale: bool = False
+    blocks_new_update: bool = False
+    stale_reason: str | None = None
     attempt_id: str | None = None
     target_version: str | None = None
     current_version_seen: str | None = None

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -43,6 +43,15 @@ _WINDOWS_UPDATER_UNREACHABLE_SUMMARY = (
     "Remote in-app upgrade is unavailable because MediaMop could not reach the local updater service. "
     "Ensure the MediaMop Updater service is running on this computer, then click Check again."
 )
+_WINDOWS_ACTIVE_UPGRADE_PHASES = {
+    "checking",
+    "downloading",
+    "verifying_download",
+    "installer_started",
+    "installer_running",
+    "restarting",
+    "verifying_install",
+}
 _REQUIRED_WINDOWS_FILES: tuple[tuple[str, str], ...] = (
     ("MediaMop.exe", "MediaMop.exe"),
     ("MediaMopServer.exe", "MediaMopServer.exe"),
@@ -135,10 +144,28 @@ def _safe_response_json(response: httpx.Response) -> dict[str, Any]:
 def _coerce_upgrade_progress(payload: dict[str, Any] | None) -> SuiteUpgradeProgressOut | None:
     if not payload:
         return None
+    phase = str(payload.get("phase") or "unknown").strip().lower()
+    if phase == "idle":
+        return None
     diagnostics = payload.get("diagnostics")
+    diagnostics_dict = diagnostics if isinstance(diagnostics, dict) else {}
+    stale_reason = (
+        str(payload.get("stale_reason") or diagnostics_dict.get("stale_reason") or "").strip()
+        or None
+    )
+    is_stale = bool(payload.get("is_stale")) or stale_reason is not None
+    is_active = bool(payload.get("is_active"))
+    if payload.get("is_active") is None:
+        is_active = phase in _WINDOWS_ACTIVE_UPGRADE_PHASES and not is_stale
+    blocks_new_update = bool(payload.get("blocks_new_update")) if payload.get("blocks_new_update") is not None else is_active
     return SuiteUpgradeProgressOut(
-        phase=str(payload.get("phase") or "unknown"),
+        phase=phase or "unknown",
+        raw_phase=str(payload.get("raw_phase") or phase or "unknown").strip() or None,
         message=str(payload.get("message") or "Updater status unavailable."),
+        is_active=is_active,
+        is_stale=is_stale,
+        blocks_new_update=blocks_new_update,
+        stale_reason=stale_reason,
         attempt_id=str(payload.get("attempt_id") or "").strip() or None,
         target_version=normalize_release_version(str(payload.get("target_version") or "")),
         current_version_seen=str(payload.get("current_version_seen") or "").strip() or None,
@@ -153,7 +180,7 @@ def _coerce_upgrade_progress(payload: dict[str, Any] | None) -> SuiteUpgradeProg
         last_updated_at=payload.get("last_updated_at"),
         last_completed_at=payload.get("last_completed_at"),
         last_error=str(payload.get("last_error") or "").strip() or None,
-        diagnostics=diagnostics if isinstance(diagnostics, dict) else {},
+        diagnostics=diagnostics_dict,
     )
 
 

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -30,6 +30,7 @@ from mediamop.platform.suite_settings.release_catalog import (
     WINDOWS_INSTALLER_SHA256_ASSET_NAME,
     fetch_release_record_by_version,
     normalize_release_version,
+    parse_version_key,
 )
 from mediamop.version import __version__, resolve_packaged_version
 
@@ -59,6 +60,7 @@ _TRUSTED_RELEASE_DOWNLOAD_HOSTS = {
     "release-assets.githubusercontent.com",
 }
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
+_PROCESS_IDENTITY_SKEW_SECONDS = 5.0
 
 
 def _append_service_log(message: str) -> None:
@@ -156,6 +158,107 @@ def _pid_is_running(pid: object) -> bool:
     except PermissionError:
         return True
     except OSError:
+        return False
+    return True
+
+
+def _normalize_executable_path(raw: object) -> str | None:
+    if raw is None:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    if ":" in text or "\\" in text:
+        return text.replace("/", "\\").rstrip("\\").casefold()
+    return os.path.normcase(os.path.normpath(text))
+
+
+def _read_process_snapshot(pid: object) -> dict[str, object] | None:
+    try:
+        numeric = int(pid)
+    except (TypeError, ValueError):
+        return None
+    if numeric <= 0:
+        return None
+    if os.name != "nt":
+        if not _pid_is_running(numeric):
+            return None
+        return {"pid": numeric}
+    script = (
+        f"$row = Get-CimInstance Win32_Process -Filter \"ProcessId = {numeric}\" | "
+        "Select-Object Name, ProcessId, ExecutablePath, CommandLine, "
+        "@{Name='CreationTimeUtc';Expression={ if ($_.CreationDate) { $_.CreationDate.ToUniversalTime().ToString('o') } else { $null } }}; "
+        "if ($null -eq $row) { exit 3 }; "
+        "$row | ConvertTo-Json -Compress"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception as exc:
+        _append_service_log(f"Could not read process snapshot for pid={numeric}: {exc}")
+        return None
+    raw = (result.stdout or "").strip()
+    if result.returncode != 0 or not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        _append_service_log(f"Could not parse process snapshot for pid={numeric}.")
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return {
+        "pid": payload.get("ProcessId"),
+        "name": str(payload.get("Name") or "").strip() or None,
+        "executable_path": str(payload.get("ExecutablePath") or "").strip() or None,
+        "command_line": str(payload.get("CommandLine") or "").strip() or None,
+        "creation_time_utc": str(payload.get("CreationTimeUtc") or "").strip() or None,
+    }
+
+
+def _state_attempt_started_at(state: dict[str, object]) -> datetime | None:
+    return _parse_iso(state.get("last_started_at")) or _parse_iso(state.get("last_updated_at"))
+
+
+def _process_started_after_attempt(snapshot: dict[str, object], attempt_started_at: datetime | None) -> bool:
+    if attempt_started_at is None:
+        return False
+    created_at = _parse_iso(snapshot.get("creation_time_utc"))
+    if created_at is None:
+        return False
+    return created_at.timestamp() + _PROCESS_IDENTITY_SKEW_SECONDS >= attempt_started_at.timestamp()
+
+
+def _process_matches_attempt(
+    pid: object,
+    *,
+    expected_path: object | None,
+    attempt_started_at: datetime | None,
+    expected_command_fragments: tuple[str, ...] = (),
+) -> bool:
+    snapshot = _read_process_snapshot(pid)
+    if snapshot is None:
+        return False
+    if not _process_started_after_attempt(snapshot, attempt_started_at):
+        return False
+    normalized_expected = _normalize_executable_path(expected_path)
+    normalized_command_line = str(snapshot.get("command_line") or "").strip().casefold()
+    if normalized_expected is None:
+        return False
+    normalized_actual = _normalize_executable_path(snapshot.get("executable_path"))
+    path_matches = normalized_actual == normalized_expected
+    command_matches_path = normalized_expected in normalized_command_line if normalized_command_line else False
+    if not path_matches and not command_matches_path:
+        return False
+    if expected_command_fragments and normalized_command_line:
+        if not all(fragment.casefold() in normalized_command_line for fragment in expected_command_fragments):
+            return False
+    elif expected_command_fragments:
         return False
     return True
 
@@ -470,6 +573,7 @@ def _fresh_attempt_state(target_version: str, attempt_id: str) -> dict[str, obje
             "last_error": None,
             "diagnostics": {
                 "helper_pid": None,
+                "helper_executable_path": None,
                 "installer_pid": None,
                 "restarted_server_pid": None,
                 "release_tag": f"v{target_version}",
@@ -479,16 +583,97 @@ def _fresh_attempt_state(target_version: str, attempt_id: str) -> dict[str, obje
     return state
 
 
+def _installer_process_is_running(state: dict[str, object]) -> bool:
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
+    installer_path = state.get("downloaded_installer_path")
+    return _process_matches_attempt(
+        installer_pid,
+        expected_path=installer_path,
+        attempt_started_at=_state_attempt_started_at(state),
+    )
+
+
+def _helper_process_is_running(state: dict[str, object]) -> bool:
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    helper_pid = diagnostics.get("helper_pid") if isinstance(diagnostics, dict) else None
+    helper_path = diagnostics.get("helper_executable_path") if isinstance(diagnostics, dict) else None
+    attempt_id = str(state.get("attempt_id") or "").strip()
+    fragments = ("--run-upgrade-helper", attempt_id) if attempt_id else ()
+    return _process_matches_attempt(
+        helper_pid,
+        expected_path=helper_path,
+        attempt_started_at=_state_attempt_started_at(state),
+        expected_command_fragments=fragments,
+    )
+
+
+def _state_matches_installed_target(target_version: str) -> tuple[bool, dict[str, object]]:
+    diagnostics = _collect_install_diagnostics(target_version, port=_read_runtime_port())
+    packaged_version = str(diagnostics.get("packaged_version") or "").strip() or None
+    backend_version = str(diagnostics.get("backend_version") or "").strip() or None
+    backend_ready = bool(diagnostics.get("backend_ready"))
+    missing_required = diagnostics.get("missing_required_files")
+    matched = (
+        packaged_version == target_version
+        and backend_ready
+        and backend_version == target_version
+        and not missing_required
+    )
+    return matched, diagnostics
+
+
+def _state_running_version_exceeds_target(
+    target_version: str,
+) -> tuple[bool, dict[str, object], str | None]:
+    diagnostics = _collect_install_diagnostics(target_version, port=_read_runtime_port())
+    target_key = parse_version_key(target_version)
+    if target_key is None:
+        return False, diagnostics, None
+    for field_name in ("backend_version", "packaged_version"):
+        observed_version = str(diagnostics.get(field_name) or "").strip() or None
+        observed_key = parse_version_key(observed_version) if observed_version else None
+        if observed_key and observed_key > target_key:
+            return True, diagnostics, observed_version
+    return False, diagnostics, None
+
+
+def _mark_attempt_completed(
+    *,
+    target_version: str,
+    diagnostics: dict[str, object],
+    message: str | None = None,
+    stale_reason: str | None = None,
+) -> dict[str, object]:
+    merged_diagnostics = dict(diagnostics)
+    if stale_reason:
+        merged_diagnostics["stale_reason"] = stale_reason
+    return _transition_state(
+        "completed",
+        message or f"Upgrade completed. Running version: {target_version}.",
+        target_version=target_version,
+        current_version_seen=target_version,
+        last_completed_at=_iso_now(),
+        last_error=None,
+        diagnostics=merged_diagnostics,
+    )
+
+
 def _stable_or_active_attempt_exists(state: dict[str, object]) -> bool:
     phase = str(state.get("phase") or "").strip().lower()
     if phase not in _ACTIVE_PHASES:
         return False
     attempt_id = str(state.get("attempt_id") or "").strip()
-    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
-    helper_pid = diagnostics.get("helper_pid") if isinstance(diagnostics, dict) else None
-    installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
-    if _pid_is_running(helper_pid) or _pid_is_running(installer_pid):
+    if _helper_process_is_running(state) or _installer_process_is_running(state):
         return True
+    target_version = normalize_release_version(str(state.get("target_version") or ""))
+    if target_version:
+        matched, _diagnostics = _state_matches_installed_target(target_version)
+        if matched:
+            return False
+        exceeded, _diagnostics, _observed_version = _state_running_version_exceeds_target(target_version)
+        if exceeded:
+            return False
     age = _state_age_seconds(state)
     if age is None:
         return bool(attempt_id)
@@ -1137,27 +1322,75 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
         state = _read_state()
         if str(state.get("attempt_id") or "").strip() != attempt_id:
             return
+        attempt_label = attempt_id or "legacy-state"
         phase = str(state.get("phase") or "").strip().lower()
         if phase not in _RECOVERABLE_PHASES:
             return
         diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
         installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
-        if _pid_is_running(installer_pid):
+        target_version = normalize_release_version(str(state.get("target_version") or ""))
+        if target_version:
+            matched, install_diagnostics = _state_matches_installed_target(target_version)
+            if matched and not _installer_process_is_running(state):
+                stale_reason = (
+                    "Persisted updater state could not prove the original installer process was still active, "
+                    f"but MediaMop {target_version} is already installed and running."
+                )
+                installer_log = _host_path(str(state.get("installer_log_path") or ""))
+                if installer_log.is_file():
+                    _copy_latest_installer_log(installer_log)
+                _append_service_log(
+                    "Upgrade reconciliation found the requested target version already running; "
+                    f"marking attempt {attempt_label} completed."
+                )
+                _mark_attempt_completed(
+                    target_version=target_version,
+                    diagnostics={
+                        **install_diagnostics,
+                        "reconciled_after_restart": True,
+                        "reconciled_from_phase": phase,
+                    },
+                    stale_reason=stale_reason,
+                )
+                return
+            exceeded, install_diagnostics, observed_version = _state_running_version_exceeds_target(target_version)
+            if exceeded and not _installer_process_is_running(state):
+                stale_reason = (
+                    f"Persisted updater state still targeted {target_version}, but MediaMop is already running "
+                    f"newer version {observed_version or 'unknown'}."
+                )
+                _append_service_log(
+                    "Upgrade reconciliation found an obsolete target version in persisted updater state; "
+                    f"marking attempt {attempt_label} failed."
+                )
+                _mark_failed(
+                    message="Upgrade failed.",
+                    last_error=stale_reason,
+                    target_version=target_version,
+                    current_version_seen=observed_version,
+                    diagnostics={
+                        **install_diagnostics,
+                        "reconciled_after_restart": True,
+                        "reconciled_from_phase": phase,
+                        "stale_reason": stale_reason,
+                    },
+                )
+                return
+        if _installer_process_is_running(state):
             deadline = time.time() + _INSTALLER_WAIT_TIMEOUT_SECONDS
-            while time.time() < deadline and _pid_is_running(installer_pid):
+            while time.time() < deadline and _installer_process_is_running(state):
                 time.sleep(_BACKEND_POLL_INTERVAL_SECONDS)
-            if _pid_is_running(installer_pid):
+            if _installer_process_is_running(state):
                 _mark_failed(
                     message="Upgrade failed.",
                     last_error="Installer did not exit before the reconciliation timeout elapsed.",
-                    target_version=str(state.get("target_version") or "").strip() or None,
+                    target_version=target_version or None,
                     diagnostics={
                         "reconciled_after_restart": True,
                         "installer_pid": installer_pid,
                     },
                 )
                 return
-        target_version = normalize_release_version(str(state.get("target_version") or ""))
         if not target_version:
             _mark_failed(
                 message="Upgrade failed.",
@@ -1189,15 +1422,7 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
         )
         verified, diagnostics, message = _verify_install(target_version)
         if verified:
-            _transition_state(
-                "completed",
-                message,
-                target_version=target_version,
-                current_version_seen=target_version,
-                last_completed_at=_iso_now(),
-                last_error=None,
-                diagnostics=diagnostics,
-            )
+            _mark_attempt_completed(target_version=target_version, diagnostics=diagnostics)
             return
         _mark_failed(
             message="Upgrade failed.",
@@ -1219,29 +1444,77 @@ def _maybe_reconcile_pending_attempt() -> None:
     phase = str(state.get("phase") or "").strip().lower()
     if phase not in _ACTIVE_PHASES:
         return
+    if _helper_process_is_running(state):
+        return
     attempt_id = str(state.get("attempt_id") or "").strip()
-    if not attempt_id:
-        return
-    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
-    helper_pid = diagnostics.get("helper_pid") if isinstance(diagnostics, dict) else None
-    installer_pid = diagnostics.get("installer_pid") if isinstance(diagnostics, dict) else None
-    if _pid_is_running(helper_pid):
-        return
+    attempt_label = attempt_id or "legacy-state"
+    target_version = normalize_release_version(str(state.get("target_version") or ""))
+    installer_running = _installer_process_is_running(state)
+    if target_version and phase in _RECOVERABLE_PHASES and not installer_running:
+        matched, install_diagnostics = _state_matches_installed_target(target_version)
+        if matched:
+            stale_reason = (
+                "Persisted updater state could not prove the original installer process was still active, "
+                f"but MediaMop {target_version} is already installed and running."
+            )
+            installer_log = _host_path(str(state.get("installer_log_path") or ""))
+            if installer_log.is_file():
+                _copy_latest_installer_log(installer_log)
+            _append_service_log(
+                "Updater status found an active attempt whose target version is already running; "
+                f"marking attempt {attempt_label} completed."
+            )
+            _mark_attempt_completed(
+                target_version=target_version,
+                diagnostics={
+                    **install_diagnostics,
+                    "reconciled_after_restart": True,
+                    "reconciled_from_phase": phase,
+                },
+                stale_reason=stale_reason,
+            )
+            return
+        exceeded, install_diagnostics, observed_version = _state_running_version_exceeds_target(target_version)
+        if exceeded:
+            stale_reason = (
+                f"Persisted updater state still targeted {target_version}, but MediaMop is already running "
+                f"newer version {observed_version or 'unknown'}."
+            )
+            _append_service_log(
+                "Updater status found an obsolete target version in persisted updater state; "
+                f"marking attempt {attempt_label} failed."
+            )
+            _mark_failed(
+                message="Upgrade failed.",
+                last_error=stale_reason,
+                target_version=target_version,
+                current_version_seen=observed_version,
+                diagnostics={
+                    **install_diagnostics,
+                    "reconciled_after_restart": True,
+                    "reconciled_from_phase": phase,
+                    "stale_reason": stale_reason,
+                },
+            )
+            return
     age = _state_age_seconds(state)
     if (
         age is not None
         and age >= _STALE_ATTEMPT_SECONDS
-        and not _pid_is_running(installer_pid)
+        and not installer_running
     ):
         _mark_failed(
             message="Upgrade failed.",
             last_error=f"Upgrade attempt stalled during {phase}.",
-            target_version=str(state.get("target_version") or "").strip() or None,
+            target_version=target_version or None,
             diagnostics={
                 "stalled_phase": phase,
                 "state_age_seconds": age,
+                "stale_reason": f"Persisted updater state remained in {phase} without a verified live installer process.",
             },
         )
+        return
+    if not attempt_id:
         return
     if phase in _RECOVERABLE_PHASES:
         if _RECONCILE_LOCK.acquire(blocking=False):
@@ -1253,6 +1526,27 @@ def _maybe_reconcile_pending_attempt() -> None:
             )
             thread.start()
         return
+
+
+def _status_view() -> dict[str, object]:
+    state = _read_state()
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    raw_phase = (
+        str(diagnostics.get("reconciled_from_phase") or state.get("phase") or "unknown").strip().lower()
+        or "unknown"
+    )
+    stale_reason = str(state.get("stale_reason") or diagnostics.get("stale_reason") or "").strip() or None
+    is_stale = stale_reason is not None
+    current_phase = str(state.get("phase") or "unknown").strip().lower() or "unknown"
+    is_active = current_phase in _ACTIVE_PHASES and not is_stale
+    return {
+        **state,
+        "raw_phase": raw_phase,
+        "is_active": is_active,
+        "is_stale": is_stale,
+        "blocks_new_update": is_active,
+        "stale_reason": stale_reason,
+    }
 
 
 class ApplyRequest(BaseModel):
@@ -1284,7 +1578,7 @@ def create_updater_app() -> FastAPI:
     def status(x_mediamop_updater_token: str | None = Header(default=None, alias="X-MediaMop-Updater-Token")) -> dict[str, object]:
         _require_token(x_mediamop_updater_token)
         _maybe_reconcile_pending_attempt()
-        return _read_state()
+        return _status_view()
 
     @app.post("/api/v1/apply")
     def apply_update(
@@ -1304,6 +1598,7 @@ def create_updater_app() -> FastAPI:
             attempt_id = uuid.uuid4().hex
             with _STATE_LOCK:
                 _persist_state(_fresh_attempt_state(target_version, attempt_id))
+            helper_command = _helper_command(attempt_id)
             try:
                 helper = _launch_helper(attempt_id)
             except Exception as exc:
@@ -1314,7 +1609,12 @@ def create_updater_app() -> FastAPI:
                     diagnostics={"attempt_id": attempt_id},
                 )
                 raise HTTPException(status_code=500, detail="Failed to start MediaMop upgrade helper.") from exc
-            _write_state(diagnostics={"helper_pid": helper.pid})
+            _write_state(
+                diagnostics={
+                    "helper_pid": helper.pid,
+                    "helper_executable_path": helper_command[0],
+                }
+            )
             _append_service_log(f"Upgrade helper launched for {target_version} (attempt_id={attempt_id}, pid={helper.pid}).")
             return {
                 "accepted": True,

--- a/apps/backend/tests/test_suite_update_service.py
+++ b/apps/backend/tests/test_suite_update_service.py
@@ -80,6 +80,8 @@ def test_windows_updater_service_ready_requires_authenticated_status(monkeypatch
         assert summary == "Remote in-app upgrade is ready on this Windows install."
         assert progress is not None
         assert progress.phase == "installer_running"
+        assert progress.is_active is True
+        assert progress.blocks_new_update is True
         assert observed["url"] == f"{update_service._updater_base_url()}/api/v1/status"
         assert observed["headers"] == {"X-MediaMop-Updater-Token": "token-value"}
         assert observed["timeout"] == 3.0
@@ -178,6 +180,78 @@ def test_build_suite_update_status_includes_upgrade_progress(monkeypatch: pytest
     assert status.upgrade is not None
     assert status.upgrade.phase == "verifying_install"
     assert status.upgrade.attempt_id == "attempt-123"
+    assert status.upgrade.is_active is True
+
+
+def test_coerce_upgrade_progress_hides_idle_state() -> None:
+    assert (
+        update_service._coerce_upgrade_progress(
+            {
+                "phase": "idle",
+                "message": "Updater ready.",
+            }
+        )
+        is None
+    )
+
+
+def test_coerce_upgrade_progress_marks_stale_completed_state_non_blocking() -> None:
+    progress = update_service._coerce_upgrade_progress(
+        {
+            "phase": "completed",
+            "raw_phase": "installer_running",
+            "message": "Upgrade completed. Running version: 2.1.0.",
+            "target_version": "2.1.0",
+            "is_active": False,
+            "blocks_new_update": False,
+            "stale_reason": "Persisted updater state could not prove the original installer process was still active.",
+        }
+    )
+
+    assert progress is not None
+    assert progress.phase == "completed"
+    assert progress.raw_phase == "installer_running"
+    assert progress.is_active is False
+    assert progress.is_stale is True
+    assert progress.blocks_new_update is False
+
+
+def test_build_suite_update_status_keeps_newer_release_available_when_old_state_is_stale(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("2.1.2"),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "2.1.0")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._detect_install_type", lambda: "windows")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_windows_updater_progress",
+        lambda _settings=None: (
+            True,
+            "Remote in-app upgrade is ready on this Windows install.",
+            update_service._coerce_upgrade_progress(
+                {
+                    "phase": "completed",
+                    "raw_phase": "installer_running",
+                    "message": "Upgrade completed. Running version: 2.1.0.",
+                    "target_version": "2.1.0",
+                    "current_version_seen": "2.1.0",
+                    "is_active": False,
+                    "blocks_new_update": False,
+                    "stale_reason": "Persisted updater state could not prove the original installer process was still active.",
+                }
+            ),
+        ),
+    )
+
+    status = update_service.build_suite_update_status()
+
+    assert status.status == "update_available"
+    assert status.latest_version == "2.1.2"
+    assert status.upgrade is not None
+    assert status.upgrade.is_active is False
+    assert status.upgrade.blocks_new_update is False
 
 
 def test_start_suite_update_now_returns_attempt_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,114 @@ def test_apply_update_starts_helper_and_returns_attempt_id(tmp_path: Path, monke
     assert state["attempt_id"] == "attempt-123"
     assert state["target_version"] == "2.0.8"
     assert state["diagnostics"]["helper_pid"] == 4321
+
+
+def test_process_matches_attempt_rejects_reused_pid_with_wrong_path(monkeypatch) -> None:
+    started_at = datetime(2026, 5, 7, 4, 39, 51, tzinfo=UTC)
+    monkeypatch.setattr(
+        updater_service,
+        "_read_process_snapshot",
+        lambda _pid: {
+            "pid": 4321,
+            "executable_path": r"C:\Windows\System32\notepad.exe",
+            "command_line": r'"C:\Windows\System32\notepad.exe"',
+            "creation_time_utc": (started_at + timedelta(seconds=20)).isoformat(),
+        },
+    )
+
+    assert (
+        updater_service._process_matches_attempt(
+            4321,
+            expected_path=r"C:\ProgramData\MediaMop\upgrades\MediaMopSetup-2.1.0.exe",
+            attempt_started_at=started_at,
+        )
+        is False
+    )
+
+
+def test_process_matches_attempt_rejects_matching_path_with_older_creation_time(monkeypatch) -> None:
+    started_at = datetime(2026, 5, 7, 4, 39, 51, tzinfo=UTC)
+    expected_path = r"C:\ProgramData\MediaMop\upgrades\MediaMopSetup-2.1.0.exe"
+    monkeypatch.setattr(
+        updater_service,
+        "_read_process_snapshot",
+        lambda _pid: {
+            "pid": 4321,
+            "executable_path": expected_path,
+            "command_line": f'"{expected_path}" /VERYSILENT',
+            "creation_time_utc": (started_at - timedelta(minutes=5)).isoformat(),
+        },
+    )
+
+    assert (
+        updater_service._process_matches_attempt(
+            4321,
+            expected_path=expected_path,
+            attempt_started_at=started_at,
+        )
+        is False
+    )
+
+
+def test_process_matches_attempt_accepts_matching_path_after_attempt_start(monkeypatch) -> None:
+    started_at = datetime(2026, 5, 7, 4, 39, 51, tzinfo=UTC)
+    expected_path = r"C:\ProgramData\MediaMop\upgrades\MediaMopSetup-2.1.0.exe"
+    monkeypatch.setattr(
+        updater_service,
+        "_read_process_snapshot",
+        lambda _pid: {
+            "pid": 4321,
+            "executable_path": expected_path,
+            "command_line": f'"{expected_path}" /VERYSILENT',
+            "creation_time_utc": (started_at + timedelta(seconds=10)).isoformat(),
+        },
+    )
+
+    assert (
+        updater_service._process_matches_attempt(
+            4321,
+            expected_path=expected_path,
+            attempt_started_at=started_at,
+        )
+        is True
+    )
+
+
+def test_process_matches_attempt_accepts_matching_command_line_when_path_missing(monkeypatch) -> None:
+    started_at = datetime(2026, 5, 7, 4, 39, 51, tzinfo=UTC)
+    expected_path = r"C:\ProgramData\MediaMop\upgrades\MediaMopSetup-2.1.0.exe"
+    monkeypatch.setattr(
+        updater_service,
+        "_read_process_snapshot",
+        lambda _pid: {
+            "pid": 4321,
+            "executable_path": None,
+            "command_line": f'"{expected_path}" /VERYSILENT',
+            "creation_time_utc": (started_at + timedelta(seconds=10)).isoformat(),
+        },
+    )
+
+    assert (
+        updater_service._process_matches_attempt(
+            4321,
+            expected_path=expected_path,
+            attempt_started_at=started_at,
+        )
+        is True
+    )
+
+
+def test_process_matches_attempt_returns_false_when_snapshot_is_unverifiable(monkeypatch) -> None:
+    monkeypatch.setattr(updater_service, "_read_process_snapshot", lambda _pid: None)
+
+    assert (
+        updater_service._process_matches_attempt(
+            4321,
+            expected_path=r"C:\ProgramData\MediaMop\upgrades\MediaMopSetup-2.1.0.exe",
+            attempt_started_at=datetime(2026, 5, 7, 4, 39, 51, tzinfo=UTC),
+        )
+        is False
+    )
 
 
 def test_perform_upgrade_attempt_marks_completed_only_after_verified_version(
@@ -594,10 +703,13 @@ def test_reconcile_attempt_worker_fails_when_installer_does_not_exit_in_time(
     monkeypatch,
 ) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.0.8-attempt-123.exe"
+    installer.write_bytes(b"installer")
     updater_service._persist_state(
         {
             **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
             "phase": "installer_running",
+            "downloaded_installer_path": str(installer),
             "diagnostics": {"helper_pid": None, "installer_pid": 6789},
         }
     )
@@ -605,7 +717,7 @@ def test_reconcile_attempt_worker_fails_when_installer_does_not_exit_in_time(
 
     monkeypatch.setattr(updater_service.time, "time", lambda: next(clock))
     monkeypatch.setattr(updater_service.time, "sleep", lambda _seconds: None)
-    monkeypatch.setattr(updater_service, "_pid_is_running", lambda pid: pid == 6789)
+    monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: True)
 
     updater_service._reconcile_attempt_worker("attempt-123")
     state = updater_service._read_state()
@@ -651,6 +763,56 @@ def test_apply_update_persists_state_before_launching_helper(tmp_path: Path, mon
     }
 
 
+def test_stable_or_active_attempt_exists_does_not_block_completed_target_version(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.0.8-attempt-123.exe"
+    installer.write_bytes(b"installer")
+    state = {
+        **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+        "phase": "installer_running",
+        "downloaded_installer_path": str(installer),
+        "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+    }
+    monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: False)
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {"backend_version": target_version, "packaged_version": target_version},
+        ),
+    )
+
+    assert updater_service._stable_or_active_attempt_exists(state) is False
+
+
+def test_stable_or_active_attempt_exists_does_not_block_when_running_version_exceeds_target(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.1.0-attempt-123.exe"
+    installer.write_bytes(b"installer")
+    state = {
+        **updater_service._fresh_attempt_state("2.1.0", "attempt-123"),
+        "phase": "installer_running",
+        "downloaded_installer_path": str(installer),
+        "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+    }
+    monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: False)
+    monkeypatch.setattr(updater_service, "_state_matches_installed_target", lambda _target_version: (False, {}))
+    monkeypatch.setattr(
+        updater_service,
+        "_state_running_version_exceeds_target",
+        lambda target_version: (True, {"backend_version": "2.1.2"}, "2.1.2"),
+    )
+
+    assert updater_service._stable_or_active_attempt_exists(state) is False
+
+
 def test_maybe_reconcile_pending_attempt_marks_stale_attempt_failed(tmp_path: Path, monkeypatch) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
     state_path = updater_service._state_path()
@@ -675,6 +837,196 @@ def test_maybe_reconcile_pending_attempt_marks_stale_attempt_failed(tmp_path: Pa
 
     assert state["phase"] == "failed"
     assert "stalled during downloading" in str(state["last_error"]).lower()
+
+
+def test_maybe_reconcile_pending_attempt_marks_already_running_target_completed(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.0.8-attempt-123.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+            "phase": "installer_running",
+            "downloaded_installer_path": str(installer),
+            "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+        }
+    )
+    Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: False)
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["current_version_seen"] == "2.0.8"
+    assert state["diagnostics"]["reconciled_after_restart"] is True
+
+
+def test_maybe_reconcile_pending_attempt_reconciles_unverifiable_installer_identity(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.0.8-attempt-123.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.0.8", "attempt-123"),
+            "phase": "installer_running",
+            "downloaded_installer_path": str(installer),
+            "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+        }
+    )
+    Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_read_process_snapshot", lambda _pid: None)
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert "could not prove" in str(state["diagnostics"]["stale_reason"]).lower()
+
+
+def test_maybe_reconcile_pending_attempt_recovers_legacy_active_state_without_attempt_id(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            "phase": "installer_running",
+            "message": "MediaMop 2.1.0 installer is running.",
+            "target_version": "2.1.0",
+            "last_started_at": "2026-05-07T04:39:51+00:00",
+            "installer_log_path": str(tmp_path / "installer-latest.log"),
+        }
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["current_version_seen"] == "2.1.0"
+    assert state["diagnostics"]["reconciled_after_restart"] is True
+
+
+def test_maybe_reconcile_pending_attempt_fails_obsolete_legacy_state_without_attempt_id(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            "phase": "installer_running",
+            "message": "MediaMop 2.1.0 installer is running.",
+            "target_version": "2.1.0",
+            "last_started_at": "2026-05-07T04:39:51+00:00",
+            "installer_log_path": str(tmp_path / "installer-latest.log"),
+        }
+    )
+    monkeypatch.setattr(updater_service, "_state_matches_installed_target", lambda _target_version: (False, {}))
+    monkeypatch.setattr(
+        updater_service,
+        "_state_running_version_exceeds_target",
+        lambda target_version: (
+            True,
+            {"backend_version": "2.1.2", "packaged_version": "2.1.2"},
+            "2.1.2",
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert state["current_version_seen"] == "2.1.2"
+    assert "still targeted 2.1.0" in str(state["last_error"]).lower()
+    assert state["diagnostics"]["reconciled_from_phase"] == "installer_running"
+
+
+def test_status_endpoint_reports_reconciled_legacy_state_as_non_active(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            "phase": "installer_running",
+            "message": "MediaMop 2.1.0 installer is running.",
+            "target_version": "2.1.0",
+            "last_started_at": "2026-05-07T04:39:51+00:00",
+            "installer_log_path": str(tmp_path / "installer-latest.log"),
+        }
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.get(
+                "/api/v1/status",
+                headers={"X-MediaMop-Updater-Token": "token"},
+            )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["phase"] == "completed"
+    assert body["raw_phase"] == "installer_running"
+    assert body["is_active"] is False
+    assert body["blocks_new_update"] is False
+    assert body["is_stale"] is True
+    assert "could not prove" in body["stale_reason"].lower()
 
 
 @pytest.mark.parametrize("phase", ["installer_running", "restarting", "verifying_install"])

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/layouts/app-shell.test.tsx
+++ b/apps/web/src/layouts/app-shell.test.tsx
@@ -16,7 +16,7 @@ vi.mock("../lib/dashboard/queries", () => ({
   useDashboardStatusQuery: () => ({
     data: {
       system: {
-        api_version: "2.1.1",
+        api_version: "2.1.2",
       },
     },
   }),
@@ -46,7 +46,7 @@ describe("AppShell", () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText("Version 2.1.1")).toBeInTheDocument();
+    expect(screen.getByText("Version 2.1.2")).toBeInTheDocument();
     expect(screen.getByTestId("sign-out")).toBeInTheDocument();
     expect(screen.queryByTestId("sidebar-support")).not.toBeInTheDocument();
     expect(screen.queryByText("Support MediaMop")).not.toBeInTheDocument();

--- a/apps/web/src/lib/suite/types.ts
+++ b/apps/web/src/lib/suite/types.ts
@@ -86,7 +86,12 @@ export type SuiteUpdateStartOut = {
 
 export type SuiteUpgradeProgressOut = {
   phase: string;
+  raw_phase?: string | null;
   message: string;
+  is_active?: boolean;
+  is_stale?: boolean;
+  blocks_new_update?: boolean;
+  stale_reason?: string | null;
   attempt_id?: string | null;
   target_version?: string | null;
   current_version_seen?: string | null;

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -599,6 +599,107 @@ describe("SettingsPage (suite settings)", () => {
         "Installer is running. MediaMop may temporarily disconnect.",
       ),
     ).toBeInTheDocument();
+    expect(screen.queryByText("installer_running")).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Phase:/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the refresh button stable while upgrade polling is active", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "installer_running",
+          message: "Installer is running. MediaMop may temporarily disconnect.",
+          attempt_id: "attempt-123",
+          target_version: "2.0.8",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.getByRole("button", { name: "Checking progress..." }),
+    ).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Check again" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the refresh button label stable while refetching with stable status data", async () => {
+    vi.spyOn(suiteSettingsApi, "fetchSuiteUpdateStatus").mockImplementation(
+      () => new Promise(() => {}),
+    );
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0 } },
+    });
+    qc.setQueryData(suiteSettingsQueryKey, minimalSuiteSettings);
+    qc.setQueryData(suiteSecurityOverviewQueryKey, minimalSecurity);
+    qc.setQueryData(qk.me, operatorMe);
+    qc.setQueryData(qk.session, minimalCurrentSession);
+    qc.setQueryData(suiteConfigurationBackupsQueryKey, {
+      directory: "C:/MediaMop/backups/suite-configuration",
+      items: [],
+    });
+    qc.setQueryData(suiteUpdateStatusQueryKey, windowsUpdateAvailableStatus);
+    qc.setQueryData(
+      [
+        ...suiteLogsQueryKey,
+        {
+          level: undefined,
+          search: undefined,
+          has_exception: undefined,
+          limit: 100,
+        },
+      ],
+      minimalLogs,
+    );
+    qc.setQueryData(suiteMetricsQueryKey, minimalMetrics);
+
+    render(wrap(<SettingsPage />, qc));
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Check again" }),
+      ).toBeDisabled();
+    });
+    expect(
+      screen.queryByRole("button", { name: "Checking..." }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render a stale old upgrade state as active when a newer release is available", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        current_version: "2.1.0",
+        latest_version: "2.1.2",
+        latest_name: "MediaMop 2.1.2",
+        summary: "MediaMop 2.1.2 is available.",
+        upgrade: {
+          phase: "completed",
+          raw_phase: "installer_running",
+          message: "Upgrade completed. Running version: 2.1.0.",
+          is_active: false,
+          is_stale: true,
+          blocks_new_update: false,
+          stale_reason:
+            "Persisted updater state could not prove the original installer process was still active.",
+          target_version: "2.1.0",
+          current_version_seen: "2.1.0",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+
+    expect(
+      screen.getByRole("button", { name: "Upgrade now" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Installer running")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Upgrade completed. Running version: 2.1.0."),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("installer_running")).not.toBeInTheDocument();
   });
 
   it("does not treat completed phase as success until the running version matches the target", () => {
@@ -710,9 +811,18 @@ describe("SettingsPage (suite settings)", () => {
         "Upgrade failed: MediaMop did not verify version 2.0.8 within 8 minutes. The running app still reports 2.0.7.",
       ),
     ).toHaveLength(2);
-    expect(screen.getByText("Phase: verification_timeout")).toBeInTheDocument();
+    expect(screen.getByText("Status: Failed")).toBeInTheDocument();
     expect(screen.getByText("Attempt ID: attempt-123")).toBeInTheDocument();
     expect(screen.getByText("Current version seen: 2.0.7")).toBeInTheDocument();
+  });
+
+  it("does not render mojibake in the upgrade panel", () => {
+    renderSettings(operatorMe, { updateStatus: windowsUpdateAvailableStatus });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+
+    expect(document.body.textContent).not.toContain("â");
+    expect(document.body.textContent).not.toContain("Ã");
+    expect(document.body.textContent).not.toContain("�");
   });
 
   it("shows change password only on Security tab", () => {

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -347,12 +347,12 @@ function describeUpgradeProgress(
   const progressIsActive = isUpgradeProgressActive(progress);
   const hideHistoricalCompletedSummary = Boolean(
     progress &&
-      progress.phase === "completed" &&
-      status &&
-      progress.target_version &&
-      status.current_version === progress.target_version &&
-      status.status === "update_available" &&
-      !monitor?.active,
+    progress.phase === "completed" &&
+    status &&
+    progress.target_version &&
+    status.current_version === progress.target_version &&
+    status.status === "update_available" &&
+    !monitor?.active,
   );
   if (monitor?.timedOutReason) {
     return {
@@ -1963,9 +1963,7 @@ export function SettingsPage() {
                                 upgradeMonitor?.attemptId}
                             </p>
                           ) : null}
-                          <p>
-                            Status: {upgradeProgressSummary.label}
-                          </p>
+                          <p>Status: {upgradeProgressSummary.label}</p>
                           {activeUpgradeProgress?.current_version_seen ||
                           updateStatusQ.data.current_version ? (
                             <p>

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -308,6 +308,18 @@ function isUpgradeActivePhase(phase: string | null | undefined): boolean {
   );
 }
 
+function isUpgradeProgressActive(
+  progress: SuiteUpgradeProgressOut | null | undefined,
+): boolean {
+  if (!progress) {
+    return false;
+  }
+  if (typeof progress.is_active === "boolean") {
+    return progress.is_active;
+  }
+  return isUpgradeActivePhase(progress.phase) && !progress.is_stale;
+}
+
 function upgradePhaseTone(
   status: SuiteUpdateStatusOut | undefined,
   progress: SuiteUpgradeProgressOut | null | undefined,
@@ -332,6 +344,16 @@ function describeUpgradeProgress(
   monitor: UpgradeMonitor | null,
   disconnected: boolean,
 ): { label: string; body: string } | null {
+  const progressIsActive = isUpgradeProgressActive(progress);
+  const hideHistoricalCompletedSummary = Boolean(
+    progress &&
+      progress.phase === "completed" &&
+      status &&
+      progress.target_version &&
+      status.current_version === progress.target_version &&
+      status.status === "update_available" &&
+      !monitor?.active,
+  );
   if (monitor?.timedOutReason) {
     return {
       label: "Failed",
@@ -352,6 +374,17 @@ function describeUpgradeProgress(
       label: "Waiting",
       body: "Upgrade request accepted. MediaMop is checking release metadata.",
     };
+  }
+  if (
+    !monitor?.active &&
+    progress.phase !== "failed" &&
+    !progressIsActive &&
+    progress.phase !== "completed"
+  ) {
+    return null;
+  }
+  if (hideHistoricalCompletedSummary) {
+    return null;
   }
   switch (progress.phase) {
     case "checking":
@@ -577,24 +610,31 @@ export function SettingsPage() {
   const upgradeInProgress =
     !upgradeMonitor?.timedOutReason &&
     (Boolean(upgradeMonitor?.active) ||
-      isUpgradeActivePhase(activeUpgradeProgress?.phase));
+      isUpgradeProgressActive(activeUpgradeProgress));
+  const hasStableUpdateStatus = Boolean(updateStatusQ.data);
+  const upgradeRefreshBusy = upgradeInProgress || updateStatusQ.isFetching;
+  const upgradeRefreshLabel = upgradeInProgress
+    ? "Checking progress..."
+    : !hasStableUpdateStatus && updateStatusQ.isFetching
+      ? "Checking..."
+      : "Check again";
 
   useEffect(() => {
-    if (isUpgradeActivePhase(activeUpgradeProgress?.phase)) {
+    if (isUpgradeProgressActive(activeUpgradeProgress)) {
       setUpgradePollActive(true);
       return;
     }
     if (!upgradeMonitor?.active) {
       setUpgradePollActive(false);
     }
-  }, [activeUpgradeProgress?.phase, upgradeMonitor?.active]);
+  }, [activeUpgradeProgress, upgradeMonitor?.active]);
 
   useEffect(() => {
     if (!updateStatusQ.data?.upgrade) {
       return;
     }
     const progress = updateStatusQ.data.upgrade;
-    if (!isUpgradeActivePhase(progress.phase)) {
+    if (!isUpgradeProgressActive(progress)) {
       return;
     }
     setUpgradeMonitor((current) => {
@@ -1924,10 +1964,7 @@ export function SettingsPage() {
                             </p>
                           ) : null}
                           <p>
-                            Phase:{" "}
-                            {upgradeMonitor?.timedOutReason
-                              ? "verification_timeout"
-                              : activeUpgradeProgress?.phase || "unknown"}
+                            Status: {upgradeProgressSummary.label}
                           </p>
                           {activeUpgradeProgress?.current_version_seen ||
                           updateStatusQ.data.current_version ? (
@@ -1970,12 +2007,12 @@ export function SettingsPage() {
                       type="button"
                       className={mmActionButtonClass({
                         variant: "secondary",
-                        disabled: updateStatusQ.isFetching,
+                        disabled: upgradeRefreshBusy,
                       })}
-                      disabled={updateStatusQ.isFetching}
+                      disabled={upgradeRefreshBusy}
                       onClick={() => void updateStatusQ.refetch()}
                     >
-                      {updateStatusQ.isFetching ? "Checking…" : "Check again"}
+                      {upgradeRefreshLabel}
                     </button>
                     {updateStatusQ.data.install_type === "windows" &&
                     updateStatusQ.data.status === "update_available" &&
@@ -1990,9 +2027,9 @@ export function SettingsPage() {
                         onClick={() => void handleUpgradeNow()}
                       >
                         {updateNow.isPending
-                          ? "Starting upgrade…"
+                          ? "Starting upgrade..."
                           : upgradeInProgress
-                            ? "Upgrade in progressâ€¦"
+                            ? "Upgrade in progress..."
                             : "Upgrade now"}
                       </button>
                     ) : null}

--- a/docs/release-notes/v2.1.2.md
+++ b/docs/release-notes/v2.1.2.md
@@ -1,0 +1,32 @@
+# MediaMop v2.1.2
+
+Date: 2026-05-07
+
+This release focuses on making Windows in-app upgrades recover cleanly from stale installer state and only report success after the new version is actually running.
+
+## What Changed
+
+- Windows in-app upgrades now clear stale upgrade state left behind by older installs instead of showing a false upgrade in progress banner.
+- The Upgrade tab stays stable while it polls real updater progress, without corrupted text or a flickering refresh button.
+- Installer downloads remain tied to the trusted MediaMop release with checksum verification before execution.
+
+## Fixes And Stability
+
+- Stale `installer_running` state from an older version no longer blocks a newer available upgrade.
+- Windows PID reuse can no longer make an old installer attempt look alive just because the same PID was reused.
+- Legacy updater state files now self-heal after restart instead of requiring manual cleanup before the next upgrade.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- This release keeps the completion gate strict: MediaMop only reports the upgrade complete after the running version matches the target version.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.1.2`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.1.1...v2.1.2

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.1.1"
+  #define AppVersion "2.1.2"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- harden Windows updater stale-state reconciliation and PID identity checks
- expose active/stale/blocking semantics to the Upgrade tab and stabilize the UI
- bump release metadata to 2.1.2 and add release notes

## Validation
- backend focused updater tests
- backend full pytest
- ruff and mypy
- web settings tests, full web tests, lint, build
- packaging/windows/build.ps1 with MEDIAMOP_BUILD_VERSION=2.1.2
- scripts/smoke-windows-package.ps1 -ExpectedVersion 2.1.2