### PR TITLE
Harden upgrade browser handoff UX

### DIFF
--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -1394,7 +1394,7 @@ def _restart_packaged_runtime_for_verification(
     try:
         if interactive_session_available:
             restart_diag["restart_action"] = "start_tray"
-            tray_pid = _start_packaged_tray_in_active_session(open_browser=True)
+            tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
             restart_diag["restarted_tray_pid"] = tray_pid
             _append_service_log(
                 "Started packaged MediaMop tray host after backend version mismatch "
@@ -1505,22 +1505,6 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
             and backend_key < target_key
         )
         if _diagnostics_prove_completed_desktop_upgrade(target_version, diagnostics):
-            if interactive_session_available and not tray_relaunch_attempted:
-                diagnostics["browser_reopen_requested"] = True
-                try:
-                    reopen_pid = _start_packaged_tray_in_active_session(open_browser=True)
-                except Exception as exc:
-                    diagnostics["browser_reopen_error"] = str(exc)
-                    _append_service_log(
-                        "Upgrade verification completed, but browser reopen request failed: "
-                        f"{exc}"
-                    )
-                else:
-                    diagnostics["browser_reopen_pid"] = reopen_pid
-                    _append_service_log(
-                        "Upgrade verification completed; requested browser reopen in active session "
-                        f"(pid={reopen_pid})."
-                    )
             return True, diagnostics, f"Upgrade completed. Running version: {target_version}."
         if packaged_version == target_version and not missing_required and backend_lagging:
             if version_mismatch_started_at is None:
@@ -1552,7 +1536,7 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
                 tray_relaunch_attempted = True
                 tray_relaunch_started_at = time.time()
                 try:
-                    restarted_tray_pid = _start_packaged_tray_in_active_session(open_browser=True)
+                    restarted_tray_pid = _start_packaged_tray_in_active_session(open_browser=False)
                 except Exception as exc:
                     tray_restart_error = str(exc)
                     diagnostics["tray_restart_error"] = tray_restart_error

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -624,13 +624,13 @@ def test_verify_install_relaunches_tray_before_marking_upgrade_complete(
     assert verified is True
     assert message == f"Upgrade completed. Running version: {target_version}."
     assert observed["tray_calls"] == 1
-    assert observed["last_open_browser"] is True
+    assert observed["last_open_browser"] is False
     assert observed["server_calls"] == 0
     assert diagnostics["restarted_tray_pid"] == 4321
     assert diagnostics["tray_relaunch_attempted"] is True
 
 
-def test_restart_packaged_runtime_relaunches_tray_with_browser_when_session_is_interactive(
+def test_restart_packaged_runtime_relaunches_tray_without_browser_when_session_is_interactive(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -650,16 +650,16 @@ def test_restart_packaged_runtime_relaunches_tray_with_browser_when_session_is_i
 
     assert diagnostics["restart_action"] == "start_tray"
     assert diagnostics["restarted_tray_pid"] == 1234
-    assert observed["open_browser"] is True
+    assert observed["open_browser"] is False
 
 
-def test_verify_install_requests_browser_reopen_when_completed_with_existing_tray(
+def test_verify_install_does_not_request_browser_reopen_when_completed_with_existing_tray(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     _configure_runtime_home(tmp_path, monkeypatch)
     target_version = "2.2.3"
-    observed: dict[str, object] = {"calls": 0, "open_browser": None}
+    observed: dict[str, object] = {"calls": 0}
 
     monkeypatch.setattr(updater_service, "_read_runtime_port", lambda: 8788)
     monkeypatch.setattr(updater_service, "_interactive_session_available", lambda: True)
@@ -678,7 +678,6 @@ def test_verify_install_requests_browser_reopen_when_completed_with_existing_tra
         updater_service,
         "_start_packaged_tray_in_active_session",
         lambda *, open_browser=False: observed.__setitem__("calls", int(observed["calls"]) + 1)
-        or observed.__setitem__("open_browser", open_browser)
         or 6789,
     )
     monkeypatch.setattr(updater_service.time, "time", lambda: 1234.0)
@@ -687,10 +686,9 @@ def test_verify_install_requests_browser_reopen_when_completed_with_existing_tra
 
     assert verified is True
     assert message == f"Upgrade completed. Running version: {target_version}."
-    assert observed["calls"] == 1
-    assert observed["open_browser"] is True
-    assert diagnostics["browser_reopen_requested"] is True
-    assert diagnostics["browser_reopen_pid"] == 6789
+    assert observed["calls"] == 0
+    assert diagnostics.get("browser_reopen_requested") is None
+    assert diagnostics.get("browser_reopen_pid") is None
 
 
 def test_verify_install_falls_back_to_server_when_tray_relaunch_is_unavailable(

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -869,9 +869,7 @@ describe("SettingsPage (suite settings)", () => {
       screen.getByRole("button", { name: "Reload now" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Reload to continue in the updated session.",
-      ),
+      screen.getByText("Reload to continue in the updated session."),
     ).toBeInTheDocument();
   });
 
@@ -910,9 +908,7 @@ describe("SettingsPage (suite settings)", () => {
       },
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: "Reload now" }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload now" }));
     expect(reloadSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -866,11 +866,11 @@ describe("SettingsPage (suite settings)", () => {
       screen.getByText("Upgrade completed. Running version: 2.0.8."),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Refresh browser now" }),
+      screen.getByRole("button", { name: "Reload now" }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "If this tab still looks stale, refresh the browser to load the upgraded MediaMop UI.",
+        "Reload to continue in the updated session.",
       ),
     ).toBeInTheDocument();
   });
@@ -888,7 +888,7 @@ describe("SettingsPage (suite settings)", () => {
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
     expect(
-      screen.queryByRole("button", { name: "Refresh browser now" }),
+      screen.queryByRole("button", { name: "Reload now" }),
     ).not.toBeInTheDocument();
   });
 
@@ -911,9 +911,30 @@ describe("SettingsPage (suite settings)", () => {
     });
     fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
     fireEvent.click(
-      screen.getByRole("button", { name: "Refresh browser now" }),
+      screen.getByRole("button", { name: "Reload now" }),
     );
     expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-refresh the browser when upgrade verification completes", () => {
+    const reloadSpy = vi
+      .spyOn(browserWindow, "reloadCurrentPage")
+      .mockImplementation(() => undefined);
+    renderSettings(operatorMe, {
+      updateStatus: {
+        ...windowsUpdateAvailableStatus,
+        current_version: "2.0.8",
+        status: "up_to_date",
+        summary: "This install is already on MediaMop 2.0.8.",
+        upgrade: upgradeProgress({
+          phase: "completed",
+          message: "Upgrade completed. Running version: 2.0.8.",
+          target_version: "2.0.8",
+        }),
+      },
+    });
+    fireEvent.click(screen.getByRole("tab", { name: "Upgrade" }));
+    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   it("computes a refresh key only after a verified Windows upgrade completes", () => {

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -680,7 +680,6 @@ export function SettingsPage() {
   const [logLevel, setLogLevel] = useState<LogLevelFilter>("");
   const [tracebacksOnly, setTracebacksOnly] = useState(false);
   const restoreInputRef = useRef<HTMLInputElement>(null);
-  const upgradeRefreshTriggeredRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!settingsQ.data) {
@@ -914,10 +913,6 @@ export function SettingsPage() {
           progress?.message ||
           `Upgrade completed. Running version: ${updateStatusQ.data.current_version}.`,
       });
-      if (upgradeRefreshTriggeredRef.current !== refreshAttemptKey) {
-        upgradeRefreshTriggeredRef.current = refreshAttemptKey;
-        browserWindow.reloadCurrentPage();
-      }
     }
   }, [upgradeMonitor, updateStatusQ.data]);
 
@@ -1191,7 +1186,6 @@ export function SettingsPage() {
 
   async function handleUpgradeNow() {
     setUpgradeNotice(null);
-    upgradeRefreshTriggeredRef.current = null;
     try {
       const result = await updateNow.mutateAsync();
       if (result.status === "started") {
@@ -2476,10 +2470,7 @@ export function SettingsPage() {
                   ) : null}
                   {completedUpgradeRefreshPromptKey ? (
                     <div className="rounded-md border border-emerald-500/30 bg-emerald-950/15 px-3 py-3 text-sm text-emerald-100">
-                      <p>
-                        If this tab still looks stale, refresh the browser to
-                        load the upgraded MediaMop UI.
-                      </p>
+                      <p>Reload to continue in the updated session.</p>
                       <div className="mt-3">
                         <button
                           type="button"
@@ -2489,7 +2480,7 @@ export function SettingsPage() {
                           })}
                           onClick={() => browserWindow.reloadCurrentPage()}
                         >
-                          Refresh browser now
+                          Reload now
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary\n- stop forced browser auto-refresh on verified upgrade completion\n- keep explicit user action: Reload now\n- avoid updater-initiated browser reopen during verification/relaunch\n- preserve verified completion gate (running version must match target)\n\n## UX intent\n- no dead-air forced navigation\n- no surprise tab reopen behavior during installer/service restart\n- clear completion handoff text: 'Reload to continue in the updated session.'\n\n## Validation\n- backend: pytest -q, ruff, mypy\n- targeted updater tests\n- frontend: settings-page tests, full tests, lint, build