### PR TITLE
Fix Windows tray relaunch scheduled task creation

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.1"
+version = "2.2.2"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -416,7 +416,6 @@ def _launch_process_in_active_session_via_schtasks(
             "HIGHEST",
             "/TR",
             str(launcher_script),
-            "/Z",
             "/F",
         ],
         check=False,

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -867,6 +867,8 @@ def test_launch_process_in_active_session_via_schtasks_creates_and_runs_launcher
     assert any(command[:2] == ["schtasks", "/Create"] for command in created_commands)
     assert any(command[:2] == ["schtasks", "/Run"] for command in created_commands)
     assert any(command[:2] == ["schtasks", "/Delete"] for command in created_commands)
+    create_command = next(command for command in created_commands if command[:2] == ["schtasks", "/Create"])
+    assert "/Z" not in create_command
 
 
 def test_launch_process_in_active_session_via_schtasks_removes_stale_tasks_and_scripts(
@@ -928,6 +930,42 @@ def test_launch_process_in_active_session_via_schtasks_removes_stale_tasks_and_s
         command[:5] == ["schtasks", "/Delete", "/TN", "MediaMop-Relaunch", "/F"]
         for command in observed_commands
     )
+
+
+def test_launch_process_in_active_session_via_schtasks_surfaces_task_creation_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    executable = tmp_path / "MediaMop.exe"
+    executable.write_text("binary", encoding="utf-8")
+    monkeypatch.setattr(updater_service, "_active_interactive_session_user", lambda: "APP-SERVER\\Administrator")
+
+    class _Result:
+        def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    def _fake_run(command: list[str], **kwargs):
+        if command[:2] == ["schtasks", "/Create"]:
+            return _Result(
+                returncode=1,
+                stderr="ERROR: The task XML is missing a required element or attribute. (45,4):EndBoundary:",
+            )
+        return _Result()
+
+    monkeypatch.setattr(updater_service.subprocess, "run", _fake_run)
+
+    with pytest.raises(OSError) as excinfo:
+        updater_service._launch_process_in_active_session_via_schtasks(
+            executable,
+            args=["--no-browser"],
+            cwd=tmp_path,
+        )
+
+    assert "Could not create MediaMop relaunch task." in str(excinfo.value)
+    assert "EndBoundary" in str(excinfo.value)
 
 
 def test_packaged_helper_exits_after_launch_and_reconciliation_completes(

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.2.md
+++ b/docs/release-notes/v2.2.2.md
@@ -1,0 +1,30 @@
+# MediaMop v2.2.2
+
+Release date: May 9, 2026
+
+## Summary
+
+This patch fixes Windows tray relaunch reliability after silent in-app upgrade.
+
+## Fixes
+
+- Fixed Windows fallback relaunch task creation for tray restart after upgrade:
+  - Removed fragile Task Scheduler `/Z` creation flag in the updater fallback path.
+  - Task cleanup is still handled explicitly with `/Delete` after `/Run`.
+- Prevents failure path where installer finishes and backend recovers but tray icon does not relaunch due scheduled task XML creation failure.
+- Added regression tests for relaunch task command construction and creation-error surfacing.
+
+## Safety guarantees preserved
+
+- Upgrade completion still requires verified running backend version equality:
+  - `current_version == target_version`
+- Installer exit code `0` is still not sufficient for success.
+- Trusted release + checksum validation flow is unchanged.
+
+## Upgrade notes
+
+- Publish as a new release tag `v2.2.2` with:
+  - `MediaMopSetup.exe`
+  - `MediaMopSetup.exe.sha256`
+- Do not replace existing `v2.2.1` assets in place.
+

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.1"
+#define AppVersion "2.2.2"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Root cause
On Windows Server 2025 the tray relaunch fallback (schtasks /Create) failed with:
The task XML is missing a required element or attribute ... EndBoundary.

This prevented tray relaunch after silent upgrade and left backend-only recovery.

## Changes
- remove /Z flag from relaunch task creation; task is already cleaned up explicitly via /Delete
- keep same relaunch flow and diagnostics
- add tests:
  - assert /Create command no longer includes /Z
  - assert creation error detail (including EndBoundary) is surfaced

## Validation
- backend: pytest -q, ruff, mypy
- frontend: test, lint, build
