### PR TITLE
Harden backend typing, metrics, and auth contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,6 +18,21 @@ MediaMop is a self-hosted media operations app:
 - Packaging: Docker and Windows installer workflows.
 - Runtime data: `MEDIAMOP_HOME`.
 
+```mermaid
+flowchart LR
+  UI["Frontend (React/Vite)"] --> API["FastAPI API Layer"]
+  API --> Core["Core + Platform Services"]
+  Core --> Refiner["Refiner Module"]
+  Core --> Pruner["Pruner Module"]
+  Core --> Subber["Subber Module"]
+  Core --> Dashboard["Dashboard + Activity"]
+  Core --> Integrations["External Integrations (Arr, OpenSubtitles, etc.)"]
+  Core --> DB["SQLite (Alembic managed)"]
+  Refiner --> Lanes["Worker Lanes / Durable Jobs"]
+  Pruner --> Lanes
+  Subber --> Lanes
+```
+
 ## Backend Map
 
 - `mediamop.api`: FastAPI app factory, router composition, request dependencies.
@@ -44,6 +59,16 @@ MediaMop is a self-hosted media operations app:
 - Frontend pages should use typed API/query helpers from `src/lib` rather than ad hoc fetch calls.
 - Cross-cutting runtime concerns belong in `mediamop.platform` or `mediamop.core`, not inside module implementation details.
 - File lifecycle changes must preserve the safety contract in [`docs/file-lifecycle-contract.md`](docs/file-lifecycle-contract.md).
+
+## Job Lifecycle
+
+```mermaid
+flowchart LR
+  Enqueue["Enqueue request"] --> Lane["Module worker lane"]
+  Lane --> Result["Job result (completed/failed/pending retry)"]
+  Result --> Activity["Activity + logs"]
+  Result --> Metrics["Runtime metrics / Prometheus"]
+```
 
 ## Architecture Decision Records
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -48,12 +48,23 @@ line-length = 120
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82"]
+select = ["E9", "F63", "F7", "F82", "B", "C4"]
+ignore = ["B008"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/test_csrf_unit.py" = ["C408"]
 
 [tool.mypy]
 python_version = "3.11"
 ignore_missing_imports = true
-follow_imports = "skip"
-check_untyped_defs = false
-warn_unused_ignores = false
+follow_imports = "normal"
+check_untyped_defs = true
+warn_unused_ignores = true
+ignore_errors = false
+
+[[tool.mypy.overrides]]
+module = [
+  "mediamop.modules.refiner.*",
+  "mediamop.windows.*",
+]
 ignore_errors = true

--- a/apps/backend/src/mediamop/core/alembic_revision_check.py
+++ b/apps/backend/src/mediamop/core/alembic_revision_check.py
@@ -80,11 +80,11 @@ def _strictly_behind_head(script: ScriptDirectory, *, head: str, current: str) -
         dr = rev.down_revision
         if dr is None:
             break
-        if isinstance(dr, tuple):
+        if isinstance(dr, tuple | list):
             return False
         if dr == current:
             return True
-        rev = script.get_revision(dr)
+        rev = script.get_revision(str(dr))
     return False
 
 

--- a/apps/backend/src/mediamop/core/db.py
+++ b/apps/backend/src/mediamop/core/db.py
@@ -39,6 +39,8 @@ def _register_sqlite_pragmas(engine: Engine) -> None:
 
     @event.listens_for(engine, "connect")
     def _sqlite_connect(dbapi_connection: object, _connection_record: object) -> None:
+        if not isinstance(dbapi_connection, sqlite3.Connection):
+            return
         cursor = dbapi_connection.cursor()
         try:
             cursor.execute("PRAGMA journal_mode=WAL")

--- a/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
@@ -15,9 +15,9 @@ from mediamop.core.credentials_rotation import credential_secret_candidates
 
 _HKDF_INFO = b"mediamop.pruner.credentials.v1.fernet"
 _ENVELOPE_VERSION = 3
-_CREDENTIALS_KEY_ID = "credentials:hkdf:v1"
+_CREDENTIALS_KEY_ID: Literal["credentials:hkdf:v1"] = "credentials:hkdf:v1"
 _CREDENTIALS_KEY_ID_LEGACY = "credentials:v1"
-_SESSION_LEGACY_KEY_ID = "session-legacy:v1"
+_SESSION_LEGACY_KEY_ID: Literal["session-legacy:v1"] = "session-legacy:v1"
 
 
 def _fernet_for_secret_hkdf(secret: str | None) -> Fernet | None:
@@ -87,24 +87,25 @@ def decrypt_pruner_credentials_json(settings: MediaMopSettings, ciphertext: str)
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
+        fernets: list[Fernet]
         if key_id == _CREDENTIALS_KEY_ID:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_hkdf)
         elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)
         else:
-            fernets = [f for f in [_legacy_fernet(settings)] if f]
-        for f in fernets:
+            fernets = [candidate for candidate in [_legacy_fernet(settings)] if candidate is not None]
+        for fernet in fernets:
             try:
-                return f.decrypt(token.encode("ascii")).decode("utf-8")
+                return fernet.decrypt(token.encode("ascii")).decode("utf-8")
             except (InvalidToken, ValueError, TypeError):
                 continue
         return None
 
-    f = _legacy_fernet(settings)
-    if f is None:
+    legacy_fernet = _legacy_fernet(settings)
+    if legacy_fernet is None:
         return None
     try:
-        return f.decrypt((ciphertext or "").strip().encode("ascii")).decode("utf-8")
+        return legacy_fernet.decrypt((ciphertext or "").strip().encode("ascii")).decode("utf-8")
     except (InvalidToken, ValueError, TypeError):
         return None
 

--- a/apps/backend/src/mediamop/modules/pruner/pruner_jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_jobs_ops.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from mediamop.modules.queue_worker.job_kind_boundaries import validate_pruner_enqueue_job_kind
 from mediamop.modules.pruner.pruner_jobs_model import PrunerJob, PrunerJobStatus
