### PR TITLE
Release 2.1.7: archive superseded completed updater state

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.6"
+version = "2.1.7"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -525,7 +525,7 @@ def _default_state() -> dict[str, object]:
 def _read_state_unlocked() -> dict[str, object]:
     path = _state_path()
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw = json.loads(path.read_text(encoding="utf-8-sig"))
     except FileNotFoundError:
         return _default_state()
     except OSError as exc:
@@ -750,10 +750,10 @@ def _mark_failed(
     )
 
 
-def _archive_superseded_failed_attempt() -> None:
+def _archive_superseded_terminal_attempt() -> None:
     state = _read_state()
     phase = str(state.get("phase") or "").strip().lower()
-    if phase != "failed":
+    if phase not in {"failed", "completed"}:
         return
     target_version = normalize_release_version(str(state.get("target_version") or ""))
     if not target_version:
@@ -765,6 +765,8 @@ def _archive_superseded_failed_attempt() -> None:
     merged_diagnostics = dict(install_diagnostics)
 
     if matched:
+        if phase == "completed":
+            return
         archive_reason = (
             f"A previous upgrade attempt for MediaMop {target_version} failed, "
             "but that version is now already installed and running."
@@ -799,8 +801,8 @@ def _archive_superseded_failed_attempt() -> None:
     archived_diagnostics = {key: value for key, value in archived_diagnostics.items() if value is not None}
 
     _append_service_log(
-        "Updater status archived a historical failed attempt because the target version is already installed "
-        f"(attempt_id={attempt_id or 'unknown'}, target_version={target_version}, observed_version={observed_version})."
+        "Updater status archived a historical terminal attempt because the target version is no longer current "
+        f"(phase={phase}, attempt_id={attempt_id or 'unknown'}, target_version={target_version}, observed_version={observed_version})."
     )
     _transition_state(
         "idle",
@@ -1580,7 +1582,7 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
 
 
 def _maybe_reconcile_pending_attempt() -> None:
-    _archive_superseded_failed_attempt()
+    _archive_superseded_terminal_attempt()
     state = _read_state()
     phase = str(state.get("phase") or "").strip().lower()
     if phase not in _ACTIVE_PHASES:

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1264,6 +1264,109 @@ def test_status_endpoint_hides_superseded_failed_attempt(
     assert body["attempt_id"] is None
 
 
+def test_maybe_reconcile_pending_attempt_archives_superseded_completed_attempt_when_running_version_is_newer(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.5", "attempt-123"),
+            "phase": "completed",
+            "message": "Upgrade completed. Running version: 2.1.5.",
+            "current_version_seen": "2.1.5",
+            "last_completed_at": "2026-05-08T00:02:11+00:00",
+        }
+    )
+    monkeypatch.setattr(updater_service, "_state_matches_installed_target", lambda _target_version: (False, {}))
+    monkeypatch.setattr(
+        updater_service,
+        "_state_running_version_exceeds_target",
+        lambda target_version: (
+            True,
+            {"backend_version": "2.1.6", "packaged_version": "2.1.6"},
+            "2.1.6",
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "idle"
+    assert state["attempt_id"] is None
+    assert state["target_version"] is None
+    assert state["current_version_seen"] == "2.1.6"
+    assert state["diagnostics"]["archived_superseded_attempt"] is True
+    assert state["diagnostics"]["archived_from_phase"] == "completed"
+    assert state["diagnostics"]["archived_target_version"] == "2.1.5"
+    assert "newer version 2.1.6" in state["diagnostics"]["stale_reason"].lower()
+
+
+def test_status_endpoint_hides_superseded_completed_attempt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.5", "attempt-123"),
+            "phase": "completed",
+            "message": "Upgrade completed. Running version: 2.1.5.",
+            "current_version_seen": "2.1.5",
+            "last_completed_at": "2026-05-08T00:02:11+00:00",
+        }
+    )
+    monkeypatch.setattr(updater_service, "_state_matches_installed_target", lambda _target_version: (False, {}))
+    monkeypatch.setattr(
+        updater_service,
+        "_state_running_version_exceeds_target",
+        lambda target_version: (
+            True,
+            {"backend_version": "2.1.6", "packaged_version": "2.1.6"},
+            "2.1.6",
+        ),
+    )
+    with monkeypatch.context() as scoped:
+        scoped.setattr(updater_service.os, "name", "nt")
+        scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
+        app = updater_service.create_updater_app()
+        with TestClient(app, raise_server_exceptions=False) as client:
+            res = client.get(
+                "/api/v1/status",
+                headers={"X-MediaMop-Updater-Token": "token"},
+            )
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["phase"] == "idle"
+    assert body["is_active"] is False
+    assert body["blocks_new_update"] is False
+    assert body["attempt_id"] is None
+
+
+def test_read_state_accepts_utf8_bom(tmp_path: Path, monkeypatch) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    state_path = updater_service._state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_bytes(
+        (
+            "\ufeff"
+            + json.dumps(
+                {
+                    "phase": "completed",
+                    "message": "Upgrade completed. Running version: 2.1.5.",
+                    "target_version": "2.1.5",
+                }
+            )
+        ).encode("utf-8")
+    )
+
+    state = updater_service._read_state()
+
+    assert state["phase"] == "completed"
+    assert state["target_version"] == "2.1.5"
+
+
 @pytest.mark.parametrize("phase", ["installer_running", "restarting", "verifying_install"])
 def test_maybe_reconcile_pending_attempt_resumes_verification_for_recoverable_phases(
     tmp_path: Path,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.6",
+  "version": "2.1.7",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.7.md
+++ b/docs/release-notes/v2.1.7.md
@@ -1,0 +1,19 @@
+# MediaMop v2.1.7
+
+This patch release fixes stale Windows updater state after manual installs and keeps the Upgrade tab from surfacing historical attempts as if they were still current.
+
+## Highlights
+
+- Archived superseded completed Windows upgrade attempts once MediaMop is already running a newer version.
+- Kept historical installer details in updater diagnostics without leaving the Upgrade tab stuck on an old target version.
+- Made updater-state parsing tolerate UTF-8 BOM files so Windows state recovery does not fail on startup.
+- Kept the verified upgrade flow, trusted checksum validation, and desktop relaunch verification from earlier 2.1.x releases.
+
+## Operator notes
+
+- If a Windows machine manually installs a newer version after an older in-app upgrade attempt, the old completed attempt is now treated as historical state instead of current upgrade progress.
+- Existing installer and updater logs remain on disk for support.
+
+## Full diff
+
+- [v2.1.6...v2.1.7](https://github.com/jampat000/MediaMop/compare/v2.1.6...v2.1.7)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.6"
+#define AppVersion "2.1.7"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.7

This patch release fixes stale Windows updater state after manual installs and keeps the Upgrade tab from surfacing historical attempts as if they were still current.

## Highlights

- Archived superseded completed Windows upgrade attempts once MediaMop is already running a newer version.
- Kept historical installer details in updater diagnostics without leaving the Upgrade tab stuck on an old target version.
- Made updater-state parsing tolerate UTF-8 BOM files so Windows state recovery does not fail on startup.
- Kept the verified upgrade flow, trusted checksum validation, and desktop relaunch verification from earlier 2.1.x releases.

## Operator notes

- If a Windows machine manually installs a newer version after an older in-app upgrade attempt, the old completed attempt is now treated as historical state instead of current upgrade progress.
- Existing installer and updater logs remain on disk for support.

## Full diff

- [v2.1.6...v2.1.7](https://github.com/jampat000/MediaMop/compare/v2.1.6...v2.1.7)
