### PR TITLE
Release 2.1.5: archive superseded updater failures

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.4"
+version = "2.1.5"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -700,6 +700,73 @@ def _mark_failed(
     )
 
 
+def _archive_superseded_failed_attempt() -> None:
+    state = _read_state()
+    phase = str(state.get("phase") or "").strip().lower()
+    if phase != "failed":
+        return
+    target_version = normalize_release_version(str(state.get("target_version") or ""))
+    if not target_version:
+        return
+
+    matched, install_diagnostics = _state_matches_installed_target(target_version)
+    observed_version = target_version
+    archive_reason: str | None = None
+    merged_diagnostics = dict(install_diagnostics)
+
+    if matched:
+        archive_reason = (
+            f"A previous upgrade attempt for MediaMop {target_version} failed, "
+            "but that version is now already installed and running."
+        )
+    else:
+        exceeded, install_diagnostics, newer_version = _state_running_version_exceeds_target(target_version)
+        if not exceeded:
+            return
+        observed_version = newer_version or observed_version
+        archive_reason = (
+            f"A previous upgrade attempt still targeted MediaMop {target_version}, "
+            f"but this install is already running newer version {observed_version}."
+        )
+        merged_diagnostics = dict(install_diagnostics)
+
+    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    attempt_id = str(state.get("attempt_id") or "").strip() or None
+    archived_diagnostics = dict(diagnostics)
+    archived_diagnostics.update(merged_diagnostics)
+    archived_diagnostics.update(
+        {
+            "archived_superseded_attempt": True,
+            "archived_from_phase": phase,
+            "archived_attempt_id": attempt_id,
+            "archived_target_version": target_version,
+            "archived_last_error": str(state.get("last_error") or "").strip() or None,
+            "archived_message": str(state.get("message") or "").strip() or None,
+            "archived_downloaded_installer_path": str(state.get("downloaded_installer_path") or "").strip() or None,
+            "stale_reason": archive_reason,
+        }
+    )
+    archived_diagnostics = {key: value for key, value in archived_diagnostics.items() if value is not None}
+
+    _append_service_log(
+        "Updater status archived a historical failed attempt because the target version is already installed "
+        f"(attempt_id={attempt_id or 'unknown'}, target_version={target_version}, observed_version={observed_version})."
+    )
+    _transition_state(
+        "idle",
+        "Updater ready.",
+        attempt_id=None,
+        target_version=None,
+        current_version_seen=observed_version,
+        downloaded_installer_path=None,
+        installer_sha256=None,
+        expected_sha256=None,
+        last_completed_at=_iso_now(),
+        last_error=None,
+        diagnostics=archived_diagnostics,
+    )
+
+
 def _harden_token_acl_windows(path: Path) -> None:
     principals = ["SYSTEM", "Administrators", "INTERACTIVE"]
     cmd = ["icacls", str(path), "/inheritance:r"]
@@ -1440,6 +1507,7 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
 
 
 def _maybe_reconcile_pending_attempt() -> None:
+    _archive_superseded_failed_attempt()
     state = _read_state()
     phase = str(state.get("phase") or "").strip().lower()
     if phase not in _ACTIVE_PHASES:

--- a/apps/backend/tests/test_suite_update_service.py
+++ b/apps/backend/tests/test_suite_update_service.py
@@ -254,6 +254,37 @@ def test_build_suite_update_status_keeps_newer_release_available_when_old_state_
     assert status.upgrade.blocks_new_update is False
 
 