+from mediamop.platform.metrics.service import record_module_job_event, set_module_queue_depth
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _record_pruner_queue_depth(session: Session) -> None:
+    depth = session.scalar(
+        select(func.count())
+        .select_from(PrunerJob)
+        .where(or_(PrunerJob.status == PrunerJobStatus.PENDING.value, PrunerJob.status == PrunerJobStatus.LEASED.value))
+    )
+    set_module_queue_depth(module="pruner", depth=int(depth or 0))
 
 
 _CLAIM_NEXT_SQL = """
@@ -68,6 +78,7 @@ def pruner_enqueue_or_get_job(
         except IntegrityError:
             pass
         else:
+            _record_pruner_queue_depth(session)
             return row
 
     found = session.scalar(select(PrunerJob).where(PrunerJob.dedupe_key == dedupe_key))
@@ -101,7 +112,10 @@ def claim_next_eligible_pruner_job(
     if row is None:
         return None
     job_id = int(row[0])
-    return session.scalars(select(PrunerJob).where(PrunerJob.id == job_id)).one()
+    claimed = session.scalars(select(PrunerJob).where(PrunerJob.id == job_id)).one()
+    record_module_job_event(module="pruner", event="started")
+    _record_pruner_queue_depth(session)
+    return claimed
 
 
 def complete_claimed_pruner_job(
@@ -128,6 +142,8 @@ def complete_claimed_pruner_job(
     job.lease_owner = None
     job.lease_expires_at = None
     session.flush()
+    record_module_job_event(module="pruner", event="completed")
+    _record_pruner_queue_depth(session)
     return True
 
 
@@ -157,9 +173,11 @@ def fail_claimed_pruner_job(
     job.lease_expires_at = None
     if job.attempt_count >= job.max_attempts:
         job.status = PrunerJobStatus.FAILED.value
+        record_module_job_event(module="pruner", event="failed")
     else:
         job.status = PrunerJobStatus.PENDING.value
     session.flush()
+    _record_pruner_queue_depth(session)
     return True
 
 
@@ -189,4 +207,6 @@ def fail_leased_pruner_job_after_complete_failure(
     job.lease_expires_at = None
     job.last_error = error_message[:10_000]
     session.flush()
+    record_module_job_event(module="pruner", event="failed")
+    _record_pruner_queue_depth(session)
     return True

--- a/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
@@ -11,16 +11,26 @@ from typing import Literal
 
 _REFINER_JOB_DEDUPE_KEY_MAX_LEN = 512
 
-from sqlalchemy import select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from mediamop.modules.queue_worker.job_kind_boundaries import validate_refiner_enqueue_job_kind
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.platform.metrics.service import record_module_job_event, set_module_queue_depth
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _record_refiner_queue_depth(session: Session) -> None:
+    depth = session.scalar(
+        select(func.count())
+        .select_from(RefinerJob)
+        .where(or_(RefinerJob.status == RefinerJobStatus.PENDING.value, RefinerJob.status == RefinerJobStatus.LEASED.value))
+    )
+    set_module_queue_depth(module="refiner", depth=int(depth or 0))
 
 
 _CLAIM_NEXT_SQL = """
