### PR TITLE
Prepare MediaMop 2.2.0 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.1.13"
+version = "2.2.0"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.1.13",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.1.13",
+      "version": "2.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.1.13",
+  "version": "2.2.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -1,0 +1,32 @@
+# MediaMop v2.2.0
+
+Date: 2026-05-09
+
+This release focuses on upgrade reliability hardening, safer backend contracts, and stronger operational diagnostics.
+
+## What Changed
+
+- Tightened backend request contracts for authentication and security-sensitive inputs.
+- Added module-level runtime metrics for job lifecycle events and queue depth visibility.
+- Improved logs/settings API resilience so malformed entries do not break operator views.
+
+## Fixes And Stability
+
+- Added direct regression tests for bootstrap locking, DB connection hook safety, auth session cleanup, and settings edge cases.
+- Hardened cross-platform backend typing checks used in CI and release gates.
+- Strengthened queue/worker observability assertions to prevent silent metric drift.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- Keep `MediaMopSetup.exe` and `MediaMopSetup.exe.sha256` together for release validation and support troubleshooting.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.2.0`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.1.13...v2.2.0

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.1.13"
+#define AppVersion "2.2.0"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary\n- bump backend/web/installer versions to 2.2.0\n- add release notes for v2.2.0\n- validate backend + frontend + windows package smoke\n\n## Validation\n- backend: pytest, ruff, mypy\n- frontend: test, lint, build\n- windows: packaging/windows/build.ps1 + scripts/smoke-windows-package.ps1 -ExpectedVersion 2.2.0\n