### PR TITLE
2.2.4: Bulletproof Windows in-app upgrade UX and relaunch reliability

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.3"
+version = "2.2.4"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -258,6 +258,7 @@ class _MediaMopTrayApp:
         self._log("Database migrations completed")
         self._icon: Any = None
         self._last_browser_open_at = 0.0
+        self._browser_open_lock = threading.Lock()
         executable_dir = Path(sys.executable).resolve().parent
         self._server_exe = executable_dir / "MediaMopServer.exe"
         self._server_process: subprocess.Popen[str] | None = None
@@ -268,14 +269,21 @@ class _MediaMopTrayApp:
             with self._log_path.open("a", encoding="utf-8") as handle:
                 handle.write(f"[{timestamp}] {message}\n")
 
-    def _handle_open(self, icon: Any, item: Any) -> None:  # noqa: ARG002
+    def _open_browser_with_debounce(self, *, source: str) -> None:
         now = time.monotonic()
-        if _is_recent_browser_open(self._last_browser_open_at, now):
-            self._log("Ignoring duplicate tray open request within debounce window.")
-            return
-        self._last_browser_open_at = now
-        self._log(f"Opening MediaMop in browser on port {self._port}")
+        with self._browser_open_lock:
+            if _is_recent_browser_open(self._last_browser_open_at, now):
+                self._log(
+                    "Ignoring duplicate browser open request within debounce window "
+                    f"(source={source})."
+                )
+                return
+            self._last_browser_open_at = now
+        self._log(f"Opening MediaMop in browser on port {self._port} (source={source})")
         _open_browser(self._port)
+
+    def _handle_open(self, icon: Any, item: Any) -> None:  # noqa: ARG002
+        self._open_browser_with_debounce(source="tray")
 
     def _handle_open_data_folder(self, icon: Any, item: Any) -> None:  # noqa: ARG002
         os.startfile(str(self._runtime_home))  # type: ignore[attr-defined]
@@ -340,7 +348,7 @@ class _MediaMopTrayApp:
             if lan:
                 self._log("MediaMop LAN URLs: " + ", ".join(lan))
             if self._open_browser_on_ready:
-                _open_browser(self._port)
+                self._open_browser_with_debounce(source="startup")
             else:
                 self._log("Skipping browser auto-open because tray host was launched in no-browser mode.")
             self._icon = self._create_icon()

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -65,6 +65,7 @@ _PROCESS_IDENTITY_SKEW_SECONDS = 5.0
 _RELAUNCH_TASK_NAME = "MediaMop-Relaunch"
 _RELAUNCH_TASK_PREFIX = f"\\{_RELAUNCH_TASK_NAME}"
 _RELAUNCH_SCRIPT_GLOB = "relaunch-MediaMop-Relaunch*.cmd"
+_LAST_INSTALL_ROOT_LOGGED: str | None = None
 
 
 def _append_service_log(message: str) -> None:
@@ -89,12 +90,19 @@ def _runtime_home() -> Path:
 
 
 def _install_root() -> Path:
+    global _LAST_INSTALL_ROOT_LOGGED
     if getattr(sys, "frozen", False) and os.name == "nt":
         resolved = _host_path(sys.executable).resolve().parent
-        _append_service_log(f"updater_service._install_root resolved to {resolved} (frozen)")
+        marker = f"frozen:{resolved}"
+        if _LAST_INSTALL_ROOT_LOGGED != marker:
+            _append_service_log(f"updater_service._install_root resolved to {resolved} (frozen)")
+            _LAST_INSTALL_ROOT_LOGGED = marker
         return resolved
     resolved = _runtime_home()
-    _append_service_log(f"updater_service._install_root resolved to {resolved} (unfrozen)")
+    marker = f"unfrozen:{resolved}"
+    if _LAST_INSTALL_ROOT_LOGGED != marker:
+        _append_service_log(f"updater_service._install_root resolved to {resolved} (unfrozen)")
+        _LAST_INSTALL_ROOT_LOGGED = marker
     return resolved
 
 