@@ -106,6 +116,7 @@ def refiner_enqueue_or_get_job(
         except IntegrityError:
             pass
         else:
+            _record_refiner_queue_depth(session)
             return row
 
     found = session.scalar(select(RefinerJob).where(RefinerJob.dedupe_key == dedupe_key))
@@ -143,7 +154,10 @@ def claim_next_eligible_refiner_job(
     if row is None:
         return None
     job_id = int(row[0])
-    return session.scalars(select(RefinerJob).where(RefinerJob.id == job_id)).one()
+    claimed = session.scalars(select(RefinerJob).where(RefinerJob.id == job_id)).one()
+    record_module_job_event(module="refiner", event="started")
+    _record_refiner_queue_depth(session)
+    return claimed
 
 
 def complete_claimed_refiner_job(
@@ -170,6 +184,8 @@ def complete_claimed_refiner_job(
     job.lease_owner = None
     job.lease_expires_at = None
     session.flush()
+    record_module_job_event(module="refiner", event="completed")
+    _record_refiner_queue_depth(session)
     return True
 
 
@@ -199,9 +215,11 @@ def fail_claimed_refiner_job(
     job.lease_expires_at = None
     if job.attempt_count >= job.max_attempts:
         job.status = RefinerJobStatus.FAILED.value
+        record_module_job_event(module="refiner", event="failed")
     else:
         job.status = RefinerJobStatus.PENDING.value
     session.flush()
+    _record_refiner_queue_depth(session)
     return True
 
 
@@ -236,6 +254,8 @@ def fail_leased_refiner_job_after_complete_failure(
     job.lease_expires_at = None
     job.last_error = error_message[:10_000]
     session.flush()
+    record_module_job_event(module="refiner", event="failed")
+    _record_refiner_queue_depth(session)
     return True
 
 
@@ -272,4 +292,6 @@ def recover_handler_ok_finalize_failed_to_completed(
     job.lease_owner = None
     job.lease_expires_at = None
     session.flush()
+    record_module_job_event(module="refiner", event="completed")
+    _record_refiner_queue_depth(session)
     return "ok"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -121,9 +121,14 @@ async def _run_periodic_watched_folder_scan_dispatch_enqueue(
                 session.commit()
                 return now_loop + interval, interval
 
-        def _once(now_loop: float) -> tuple[float, float, float]:
-            next_movie, poll_movie = _scope_once("movie", now_loop=now_loop, next_run_loop=next_run_movie)
-            next_tv, poll_tv = _scope_once("tv", now_loop=now_loop, next_run_loop=next_run_tv)
+        def _once(
+            now_loop: float,
+            *,
+            next_movie_loop: float = next_run_movie,
+            next_tv_loop: float = next_run_tv,
+        ) -> tuple[float, float, float]:
+            next_movie, poll_movie = _scope_once("movie", now_loop=now_loop, next_run_loop=next_movie_loop)
+            next_tv, poll_tv = _scope_once("tv", now_loop=now_loop, next_run_loop=next_tv_loop)
             return next_movie, next_tv, min(poll_movie, poll_tv)
 
         try:

--- a/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
@@ -15,9 +15,9 @@ from mediamop.core.credentials_rotation import credential_secret_candidates
 
 _HKDF_INFO = b"mediamop.subber.credentials.v1.fernet"
 _ENVELOPE_VERSION = 3
-_CREDENTIALS_KEY_ID = "credentials:hkdf:v1"
+_CREDENTIALS_KEY_ID: Literal["credentials:hkdf:v1"] = "credentials:hkdf:v1"
 _CREDENTIALS_KEY_ID_LEGACY = "credentials:v1"
-_SESSION_LEGACY_KEY_ID = "session-legacy:v1"
+_SESSION_LEGACY_KEY_ID: Literal["session-legacy:v1"] = "session-legacy:v1"
 
 
 def _fernet_for_secret_hkdf(secret: str | None) -> Fernet | None:
@@ -86,23 +86,24 @@ def decrypt_subber_credentials_json(settings: MediaMopSettings, ciphertext: str)
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
+        fernets: list[Fernet]
         if key_id == _CREDENTIALS_KEY_ID:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_hkdf)
         elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)
         else:
-            fernets = [f for f in [_legacy_fernet(settings)] if f]
-        for f in fernets:
+            fernets = [candidate for candidate in [_legacy_fernet(settings)] if candidate is not None]
+        for fernet in fernets:
             try:
-                return f.decrypt(token.encode("ascii")).decode("utf-8")
+                return fernet.decrypt(token.encode("ascii")).decode("utf-8")
             except (InvalidToken, ValueError, TypeError):
                 continue
         return None
-    f = _legacy_fernet(settings)
-    if f is None:
+    legacy_fernet = _legacy_fernet(settings)
+    if legacy_fernet is None:
         return None
     try:
-        return f.decrypt(raw.encode("ascii")).decode("utf-8")
+        return legacy_fernet.decrypt(raw.encode("ascii")).decode("utf-8")
     except (InvalidToken, ValueError, TypeError):
         return None
 
@@ -138,7 +139,7 @@ def parse_provider_secrets_json(provider_key: str, plaintext: str | None) -> dic
     from mediamop.modules.subber.subber_provider_registry import PROVIDER_CREDENTIAL_FIELDS
 
     fields = PROVIDER_CREDENTIAL_FIELDS.get(provider_key, [])
-    out = {k: "" for k in fields}
+    out = dict.fromkeys(fields, "")
     if not plaintext or not plaintext.strip():
         return out
     try:

--- a/apps/backend/src/mediamop/modules/subber/subber_jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_jobs_ops.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from mediamop.modules.queue_worker.job_kind_boundaries import validate_subber_enqueue_job_kind
 from mediamop.modules.subber.subber_jobs_model import SubberJob, SubberJobStatus
+from mediamop.platform.metrics.service import record_module_job_event, set_module_queue_depth
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
+
+def _record_subber_queue_depth(session: Session) -> None:
+    depth = session.scalar(
+        select(func.count())
+        .select_from(SubberJob)
+        .where(or_(SubberJob.status == SubberJobStatus.PENDING.value, SubberJob.status == SubberJobStatus.LEASED.value))
+    )
+    set_module_queue_depth(module="subber", depth=int(depth or 0))
 
 
 _CLAIM_NEXT_SQL = """
@@ -68,6 +78,7 @@ def subber_enqueue_or_get_job(
         except IntegrityError:
             pass
         else:
+            _record_subber_queue_depth(session)
             return row
 
     found = session.scalar(select(SubberJob).where(SubberJob.dedupe_key == dedupe_key))
@@ -99,7 +110,10 @@ def claim_next_eligible_subber_job(
     if row is None:
         return None
     job_id = int(row[0])
-    return session.scalars(select(SubberJob).where(SubberJob.id == job_id)).one()
+    claimed = session.scalars(select(SubberJob).where(SubberJob.id == job_id)).one()
+    record_module_job_event(module="subber", event="started")
+    _record_subber_queue_depth(session)
+    return claimed
 
 
 def complete_claimed_subber_job(
@@ -124,6 +138,8 @@ def complete_claimed_subber_job(
     job.lease_owner = None
     job.lease_expires_at = None
     session.flush()
+    record_module_job_event(module="subber", event="completed")
+    _record_subber_queue_depth(session)
     return True
 
 
@@ -151,9 +167,11 @@ def fail_claimed_subber_job(
     job.lease_expires_at = None
     if job.attempt_count >= job.max_attempts:
         job.status = SubberJobStatus.FAILED.value
+        record_module_job_event(module="subber", event="failed")
     else:
         job.status = SubberJobStatus.PENDING.value
     session.flush()
+    _record_subber_queue_depth(session)
     return True
 
 
@@ -181,4 +199,6 @@ def fail_leased_subber_job_after_complete_failure(
     job.lease_expires_at = None
     job.last_error = error_message[:10_000]
     session.flush()
+    record_module_job_event(module="subber", event="failed")
+    _record_subber_queue_depth(session)
     return True

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
@@ -108,7 +108,7 @@ def put_subber_provider(
             cur["password"] = body.password
         if body.api_key is not None and body.api_key.strip():
             cur["api_key"] = body.api_key.strip()
-        creds = cur
+        creds = dict(cur)
     row = upsert_provider_settings(
         db,
         settings,

--- a/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
@@ -93,7 +93,7 @@ def make_subber_subtitle_search_handler(
                         state_id,
                     )
                     return
-                provider_events: list[dict[str, str]] = []
+                provider_events: list[dict[str, object]] = []
                 ok = search_and_download_subtitle(
                     settings=settings,
                     settings_row=settings_row,

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
@@ -45,6 +45,23 @@ def _masked_set(ciphertext: str | None) -> bool:
     return bool((ciphertext or "").strip())
 
 
+def _load_secrets_envelope(raw: str | None, *, provider: str) -> tuple[dict[str, object], dict[str, str]]:
+    try:
+        decoded = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        decoded = {}
+    if not isinstance(decoded, dict):
+        decoded = {}
+    envelope: dict[str, object] = dict(decoded)
+    secrets_raw = envelope.get("secrets")
+    secrets: dict[str, str] = {}
+    if isinstance(secrets_raw, dict):
+        for key, value in secrets_raw.items():
+            secrets[str(key)] = str(value or "")
+    envelope["provider"] = provider
+    return envelope, secrets
+
+
 def _settings_out(db, row: SubberSettingsRow, request: Request, settings: MediaMopSettings) -> SubberSettingsOut:
     son_hint, rad_hint = get_arr_library_connection_hints(db)
     _ = request, settings
@@ -132,44 +149,29 @@ def put_subber_settings(
         row.enabled = bool(body.enabled)
     if body.opensubtitles_username is not None:
         row.opensubtitles_username = body.opensubtitles_username.strip()
-        raw_u = decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or "") or "{}"
-        try:
-            cur_u = json.loads(raw_u)
-        except json.JSONDecodeError:
-            cur_u = {"provider": "opensubtitles", "secrets": {}}
-        if not isinstance(cur_u, dict):
-            cur_u = {"provider": "opensubtitles", "secrets": {}}
-        sec_u = cur_u.get("secrets") if isinstance(cur_u.get("secrets"), dict) else {}
-        sec_u["username"] = row.opensubtitles_username
-        cur_u["provider"] = "opensubtitles"
-        cur_u["secrets"] = sec_u
-        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(cur_u))
+        envelope_u, secrets_u = _load_secrets_envelope(
+            decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or ""),
+            provider="opensubtitles",
+        )
+        secrets_u["username"] = row.opensubtitles_username
+        envelope_u["secrets"] = secrets_u
+        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(envelope_u))
     if body.opensubtitles_password is not None and body.opensubtitles_password.strip():
-        raw = decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or "") or "{}"
-        try:
-            cur = json.loads(raw)
-        except json.JSONDecodeError:
-            cur = {"provider": "opensubtitles", "secrets": {}}
-        if not isinstance(cur, dict):
-            cur = {"provider": "opensubtitles", "secrets": {}}
-        sec = cur.get("secrets") if isinstance(cur.get("secrets"), dict) else {}
-        sec["password"] = body.opensubtitles_password
-        cur["provider"] = "opensubtitles"
-        cur["secrets"] = sec
-        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(cur))
+        envelope, secrets = _load_secrets_envelope(
+            decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or ""),
+            provider="opensubtitles",
+        )
+        secrets["password"] = body.opensubtitles_password
+        envelope["secrets"] = secrets
+        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(envelope))
     if body.opensubtitles_api_key is not None and body.opensubtitles_api_key.strip():
-        raw = decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or "") or "{}"
-        try:
-            cur = json.loads(raw)
-        except json.JSONDecodeError:
-            cur = {"provider": "opensubtitles", "secrets": {}}
-        if not isinstance(cur, dict):
-            cur = {"provider": "opensubtitles", "secrets": {}}
-        sec = cur.get("secrets") if isinstance(cur.get("secrets"), dict) else {}
-        sec["api_key"] = body.opensubtitles_api_key.strip()
-        cur["provider"] = "opensubtitles"
-        cur["secrets"] = sec
-        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(cur))
+        envelope, secrets = _load_secrets_envelope(
+            decrypt_subber_credentials_json(settings, row.opensubtitles_credentials_ciphertext or ""),
+            provider="opensubtitles",
+        )
+        secrets["api_key"] = body.opensubtitles_api_key.strip()
+        envelope["secrets"] = secrets
+        row.opensubtitles_credentials_ciphertext = encrypt_subber_credentials_json(settings, json.dumps(envelope))
     if body.sonarr_base_url is not None:
         row.sonarr_base_url = body.sonarr_base_url.strip()
     if body.sonarr_api_key is not None and body.sonarr_api_key.strip():

--- a/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
@@ -796,7 +796,7 @@ def search_and_download_subtitle(
     db: Session,
     providers: list[SubberProviderRow] | None = None,
     retain_found_on_failure: bool = False,
-    provider_events: list[dict[str, str]] | None = None,
+    provider_events: list[dict[str, object]] | None = None,
 ) -> bool:
     """Search providers in order; legacy settings path when ``providers`` is empty.
 

--- a/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
@@ -20,8 +20,8 @@ _ARR_API_KEY_KDF_PEPPER = binascii.a2b_hex(
 )
 _ARR_API_KEY_KDF_ITERATIONS = 390_000
 _ENVELOPE_VERSION = 2
-_CREDENTIALS_KEY_ID = "credentials:v1"
-_SESSION_LEGACY_KEY_ID = "session-legacy:v1"
+_CREDENTIALS_KEY_ID: Literal["credentials:v1"] = "credentials:v1"
+_SESSION_LEGACY_KEY_ID: Literal["session-legacy:v1"] = "session-legacy:v1"
 
 
 def _fernet_for_secret(secret: str | None) -> Fernet | None:
@@ -83,22 +83,22 @@ def decrypt_arr_api_key(settings: MediaMopSettings, ciphertext: str) -> str | No
         key_id = str(env.get("key_id") or "")
         if not token:
             return None
-        fernets = (
+        fernets: list[Fernet] = (
             credential_secret_candidates(settings, _fernet_for_secret)
             if key_id == _CREDENTIALS_KEY_ID
-            else [f for f in [_legacy_fernet(settings)] if f]
+            else [candidate for candidate in [_legacy_fernet(settings)] if candidate is not None]
         )
-        for f in fernets:
+        for fernet in fernets:
             try:
-                return f.decrypt(token.encode("ascii")).decode("utf-8")
+                return fernet.decrypt(token.encode("ascii")).decode("utf-8")
             except (InvalidToken, ValueError, TypeError):
                 continue
         return None
-    f = _legacy_fernet(settings)
-    if f is None:
+    legacy_fernet = _legacy_fernet(settings)
+    if legacy_fernet is None:
         return None
     try:
-        return f.decrypt(raw.encode("ascii")).decode("utf-8")
+        return legacy_fernet.decrypt(raw.encode("ascii")).decode("utf-8")
     except (InvalidToken, ValueError, TypeError):
         return None
 

--- a/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
+++ b/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
@@ -227,8 +227,10 @@ def post_arr_library_connection_test(
             )
             record_connection_test_result_sonarr(db, ok=False, detail=detail)
             return ArrLibraryConnectionTestOut(ok=False, message=detail)
+        base_url = (base or "").strip()
+        api_key = (key or "").strip()
         try:
-            ArrLibraryV3Client(base.strip(), key.strip()).health_ok()
+            ArrLibraryV3Client(base_url, api_key).health_ok()
         except ArrLibraryV3HttpError as e:
             msg = (
                 "MediaMop could reach your TV library app, but it did not accept the request. "
@@ -296,8 +298,10 @@ def post_arr_library_connection_test(
         )
         record_connection_test_result_radarr(db, ok=False, detail=detail)
         return ArrLibraryConnectionTestOut(ok=False, message=detail)
+    base_url = (base or "").strip()
+    api_key = (key or "").strip()
     try:
-        ArrLibraryV3Client(base.strip(), key.strip()).health_ok()
+        ArrLibraryV3Client(base_url, api_key).health_ok()
     except ArrLibraryV3HttpError as e:
         msg = (
             "MediaMop could reach your movie library app, but it did not accept the request. "

--- a/apps/backend/src/mediamop/platform/auth/bootstrap.py
+++ b/apps/backend/src/mediamop/platform/auth/bootstrap.py
@@ -22,6 +22,9 @@ def acquire_bootstrap_transaction_lock(db: Session) -> None:
     """
 
     raw = db.connection().connection.driver_connection
+    if raw is None:
+        msg = "Could not acquire bootstrap transaction lock: database driver connection is unavailable."
+        raise RuntimeError(msg)
     raw.execute("BEGIN IMMEDIATE")
 
 

--- a/apps/backend/src/mediamop/platform/auth/csrf.py
+++ b/apps/backend/src/mediamop/platform/auth/csrf.py
@@ -14,6 +14,7 @@ you open.
 from __future__ import annotations
 
 import secrets
+from typing import cast
 from urllib.parse import urlparse
 
 from fastapi import HTTPException, Request, status
@@ -48,9 +49,10 @@ def current_raw_session_token(request: Request, settings: MediaMopSettings) -> s
 def issue_csrf_token(secret: str, raw_session_token: str | None = None) -> str:
     if not secret.strip():
         raise ValueError("session secret required for CSRF")
+    bound_session = (raw_session_token or "").strip()
     payload = (
-        _session_subject_payload(raw_session_token)
-        if (raw_session_token or "").strip()
+        _session_subject_payload(bound_session)
+        if bound_session
         else CSRF_SUBJECT_ANONYMOUS
     )
     return _signer(secret).sign(payload.encode("utf-8")).decode("utf-8")
@@ -75,7 +77,7 @@ def verify_csrf_token(
         return True
     if not (raw_session_token or "").strip():
         return False
-    return secrets.compare_digest(payload, _session_subject_payload(raw_session_token))
+    return secrets.compare_digest(payload, _session_subject_payload(cast(str, raw_session_token)))
 
 
 def validate_browser_post_origin(request: Request, settings: MediaMopSettings) -> None:

--- a/apps/backend/src/mediamop/platform/auth/schemas.py
+++ b/apps/backend/src/mediamop/platform/auth/schemas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from mediamop.platform.auth.password import MIN_PASSWORD_LENGTH
 
@@ -14,6 +14,8 @@ class CsrfOut(BaseModel):
 
 
 class LoginIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     username: str = Field(..., min_length=1, max_length=64)
     password: str = Field(..., min_length=1)
     csrf_token: str = Field(..., min_length=1)
@@ -32,6 +34,8 @@ class LoginOut(BaseModel):
 
 class LogoutIn(BaseModel):
     """Optional body CSRF fallback when header is awkward for a client."""
+
+    model_config = ConfigDict(extra="forbid")
 
     csrf_token: str | None = None
 
@@ -57,6 +61,8 @@ class BootstrapStatusOut(BaseModel):
 
 
 class BootstrapIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     username: str = Field(..., min_length=1, max_length=64)
     password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=512)
     csrf_token: str = Field(..., min_length=1)
@@ -68,6 +74,8 @@ class BootstrapOut(BaseModel):
 
 
 class ChangePasswordIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     current_password: str = Field(..., min_length=1)
     new_password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=512)
     csrf_token: str = Field(..., min_length=1)

--- a/apps/backend/src/mediamop/platform/auth/service.py
+++ b/apps/backend/src/mediamop/platform/auth/service.py
@@ -81,7 +81,7 @@ def cleanup_inactive_sessions(db: Session, *, settings: MediaMopSettings, now=No
             ),
         )
     )
-    return int(result.rowcount or 0)
+    return int(getattr(result, "rowcount", 0) or 0)
 
 
 def enforce_session_limit_for_user(

--- a/apps/backend/src/mediamop/platform/configuration_bundle/service.py
+++ b/apps/backend/src/mediamop/platform/configuration_bundle/service.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
 
 from sqlalchemy import DateTime, delete, inspect, select
+from sqlalchemy.orm import Mapper
 from sqlalchemy.orm import Session
 
 from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
@@ -31,7 +32,7 @@ def _serialize_cell(value: Any) -> Any:
 
 
 def orm_row_to_dict(obj: Any) -> dict[str, Any]:
-    mapper = inspect(obj.__class__).mapper
+    mapper = cast(Mapper[Any], inspect(obj.__class__, raiseerr=True))
     out: dict[str, Any] = {}
     for col in mapper.columns:
         key = col.key
@@ -51,7 +52,7 @@ def _parse_datetime(raw: Any) -> datetime | None:
 
 
 def dict_to_model_kwargs(model_cls: type[T], data: dict[str, Any]) -> dict[str, Any]:
-    mapper = inspect(model_cls).mapper
+    mapper = cast(Mapper[Any], inspect(model_cls, raiseerr=True))
     cols = {c.key: c for c in mapper.columns}
     out: dict[str, Any] = {}
     for key, raw in data.items():

--- a/apps/backend/src/mediamop/platform/local_browse/router.py
+++ b/apps/backend/src/mediamop/platform/local_browse/router.py
@@ -48,7 +48,10 @@ def _list_root_entries() -> list[DirectoryBrowseEntry]:
             try:
                 import ctypes
 
-                drive_type = ctypes.windll.kernel32.GetDriveTypeW(root)
+                windll = getattr(ctypes, "windll", None)
+                if windll is None:
+                    raise RuntimeError("ctypes windll is unavailable")
+                drive_type = windll.kernel32.GetDriveTypeW(root)
                 description = {
                     2: "External drive",
                     3: "Local drive",

--- a/apps/backend/src/mediamop/platform/metrics/service.py
+++ b/apps/backend/src/mediamop/platform/metrics/service.py
@@ -6,12 +6,30 @@ import threading
 import time
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from typing import TypedDict
 
 
 @dataclass
 class RouteMetric:
     count: int = 0
     total_duration_ms: float = 0.0
+
+
+class RouteSummary(TypedDict):
+    route: str
+    request_count: int
+    average_response_ms: float
+
+
+class RuntimeMetricsSummary(TypedDict):
+    uptime_seconds: float
+    total_requests: int
+    average_response_ms: float
+    error_log_count: int
+    status_counts: dict[str, int]
+    busiest_routes: list[RouteSummary]
+    module_job_counts: dict[str, dict[str, int]]
+    module_queue_depths: dict[str, int]
 
 
 class RuntimeMetricsStore:
@@ -23,6 +41,8 @@ class RuntimeMetricsStore:
         self.status_counts: Counter[str] = Counter()
         self.route_metrics: dict[str, RouteMetric] = defaultdict(RouteMetric)
         self.log_counts: Counter[str] = Counter()
+        self.module_job_counts: Counter[tuple[str, str]] = Counter()
+        self.module_queue_depths: dict[str, int] = defaultdict(int)
 
     def record_request(self, *, method: str, route: str, status_code: int, duration_ms: float) -> None:
         bucket = f"{status_code // 100}xx"
@@ -39,7 +59,21 @@ class RuntimeMetricsStore:
         with self._lock:
             self.log_counts[level.upper()] += 1
 
-    def summary(self) -> dict[str, object]:
+    def record_module_job_event(self, *, module: str, event: str) -> None:
+        if not module:
+            return
+        if event not in {"started", "completed", "failed"}:
+            return
+        with self._lock:
+            self.module_job_counts[(module, event)] += 1
+
+    def set_module_queue_depth(self, *, module: str, depth: int) -> None:
+        if not module:
+            return
+        with self._lock:
+            self.module_queue_depths[module] = max(0, int(depth))
+
+    def summary(self) -> RuntimeMetricsSummary:
         with self._lock:
             uptime_seconds = max(time.time() - self.started_at, 0.0)
             average_response_ms = self.http_total_duration_ms / self.http_total if self.http_total else 0.0
@@ -47,6 +81,10 @@ class RuntimeMetricsStore:
                 self.route_metrics.items(),
                 key=lambda item: (-item[1].count, item[0]),
             )[:5]
+            module_job_counts: dict[str, dict[str, int]] = {}
+            for (module, event), count in sorted(self.module_job_counts.items()):
+                bucket = module_job_counts.setdefault(module, {"started": 0, "completed": 0, "failed": 0})
+                bucket[event] = int(count)
             return {
                 "uptime_seconds": uptime_seconds,
                 "total_requests": self.http_total,
@@ -66,10 +104,13 @@ class RuntimeMetricsStore:
                     }
                     for route, metric in busiest
                 ],
+                "module_job_counts": module_job_counts,
+                "module_queue_depths": dict(self.module_queue_depths),
             }
 
     def render_prometheus(self) -> str:
         summary = self.summary()
+        status_counts = summary["status_counts"]
         lines = [
             "# HELP mediamop_process_uptime_seconds Seconds since the current MediaMop process started.",
             "# TYPE mediamop_process_uptime_seconds gauge",
@@ -85,8 +126,13 @@ class RuntimeMetricsStore:
         ]
         for level in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
             lines.append(f'mediamop_log_records_total{{level="{level.lower()}"}} {self.log_counts[level]}')
-        for bucket, count in summary["status_counts"].items():
+        for bucket, count in status_counts.items():
             lines.append(f'mediamop_http_status_total{{status="{bucket}"}} {count}')
+        for module, counts in summary["module_job_counts"].items():
+            for event, count in counts.items():
+                lines.append(f'mediamop_module_jobs_total{{module="{module}",event="{event}"}} {count}')
+        for module, depth in summary["module_queue_depths"].items():
+            lines.append(f'mediamop_module_queue_depth{{module="{module}"}} {depth}')
         return "\n".join(lines) + "\n"
 
 
@@ -101,9 +147,22 @@ def record_log_record(level: str) -> None:
     runtime_metrics.record_log(level)
 
 
-def build_runtime_metrics_summary() -> dict[str, object]:
+def record_module_job_event(*, module: str, event: str) -> None:
+    runtime_metrics.record_module_job_event(module=module, event=event)
+
+
+def set_module_queue_depth(*, module: str, depth: int) -> None:
+    runtime_metrics.set_module_queue_depth(module=module, depth=depth)
+
+
+def build_runtime_metrics_summary() -> RuntimeMetricsSummary:
     return runtime_metrics.summary()
 
 
 def render_prometheus_metrics() -> str:
     return runtime_metrics.render_prometheus()
+
+
+def reset_runtime_metrics_for_tests() -> None:
+    global runtime_metrics
+    runtime_metrics = RuntimeMetricsStore()

--- a/apps/backend/src/mediamop/platform/reconciliation/service.py
+++ b/apps/backend/src/mediamop/platform/reconciliation/service.py
@@ -208,8 +208,8 @@ def repair_reconciliation_issue(
             raise ValueError("confirm=true is required before removing a Refiner temp artifact.")
         if not path or not path.strip():
             raise ValueError("path is required for this repair action.")
-        row = session.get(RefinerPathSettingsRow, 1)
-        roots = _configured_refiner_work_roots(row)
+        path_row = session.get(RefinerPathSettingsRow, 1)
+        roots = _configured_refiner_work_roots(path_row)
         target = Path(path)
         if not _is_temp_artifact(target):
             raise ValueError("Refusing to remove a file that does not look like a temp artifact.")

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+import logging
+
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, RedirectResponse
 from starlette import status
@@ -51,6 +54,14 @@ from mediamop.platform.suite_settings.update_service import (
 )
 
 router = APIRouter(tags=["suite"])
+logger = logging.getLogger(__name__)
+
+
+def _parse_iso8601_timestamp(raw: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 @router.get("/suite/settings", response_model=SuiteSettingsOut)
@@ -275,10 +286,15 @@ def get_suite_logs(
         has_exception=has_exception,
         limit=limit,
     )
-    return SuiteLogsOut(
-        items=[
+    parsed_items: list[SuiteLogEntryOut] = []
+    for item in items:
+        parsed_timestamp = _parse_iso8601_timestamp(item.timestamp)
+        if parsed_timestamp is None:
+            logger.warning("Skipping suite log entry with invalid timestamp: %s", item.timestamp)
+            continue
+        parsed_items.append(
             SuiteLogEntryOut(
-                timestamp=item.timestamp,
+                timestamp=parsed_timestamp,
                 level=item.level,
                 component=item.component,
                 message=item.message,
@@ -289,8 +305,9 @@ def get_suite_logs(
                 correlation_id=item.correlation_id,
                 job_id=item.job_id,
             )
-            for item in items
-        ],
+        )
+    return SuiteLogsOut(
+        items=parsed_items,
         total=total,
         counts=SuiteLogCountsOut(
             error=counts["ERROR"],
@@ -303,18 +320,19 @@ def get_suite_logs(
 @router.get("/suite/metrics", response_model=SuiteMetricsOut)
 def get_suite_metrics(_user: UserPublicDep) -> SuiteMetricsOut:
     summary = build_runtime_metrics_summary()
+    busiest_routes = summary["busiest_routes"]
     return SuiteMetricsOut(
-        uptime_seconds=float(summary["uptime_seconds"]),
-        total_requests=int(summary["total_requests"]),
-        average_response_ms=float(summary["average_response_ms"]),
-        error_log_count=int(summary["error_log_count"]),
-        status_counts={k: int(v) for k, v in dict(summary["status_counts"]).items()},
+        uptime_seconds=summary["uptime_seconds"],
+        total_requests=summary["total_requests"],
+        average_response_ms=summary["average_response_ms"],
+        error_log_count=summary["error_log_count"],
+        status_counts=summary["status_counts"],
         busiest_routes=[
             SuiteMetricsRouteOut(
-                route=str(row["route"]),
-                request_count=int(row["request_count"]),
-                average_response_ms=float(row["average_response_ms"]),
+                route=row["route"],
+                request_count=row["request_count"],
+                average_response_ms=row["average_response_ms"],
             )
-            for row in list(summary["busiest_routes"])
+            for row in busiest_routes
         ],
     )

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timezone, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -46,6 +46,7 @@ def run_suite_configuration_backup_tick(
             interval_seconds = max(3600, min(30 * 24 * 3600, hours * 3600))
             last = getattr(suite, "configuration_backup_last_run_at", None)
             tz_name = str(getattr(suite, "app_timezone", "") or "UTC").strip() or "UTC"
+            app_tz: tzinfo
             try:
                 app_tz = ZoneInfo(tz_name)
             except ZoneInfoNotFoundError:

--- a/apps/backend/tests/test_arr_library_operator_settings_api.py
+++ b/apps/backend/tests/test_arr_library_operator_settings_api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from starlette.testclient import TestClient
+
+from tests.integration_helpers import auth_post, csrf, trusted_browser_origin_headers
+
+
+def _login_admin(client: TestClient) -> None:
+    token = csrf(client)
+    response = auth_post(
+        client,
+        "/api/v1/auth/login",
+        json={"username": "alice", "password": "test-password-strong", "csrf_token": token},
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_arr_connection_test_handles_none_preview_credentials_without_strip_crash(
+    client_with_admin: TestClient,
+) -> None:
+    _login_admin(client_with_admin)
+    token = csrf(client_with_admin)
+
+    with (
+        patch(
+            "mediamop.platform.arr_library.operator_settings_api.preview_sonarr_http_credentials_after_put",
+            return_value=(None, "   "),
+        ),
+        patch("mediamop.platform.arr_library.operator_settings_api.ArrLibraryV3Client") as client_ctor,
+    ):
+        response = client_with_admin.post(
+            "/api/v1/arr-library/arr-operator-settings/connection-test",
+            json={
+                "app": "sonarr",
+                "enabled": True,
+                "base_url": None,
+                "api_key": None,
+                "csrf_token": token,
+            },
+            headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert "not set up yet" in body["message"].lower()
+    client_ctor.assert_not_called()

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -74,6 +74,21 @@ def test_login_invalid_password(client_with_admin: TestClient) -> None:
     assert r.status_code == 401
 
 
+def test_login_rejects_unexpected_fields(client_with_admin: TestClient) -> None:
+    csrf = fetch_csrf(client_with_admin)
+    r = auth_post(
+        client_with_admin,
+        "/api/v1/auth/login",
+        json={
+            "username": "alice",
+            "password": "test-password-strong",
+            "csrf_token": csrf,
+            "unexpected": "value",
+        },
+    )
+    assert r.status_code == 422
+
+
 def test_change_password_requires_current_and_forces_new_login(client_with_admin: TestClient) -> None:
     csrf = fetch_csrf(client_with_admin)
     r_login = auth_post(
@@ -645,7 +660,7 @@ def test_login_rate_limited(monkeypatch: pytest.MonkeyPatch) -> None:
         db.commit()
     app = create_app()
     with TestClient(app) as client:
-        for i in range(3):
+        for _i in range(3):
             csrf = fetch_csrf(client)
             r = auth_post(
                 client,
@@ -855,6 +870,10 @@ def test_security_headers_on_health_and_api(monkeypatch: pytest.MonkeyPatch) -> 
         assert r_csrf.headers.get("Cache-Control", "").startswith("no-store")
         r_system = client.get("/api/v1/system/directories")
         assert r_system.headers.get("Cache-Control", "").startswith("no-store")
+        r_suite_security = client.get("/api/v1/suite/security-overview")
+        assert r_suite_security.headers.get("Cache-Control", "").startswith("no-store")
+        r_suite_update = client.get("/api/v1/suite/update-status")
+        assert r_suite_update.headers.get("Cache-Control", "").startswith("no-store")
         r_metrics = client.get("/metrics")
         assert r_metrics.headers.get("Cache-Control", "").startswith("no-store")
 

--- a/apps/backend/tests/test_auth_service.py
+++ b/apps/backend/tests/test_auth_service.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import pytest
+
 from mediamop.platform.auth import service
+from mediamop.platform.auth import bootstrap as bootstrap_service
 from mediamop.platform.auth.password import DUMMY_PASSWORD_HASH
 
 
@@ -20,6 +24,24 @@ class _FakeSession:
 
     def scalars(self, _stmt):
         return _ScalarResult(self._user)
+
+
+class _FakeDeleteSession:
+    def execute(self, _stmt):  # noqa: ANN001
+        class _ResultWithoutRowcount:
+            pass
+
+        return _ResultWithoutRowcount()
+
+
+class _FakeBootstrapDb:
+    def __init__(self, driver_connection: object | None) -> None:
+        self._driver_connection = driver_connection
+
+    def connection(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            connection=SimpleNamespace(driver_connection=self._driver_connection),
+        )
 
 
 def test_authenticate_user_pads_missing_username_with_dummy_verify(monkeypatch) -> None:
@@ -51,3 +73,17 @@ def test_authenticate_user_pads_inactive_account_with_dummy_verify(monkeypatch) 
 
     assert user is None
     assert calls == [("wrong-password", DUMMY_PASSWORD_HASH)]
+
+
+def test_cleanup_inactive_sessions_handles_missing_rowcount() -> None:
+    removed = service.cleanup_inactive_sessions(
+        _FakeDeleteSession(),
+        settings=SimpleNamespace(session_idle_minutes=60, session_trusted_idle_minutes=1440),
+        now=datetime(2026, 5, 9, tzinfo=UTC),
+    )
+    assert removed == 0
+
+
+def test_acquire_bootstrap_transaction_lock_raises_when_driver_connection_missing() -> None:
+    with pytest.raises(RuntimeError, match="driver connection is unavailable"):
+        bootstrap_service.acquire_bootstrap_transaction_lock(_FakeBootstrapDb(None))

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -156,6 +156,75 @@ def test_periodic_scheduler_scope_failure_does_not_block_other_scope(
             db.commit()
 
 
+def test_periodic_scheduler_keeps_scope_next_run_values_independent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class _SessionCtx:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def commit(self) -> None:
+            return None
+
+        def rollback(self) -> None:
+            return None
+
+    def _session_factory():
+        return _SessionCtx()
+
+    monkeypatch.setattr(
+        periodic_enqueue,
+        "ensure_refiner_operator_settings_row",
+        lambda _session: SimpleNamespace(movie_schedule_enabled=True, tv_schedule_enabled=True),
+    )
+    monkeypatch.setattr(
+        periodic_enqueue,
+        "ensure_refiner_path_settings_row",
+        lambda _session: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        periodic_enqueue,
+        "refiner_periodic_scope_in_schedule_window",
+        lambda _session, _row, *, media_scope: media_scope in {"movie", "tv"},
+    )
+    monkeypatch.setattr(
+        periodic_enqueue,
+        "_watched_folder_scan_interval_seconds",
+        lambda _row, *, media_scope: 1.0 if media_scope == "movie" else 0.25,
+    )
+
+    async def _run() -> None:
+        stop_event = asyncio.Event()
+
+        def _fake_enqueue(_session, _settings, *, media_scope: str = "movie"):
+            calls.append(media_scope)
+            if len(calls) >= 3:
+                stop_event.set()
+            return True, None
+
+        monkeypatch.setattr(
+            periodic_enqueue,
+            "try_enqueue_periodic_watched_folder_remux_scan_dispatch",
+            _fake_enqueue,
+        )
+        await asyncio.wait_for(
+            periodic_enqueue._run_periodic_watched_folder_scan_dispatch_enqueue(
+                _session_factory,
+                stop_event=stop_event,
+                settings=_settings_on(),
+            ),
+            timeout=3.0,
+        )
+
+    asyncio.run(_run())
+    assert calls[:3] == ["movie", "tv", "tv"]
+
+
 def test_queue_has_active_scan_detects_pending_and_leased_per_scope() -> None:
     fac = _fac()
     with fac() as db:

--- a/apps/backend/tests/test_runtime_metrics_service.py
+++ b/apps/backend/tests/test_runtime_metrics_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from mediamop.platform.metrics.service import (
+    record_http_request,
+    record_log_record,
+    record_module_job_event,
+    render_prometheus_metrics,
+    reset_runtime_metrics_for_tests,
+    set_module_queue_depth,
+)
+
+
+def test_runtime_metrics_summary_and_prometheus_include_module_job_metrics() -> None:
+    reset_runtime_metrics_for_tests()
+
+    record_http_request(method="GET", route="/api/v1/health", status_code=200, duration_ms=12.5)
+    record_http_request(method="POST", route="/api/v1/refiner/jobs", status_code=500, duration_ms=33.0)
+    record_log_record("error")
+    record_module_job_event(module="refiner", event="started")
+    record_module_job_event(module="refiner", event="completed")
+    record_module_job_event(module="subber", event="failed")
+    set_module_queue_depth(module="refiner", depth=3)
+    set_module_queue_depth(module="subber", depth=1)
+
+    output = render_prometheus_metrics()
+
+    assert 'mediamop_module_jobs_total{module="refiner",event="started"} 1' in output
+    assert 'mediamop_module_jobs_total{module="refiner",event="completed"} 1' in output
+    assert 'mediamop_module_jobs_total{module="subber",event="failed"} 1' in output
+    assert 'mediamop_module_queue_depth{module="refiner"} 3' in output
+    assert 'mediamop_module_queue_depth{module="subber"} 1' in output
+    assert "mediamop_http_requests_total 2" in output

--- a/apps/backend/tests/test_sqlite_foundation.py
+++ b/apps/backend/tests/test_sqlite_foundation.py
@@ -9,9 +9,13 @@ import sys
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
+from sqlalchemy.engine import Engine
+
+from mediamop.core import db as db_module
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, verify_sqlite_pragmas
 
@@ -38,6 +42,31 @@ def test_engine_applies_sqlite_hardening_pragmas(monkeypatch: pytest.MonkeyPatch
         assert p["synchronous"] == "1"
     finally:
         engine.dispose()
+
+
+def test_register_sqlite_pragmas_connect_hook_noops_for_non_sqlite_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_listens_for(_engine: object, event_name: str):
+        assert event_name == "connect"
+
+        def _decorator(fn):  # noqa: ANN001
+            captured["hook"] = fn
+            return fn
+
+        return _decorator
+
+    monkeypatch.setattr(db_module.event, "listens_for", _fake_listens_for)
+    db_module._register_sqlite_pragmas(cast(Engine, object()))
+
+    hook = captured["hook"]
+
+    class _NotSqliteConnection:
+        pass
+
+    hook(_NotSqliteConnection(), object())
 
 
 def test_create_db_engine_registers_sqlite_datetime_adapter(

--- a/apps/backend/tests/test_subber_jobs_lane.py
+++ b/apps/backend/tests/test_subber_jobs_lane.py
@@ -26,6 +26,7 @@ from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleSt
 from mediamop.modules.subber.worker_loop import process_one_subber_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
+from mediamop.platform.metrics.service import build_runtime_metrics_summary, reset_runtime_metrics_for_tests
 
 import mediamop.modules.subber.subber_jobs_model  # noqa: F401
 import mediamop.modules.subber.subber_settings_model  # noqa: F401
@@ -67,6 +68,7 @@ def test_build_subber_job_handlers_registry_matches_production_kinds(session_fac
 
 
 def test_webhook_import_tv_runs_on_subber_lane_records_activity(session_factory) -> None:
+    reset_runtime_metrics_for_tests()
     t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
     settings = MediaMopSettings.load()
     payload = {
@@ -122,3 +124,9 @@ def test_webhook_import_tv_runs_on_subber_lane_records_activity(session_factory)
         assert ev is not None
         assert ev.module == "subber"
         assert json.loads(ev.detail or "{}")["media_scope"] == "tv"
+
+    metrics = build_runtime_metrics_summary()
+    subber_counts = metrics["module_job_counts"].get("subber", {})
+    assert subber_counts.get("started", 0) >= 1
+    assert subber_counts.get("completed", 0) >= 1
+    assert metrics["module_queue_depths"].get("subber") == 1

--- a/apps/backend/tests/test_subber_jobs_ops_metrics.py
+++ b/apps/backend/tests/test_subber_jobs_ops_metrics.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from sqlalchemy import delete
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.modules.subber.subber_jobs_model import SubberJob, SubberJobStatus
+from mediamop.modules.subber.subber_jobs_ops import _record_subber_queue_depth
+from mediamop.platform.metrics.service import build_runtime_metrics_summary, reset_runtime_metrics_for_tests
+
+
+def test_subber_queue_depth_metric_counts_pending_plus_leased_only() -> None:
+    reset_runtime_metrics_for_tests()
+    settings = MediaMopSettings.load()
+    session_factory = create_session_factory(create_db_engine(settings))
+
+    with session_factory() as session:
+        session.execute(delete(SubberJob))
+        session.add_all(
+            [
+                SubberJob(dedupe_key="depth-pending", job_kind="subber.search", status=SubberJobStatus.PENDING.value),
+                SubberJob(dedupe_key="depth-leased", job_kind="subber.search", status=SubberJobStatus.LEASED.value),
+                SubberJob(
+                    dedupe_key="depth-completed",
+                    job_kind="subber.search",
+                    status=SubberJobStatus.COMPLETED.value,
+                ),
+                SubberJob(dedupe_key="depth-failed", job_kind="subber.search", status=SubberJobStatus.FAILED.value),
+            ]
+        )
+        session.commit()
+
+    with session_factory() as session:
+        _record_subber_queue_depth(session)
+
+    metrics = build_runtime_metrics_summary()
+    assert metrics["module_queue_depths"].get("subber") == 2

--- a/apps/backend/tests/test_subber_settings_api.py
+++ b/apps/backend/tests/test_subber_settings_api.py
@@ -12,6 +12,7 @@ from alembic.config import Config
 from starlette.testclient import TestClient
 
 from mediamop.api.factory import create_app
+from mediamop.modules.subber.subber_settings_api import _load_secrets_envelope
 from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_in_process_workers,
     integration_test_quiesce_periodic_enqueue,
@@ -146,6 +147,22 @@ def _put_settings(client_admin: TestClient, payload: dict) -> dict:
     )
     assert r.status_code == 200, r.text
     return r.json()
+
+
+def test_load_secrets_envelope_normalizes_invalid_shapes() -> None:
+    envelope, secrets = _load_secrets_envelope(
+        '{"provider":"legacy","secrets":["bad","shape"],"other":123}',
+        provider="opensubtitles",
+    )
+    assert envelope["provider"] == "opensubtitles"
+    assert secrets == {}
+
+    envelope2, secrets2 = _load_secrets_envelope(
+        '{"secrets":{"username":123,"password":null}}',
+        provider="opensubtitles",
+    )
+    assert envelope2["provider"] == "opensubtitles"
+    assert secrets2 == {"username": "123", "password": ""}
 
 
 def test_put_settings_language_preferences(client_admin: TestClient) -> None:

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -30,6 +30,7 @@ from mediamop.platform.suite_settings.logs_retention_periodic import (
     reset_log_retention_periodic_state_for_tests,
     run_log_retention_tick,
 )
+from mediamop.platform.suite_settings.logs_service import ParsedLogEntry
 from mediamop.platform.suite_settings.update_service import start_suite_update_now
 
 from tests.integration_helpers import (
@@ -424,6 +425,53 @@ def test_suite_update_status_alias_ok(client_with_admin: TestClient, monkeypatch
     body = r.json()
     assert body["status"] == "update_available"
     assert body["upgrade"]["phase"] == "installer_running"
+
+
+def test_suite_logs_skips_items_with_invalid_timestamp(
+    client_with_admin: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_admin)
+    monkeypatch.setattr(
+        "mediamop.platform.suite_settings.router.read_suite_logs",
+        lambda *_args, **_kwargs: (
+            [
+                ParsedLogEntry(
+                    timestamp="not-a-time",
+                    level="INFO",
+                    component="System",
+                    message="broken timestamp",
+                    detail=None,
+                    traceback=None,
+                    source=None,
+                    logger="mediamop.platform.suite_settings",
+                    correlation_id=None,
+                    job_id=None,
+                ),
+                ParsedLogEntry(
+                    timestamp="2026-05-09T10:00:00Z",
+                    level="INFO",
+                    component="System",
+                    message="valid timestamp",
+                    detail=None,
+                    traceback=None,
+                    source=None,
+                    logger="mediamop.platform.suite_settings",
+                    correlation_id=None,
+                    job_id=None,
+                ),
+            ],
+            2,
+            {"ERROR": 0, "WARNING": 0, "INFO": 2},
+        ),
+    )
+
+    response = client_with_admin.get("/api/v1/suite/logs")
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["items"]) == 1
+    assert body["items"][0]["message"] == "valid timestamp"
 
 
 def test_suite_update_now_get_redirects_back_to_settings(client_with_admin: TestClient) -> None:

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -1,0 +1,38 @@
+# Tech Debt Tracker
+
+This file tracks known follow-up items that were intentionally deferred from `hardening/code-quality-pass-1`.
+
+## P1 — Mypy coverage gaps in legacy modules
+
+- **File/context:** `apps/backend/pyproject.toml` (`[[tool.mypy.overrides]]`)
+- **Issue:** `mediamop.modules.refiner.*` and `mediamop.windows.*` are temporarily excluded from stricter mypy checks.
+- **Suggested fix:** Remove overrides incrementally by fixing module-local typing debt (module export typing, legacy dynamic dict payloads, and Windows process-state typing).
+- **Reason deferred:** High churn/risk areas; this pass intentionally avoided broad updater/refiner rewrites.
+
+## P2 — Ruff rule families deferred to avoid high-churn rewrites
+
+- **File/context:** `apps/backend/pyproject.toml` (`[tool.ruff.lint]`)
+- **Issue:** `I` (isort), `UP` (pyupgrade), and `SIM` (simplify) were evaluated but not enabled globally.
+- **Suggested fix:** Enable one family at a time with dedicated cleanup PRs and ownership boundaries.
+- **Reason deferred:** Current repo produces high-volume churn for these families; would bloat this hardening pass.
+
+## P2 — Remaining targeted `type: ignore` comments
+
+- **File/context:** `apps/backend/src/mediamop/windows/tray_app.py:240`, multiple `apps/backend/src/mediamop/modules/refiner/*` locations, `apps/backend/src/mediamop/platform/auth/router.py:116`, `:302`
+- **Issue:** Existing ignores are still required for platform-specific/runtime edge typing and legacy payload shims.
+- **Suggested fix:** Replace ignores with typed wrappers/protocols and narrowed helper return types in module-specific PRs.
+- **Reason deferred:** Most are in Windows/refiner scopes intentionally out-of-scope for this pass.
+
+## P2 — Storage-savings metrics not yet exposed
+
+- **File/context:** `apps/backend/src/mediamop/platform/metrics/service.py` and module-specific result handlers
+- **Issue:** Runtime metrics now expose module job counters and queue depth gauges, but not durable storage-savings totals.
+- **Suggested fix:** Emit explicit savings events from canonical module completion paths (Refiner output writes, Pruner removals) and aggregate in metrics service.
+- **Reason deferred:** Savings values are not consistently surfaced in a single trusted result contract across all handlers yet.
+
+## P2 — OpenAPI TypeScript contract generation workflow
+
+- **File/context:** `apps/web` build/scripts (no committed typegen workflow yet)
+- **Issue:** Frontend does not currently use generated OpenAPI TS contracts.
+- **Suggested fix:** Add a dedicated generation script (e.g., `openapi-typescript`) that reads a pinned OpenAPI artifact (committed JSON or CI-produced artifact), plus CI drift check.
+- **Reason deferred:** Need to avoid coupling normal frontend dev/build to a live backend and decide artifact ownership.


### PR DESCRIPTION
## Summary\n- tighten backend static checks (mypy/ruff) and clean violations\n- harden auth and schema contracts for safer request handling\n- add runtime metrics for module job lifecycle + queue depth\n- add focused risk tests for bootstrap lock, sqlite pragma hook safety, rowcount fallback, ARR connection normalization, subber secret envelope normalization, periodic scheduler binding, and suite log timestamp resilience\n\n## Validation\n- cd apps/backend && .\\.venv\\Scripts\\python.exe -m pytest -q\n- cd apps/backend && .\\.venv\\Scripts\\python.exe -m ruff check src tests\n- cd apps/backend && .\\.venv\\Scripts\\python.exe -m mypy src/mediamop\n\nAll pass on this branch.