+def test_build_suite_update_status_hides_archived_idle_upgrade_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service.fetch_latest_release_record",
+        lambda **_kwargs: _release_record("2.1.4"),
+    )
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service.__version__", "2.1.4")
+    monkeypatch.setattr("mediamop.platform.suite_settings.update_service._detect_install_type", lambda: "windows")
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.update_service._fetch_windows_updater_progress",
+        lambda _settings=None: (
+            True,
+            "Remote in-app upgrade is ready on this Windows install.",
+            update_service._coerce_upgrade_progress(
+                {
+                    "phase": "idle",
+                    "message": "Updater ready.",
+                    "current_version_seen": "2.1.4",
+                }
+            ),
+        ),
+    )
+
+    status = update_service.build_suite_update_status()
+
+    assert status.status == "up_to_date"
+    assert status.latest_version == "2.1.4"
+    assert status.upgrade is None
+
+
 def test_start_suite_update_now_returns_attempt_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     settings = type("Settings", (), {"mediamop_home": str(tmp_path)})()
     monkeypatch.setenv("MEDIAMOP_RUNTIME", "windows")

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1074,6 +1074,121 @@ def test_status_endpoint_reports_reconciled_legacy_state_as_non_active(
     assert "could not prove" in body["stale_reason"].lower()
 
 
+def test_maybe_reconcile_pending_attempt_archives_superseded_failed_attempt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.4", "attempt-123"),
+            "phase": "failed",
+            "message": "Upgrade failed.",
+            "last_error": "'httpx.Response' object does not support the context manager protocol",
+        }
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "idle"
+    assert state["attempt_id"] is None
+    assert state["target_version"] is None
+    assert state["current_version_seen"] == "2.1.4"
+    assert state["last_error"] is None
+    assert state["diagnostics"]["archived_superseded_attempt"] is True
+    assert state["diagnostics"]["archived_target_version"] == "2.1.4"
+    assert "already installed and running" in state["diagnostics"]["stale_reason"].lower()
+
+
+def test_maybe_reconcile_pending_attempt_archives_failed_attempt_when_running_version_is_newer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.4", "attempt-123"),
+            "phase": "failed",
+            "message": "Upgrade failed.",
+            "last_error": "historical failure",
+        }
+    )
+    monkeypatch.setattr(updater_service, "_state_matches_installed_target", lambda _target_version: (False, {}))
+    monkeypatch.setattr(
+        updater_service,
+        "_state_running_version_exceeds_target",
+        lambda target_version: (
+            True,
+            {"backend_version": "2.1.5", "packaged_version": "2.1.5"},
+            "2.1.5",
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "idle"
+    assert state["current_version_seen"] == "2.1.5"
+    assert state["diagnostics"]["archived_superseded_attempt"] is True
+    assert "newer version 2.1.5" in state["diagnostics"]["stale_reason"].lower()
+
+
+def test_status_endpoint_hides_superseded_failed_attempt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.4", "attempt-123"),
+            "phase": "failed",
+            "message": "Upgrade failed.",
+            "last_error": "historical failure",
+        }
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+            },
+        ),
+    )
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.get(
+                "/api/v1/status",
+                headers={"X-MediaMop-Updater-Token": "token"},
+            )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["phase"] == "idle"
+    assert body["is_active"] is False
+    assert body["blocks_new_update"] is False
+    assert body["attempt_id"] is None
+
+
 @pytest.mark.parametrize("phase", ["installer_running", "restarting", "verifying_install"])
 def test_maybe_reconcile_pending_attempt_resumes_verification_for_recoverable_phases(
     tmp_path: Path,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.4",
+  "version": "2.1.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.5.md
+++ b/docs/release-notes/v2.1.5.md
@@ -1,0 +1,19 @@
+# MediaMop v2.1.5
+
+This patch release cleans up the Windows Upgrade screen after a failed in-app attempt has later been superseded by a successful manual install.
+
+## Highlights
+
+- Fixed stale failed updater state remaining visible after MediaMop is already running the target version.
+- Historical failed attempts are now archived once MediaMop proves the target version is already installed and healthy.
+- Preserved updater diagnostics and installer logs for support without continuing to show the old failure as a live upgrade problem.
+- Kept the verified Windows upgrade flow, checksum validation, and running-version completion gate introduced in earlier 2.1.x releases.
+
+## Operator notes
+
+- A previous failed attempt should no longer keep the Upgrade tab stuck on a red failure card after the machine has already been manually updated to that version.
+- This release does not change support UI behavior, billing behavior, or feature gating.
+
+## Full diff
+
+- [v2.1.4...v2.1.5](https://github.com/jampat000/MediaMop/compare/v2.1.4...v2.1.5)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.4"
+#define AppVersion "2.1.5"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.5

This patch release cleans up the Windows Upgrade screen after a failed in-app attempt has later been superseded by a successful manual install.

## Highlights

- Fixed stale failed updater state remaining visible after MediaMop is already running the target version.
- Historical failed attempts are now archived once MediaMop proves the target version is already installed and healthy.
- Preserved updater diagnostics and installer logs for support without continuing to show the old failure as a live upgrade problem.
- Kept the verified Windows upgrade flow, checksum validation, and running-version completion gate introduced in earlier 2.1.x releases.

## Operator notes

- A previous failed attempt should no longer keep the Upgrade tab stuck on a red failure card after the machine has already been manually updated to that version.
- This release does not change support UI behavior, billing behavior, or feature gating.

## Full diff

- [v2.1.4...v2.1.5](https://github.com/jampat000/MediaMop/compare/v2.1.4...v2.1.5)
