### PR TITLE
Release 2.1.3: updater fixes, support build config, and UI polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
+  VITE_SUPPORT_URL: ${{ vars.VITE_SUPPORT_URL }}
 
 jobs:
   windows-smoke:
@@ -92,6 +93,8 @@ jobs:
 
       - name: MediaMop web - install and build
         working-directory: apps/web
+        env:
+          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
         run: |
           npm ci
           npm run build
@@ -102,6 +105,7 @@ jobs:
       - name: Build MediaMop Windows installer
         env:
           MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}
+          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
       - name: Smoke test packaged Windows server
@@ -204,6 +208,8 @@ jobs:
 
       - name: MediaMop web - install, build, unit tests
         working-directory: apps/web
+        env:
+          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
         run: |
           npm ci
           npm run build

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ If MediaMop saves you time or helps keep your library cleaner, you can support o
 
 Set `VITE_SUPPORT_URL` in `apps/web/.env` or your deployment environment to show the in-app support button.
 
+`VITE_SUPPORT_URL` is a Vite build-time variable. Set it before running `npm run build` or packaging a release. Changing it after the frontend has been built or after a Windows installer has been packaged does not update the installed UI until the frontend is rebuilt and repackaged.
+
+Official GitHub releases should set the repository variable `VITE_SUPPORT_URL` to `https://github.com/sponsors/jampat000` so the packaged production frontend includes **Settings > Support**.
+
 ## Verification
 
 Optional local verification:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.2"
+version = "2.1.3"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -851,15 +851,15 @@ def _download_installer(url: str, *, target_version: str, attempt_id: str) -> Pa
     total = 0
     client, response = _open_trusted_download_stream(url)
     try:
-        with response:
-            tmp.parent.mkdir(parents=True, exist_ok=True)
-            with tmp.open("wb") as handle:
-                for chunk in response.iter_bytes():
-                    if not chunk:
-                        continue
-                    handle.write(chunk)
-                    total += len(chunk)
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        with tmp.open("wb") as handle:
+            for chunk in response.iter_bytes():
+                if not chunk:
+                    continue
+                handle.write(chunk)
+                total += len(chunk)
     finally:
