### PR TITLE
Prepare 2.2.6 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.5"
+version = "2.2.6"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6616,7 +6616,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.2.5"
+    "version": "2.2.6"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.5",
+  "version": "2.2.6",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.6.md
+++ b/docs/release-notes/v2.2.6.md
@@ -1,0 +1,33 @@
+# MediaMop v2.2.6
+
+This release finalizes the browser handoff UX after successful Windows in-app upgrades.
+
+## Highlights
+
+- Removed forced browser auto-refresh when an upgrade reaches verified completion.
+- Removed updater-driven browser reopen during verification/relaunch.
+- Kept explicit operator action in Settings > Upgrade with a clear **Reload now** handoff.
+- Preserved verified completion guard: upgrade completion is only shown when running version equals target version.
+- Included CI formatting hardening for the updated upgrade settings tests.
+
+## Upgrade reliability status
+
+The in-app Windows upgrader still enforces:
+
+- trusted release asset resolution,
+- installer checksum verification,
+- no success from attempt acceptance alone,
+- no success from installer exit code alone,
+- completion only after runtime version verification.
+
+## Version consistency
+
+- Internal app/package version: `2.2.6`
+- Tag: `v2.2.6`
+
+## Validation focus
+
+1. Start from Windows host on `2.2.5` (or older supported version).
+2. Use **Settings → Upgrade → Upgrade now**.
+3. Confirm completion appears only after running version is `2.2.6`.
+4. On completion, click **Reload now** to continue in the updated session.

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.5"
+#define AppVersion "2.2.6"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
# MediaMop v2.2.6

This release finalizes the browser handoff UX after successful Windows in-app upgrades.

## Highlights

- Removed forced browser auto-refresh when an upgrade reaches verified completion.
- Removed updater-driven browser reopen during verification/relaunch.
- Kept explicit operator action in Settings > Upgrade with a clear **Reload now** handoff.
- Preserved verified completion guard: upgrade completion is only shown when running version equals target version.
- Included CI formatting hardening for the updated upgrade settings tests.

## Upgrade reliability status

The in-app Windows upgrader still enforces:

- trusted release asset resolution,
- installer checksum verification,
- no success from attempt acceptance alone,
- no success from installer exit code alone,
- completion only after runtime version verification.

## Version consistency

- Internal app/package version: `2.2.6`
- Tag: `v2.2.6`

## Validation focus

1. Start from Windows host on `2.2.5` (or older supported version).
2. Use **Settings → Upgrade → Upgrade now**.
3. Confirm completion appears only after running version is `2.2.6`.
4. On completion, click **Reload now** to continue in the updated session.
