### PR TITLE
Fix upgrade refresh and preserve setup state in 2.1.9

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.8"
+version = "2.1.9"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -31,6 +31,7 @@ from mediamop.platform.auth.csrf import (
 from mediamop.platform.activity import constants as activity_constants
 from mediamop.platform.activity import service as activity_service
 from mediamop.platform.auth.deps_auth import UserPublicDep
+from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 logger = logging.getLogger(__name__)
@@ -247,6 +248,8 @@ def post_bootstrap(
         title="Initial admin created",
         detail=user.username,
     )
+    suite_settings = ensure_suite_settings_row(db)
+    suite_settings.setup_wizard_state = "pending"
     return schemas.BootstrapOut(
         message="Bootstrap complete. Sign in with POST /api/v1/auth/login.",
         username=user.username,

--- a/apps/backend/src/mediamop/platform/suite_settings/service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/service.py
@@ -6,11 +6,19 @@ from datetime import time
 from zoneinfo import ZoneInfo
 from zoneinfo import ZoneInfoNotFoundError
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from mediamop.platform.auth.models import User
 from mediamop.platform.suite_settings.model import SuiteSettingsRow
 from mediamop.platform.suite_settings.schemas import SuiteSettingsOut
+
+
+def _default_setup_wizard_state(session: Session) -> str:
+    """Avoid reopening first-run setup on an established install if the singleton row is recreated."""
+
+    existing_users = session.scalar(select(func.count()).select_from(User)) or 0
+    return "skipped" if int(existing_users) > 0 else "pending"
 
 
 def ensure_suite_settings_row(session: Session) -> SuiteSettingsRow:
@@ -20,7 +28,7 @@ def ensure_suite_settings_row(session: Session) -> SuiteSettingsRow:
             id=1,
             product_display_name="MediaMop",
             signed_in_home_notice=None,
-            setup_wizard_state="pending",
+            setup_wizard_state=_default_setup_wizard_state(session),
             app_timezone="UTC",
             log_retention_days=30,
             configuration_backup_enabled=False,

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -7,9 +7,10 @@ from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from starlette.testclient import TestClient
 
+from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.activity import constants as act_c
@@ -20,7 +21,9 @@ from mediamop.platform.suite_settings.release_catalog import (
     GitHubReleaseRecord,
 )
 from mediamop.platform.suite_settings.model import SuiteSettingsRow
-from mediamop.platform.suite_settings.service import apply_suite_settings_put
+from mediamop.platform.suite_settings.service import apply_suite_settings_put, ensure_suite_settings_row
+from mediamop.platform.auth.models import User
+from mediamop.platform.auth.password import hash_password
 from mediamop.platform.suite_settings.suite_configuration_backup_periodic import run_suite_configuration_backup_tick
 from mediamop.platform.suite_settings.suite_configuration_backup_service import list_suite_configuration_backups
 from mediamop.platform.suite_settings.logs_retention_periodic import (
@@ -29,7 +32,12 @@ from mediamop.platform.suite_settings.logs_retention_periodic import (
 )
 from mediamop.platform.suite_settings.update_service import start_suite_update_now
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import (
+    auth_post,
+    csrf as fetch_csrf,
+    reset_user_tables,
+    trusted_browser_origin_headers,
+)
 
 
 def _release_record(version: str = "1.2.3") -> GitHubReleaseRecord:
@@ -96,6 +104,59 @@ def test_suite_settings_get_default_shape(client_with_admin: TestClient) -> None
     assert body["configuration_backup_preferred_time"] == "02:00"
     assert body["configuration_backup_last_run_at"] is None
     assert "updated_at" in body
+
+
+def test_ensure_suite_settings_row_defaults_to_skipped_for_existing_install() -> None:
+    settings = MediaMopSettings.load()
+    fac = create_session_factory(create_db_engine(settings))
+    with fac() as db:
+        db.execute(delete(SuiteSettingsRow))
+        db.add(
+            User(
+                username="existing-admin",
+                password_hash=hash_password("existing-admin-password"),
+                role="admin",
+                is_active=True,
+            )
+        )
+        db.flush()
+
+        row = ensure_suite_settings_row(db)
+
+        assert row.setup_wizard_state == "skipped"
+
+
+def test_bootstrap_explicitly_keeps_setup_wizard_pending_for_true_first_run(
+) -> None:
+    reset_user_tables()
+    with TestClient(create_app()) as client:
+        bootstrap_csrf = fetch_csrf(client)
+        response = auth_post(
+            client,
+            "/api/v1/auth/bootstrap",
+            json={
+                "username": "fresh-admin",
+                "password": "bootstrap-password-strong",
+                "csrf_token": bootstrap_csrf,
+            },
+        )
+        assert response.status_code == 200, response.text
+
+        login_csrf = fetch_csrf(client)
+        login_response = auth_post(
+            client,
+            "/api/v1/auth/login",
+            json={
+                "username": "fresh-admin",
+                "password": "bootstrap-password-strong",
+                "csrf_token": login_csrf,
+            },
+        )
+        assert login_response.status_code == 200, login_response.text
+
+        settings_response = client.get("/api/v1/suite/settings")
+        assert settings_response.status_code == 200, settings_response.text
+        assert settings_response.json()["setup_wizard_state"] == "pending"
 
 
 def test_log_retention_tick_runs_once_per_day(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.8",
+  "version": "2.1.9",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/browser-window.ts
+++ b/apps/web/src/lib/browser-window.ts
@@ -1,0 +1,5 @@
+export const browserWindow = {
+  reloadCurrentPage(): void {
+    window.location.reload();
+  },
+};

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -22,7 +22,7 @@ import type {
   SuiteSettingsOut,
   SuiteUpdateStatusOut,
 } from "../../lib/suite/types";
-import { SettingsPage } from "./settings-page";
+import { SettingsPage, verifiedUpgradeRefreshKey } from "./settings-page";
 
 const operatorMe: UserPublic = { id: 1, username: "alice", role: "operator" };
 const viewerMe: UserPublic = { id: 2, username: "bob", role: "viewer" };
@@ -747,6 +747,57 @@ describe("SettingsPage (suite settings)", () => {
     expect(
       screen.getByText("Upgrade completed. Running version: 2.0.8."),
     ).toBeInTheDocument();
+  });
+
+  it("computes a refresh key only after a verified Windows upgrade completes", () => {
+    expect(
+      verifiedUpgradeRefreshKey(
+        {
+          ...windowsUpdateAvailableStatus,
+          current_version: "2.0.8",
+          status: "up_to_date",
+          summary: "This install is already on MediaMop 2.0.8.",
+        },
+        {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          attempt_id: "attempt-verified",
+          target_version: "2.0.8",
+          current_version_seen: "2.0.8",
+        },
+        {
+          attemptId: "attempt-verified",
+          targetVersion: "2.0.8",
+          disconnects: 0,
+          active: true,
+          startedAtMs: Date.now(),
+          timedOutReason: null,
+        },
+      ),
+    ).toBe("attempt-verified:2.0.8");
+  });
+
+  it("does not compute a refresh key before the running version matches the verified target", () => {
+    expect(
+      verifiedUpgradeRefreshKey(
+        windowsUpdateAvailableStatus,
+        {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          attempt_id: "attempt-unverified",
+          target_version: "2.0.8",
+          current_version_seen: "2.0.7",
+        },
+        {
+          attemptId: "attempt-unverified",
+          targetVersion: "2.0.8",
+          disconnects: 0,
+          active: true,
+          startedAtMs: Date.now(),
+          timedOutReason: null,
+        },
+      ),
+    ).toBeNull();
   });
 
   it("shows failed upgrade diagnostics with log paths", () => {

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent } from "react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PageLoading } from "../../components/shared/page-loading";
+import { browserWindow } from "../../lib/browser-window";
 import {
   isHttpErrorFromApi,
   isLikelyNetworkFailure,
@@ -458,6 +459,31 @@ function describeUpgradeProgress(
   }
 }
 
+export function verifiedUpgradeRefreshKey(
+  status: SuiteUpdateStatusOut | undefined,
+  progress: SuiteUpgradeProgressOut | null | undefined,
+  monitor: UpgradeMonitor | null,
+): string | null {
+  if (!status || status.install_type !== "windows" || !monitor?.active) {
+    return null;
+  }
+  const targetVersion = (
+    progress?.target_version ||
+    monitor.targetVersion ||
+    ""
+  ).trim();
+  if (!targetVersion || status.current_version !== targetVersion) {
+    return null;
+  }
+  if (progress && progress.phase !== "completed") {
+    return null;
+  }
+  return [
+    progress?.attempt_id || monitor.attemptId || "unknown-attempt",
+    targetVersion,
+  ].join(":");
+}
+
 /** Settings: General (timezone, display density, configuration export), Security, Logs (retention + recent events). */
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -518,6 +544,7 @@ export function SettingsPage() {
   const [logLevel, setLogLevel] = useState<LogLevelFilter>("");
   const [tracebacksOnly, setTracebacksOnly] = useState(false);
   const restoreInputRef = useRef<HTMLInputElement>(null);
+  const upgradeRefreshTriggeredRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!settingsQ.data) {
@@ -701,16 +728,12 @@ export function SettingsPage() {
       });
       return;
     }
-    const targetVersion = (
-      progress?.target_version ||
-      upgradeMonitor.targetVersion ||
-      ""
-    ).trim();
-    if (
-      targetVersion &&
-      updateStatusQ.data.current_version === targetVersion &&
-      (progress?.phase === "completed" || !progress)
-    ) {
+    const refreshAttemptKey = verifiedUpgradeRefreshKey(
+      updateStatusQ.data,
+      progress,
+      upgradeMonitor,
+    );
+    if (refreshAttemptKey) {
       setUpgradePollActive(false);
       setUpgradeMonitor((current) =>
         current ? { ...current, active: false, timedOutReason: null } : current,
@@ -721,6 +744,10 @@ export function SettingsPage() {
           progress?.message ||
           `Upgrade completed. Running version: ${updateStatusQ.data.current_version}.`,
       });
+      if (upgradeRefreshTriggeredRef.current !== refreshAttemptKey) {
+        upgradeRefreshTriggeredRef.current = refreshAttemptKey;
+        browserWindow.reloadCurrentPage();
+      }
     }
   }, [upgradeMonitor, updateStatusQ.data]);
 
@@ -985,6 +1012,7 @@ export function SettingsPage() {
 
   async function handleUpgradeNow() {
     setUpgradeNotice(null);
+    upgradeRefreshTriggeredRef.current = null;
     try {
       const result = await updateNow.mutateAsync();
       if (result.status === "started") {

--- a/docs/release-notes/v2.1.9.md
+++ b/docs/release-notes/v2.1.9.md
@@ -1,0 +1,14 @@
+# MediaMop v2.1.9
+
+## What Changed
+
+- Fixed the Windows Upgrade tab so the browser refreshes after a verified in-app upgrade completes. MediaMop now reloads the page only after it has proved the running version changed.
+- Fixed established installs that could reopen the setup wizard after an upgrade or recovery path recreated the `suite_settings` singleton row.
+- Kept first-run onboarding intact: brand-new installs still land in the setup wizard after the first admin account is created.
+
+## Support Notes
+
+- Windows in-app upgrades still complete only after MediaMop verifies the running version matches the target version.
+- Existing Docker/session persistence behavior remains unchanged. The official compose and container entrypoint still require a persistent `MEDIAMOP_HOME` volume so the database and session secret survive restarts.
+
+[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.8...v2.1.9)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.8"
+#define AppVersion "2.1.9"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.9

## What Changed

- Fixed the Windows Upgrade tab so the browser refreshes after a verified in-app upgrade completes. MediaMop now reloads the page only after it has proved the running version changed.
- Fixed established installs that could reopen the setup wizard after an upgrade or recovery path recreated the `suite_settings` singleton row.
- Kept first-run onboarding intact: brand-new installs still land in the setup wizard after the first admin account is created.

## Support Notes

- Windows in-app upgrades still complete only after MediaMop verifies the running version matches the target version.
- Existing Docker/session persistence behavior remains unchanged. The official compose and container entrypoint still require a persistent `MEDIAMOP_HOME` volume so the database and session secret survive restarts.

[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.8...v2.1.9)