+        response.close()
         client.close()
     if total < _MIN_INSTALLER_BYTES:
         tmp.unlink(missing_ok=True)

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -468,6 +468,51 @@ def test_perform_upgrade_attempt_fails_on_sha256_mismatch(
     assert "sha-256 mismatch" in str(state["last_error"]).lower()
 
 
+def test_download_installer_streams_response_without_context_manager(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    monkeypatch.setattr(updater_service, "_MIN_INSTALLER_BYTES", 4)
+
+    class _Client:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _Response:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def iter_bytes(self):
+            yield b"abcd"
+            yield b"efgh"
+
+        def close(self) -> None:
+            self.closed = True
+
+    client = _Client()
+    response = _Response()
+    monkeypatch.setattr(
+        updater_service,
+        "_open_trusted_download_stream",
+        lambda _url: (client, response),
+    )
+
+    downloaded = updater_service._download_installer(
+        "https://github.com/jampat000/MediaMop/releases/download/v2.1.2/MediaMopSetup.exe",
+        target_version="2.1.2",
+        attempt_id="attempt-123",
+    )
+
+    assert downloaded.exists()
+    assert downloaded.read_bytes() == b"abcdefgh"
+    assert response.closed is True
+    assert client.closed is True
+
+
 def test_perform_upgrade_attempt_allows_missing_checksum_only_with_explicit_override(
     tmp_path: Path,
     monkeypatch,

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -7,4 +7,4 @@
 
 # Optional support/sponsorship URL for the in-app "Support MediaMop" button.
 # Keep unset to hide the button in production.
-# VITE_SUPPORT_URL=https://github.com/sponsors/your-github-username
+# VITE_SUPPORT_URL=https://github.com/sponsors/jampat000

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.2",
+  "version": "2.1.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/support.test.ts
+++ b/apps/web/src/lib/support.test.ts
@@ -20,6 +20,8 @@ describe("support helpers", () => {
     expect(normalizeSupportUrl("   ")).toBeNull();
     expect(normalizeSupportUrl("not-a-url")).toBeNull();
     expect(normalizeSupportUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeSupportUrl("mailto:support@example.com")).toBeNull();
+    expect(normalizeSupportUrl("file:///tmp/support-link")).toBeNull();
   });
 
   it("only shows placeholder in development when no URL is configured", () => {

--- a/apps/web/src/pages/activity/activity-page.test.tsx
+++ b/apps/web/src/pages/activity/activity-page.test.tsx
@@ -158,4 +158,37 @@ describe("ActivityPage", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("keeps long activity titles wrappable while preserving the full title", () => {
+    const fileName =
+      "Fantastic.Beasts.The.Secrets.of.Dumbledore.2022.UHD.BluRay.2160p.TrueHD.Atmos.FraMeSToR.mkv";
+    const longTitle = `${fileName} was processed successfully`;
+    useActivityRecentQuery.mockReturnValue({
+      isPending: false,
+      isError: false,
+      data: {
+        items: [
+          {
+            id: 3,
+            created_at: "2026-05-07T03:45:00Z",
+            event_type: "refiner.file_remux_pass_completed",
+            module: "refiner",
+            title: longTitle,
+            detail: JSON.stringify({
+              outcome: "ok",
+              relative_media_path: fileName,
+            }),
+          },
+        ],
+        total: 1,
+        system_events: 0,
+      },
+    });
+
+    render(<ActivityPage />);
+
+    const heading = screen.getByRole("heading", { name: longTitle });
+    expect(heading).toHaveAttribute("title", longTitle);
+    expect(heading.className).toContain("[overflow-wrap:anywhere]");
+  });
 });

--- a/apps/web/src/pages/activity/activity-page.tsx
+++ b/apps/web/src/pages/activity/activity-page.tsx
@@ -1167,7 +1167,7 @@ export function ActivityPage() {
                 data-testid="activity-row"
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="space-y-2">
+                  <div className="min-w-0 flex-1 space-y-2">
                     <div className="flex flex-wrap items-center gap-2">
                       <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-gold)]">
                         {ev.module === "system" ||
@@ -1182,10 +1182,13 @@ export function ActivityPage() {
                         {display.chip}
                       </span>
                     </div>
-                    <h2 className="text-lg font-semibold text-[var(--mm-text1)]">
+                    <h2
+                      className="min-w-0 break-words text-lg font-semibold text-[var(--mm-text1)] [overflow-wrap:anywhere]"
+                      title={display.title}
+                    >
                       {display.title}
                     </h2>
-                    <p className="text-sm text-[var(--mm-text3)]">
+                    <p className="break-words text-sm text-[var(--mm-text3)]">
                       {display.summary}
                     </p>
                   </div>

--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -283,4 +283,36 @@ describe("DashboardPage", () => {
       screen.getByText(/Refiner workers: Refiner expected 1 worker/),
     ).toBeInTheDocument();
   });
+
+  it("keeps long last-activity file names compact without losing the full title", () => {
+    const longTitle =
+      "Fantastic.Beasts.The.Secrets.of.Dumbledore.2022.UHD.BluRay.2160p.TrueHD.Atmos.FraMeSToR.mkv was processed successfully";
+    useActivityRecentQuery.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 1,
+            created_at: "2026-05-07T15:45:00Z",
+            event_type: "refiner.file.remux_pass_completed",
+            module: "refiner",
+            title: longTitle,
+            detail: null,
+          },
+        ],
+        total: 1,
+        system_events: 0,
+      },
+    });
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const compactValue = screen.getByTitle(longTitle);
+    expect(compactValue).toHaveTextContent("…");
+    expect(compactValue.textContent).not.toBe(longTitle);
+    expect(screen.getByText("2026-05-07T15:45:00Z")).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -92,7 +92,11 @@ const REFINER_DASHBOARD_JOB_KINDS = new Set([
   "refiner.supplied_payload_evaluation.v1",
 ]);
 
-function compactMetricText(text: string, maxLength = 84, tailLength = 28): string {
+function compactMetricText(
+  text: string,
+  maxLength = 84,
+  tailLength = 28,
+): string {
   const normalized = text.trim();
   if (normalized.length <= maxLength) {
     return normalized;

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -79,6 +79,12 @@ type DashboardJobRow = {
   updated_at: string;
 };
 
+type DashboardMetricValue = {
+  value: string;
+  detail?: string;
+  valueTitle?: string;
+};
+
 const REFINER_FILE_REMUX_PASS_JOB_KIND = "refiner.file.remux_pass.v1";
 const REFINER_DASHBOARD_JOB_KINDS = new Set([
   REFINER_FILE_REMUX_PASS_JOB_KIND,
@@ -86,13 +92,29 @@ const REFINER_DASHBOARD_JOB_KINDS = new Set([
   "refiner.supplied_payload_evaluation.v1",
 ]);
 
+function compactMetricText(text: string, maxLength = 84, tailLength = 28): string {
+  const normalized = text.trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  const tail = Math.max(12, Math.min(tailLength, maxLength - 16));
+  const head = Math.max(16, maxLength - tail - 1);
+  return `${normalized.slice(0, head).trimEnd()}…${normalized.slice(-tail).trimStart()}`;
+}
+
 function shortLastActivity(
   items: ActivityEventItem[],
   fmt: (iso: string) => string,
-): string {
-  if (items.length === 0) return "No recent activity";
+): DashboardMetricValue {
+  if (items.length === 0) {
+    return { value: "No recent activity" };
+  }
   const ev = items[0];
-  return `${ev.title} - ${fmt(ev.created_at)}`;
+  return {
+    value: compactMetricText(ev.title),
+    detail: fmt(ev.created_at),
+    valueTitle: ev.title,
+  };
 }
 
 function healthTone(status: ModuleStatus): string {
@@ -152,24 +174,26 @@ function MetricCard({
   label,
   value,
   detail,
+  valueTitle,
 }: {
   label: string;
   value: string;
   detail?: string;
+  valueTitle?: string;
 }) {
   return (
-    <section className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3">
+    <section className="min-w-0 rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-4 py-3">
       <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[var(--mm-text3)]">
         {label}
       </p>
-      <p className="mt-1 text-lg font-semibold text-[var(--mm-text1)]">
+      <p
+        className="mt-1 min-w-0 text-lg font-semibold leading-snug text-[var(--mm-text1)] [overflow-wrap:anywhere]"
+        title={valueTitle ?? value}
+      >
         {value}
       </p>
       {detail ? (
-        <p
-          className="mt-1 truncate text-xs text-[var(--mm-text3)]"
-          title={detail}
-        >
+        <p className="mt-1 text-xs text-[var(--mm-text3)]" title={detail}>
           {detail}
         </p>
       ) : null}
@@ -485,6 +509,7 @@ export function DashboardPage() {
   }
 
   const recentItems = recent.data?.items ?? [];
+  const lastActivityMetric = shortLastActivity(recentItems, fmt);
   const refinerCard = buildRefinerCard({
     processed: refinerStats.data?.files_processed ?? 0,
     failed: refinerStats.data?.files_failed ?? 0,
@@ -669,7 +694,9 @@ export function DashboardPage() {
         />
         <MetricCard
           label="Last activity"
-          value={shortLastActivity(recentItems, fmt)}
+          value={lastActivityMetric.value}
+          detail={lastActivityMetric.detail}
+          valueTitle={lastActivityMetric.valueTitle}
         />
       </section>
 

--- a/docs/release-notes/v2.1.3.md
+++ b/docs/release-notes/v2.1.3.md
@@ -1,0 +1,32 @@
+# MediaMop v2.1.3
+
+Date: 2026-05-08
+
+This release focuses on tightening Windows upgrade reliability, fixing a failed in-app installer download path, and shipping the Support tab correctly in official production builds.
+
+## What Changed
+
+- Official release builds now include **Settings -> Support** when the configured support URL is present in the GitHub Actions release environment.
+- Long media filenames now render more cleanly in dashboard and activity summary surfaces instead of pushing awkwardly through compact cards.
+- Windows release builds continue to verify trusted installer downloads and only report upgrade completion after the running version is confirmed.
+
+## Fixes And Stability
+
+- Fixed a Windows in-app upgrade failure where the updater used an invalid `httpx.Response` context-manager pattern while downloading the installer.
+- Stale legacy updater state still self-heals, and stale installer PID reuse still cannot block newer upgrades.
+- The Upgrade tab remains stable without mojibake text or flickering refresh labels while progress polling is active.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- Official packaged builds now depend on the release workflow repository variable `VITE_SUPPORT_URL` when you want **Settings -> Support** visible in production.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.1.3`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.1.2...v2.1.3

--- a/docs/release.md
+++ b/docs/release.md
@@ -54,6 +54,8 @@ The `Release` workflow:
 - runs the published Docker image and waits for `/health`
 - creates the GitHub Release
 
+`VITE_SUPPORT_URL` is a Vite build-time variable. Official releases should set the GitHub Actions repository variable `VITE_SUPPORT_URL` to `https://github.com/sponsors/jampat000` so the production frontend and packaged Windows installer include **Settings -> Support**. If that variable is missing, release builds still succeed, but production safely hides the Support tab.
+
 ## Registry authentication
 
 The release workflow publishes GHCR images with the repository `GITHUB_TOKEN` and
@@ -72,6 +74,13 @@ The release workflow publishes GHCR images with the repository `GITHUB_TOKEN` an
 ## Windows installer
 
 `MediaMopSetup.exe` is the supported Windows release artifact.
+
+If you build the Windows package locally and want the installer to include **Settings -> Support**, set `VITE_SUPPORT_URL` before running `packaging/windows/build.ps1`:
+
+```powershell
+$env:VITE_SUPPORT_URL = "https://github.com/sponsors/jampat000"
+powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
+```
 
 Important upgrade requirement:
 

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.1.2"
+  #define AppVersion "2.1.3"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- fix the Windows updater installer download failure and keep stale legacy updater state from blocking new upgrades
- improve long filename rendering in dashboard and activity summary surfaces
- inject VITE_SUPPORT_URL into official release builds and document the build-time support configuration
- bump MediaMop to 2.1.3 and add release notes

## Validation
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m pytest -q
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m ruff check src tests
- cd apps/backend && .\\.venv\\Scripts\\python.exe -m mypy src/mediamop
- cd apps/web && npm run lint
- cd apps/web && npm run test -- --run
- cd apps/web && npm run build
- $env:MEDIAMOP_BUILD_VERSION='2.1.3'; $env:VITE_SUPPORT_URL='https://github.com/sponsors/jampat000'; powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
- powershell -ExecutionPolicy Bypass -File scripts/smoke-windows-package.ps1 -ExpectedVersion 2.1.3