### PR TITLE
Fix Windows tray relaunch fallback and release 2.1.8

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.7"
+version = "2.1.8"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -294,6 +294,108 @@ def _active_interactive_session_id() -> int:
     raise RuntimeError("No active interactive Windows session was available for MediaMop relaunch.")
 
 
+def _active_interactive_session_user() -> str:
+    import ctypes
+    from ctypes import wintypes
+
+    WTSUserName = 5
+    WTSDomainName = 7
+
+    wtsapi32 = ctypes.WinDLL("wtsapi32", use_last_error=True)
+    session_id = _active_interactive_session_id()
+
+    def _query_session_string(info_class: int) -> str | None:
+        buffer = wintypes.LPWSTR()
+        bytes_returned = wintypes.DWORD()
+        if not wtsapi32.WTSQuerySessionInformationW(
+            0,
+            session_id,
+            info_class,
+            ctypes.byref(buffer),
+            ctypes.byref(bytes_returned),
+        ):
+            raise OSError(
+                ctypes.get_last_error(),
+                f"Could not query Windows session information class {info_class} for session {session_id}.",
+            )
+        try:
+            return str(buffer.value or "").strip() or None
+        finally:
+            if buffer:
+                wtsapi32.WTSFreeMemory(buffer)
+
+    username = _query_session_string(WTSUserName)
+    if not username:
+        raise RuntimeError(f"Interactive Windows session {session_id} does not have a logged-in user.")
+    domain = _query_session_string(WTSDomainName)
+    return f"{domain}\\{username}" if domain else username
+
+
+def _launch_process_in_active_session_via_schtasks(
+    executable: Path,
+    *,
+    args: list[str] | None = None,
+    cwd: Path | None = None,
+) -> int:
+    task_name = f"MediaMop-Relaunch-{uuid.uuid4().hex}"
+    upgrades_dir = _runtime_home() / "upgrades"
+    upgrades_dir.mkdir(parents=True, exist_ok=True)
+    launcher_script = upgrades_dir / f"relaunch-{task_name}.cmd"
+    working_directory = (cwd or executable.parent).resolve()
+    command = subprocess.list2cmdline([str(executable.resolve()), *(args or [])])
+    launcher_script.write_text(
+        "\n".join(
+            [
+                "@echo off",
+                f'cd /d "{working_directory}"',
+                f"start \"\" {command}",
+                "exit /b 0",
+            ]
+        )
+        + "\n",
+        encoding="ascii",
+    )
+    session_user = _active_interactive_session_user()
+    create_result = subprocess.run(
+        [
+            "schtasks",
+            "/Create",
+            "/TN",
+            task_name,
+            "/SC",
+            "ONCE",
+            "/ST",
+            "23:59",
+            "/RU",
+            session_user,
+            "/IT",
+            "/RL",
+            "HIGHEST",
+            "/TR",
+            str(launcher_script),
+            "/F",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if create_result.returncode != 0:
+        detail = (create_result.stderr or create_result.stdout or "").strip()
+        raise OSError(create_result.returncode, f"Could not create MediaMop relaunch task. {detail}")
+    run_result = subprocess.run(
+        ["schtasks", "/Run", "/TN", task_name],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if run_result.returncode != 0:
+        detail = (run_result.stderr or run_result.stdout or "").strip()
+        raise OSError(run_result.returncode, f"Could not run MediaMop relaunch task. {detail}")
+    return 0
+
+
 def _launch_process_in_active_session(
     executable: Path,
     *,
@@ -423,6 +525,8 @@ def _launch_process_in_active_session(
                     f"{create_process_error.strerror} {fallback_error.strerror}",
                 )
         return int(process_info.dwProcessId)
+    except OSError:
+        return _launch_process_in_active_session_via_schtasks(executable, args=args, cwd=cwd)
     finally:
         if process_info.hThread:
             kernel32.CloseHandle(process_info.hThread)
@@ -671,6 +775,29 @@ def _state_matches_installed_target(target_version: str) -> tuple[bool, dict[str
         and not missing_required
     )
     return matched, diagnostics
+
+
+def _diagnostics_prove_completed_desktop_upgrade(
+    target_version: str,
+    diagnostics: dict[str, object],
+) -> bool:
+    packaged_version = str(diagnostics.get("packaged_version") or "").strip() or None
+    backend_version = str(diagnostics.get("backend_version") or "").strip() or None
+    backend_ready = bool(diagnostics.get("backend_ready"))
+    missing_required = diagnostics.get("missing_required_files")
+    tray_running = bool(diagnostics.get("tray_running"))
+    interactive_session_available = bool(
+        diagnostics.get("interactive_session_available")
+        if "interactive_session_available" in diagnostics
+        else _interactive_session_available()
+    )
+    return (
+        packaged_version == target_version
+        and backend_ready
+        and backend_version == target_version
+        and not missing_required
+        and (not interactive_session_available or tray_running)
+    )
 
 
 def _state_running_version_exceeds_target(
@@ -1222,13 +1349,7 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
         backend_version = str(diagnostics.get("backend_version") or "").strip() or None
         tray_running = bool(diagnostics.get("tray_running"))
         missing_required = diagnostics.get("missing_required_files")
-        if (
-            packaged_version == target_version
-            and not missing_required
-            and backend_ready
-            and backend_version == target_version
-            and (not interactive_session_available or tray_running)
-        ):
+        if _diagnostics_prove_completed_desktop_upgrade(target_version, diagnostics):
             return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
         if packaged_version == target_version and not missing_required and (
             not backend_ready or (interactive_session_available and not tray_running)
@@ -1473,7 +1594,11 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
         target_version = normalize_release_version(str(state.get("target_version") or ""))
         if target_version:
             matched, install_diagnostics = _state_matches_installed_target(target_version)
-            if matched and not _installer_process_is_running(state):
+            if (
+                matched
+                and not _installer_process_is_running(state)
+                and _diagnostics_prove_completed_desktop_upgrade(target_version, install_diagnostics)
+            ):
                 stale_reason = (
                     "Persisted updater state could not prove the original installer process was still active, "
                     f"but MediaMop {target_version} is already installed and running."
@@ -1595,7 +1720,7 @@ def _maybe_reconcile_pending_attempt() -> None:
     installer_running = _installer_process_is_running(state)
     if target_version and phase in _RECOVERABLE_PHASES and not installer_running:
         matched, install_diagnostics = _state_matches_installed_target(target_version)
-        if matched:
+        if matched and _diagnostics_prove_completed_desktop_upgrade(target_version, install_diagnostics):
             stale_reason = (
                 "Persisted updater state could not prove the original installer process was still active, "
                 f"but MediaMop {target_version} is already installed and running."
@@ -1615,6 +1740,22 @@ def _maybe_reconcile_pending_attempt() -> None:
                     "reconciled_from_phase": phase,
                 },
                 stale_reason=stale_reason,
+            )
+            return
+        if matched and not attempt_id:
+            _mark_failed(
+                message="Upgrade failed.",
+                last_error=(
+                    f"MediaMop {target_version} is installed, but the desktop tray host is not running "
+                    "in the active Windows session."
+                ),
+                target_version=target_version,
+                current_version_seen=target_version,
+                diagnostics={
+                    **install_diagnostics,
+                    "reconciled_after_restart": True,
+                    "reconciled_from_phase": phase,
+                },
             )
             return
         exceeded, install_diagnostics, observed_version = _state_running_version_exceeds_target(target_version)

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import time
+import threading
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -764,6 +766,40 @@ def test_verify_install_fails_when_active_session_exists_but_tray_does_not_relau
     assert "desktop tray host did not relaunch" in message.lower()
 
 
+def test_launch_process_in_active_session_via_schtasks_creates_and_runs_launcher_task(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    executable = tmp_path / "MediaMop.exe"
+    executable.write_text("binary", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_active_interactive_session_user", lambda: "APP-SERVER\\Administrator")
+
+    created_commands: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(command: list[str], **kwargs):
+        created_commands.append(command)
+        return _Result()
+
+    monkeypatch.setattr(updater_service.subprocess, "run", _fake_run)
+
+    pid = updater_service._launch_process_in_active_session_via_schtasks(
+        executable,
+        args=["--no-browser"],
+        cwd=tmp_path,
+    )
+
+    assert pid == 0
+    assert any(command[:2] == ["schtasks", "/Create"] for command in created_commands)
+    assert any(command[:2] == ["schtasks", "/Run"] for command in created_commands)
+
+
 def test_packaged_helper_exits_after_launch_and_reconciliation_completes(
     tmp_path: Path,
     monkeypatch,
@@ -976,18 +1012,20 @@ def test_maybe_reconcile_pending_attempt_marks_already_running_target_completed(
     )
     Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
     monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: False)
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: False)
     monkeypatch.setattr(
         updater_service,
         "_state_matches_installed_target",
         lambda target_version: (
             True,
-            {
-                "backend_version": target_version,
-                "packaged_version": target_version,
-                "missing_required_files": [],
-            },
-        ),
-    )
+                {
+                    "backend_version": target_version,
+                    "packaged_version": target_version,
+                    "backend_ready": True,
+                    "missing_required_files": [],
+                },
+            ),
+        )
 
     updater_service._maybe_reconcile_pending_attempt()
     state = updater_service._read_state()
@@ -1014,18 +1052,20 @@ def test_maybe_reconcile_pending_attempt_reconciles_unverifiable_installer_ident
     )
     Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
     monkeypatch.setattr(updater_service, "_read_process_snapshot", lambda _pid: None)
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: False)
     monkeypatch.setattr(
         updater_service,
         "_state_matches_installed_target",
         lambda target_version: (
             True,
-            {
-                "backend_version": target_version,
-                "packaged_version": target_version,
-                "missing_required_files": [],
-            },
-        ),
-    )
+                {
+                    "backend_version": target_version,
+                    "packaged_version": target_version,
+                    "backend_ready": True,
+                    "missing_required_files": [],
+                },
+            ),
+        )
 
     updater_service._maybe_reconcile_pending_attempt()
     state = updater_service._read_state()
@@ -1048,18 +1088,20 @@ def test_maybe_reconcile_pending_attempt_recovers_legacy_active_state_without_at
             "installer_log_path": str(tmp_path / "installer-latest.log"),
         }
     )
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: False)
     monkeypatch.setattr(
         updater_service,
         "_state_matches_installed_target",
         lambda target_version: (
             True,
-            {
-                "backend_version": target_version,
-                "packaged_version": target_version,
-                "missing_required_files": [],
-            },
-        ),
-    )
+                {
+                    "backend_version": target_version,
+                    "packaged_version": target_version,
+                    "backend_ready": True,
+                    "missing_required_files": [],
+                },
+            ),
+        )
 
     updater_service._maybe_reconcile_pending_attempt()
     state = updater_service._read_state()
