### PR TITLE
Fix tray browser duplicate open and release 2.1.11

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.10"
+version = "2.1.11"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -128,7 +128,12 @@ def _run_migrations(resource_root: Path) -> None:
 
 
 def _open_browser(port: int) -> None:
-    webbrowser.open(f"http://127.0.0.1:{port}/", new=2)
+    # Prefer reusing an existing browser window/tab when possible.
+    webbrowser.open(f"http://127.0.0.1:{port}/", new=0)
+
+
+def _is_recent_browser_open(last_open_at: float, now: float, cooldown_seconds: float = 1.25) -> bool:
+    return (now - last_open_at) < cooldown_seconds
 
 
 def _lan_urls(port: int) -> list[str]:
@@ -211,6 +216,7 @@ class _MediaMopTrayApp:
         _run_migrations(self._resource_root)
         self._log("Database migrations completed")
         self._icon: Any = None
+        self._last_browser_open_at = 0.0
         executable_dir = Path(sys.executable).resolve().parent
         self._server_exe = executable_dir / "MediaMopServer.exe"
         self._server_process: subprocess.Popen[str] | None = None
@@ -222,6 +228,12 @@ class _MediaMopTrayApp:
                 handle.write(f"[{timestamp}] {message}\n")
 
     def _handle_open(self, icon: Any, item: Any) -> None:  # noqa: ARG002
+        now = time.monotonic()
+        if _is_recent_browser_open(self._last_browser_open_at, now):
+            self._log("Ignoring duplicate tray open request within debounce window.")
+            return
+        self._last_browser_open_at = now
+        self._log(f"Opening MediaMop in browser on port {self._port}")
         _open_browser(self._port)
 
     def _handle_open_data_folder(self, icon: Any, item: Any) -> None:  # noqa: ARG002

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -188,3 +188,14 @@ def test_tray_double_click_opens_mediamop() -> None:
     assert 'if "--version" in sys.argv:' in source
     assert '"--no-browser" in sys.argv' in source
     assert "open_browser_on_ready=not no_browser" in source
+
+
+def test_tray_open_action_debounces_duplicate_open_requests() -> None:
+    assert tray_app._is_recent_browser_open(10.0, 10.8) is True
+    assert tray_app._is_recent_browser_open(10.0, 11.5) is False
+
+
+def test_tray_open_action_uses_browser_window_reuse_mode() -> None:
+    source = Path(tray_app.__file__).read_text(encoding="utf-8")
+
+    assert "webbrowser.open(f\"http://127.0.0.1:{port}/\", new=0)" in source

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.10",
+      "version": "2.1.11",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.10",
+  "version": "2.1.11",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.11.md
+++ b/docs/release-notes/v2.1.11.md
@@ -1,0 +1,17 @@
+# MediaMop v2.1.11
+
+This patch release hardens tray browser launching behavior after desktop upgrades.
+
+## Highlights
+
+- Fixed a Windows tray regression where one tray open action could trigger multiple browser tabs.
+- Tray open now reuses an existing browser window/tab when available instead of forcing a new tab.
+- Added duplicate-open debouncing so repeated tray activation events in a short window only open one browser navigation.
+- Keeps the existing post-upgrade `--no-browser` startup behavior for upgrade safety, while making manual tray-open behavior predictable.
+
+## Support notes
+
+- This release does not change billing, licence, or feature-gating behavior.
+- In-app upgrade completion checks and trusted installer verification behavior are unchanged.
+
+[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.10...v2.1.11)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.10"
+#define AppVersion "2.1.11"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.11

This patch release hardens tray browser launching behavior after desktop upgrades.

## Highlights

- Fixed a Windows tray regression where one tray open action could trigger multiple browser tabs.
- Tray open now reuses an existing browser window/tab when available instead of forcing a new tab.
- Added duplicate-open debouncing so repeated tray activation events in a short window only open one browser navigation.
- Keeps the existing post-upgrade `--no-browser` startup behavior for upgrade safety, while making manual tray-open behavior predictable.

## Support notes

- This release does not change billing, licence, or feature-gating behavior.
- In-app upgrade completion checks and trusted installer verification behavior are unchanged.

[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.10...v2.1.11)
