### PR TITLE
Fix upgrade completion refresh in 2.1.10

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.9"
+version = "2.1.10"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.9",
+  "version": "2.1.10",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/browser-window.ts
+++ b/apps/web/src/lib/browser-window.ts
@@ -1,5 +1,18 @@
 export const browserWindow = {
   reloadCurrentPage(): void {
+    const href = window.location.href;
+    try {
+      window.location.replace(href);
+      return;
+    } catch {
+      // Fall through to the next navigation strategy.
+    }
+    try {
+      window.location.assign(href);
+      return;
+    } catch {
+      // Fall through to the final hard reload.
+    }
     window.location.reload();
   },
 };

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { browserWindow } from "../../lib/browser-window";
 import { DISPLAY_DENSITY_STORAGE_KEY } from "../../lib/ui/display-density";
 import type { CurrentSession, UserPublic } from "../../lib/api/types";
 import { qk } from "../../lib/auth/queries";
@@ -747,6 +748,53 @@ describe("SettingsPage (suite settings)", () => {
     expect(
       screen.getByText("Upgrade completed. Running version: 2.0.8."),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Refresh browser now" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "If this tab still looks stale, refresh the browser to load the upgraded MediaMop UI.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show the refresh browser prompt before the running version matches the target", () => {
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        upgrade: {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          target_version: "2.0.8",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(
+      screen.queryByRole("button", { name: "Refresh browser now" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lets the user manually refresh the browser from the completed upgrade state", () => {
+    const reloadSpy = vi
+      .spyOn(browserWindow, "reloadCurrentPage")
+      .mockImplementation(() => undefined);
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        current_version: "2.0.8",
+        status: "up_to_date",
+        summary: "This install is already on MediaMop 2.0.8.",
+        upgrade: {
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          target_version: "2.0.8",
+        },
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh browser now" }));
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 
   it("computes a refresh key only after a verified Windows upgrade completes", () => {

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -793,7 +793,9 @@ describe("SettingsPage (suite settings)", () => {
       },
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
-    fireEvent.click(screen.getByRole("button", { name: "Refresh browser now" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Refresh browser now" }),
+    );
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -484,6 +484,24 @@ export function verifiedUpgradeRefreshKey(
   ].join(":");
 }
 
+function completedUpgradeRefreshKey(
+  status: SuiteUpdateStatusOut | undefined,
+  progress: SuiteUpgradeProgressOut | null | undefined,
+): string | null {
+  if (!status || status.install_type !== "windows" || !progress) {
+    return null;
+  }
+  const targetVersion = progress.target_version?.trim();
+  if (
+    !targetVersion ||
+    progress.phase !== "completed" ||
+    status.current_version !== targetVersion
+  ) {
+    return null;
+  }
+  return [progress.attempt_id || "unknown-attempt", targetVersion].join(":");
+}
+
 /** Settings: General (timezone, display density, configuration export), Security, Logs (retention + recent events). */
 export function SettingsPage() {
   const navigate = useNavigate();
@@ -638,6 +656,10 @@ export function SettingsPage() {
     !upgradeMonitor?.timedOutReason &&
     (Boolean(upgradeMonitor?.active) ||
       isUpgradeProgressActive(activeUpgradeProgress));
+  const completedUpgradeRefreshPromptKey = completedUpgradeRefreshKey(
+    updateStatusQ.data,
+    activeUpgradeProgress,
+  );
   const hasStableUpdateStatus = Boolean(updateStatusQ.data);
   const upgradeRefreshBusy = upgradeInProgress || updateStatusQ.isFetching;
   const upgradeRefreshLabel = upgradeInProgress
@@ -2090,6 +2112,26 @@ export function SettingsPage() {
                     <p className={upgradeNoticeClass(upgradeNotice.tone)}>
                       {upgradeNotice.text}
                     </p>
+                  ) : null}
+                  {completedUpgradeRefreshPromptKey ? (
+                    <div className="rounded-md border border-emerald-500/30 bg-emerald-950/15 px-3 py-3 text-sm text-emerald-100">
+                      <p>
+                        If this tab still looks stale, refresh the browser to
+                        load the upgraded MediaMop UI.
+                      </p>
+                      <div className="mt-3">
+                        <button
+                          type="button"
+                          className={mmActionButtonClass({
+                            variant: "secondary",
+                            disabled: false,
+                          })}
+                          onClick={() => browserWindow.reloadCurrentPage()}
+                        >
+                          Refresh browser now
+                        </button>
+                      </div>
+                    </div>
                   ) : null}
                   {updateNow.isError ? (
                     <p

--- a/docs/release-notes/v2.1.10.md
+++ b/docs/release-notes/v2.1.10.md
@@ -1,0 +1,18 @@
+# MediaMop v2.1.10
+
+This patch release tightens the upgrade experience after a verified Windows in-app upgrade.
+
+## Highlights
+
+- The Upgrade tab now gives users an explicit next step after a verified completion:
+  - automatic same-page refresh is attempted more aggressively
+  - if the embedded browser still looks stale, the page now shows a clear `Refresh browser now` action
+- The browser refresh only remains available after MediaMop has already proved the running version matches the upgrade target.
+- Established installs still keep the setup wizard closed when the `suite_settings` singleton is recreated, while true first-run bootstrap continues to open onboarding.
+
+## Support notes
+
+- This release does not change billing, licence, or feature-gating behavior.
+- The new browser refresh prompt is a UX hardening fix for embedded browser shells that do not reliably honor a plain `window.location.reload()`.
+
+[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.9...v2.1.10)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.9"
+#define AppVersion "2.1.10"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.10

This patch release tightens the upgrade experience after a verified Windows in-app upgrade.

## Highlights

- The Upgrade tab now gives users an explicit next step after a verified completion:
  - automatic same-page refresh is attempted more aggressively
  - if the embedded browser still looks stale, the page now shows a clear `Refresh browser now` action
- The browser refresh only remains available after MediaMop has already proved the running version matches the upgrade target.
- Established installs still keep the setup wizard closed when the `suite_settings` singleton is recreated, while true first-run bootstrap continues to open onboarding.

## Support notes

- This release does not change billing, licence, or feature-gating behavior.
- The new browser refresh prompt is a UX hardening fix for embedded browser shells that do not reliably honor a plain `window.location.reload()`.

[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.9...v2.1.10)