@@ -1117,18 +1159,20 @@ def test_status_endpoint_reports_reconciled_legacy_state_as_non_active(
             "installer_log_path": str(tmp_path / "installer-latest.log"),
         }
     )
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: False)
     monkeypatch.setattr(
         updater_service,
         "_state_matches_installed_target",
         lambda target_version: (
             True,
-            {
-                "backend_version": target_version,
-                "packaged_version": target_version,
-                "missing_required_files": [],
-            },
-        ),
-    )
+                {
+                    "backend_version": target_version,
+                    "packaged_version": target_version,
+                    "backend_ready": True,
+                    "missing_required_files": [],
+                },
+            ),
+        )
     with monkeypatch.context() as scoped:
         scoped.setattr(updater_service.os, "name", "nt")
         scoped.setattr(updater_service, "_load_or_create_token", lambda: "token")
@@ -1147,6 +1191,71 @@ def test_status_endpoint_reports_reconciled_legacy_state_as_non_active(
     assert body["blocks_new_update"] is False
     assert body["is_stale"] is True
     assert "could not prove" in body["stale_reason"].lower()
+
+
+def test_maybe_reconcile_pending_attempt_does_not_mark_completed_without_tray_in_active_session(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    installer = tmp_path / "MediaMopSetup-2.1.7-attempt-123.exe"
+    installer.write_bytes(b"installer")
+    updater_service._persist_state(
+        {
+            **updater_service._fresh_attempt_state("2.1.7", "attempt-123"),
+            "phase": "installer_running",
+            "downloaded_installer_path": str(installer),
+            "diagnostics": {"helper_pid": None, "installer_pid": 6789},
+        }
+    )
+    Path(updater_service._read_state()["installer_log_path"]).write_text("installer log", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_installer_process_is_running", lambda _state: False)
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: True)
+    monkeypatch.setattr(updater_service, "_RECONCILE_LOCK", threading.Lock())
+
+    class _ImmediateThread:
+        def __init__(self, *, target, args, daemon, name) -> None:
+            self._target = target
+            self._args = args
+
+        def start(self) -> None:
+            self._target(*self._args)
+
+    monkeypatch.setattr(updater_service.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        updater_service,
+        "_state_matches_installed_target",
+        lambda target_version: (
+            True,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "tray_running": False,
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_verify_install",
+        lambda target_version: (
+            False,
+            {
+                "backend_version": target_version,
+                "packaged_version": target_version,
+                "backend_ready": True,
+                "tray_running": False,
+            },
+            "MediaMop upgraded successfully, but the desktop tray host did not relaunch in the active Windows session.",
+        ),
+    )
+
+    updater_service._maybe_reconcile_pending_attempt()
+    state = updater_service._read_state()
+
+    assert state["phase"] == "failed"
+    assert "desktop tray host did not relaunch" in str(state["last_error"]).lower()
 
 
 def test_maybe_reconcile_pending_attempt_archives_superseded_failed_attempt(
@@ -1394,6 +1503,7 @@ def test_maybe_reconcile_pending_attempt_resumes_verification_for_recoverable_ph
 
     monkeypatch.setattr(updater_service, "_state_age_seconds", lambda _state: 5)
     monkeypatch.setattr(updater_service, "_pid_is_running", lambda _pid: False)
+    monkeypatch.setattr(updater_service, "_RECONCILE_LOCK", threading.Lock())
     monkeypatch.setattr(updater_service.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(
         updater_service,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.7",
+  "version": "2.1.8",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.8.md
+++ b/docs/release-notes/v2.1.8.md
@@ -1,0 +1,14 @@
+# MediaMop v2.1.8
+
+## Windows updater fixes
+
+- Fixed a Windows in-app upgrade regression where MediaMop could mark an upgrade as completed after the backend returned, even though the desktop tray app had not relaunched.
+- Added a more reliable interactive-session relaunch fallback for the MediaMop tray host after silent upgrades.
+- Fixed stale recovery logic so post-restart reconciliation no longer treats "target version is running" as sufficient success when the tray host is still missing from an active Windows session.
+- Preserved existing checksum verification and target-version completion rules for Windows in-app upgrades.
+
+## Support notes
+
+- If a Windows upgrade still needs manual recovery, updater diagnostics continue to preserve the original attempt details and logs.
+
+[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.7...v2.1.8)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.7"
+#define AppVersion "2.1.8"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.8

## Windows updater fixes

- Fixed a Windows in-app upgrade regression where MediaMop could mark an upgrade as completed after the backend returned, even though the desktop tray app had not relaunched.
- Added a more reliable interactive-session relaunch fallback for the MediaMop tray host after silent upgrades.
- Fixed stale recovery logic so post-restart reconciliation no longer treats "target version is running" as sufficient success when the tray host is still missing from an active Windows session.
- Preserved existing checksum verification and target-version completion rules for Windows in-app upgrades.

## Support notes

- If a Windows upgrade still needs manual recovery, updater diagnostics continue to preserve the original attempt details and logs.

[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.7...v2.1.8)
