### PR TITLE
Release 2.1.4: fix support build env scoping

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  VITE_SUPPORT_URL: ${{ vars.VITE_SUPPORT_URL }}
 
 jobs:
   windows-smoke:
@@ -94,7 +93,7 @@ jobs:
       - name: MediaMop web - install and build
         working-directory: apps/web
         env:
-          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
+          VITE_SUPPORT_URL: ${{ vars.VITE_SUPPORT_URL }}
         run: |
           npm ci
           npm run build
@@ -105,7 +104,7 @@ jobs:
       - name: Build MediaMop Windows installer
         env:
           MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}
-          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
+          VITE_SUPPORT_URL: ${{ vars.VITE_SUPPORT_URL }}
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build.ps1
 
       - name: Smoke test packaged Windows server
@@ -206,14 +205,17 @@ jobs:
         with:
           node-version: "20"
 
-      - name: MediaMop web - install, build, unit tests
+      - name: MediaMop web - install and unit tests
         working-directory: apps/web
-        env:
-          VITE_SUPPORT_URL: ${{ env.VITE_SUPPORT_URL }}
         run: |
           npm ci
-          npm run build
           npm run test
+
+      - name: MediaMop web - production build
+        working-directory: apps/web
+        env:
+          VITE_SUPPORT_URL: ${{ vars.VITE_SUPPORT_URL }}
+        run: npm run build
 
       - name: Pack web dist
         run: |

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.3"
+version = "2.1.4"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.4.md
+++ b/docs/release-notes/v2.1.4.md
@@ -1,0 +1,20 @@
+# MediaMop v2.1.4
+
+This patch release finalizes the Windows updater fixes and corrects the official release build so the Settings > Support tab is included when the configured support URL is present at build time.
+
+## Highlights
+
+- Fixed Windows in-app upgrade reliability across download, verification, install, restart, and version confirmation.
+- Fixed stale `installer_running` updater state recovery, including PID reuse and legacy updater state self-healing.
+- Fixed the Windows updater installer download failure caused by incorrect `httpx.Response` handling.
+- Improved long filename rendering in dashboard and activity summary cards.
+- Fixed official release packaging so `VITE_SUPPORT_URL` is injected into production web builds without contaminating unit test environment behavior.
+
+## Operator notes
+
+- Official releases now include Settings > Support when the GitHub Actions repository variable `VITE_SUPPORT_URL` is set to a valid `http` or `https` URL.
+- MediaMop still does not mark an upgrade complete until the running version matches the target version.
+
+## Full diff
+
+- [v2.1.3...v2.1.4](https://github.com/jampat000/MediaMop/compare/v2.1.3...v2.1.4)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-  #define AppVersion "2.1.3"
+#define AppVersion "2.1.4"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- scope VITE_SUPPORT_URL to production build steps in the release workflow
- keep frontend unit tests environment-neutral in tagged releases
- bump MediaMop version metadata to 2.1.4 and add release notes

## Validation
- backend pytest -q
- backend ruff check src tests
- backend mypy src/mediamop
- web npm run test -- --run
- web npm run lint
- web npm run build
- windows build.ps1 with VITE_SUPPORT_URL and MEDIAMOP_BUILD_VERSION=2.1.4
- smoke-windows-package.ps1 -ExpectedVersion 2.1.4