@@ -1386,7 +1394,7 @@ def _restart_packaged_runtime_for_verification(
     try:
         if interactive_session_available:
             restart_diag["restart_action"] = "start_tray"
-            tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
+            tray_pid = _start_packaged_tray_in_active_session(open_browser=True)
             restart_diag["restarted_tray_pid"] = tray_pid
             _append_service_log(
                 "Started packaged MediaMop tray host after backend version mismatch "
@@ -1497,6 +1505,22 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
             and backend_key < target_key
         )
         if _diagnostics_prove_completed_desktop_upgrade(target_version, diagnostics):
+            if interactive_session_available and not tray_relaunch_attempted:
+                diagnostics["browser_reopen_requested"] = True
+                try:
+                    reopen_pid = _start_packaged_tray_in_active_session(open_browser=True)
+                except Exception as exc:
+                    diagnostics["browser_reopen_error"] = str(exc)
+                    _append_service_log(
+                        "Upgrade verification completed, but browser reopen request failed: "
+                        f"{exc}"
+                    )
+                else:
+                    diagnostics["browser_reopen_pid"] = reopen_pid
+                    _append_service_log(
+                        "Upgrade verification completed; requested browser reopen in active session "
+                        f"(pid={reopen_pid})."
+                    )
             return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
         if packaged_version == target_version and not missing_required and backend_lagging:
             if version_mismatch_started_at is None:
@@ -1528,7 +1552,7 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
                 tray_relaunch_attempted = True
                 tray_relaunch_started_at = time.time()
                 try:
-                    restarted_tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
+                    restarted_tray_pid = _start_packaged_tray_in_active_session(open_browser=True)
                 except Exception as exc:
                     tray_restart_error = str(exc)
                     diagnostics["tray_restart_error"] = tray_restart_error

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import re
+import threading
 
 from mediamop.windows import tray_app
 
@@ -193,6 +194,21 @@ def test_tray_double_click_opens_mediamop() -> None:
 def test_tray_open_action_debounces_duplicate_open_requests() -> None:
     assert tray_app._is_recent_browser_open(10.0, 10.8) is True
     assert tray_app._is_recent_browser_open(10.0, 11.5) is False
+
+
+def test_tray_open_handler_ignores_duplicate_callbacks_within_cooldown(monkeypatch) -> None:
+    app = tray_app._MediaMopTrayApp.__new__(tray_app._MediaMopTrayApp)
+    app._port = 8788
+    app._last_browser_open_at = 0.0
+    app._browser_open_lock = threading.Lock()
+    app._log = lambda _message: None
+    opened_ports: list[int] = []
+    monkeypatch.setattr(tray_app, "_open_browser", lambda port: opened_ports.append(port))
+
+    app._open_browser_with_debounce(source="tray")
+    app._open_browser_with_debounce(source="tray")
+
+    assert opened_ports == [8788]
 
 
 def test_tray_open_action_uses_browser_window_reuse_mode() -> None:

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -569,7 +569,7 @@ def test_verify_install_relaunches_tray_before_marking_upgrade_complete(
 ) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
     target_version = "2.0.8"
-    observed = {"tray_calls": 0, "server_calls": 0}
+    observed = {"tray_calls": 0, "server_calls": 0, "last_open_browser": None}
     diagnostics_iter = iter(
         [
             {
@@ -607,7 +607,9 @@ def test_verify_install_relaunches_tray_before_marking_upgrade_complete(
     monkeypatch.setattr(
         updater_service,
         "_start_packaged_tray_in_active_session",
-        lambda *, open_browser=False: observed.__setitem__("tray_calls", observed["tray_calls"] + 1) or 4321,
+        lambda *, open_browser=False: observed.__setitem__("tray_calls", observed["tray_calls"] + 1)
+        or observed.__setitem__("last_open_browser", open_browser)
+        or 4321,
     )
     monkeypatch.setattr(
         updater_service,
@@ -622,9 +624,73 @@ def test_verify_install_relaunches_tray_before_marking_upgrade_complete(
     assert verified is True
     assert message == f"Upgrade completed. Running version: {target_version}."
     assert observed["tray_calls"] == 1
+    assert observed["last_open_browser"] is True
     assert observed["server_calls"] == 0
     assert diagnostics["restarted_tray_pid"] == 4321
     assert diagnostics["tray_relaunch_attempted"] is True
+
+
+def test_restart_packaged_runtime_relaunches_tray_with_browser_when_session_is_interactive(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    observed: dict[str, object] = {"open_browser": None}
+    monkeypatch.setattr(updater_service, "_running_media_processes", lambda: [])
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_tray_in_active_session",
+        lambda *, open_browser=False: observed.__setitem__("open_browser", open_browser) or 1234,
+    )
+
+    diagnostics = updater_service._restart_packaged_runtime_for_verification(
+        port=8788,
+        interactive_session_available=True,
+    )
+
+    assert diagnostics["restart_action"] == "start_tray"
+    assert diagnostics["restarted_tray_pid"] == 1234
+    assert observed["open_browser"] is True
+
+
+def test_verify_install_requests_browser_reopen_when_completed_with_existing_tray(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _configure_runtime_home(tmp_path, monkeypatch)
+    target_version = "2.2.3"
+    observed: dict[str, object] = {"calls": 0, "open_browser": None}
+
+    monkeypatch.setattr(updater_service, "_read_runtime_port", lambda: 8788)
+    monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: True)
+    monkeypatch.setattr(
+        updater_service,
+        "_collect_install_diagnostics",
+        lambda _target_version, *, port: {
+            "packaged_version": target_version,
+            "missing_required_files": [],
+            "backend_ready": True,
+            "backend_version": target_version,
+            "tray_running": True,
+        },
+    )
+    monkeypatch.setattr(
+        updater_service,
+        "_start_packaged_tray_in_active_session",
+        lambda *, open_browser=False: observed.__setitem__("calls", int(observed["calls"]) + 1)
+        or observed.__setitem__("open_browser", open_browser)
+        or 6789,
+    )
+    monkeypatch.setattr(updater_service.time, "time", lambda: 1234.0)
+
+    verified, diagnostics, message = updater_service._verify_install(target_version)
+
+    assert verified is True
+    assert message == f"Upgrade completed. Running version: {target_version}."
+    assert observed["calls"] == 1
+    assert observed["open_browser"] is True
+    assert diagnostics["browser_reopen_requested"] is True
+    assert diagnostics["browser_reopen_pid"] == 6789
 
 
 def test_verify_install_falls_back_to_server_when_tray_relaunch_is_unavailable(

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6616,7 +6616,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.2.3"
+    "version": "2.2.4"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.3",
+  "version": "2.2.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -149,7 +149,10 @@ function wrap(ui: ReactNode, client: QueryClient) {
 
 function renderSettings(
   me: UserPublic,
-  overrides?: { updateStatus?: SuiteUpdateStatusOut },
+  overrides?: {
+    updateStatus?: SuiteUpdateStatusOut;
+    initialEntries?: string[];
+  },
 ) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
@@ -179,7 +182,13 @@ function renderSettings(
     minimalLogs,
   );
   qc.setQueryData(suiteMetricsQueryKey, minimalMetrics);
-  return render(wrap(<SettingsPage />, qc));
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={overrides?.initialEntries}>
+        <SettingsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
 }
 
 async function renderSettingsWithSupportConfig(
@@ -476,6 +485,22 @@ describe("SettingsPage (suite settings)", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByText("Optional home dashboard notice"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps Upgrade selected when the URL tab query is upgrade", () => {
+    renderSettings(operatorMe, {
+      updateStatus: windowsUpdateAvailableStatus,
+      initialEntries: ["/settings?tab=upgrade"],
+    });
+
+    expect(screen.getByRole("tab", { name: "Upgrade" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("suite-settings-upgrade-tab")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("suite-settings-global"),
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -498,7 +498,9 @@ describe("SettingsPage (suite settings)", () => {
       "aria-selected",
       "true",
     );
-    expect(screen.getByTestId("suite-settings-upgrade-tab")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("suite-settings-upgrade-tab"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByTestId("suite-settings-global"),
     ).not.toBeInTheDocument();

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import type { ChangeEvent } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { PageLoading } from "../../components/shared/page-loading";
 import { browserWindow } from "../../lib/browser-window";
 import {
@@ -580,9 +580,30 @@ function completedUpgradeRefreshKey(
   return [progress.attempt_id || "unknown-attempt", targetVersion].join(":");
 }
 
+function normalizeSettingsTab(
+  candidate: string | null | undefined,
+  supportEnabled: boolean,
+): TabId {
+  switch ((candidate || "").trim().toLowerCase()) {
+    case "backup":
+      return "backup";
+    case "upgrade":
+      return "upgrade";
+    case "security":
+      return "security";
+    case "logs":
+      return "logs";
+    case "support":
+      return supportEnabled ? "support" : "general";
+    default:
+      return "general";
+  }
+}
+
 /** Settings: General (timezone, display density, configuration export), Security, Logs (retention + recent events). */
 export function SettingsPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const formatDateTime = useAppDateFormatter();
   const me = useMeQuery();
@@ -594,7 +615,21 @@ export function SettingsPage() {
   const updateNow = useSuiteUpdateNowMutation();
   const resetHistory = useSuiteOperationalHistoryResetMutation();
 
-  const [tab, setTab] = useState<TabId>("general");
+  const showSupportTab = SHOW_SUPPORT_CARD;
+  const [tab, setTab] = useState<TabId>(() =>
+    normalizeSettingsTab(searchParams.get("tab"), showSupportTab),
+  );
+
+  function setSettingsTab(nextTab: TabId): void {
+    setTab(nextTab);
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextTab === "general") {
+      nextParams.delete("tab");
+    } else {
+      nextParams.set("tab", nextTab);
+    }
+    setSearchParams(nextParams, { replace: true });
+  }
   const [appTimezone, setAppTimezone] = useState<string | null>(null);
   const [logRetentionDaysDraft, setLogRetentionDaysDraft] = useState<
     string | null
@@ -1001,6 +1036,15 @@ export function SettingsPage() {
     }
   }
 
+  useEffect(() => {
+    if (tab === "support" && !showSupportTab) {
+      setTab("general");
+      const nextParams = new URLSearchParams(searchParams);
+      nextParams.delete("tab");
+      setSearchParams(nextParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams, showSupportTab, tab]);
+
   if (loadingAny) {
     return <PageLoading label="Loading settings" />;
   }
@@ -1205,7 +1249,6 @@ export function SettingsPage() {
   const runtimeRequestIssues = requestIssueSummary(
     runtimeMetrics?.status_counts,
   );
-  const showSupportTab = SHOW_SUPPORT_CARD;
 
   return (
     <div className="mm-page" data-testid="suite-settings-page">
@@ -1229,7 +1272,7 @@ export function SettingsPage() {
             role="tab"
             aria-selected={tab === "general"}
             className={tabButtonClass(tab === "general")}
-            onClick={() => setTab("general")}
+            onClick={() => setSettingsTab("general")}
           >
             General
           </button>
@@ -1238,7 +1281,7 @@ export function SettingsPage() {
             role="tab"
             aria-selected={tab === "security"}
             className={tabButtonClass(tab === "security")}
-            onClick={() => setTab("security")}
+            onClick={() => setSettingsTab("security")}
           >
             Security
           </button>
@@ -1247,7 +1290,7 @@ export function SettingsPage() {
             role="tab"
             aria-selected={tab === "backup"}
             className={tabButtonClass(tab === "backup")}
-            onClick={() => setTab("backup")}
+            onClick={() => setSettingsTab("backup")}
           >
             Backup and restore
           </button>
@@ -1256,7 +1299,7 @@ export function SettingsPage() {
             role="tab"
             aria-selected={tab === "upgrade"}
             className={tabButtonClass(tab === "upgrade")}
-            onClick={() => setTab("upgrade")}
+            onClick={() => setSettingsTab("upgrade")}
           >
             Upgrade
           </button>
@@ -1265,7 +1308,7 @@ export function SettingsPage() {
             role="tab"
             aria-selected={tab === "logs"}
             className={tabButtonClass(tab === "logs")}
-            onClick={() => setTab("logs")}
+            onClick={() => setSettingsTab("logs")}
           >
             Logs
           </button>
@@ -1275,7 +1318,7 @@ export function SettingsPage() {
               role="tab"
               aria-selected={tab === "support"}
               className={tabButtonClass(tab === "support")}
-              onClick={() => setTab("support")}
+              onClick={() => setSettingsTab("support")}
             >
               Support
             </button>

--- a/docs/release-notes/v2.2.4.md
+++ b/docs/release-notes/v2.2.4.md
@@ -1,0 +1,29 @@
+# MediaMop v2.2.4
+
+Release date: May 9, 2026
+
+## Summary
+
+This patch closes Windows in-app upgrade regressions in the final user workflow.
+
+## Fixes
+
+- Fixed Settings tab regression where Upgrade could jump back to General during reconnect/refetch cycles.
+- Fixed post-upgrade relaunch behavior so upgrade verification relaunches the desktop app with browser open, not tray-only.
+- Added explicit browser reopen request after successful install verification in interactive Windows sessions.
+- Hardened tray browser open handling with thread-safe debounce to prevent duplicate tabs from rapid/duplicate tray callbacks.
+- Reduced noisy repeated updater install-root logging so operator diagnostics are easier to read during upgrade incidents.
+
+## Safety guarantees preserved
+
+- Upgrade completion still requires verified running version equality:
+  - `current_version == target_version`
+- Installer exit code `0` alone is still not treated as success.
+- Trusted release + checksum validation remains required for official in-app upgrades.
+
+## Upgrade notes
+
+- Publish as a new release tag `v2.2.4` with:
+  - `MediaMopSetup.exe`
+  - `MediaMopSetup.exe.sha256`
+- Do not replace existing `v2.2.3` assets in place.

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.3"
+#define AppVersion "2.2.4"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary\n- fix Settings tab regression so Upgrade stays selected during reconnect/refetch\n- relaunch desktop app with browser enabled during/after verified in-app upgrade\n- add explicit browser reopen request after successful verification in interactive session\n- harden tray browser open path with thread-safe debounce to prevent duplicate tabs\n- reduce updater log noise for cleaner diagnostics\n- bump versions to 2.2.4 and add release notes\n\n## Validation\n- backend: pytest (871 passed, 2 skipped), ruff, mypy\n- frontend: test (189 passed), lint, build\n- windows package build: packaging/windows/build.ps1 with MEDIAMOP_BUILD_VERSION=2.2.4\n