### PR TITLE
Harden Windows upgrade recovery and prepare 2.2.1

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.0"
+version = "2.2.1"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -52,6 +52,7 @@ _INSTALLER_WAIT_TIMEOUT_SECONDS = 90 * 60
 _VERIFY_INSTALL_TIMEOUT_SECONDS = 5 * 60
 _STALE_ATTEMPT_SECONDS = 30 * 60
 _BACKEND_POLL_INTERVAL_SECONDS = 2.0
+_VERSION_MISMATCH_RECOVERY_GRACE_SECONDS = 12.0
 _MIN_INSTALLER_BYTES = 512 * 1024
 _SHA256_RE = re.compile(r"\b([0-9a-fA-F]{64})\b")
 _TRUSTED_RELEASE_DOWNLOAD_HOSTS = {
@@ -1321,6 +1322,91 @@ def _start_packaged_tray_in_active_session(*, open_browser: bool = False) -> int
     return _launch_process_in_active_session(tray_exe, args=args, cwd=install_root)
 
 
+def _terminate_pid(pid: object) -> str | None:
+    try:
+        numeric = int(pid)
+    except (TypeError, ValueError):
+        return "Invalid PID."
+    if numeric <= 0:
+        return "Invalid PID."
+    try:
+        result = subprocess.run(
+            ["taskkill", "/PID", str(numeric), "/T", "/F"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except Exception as exc:
+        return str(exc)
+    if result.returncode in {0, 128}:
+        return None
+    detail = (result.stderr or result.stdout or "").strip()
+    return detail or f"taskkill exited with {result.returncode}."
+
+
+def _restart_packaged_runtime_for_verification(
+    *,
+    port: int,
+    interactive_session_available: bool,
+) -> dict[str, object]:
+    install_root = _install_root()
+    install_root_norm = _normalize_executable_path(install_root) or ""
+    killed_processes: list[dict[str, object]] = []
+    kill_errors: list[dict[str, object]] = []
+    restart_diag: dict[str, object] = {
+        "killed_processes": killed_processes,
+        "kill_errors": kill_errors,
+        "restart_action": None,
+        "restart_error": None,
+        "restarted_tray_pid": None,
+        "restarted_server_pid": None,
+    }
+
+    for row in _running_media_processes():
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "").strip().lower()
+        pid = row.get("pid")
+        if name not in {"mediamop.exe", "mediamopserver.exe"}:
+            continue
+        executable_path = _normalize_executable_path(row.get("executable_path"))
+        command_line = str(row.get("command_line") or "").strip().casefold()
+        path_match = executable_path is not None and install_root_norm and executable_path.startswith(install_root_norm)
+        command_match = install_root_norm in command_line if install_root_norm and command_line else False
+        if not path_match and not command_match:
+            continue
+        error = _terminate_pid(pid)
+        if error:
+            kill_errors.append({"pid": pid, "name": name, "error": error})
+            _append_service_log(f"Could not terminate {name} pid={pid} before runtime restart: {error}")
+            continue
+        killed_processes.append({"pid": pid, "name": name})
+        _append_service_log(f"Terminated {name} pid={pid} before runtime restart.")
+
+    try:
+        if interactive_session_available:
+            restart_diag["restart_action"] = "start_tray"
+            tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
+            restart_diag["restarted_tray_pid"] = tray_pid
+            _append_service_log(
+                "Started packaged MediaMop tray host after backend version mismatch "
+                f"(pid={tray_pid}, port={port})."
+            )
+        else:
+            restart_diag["restart_action"] = "start_server"
+            process = _start_packaged_server(port)
+            restart_diag["restarted_server_pid"] = process.pid
+            _append_service_log(
+                "Started packaged MediaMop server after backend version mismatch "
+                f"(pid={process.pid}, port={port})."
+            )
+    except Exception as exc:
+        restart_diag["restart_error"] = str(exc)
+        _append_service_log(f"Could not restart packaged runtime after version mismatch: {exc}")
+    return restart_diag
+
+
 def _interactive_session_available() -> bool:
     if os.name != "nt":
         return False
@@ -1376,27 +1462,66 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
     restarted_tray_pid: int | None = None
     tray_relaunch_attempted = False
     tray_relaunch_started_at: float | None = None
+    version_mismatch_started_at: float | None = None
+    mismatch_runtime_restart_attempted = False
     tray_restart_error: str | None = None
     server_restart_error: str | None = None
+    mismatch_restart_error: str | None = None
     interactive_session_available = _interactive_session_available()
     last_diagnostics: dict[str, object] = _collect_install_diagnostics(target_version, port=port)
+    target_key = parse_version_key(target_version)
     while time.time() < deadline:
         diagnostics = _collect_install_diagnostics(target_version, port=port)
         diagnostics["restarted_server_pid"] = started_server_pid
         diagnostics["restarted_tray_pid"] = restarted_tray_pid
         diagnostics["tray_relaunch_attempted"] = tray_relaunch_attempted
+        diagnostics["mismatch_runtime_restart_attempted"] = mismatch_runtime_restart_attempted
         diagnostics["interactive_session_available"] = interactive_session_available
         if tray_restart_error:
             diagnostics["tray_restart_error"] = tray_restart_error
         if server_restart_error:
             diagnostics["server_restart_error"] = server_restart_error
+        if mismatch_restart_error:
+            diagnostics["mismatch_restart_error"] = mismatch_restart_error
         packaged_version = str(diagnostics.get("packaged_version") or "").strip() or None
         backend_ready = bool(diagnostics.get("backend_ready"))
         backend_version = str(diagnostics.get("backend_version") or "").strip() or None
         tray_running = bool(diagnostics.get("tray_running"))
         missing_required = diagnostics.get("missing_required_files")
+        backend_key = parse_version_key(backend_version) if backend_version else None
+        backend_lagging = (
+            backend_ready
+            and backend_version is not None
+            and backend_version != target_version
+            and backend_key is not None
+            and target_key is not None
+            and backend_key < target_key
+        )
         if _diagnostics_prove_completed_desktop_upgrade(target_version, diagnostics):
             return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
+        if packaged_version == target_version and not missing_required and backend_lagging:
+            if version_mismatch_started_at is None:
+                version_mismatch_started_at = time.time()
+            if (
+                not mismatch_runtime_restart_attempted
+                and time.time() - version_mismatch_started_at >= _VERSION_MISMATCH_RECOVERY_GRACE_SECONDS
+            ):
+                mismatch_runtime_restart_attempted = True
+                restart_diag = _restart_packaged_runtime_for_verification(
+                    port=port,
+                    interactive_session_available=interactive_session_available,
+                )
+                diagnostics["mismatch_restart"] = restart_diag
+                if restart_diag.get("restarted_tray_pid"):
+                    restarted_tray_pid = int(restart_diag["restarted_tray_pid"])
+                if restart_diag.get("restarted_server_pid"):
+                    started_server_pid = int(restart_diag["restarted_server_pid"])
+                if restart_diag.get("restart_error"):
+                    mismatch_restart_error = str(restart_diag["restart_error"])
+                else:
+                    mismatch_restart_error = None
+        else:
+            version_mismatch_started_at = None
         if packaged_version == target_version and not missing_required and (
             not backend_ready or (interactive_session_available and not tray_running)
         ):

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -766,6 +766,73 @@ def test_verify_install_fails_when_active_session_exists_but_tray_does_not_relau
     assert "desktop tray host did not relaunch" in message.lower()
 
 
+def test_verify_install_restarts_runtime_when_backend_version_lags_target(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    target_version = "2.2.0"
+    restart_calls = {"count": 0}
+    diagnostics_iter = iter(
+        [
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "backend_version": "2.1.13",
+                "tray_running": True,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "backend_version": "2.1.13",
+                "tray_running": True,
+            },
+            {
+                "packaged_version": target_version,
+                "missing_required_files": [],
+                "backend_ready": True,
+                "backend_version": target_version,
+                "tray_running": True,
+            },
+        ]
+    )
+    clock = iter(range(1000))
+
+    monkeypatch.setattr(updater_service, "_read_runtime_port", lambda: 8788)
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: True)
+    monkeypatch.setattr(updater_service, "_VERSION_MISMATCH_RECOVERY_GRACE_SECONDS", 0.0)
+    monkeypatch.setattr(
+        updater_service,
+        "_collect_install_diagnostics",
+        lambda _target_version, *, port: next(diagnostics_iter),
+    )
+    monkeypatch.setattr(updater_service.time, "time", lambda: float(next(clock)))
+    monkeypatch.setattr(updater_service.time, "sleep", lambda _seconds: None)
+
+    def _restart_runtime(*, port: int, interactive_session_available: bool) -> dict[str, object]:
+        restart_calls["count"] += 1
+        return {
+            "killed_processes": [{"pid": 111, "name": "MediaMopServer.exe"}],
+            "kill_errors": [],
+            "restart_action": "start_tray",
+            "restart_error": None,
+            "restarted_tray_pid": 222,
+            "restarted_server_pid": None,
+        }
+
+    monkeypatch.setattr(updater_service, "_restart_packaged_runtime_for_verification", _restart_runtime)
+
+    verified, diagnostics, message = updater_service._verify_install(target_version)
+
+    assert verified is True
+    assert message == f"Upgrade completed. Running version: {target_version}."
+    assert restart_calls["count"] == 1
+    assert diagnostics["mismatch_runtime_restart_attempted"] is True
+    assert diagnostics["restarted_tray_pid"] == 222
+
+
 def test_launch_process_in_active_session_via_schtasks_creates_and_runs_launcher_task(
     tmp_path: Path,
     monkeypatch,

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.1.md
+++ b/docs/release-notes/v2.2.1.md
@@ -1,0 +1,35 @@
+# MediaMop v2.2.1
+
+Release date: May 9, 2026
+
+## Summary
+
+This patch hardens Windows in-app upgrade recovery for production Windows and Windows Server installs.
+
+## Fixes
+
+- Fixed a Windows upgrader verification gap where MediaMop could stay in **Verifying installed version** when:
+  - installer completed,
+  - packaged files were on the target version,
+  - but the running backend still reported an older version.
+- Added controlled runtime recovery during verification when backend version lags target:
+  - detects lagging backend version against target semver,
+  - terminates stale packaged MediaMop tray/server processes from the install root,
+  - relaunches packaged runtime (tray in interactive session, server fallback otherwise),
+  - continues verification until `current_version == target_version` or timeout.
+- Added regression test coverage for lagging backend version recovery in updater verification.
+
+## Safety guarantees preserved
+
+- Upgrade completion still requires verified running backend version equality:
+  - `current_version == target_version`
+- Installer exit code `0` is still not treated as success by itself.
+- Checksum/trusted release validation flow is unchanged.
+
+## Upgrade notes
+
+- This release should be published as a new tag (`v2.2.1`) with:
+  - `MediaMopSetup.exe`
+  - `MediaMopSetup.exe.sha256`
+- Do not replace `v2.2.0` assets in place.
+

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.0"
+#define AppVersion "2.2.1"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary
- fix Windows in-app upgrade verification gap when backend remains on an older version after installer completion
- add controlled runtime recovery path during verifying_install for lagging backend version
- add regression tests for mismatch recovery
- bump release version to 2.2.1 and add release notes

## Validation
- backend: pytest -q, ruff, mypy
- frontend: test, lint, build
- windows package build + smoke
- checksum generated for final installer artifact
