### PR TITLE
Prepare 2.2.5 release versions and notes

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.4"
+version = "2.2.5"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6616,7 +6616,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.2.4"
+    "version": "2.2.5"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.5.md
+++ b/docs/release-notes/v2.2.5.md
@@ -1,0 +1,31 @@
+# MediaMop v2.2.5
+
+## Summary
+
+This release rolls forward the fully hardened upgrade flow from v2.2.4 as a fresh patch package.
+
+## Included
+
+- Windows in-app upgrade reliability hardening remains in place:
+  - completion only after running version equals target version
+  - trusted installer and checksum verification
+  - stale updater-state recovery and PID reuse protection
+  - tray/browser relaunch resilience improvements
+- Settings Upgrade UX stability improvements remain in place.
+- Support tab build-time behavior remains unchanged (`VITE_SUPPORT_URL` gated).
+
+## Packaging and release
+
+- Internal app/package version: `2.2.5`
+- Tag: `v2.2.5`
+- Windows artifacts to publish:
+  - `MediaMopSetup.exe`
+  - `MediaMopSetup.exe.sha256`
+
+## Validation checklist
+
+1. Upgrade from older Windows install through Settings -> Upgrade.
+2. Confirm progress phases are truthful during install/reconnect.
+3. Confirm completion only appears after running version is `2.2.5`.
+4. Confirm tray icon and browser session relaunch behavior.
+5. Confirm checksum failure path blocks install and reports diagnostics.

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.4"
+#define AppVersion "2.2.5"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary\n- bump backend/web/installer versions to 2.2.5\n- add release notes at docs/release-notes/v2.2.5.md\n- run full backend/frontend validation and Windows packaging smoke\n\n## Validation\n- backend: pytest -q, ruff, mypy\n- frontend: test, lint, build\n- windows: packaging build + smoke-windows-package.ps1 -ExpectedVersion 2.2.5