### PR TITLE
Release 2.1.13: fix duplicate tray relaunch tasks

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.12"
+version = "2.1.13"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -61,6 +61,9 @@ _TRUSTED_RELEASE_DOWNLOAD_HOSTS = {
 }
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _PROCESS_IDENTITY_SKEW_SECONDS = 5.0
+_RELAUNCH_TASK_NAME = "MediaMop-Relaunch"
+_RELAUNCH_TASK_PREFIX = f"\\{_RELAUNCH_TASK_NAME}"
+_RELAUNCH_SCRIPT_GLOB = "relaunch-MediaMop-Relaunch*.cmd"
 
 
 def _append_service_log(message: str) -> None:
@@ -331,15 +334,54 @@ def _active_interactive_session_user() -> str:
     return f"{domain}\\{username}" if domain else username
 
 
+def _delete_relaunch_schtask(task_name: str) -> None:
+    subprocess.run(
+        ["schtasks", "/Delete", "/TN", task_name, "/F"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _cleanup_stale_relaunch_artifacts(upgrades_dir: Path) -> None:
+    for script_path in upgrades_dir.glob(_RELAUNCH_SCRIPT_GLOB):
+        try:
+            script_path.unlink()
+        except OSError as exc:
+            _append_service_log(f"Could not remove stale relaunch script {script_path}: {exc}")
+    query_result = subprocess.run(
+        ["schtasks", "/Query", "/FO", "LIST"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if query_result.returncode != 0:
+        detail = (query_result.stderr or query_result.stdout or "").strip()
+        _append_service_log(f"Could not query scheduled tasks before tray relaunch: {detail}")
+        return
+    for raw_line in query_result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line.lower().startswith("taskname:"):
+            continue
+        _, _, raw_task_name = line.partition(":")
+        task_name = raw_task_name.strip()
+        if not task_name.startswith(_RELAUNCH_TASK_PREFIX):
+            continue
+        _delete_relaunch_schtask(task_name.lstrip("\\"))
+
+
 def _launch_process_in_active_session_via_schtasks(
     executable: Path,
     *,
     args: list[str] | None = None,
     cwd: Path | None = None,
 ) -> int:
-    task_name = f"MediaMop-Relaunch-{uuid.uuid4().hex}"
+    task_name = _RELAUNCH_TASK_NAME
     upgrades_dir = _runtime_home() / "upgrades"
     upgrades_dir.mkdir(parents=True, exist_ok=True)
+    _cleanup_stale_relaunch_artifacts(upgrades_dir)
     launcher_script = upgrades_dir / f"relaunch-{task_name}.cmd"
     working_directory = (cwd or executable.parent).resolve()
     command = subprocess.list2cmdline([str(executable.resolve()), *(args or [])])
@@ -373,6 +415,7 @@ def _launch_process_in_active_session_via_schtasks(
             "HIGHEST",
             "/TR",
             str(launcher_script),
+            "/Z",
             "/F",
         ],
         check=False,
@@ -383,16 +426,19 @@ def _launch_process_in_active_session_via_schtasks(
     if create_result.returncode != 0:
         detail = (create_result.stderr or create_result.stdout or "").strip()
         raise OSError(create_result.returncode, f"Could not create MediaMop relaunch task. {detail}")
-    run_result = subprocess.run(
-        ["schtasks", "/Run", "/TN", task_name],
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-    if run_result.returncode != 0:
-        detail = (run_result.stderr or run_result.stdout or "").strip()
-        raise OSError(run_result.returncode, f"Could not run MediaMop relaunch task. {detail}")
+    try:
+        run_result = subprocess.run(
+            ["schtasks", "/Run", "/TN", task_name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if run_result.returncode != 0:
+            detail = (run_result.stderr or run_result.stdout or "").strip()
+            raise OSError(run_result.returncode, f"Could not run MediaMop relaunch task. {detail}")
+    finally:
+        _delete_relaunch_schtask(task_name)
     return 0
 
 

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -796,8 +796,71 @@ def test_launch_process_in_active_session_via_schtasks_creates_and_runs_launcher
     )
 
     assert pid == 0
+    assert any(command[:2] == ["schtasks", "/Query"] for command in created_commands)
     assert any(command[:2] == ["schtasks", "/Create"] for command in created_commands)
     assert any(command[:2] == ["schtasks", "/Run"] for command in created_commands)
+    assert any(command[:2] == ["schtasks", "/Delete"] for command in created_commands)
+
+
+def test_launch_process_in_active_session_via_schtasks_removes_stale_tasks_and_scripts(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    executable = tmp_path / "MediaMop.exe"
+    executable.write_text("binary", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_active_interactive_session_user", lambda: "APP-SERVER\\Administrator")
+    upgrades_dir = tmp_path / "upgrades"
+    upgrades_dir.mkdir(parents=True, exist_ok=True)
+    stale_scripts = [
+        upgrades_dir / "relaunch-MediaMop-Relaunch-old-a.cmd",
+        upgrades_dir / "relaunch-MediaMop-Relaunch-old-b.cmd",
+    ]
+    for script_path in stale_scripts:
+        script_path.write_text("@echo off\n", encoding="ascii")
+
+    observed_commands: list[list[str]] = []
+
+    class _Result:
+        def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(command: list[str], **kwargs):
+        observed_commands.append(command)
+        if command[:3] == ["schtasks", "/Query", "/FO"]:
+            return _Result(
+                stdout=(
+                    "TaskName:                             \\MediaMop-Relaunch-old-a\r\n"
+                    "TaskName:                             \\UnrelatedTask\r\n"
+                    "TaskName:                             \\MediaMop-Relaunch-old-b\r\n"
+                )
+            )
+        return _Result()
+
+    monkeypatch.setattr(updater_service.subprocess, "run", _fake_run)
+
+    updater_service._launch_process_in_active_session_via_schtasks(
+        executable,
+        args=["--no-browser"],
+        cwd=tmp_path,
+    )
+
+    for stale_script in stale_scripts:
+        assert stale_script.exists() is False
+    assert any(
+        command[:5] == ["schtasks", "/Delete", "/TN", "MediaMop-Relaunch-old-a", "/F"]
+        for command in observed_commands
+    )
+    assert any(
+        command[:5] == ["schtasks", "/Delete", "/TN", "MediaMop-Relaunch-old-b", "/F"]
+        for command in observed_commands
+    )
+    assert any(
+        command[:5] == ["schtasks", "/Delete", "/TN", "MediaMop-Relaunch", "/F"]
+        for command in observed_commands
+    )
 
 
 def test_packaged_helper_exits_after_launch_and_reconciliation_completes(

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.12",
+      "version": "2.1.13",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.12",
+  "version": "2.1.13",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.1.13.md
+++ b/docs/release-notes/v2.1.13.md
@@ -1,0 +1,19 @@
+# MediaMop v2.1.13
+
+This patch release fixes a Windows in-app upgrade relaunch regression that could spawn multiple tray instances/icons after repeated upgrades.
+
+## Highlights
+
+- Fixed scheduled relaunch task handling in the Windows updater:
+  - relaunch task is now a singleton (`MediaMop-Relaunch`) instead of creating unbounded per-attempt task names
+  - stale `MediaMop-Relaunch-*` scheduled tasks are purged before relaunch
+  - stale `relaunch-MediaMop-Relaunch*.cmd` launcher scripts are purged before relaunch
+  - relaunch task uses `schtasks /Z` and explicit delete after run so it cannot accumulate
+- Added regression tests to lock in cleanup behavior and prevent future multi-tray regressions.
+
+## Support notes
+
+- Upgrade verification rules are unchanged: completion still requires running version == target version.
+- Trusted installer/checksum validation behavior is unchanged.
+
+[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.12...v2.1.13)

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.12"
+#define AppVersion "2.1.13"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.1.13

This patch release fixes a Windows in-app upgrade relaunch regression that could spawn multiple tray instances/icons after repeated upgrades.

## Highlights

- Fixed scheduled relaunch task handling in the Windows updater:
  - relaunch task is now a singleton (`MediaMop-Relaunch`) instead of creating unbounded per-attempt task names
  - stale `MediaMop-Relaunch-*` scheduled tasks are purged before relaunch
  - stale `relaunch-MediaMop-Relaunch*.cmd` launcher scripts are purged before relaunch
  - relaunch task uses `schtasks /Z` and explicit delete after run so it cannot accumulate
- Added regression tests to lock in cleanup behavior and prevent future multi-tray regressions.

## Support notes

- Upgrade verification rules are unchanged: completion still requires running version == target version.
- Trusted installer/checksum validation behavior is unchanged.

[Full Changelog](https://github.com/jampat000/MediaMop/compare/v2.1.12...v2.1.13)
