### PR TITLE
Prepare 2.2.7 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.2.6"
+version = "2.2.7"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6793,7 +6793,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.2.6"
+    "version": "2.2.7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.2.7.md
+++ b/docs/release-notes/v2.2.7.md
@@ -12,11 +12,11 @@ This release adds outbound webhook notifications for job events and refactors th
 
 ## Fixes And Stability
 
-- Added `X-Requested-With` CSRF protection for all mutating API endpoints; browser-initiated requests are validated while direct API calls (CLI, test clients) are unaffected.
-- Added HKDF salt to Subber and Pruner credential envelopes, hardening key derivation.
-- Job rows older than the configured retention window are now pruned automatically by a background task.
-- Database migrations add covering indexes and a `not_before` column used for retry backoff.
-- Pre-migration database backups are taken automatically before any schema change.
+- API endpoints are now protected against cross-site request forgery; direct API access (scripts, CLI tools) is unaffected.
+- Stored Subber and Pruner credentials are now harder to brute-force if the database is ever exposed.
+- Job history older than the configured retention window is pruned automatically, keeping the database lean over time.
+- Failed jobs now retry with progressive backoff instead of retrying immediately, reducing noise under repeated failures.
+- A database backup is taken automatically before any schema migration, giving a recovery point for upgrades.
 
 ## Upgrade Notes
 

--- a/docs/release-notes/v2.2.7.md
+++ b/docs/release-notes/v2.2.7.md
@@ -1,0 +1,34 @@
+# MediaMop v2.2.7
+
+Date: 2026-05-12
+
+This release adds outbound webhook notifications for job events and refactors the Settings page into organised tabs.
+
+## What Changed
+
+- **Notification channels**: configure webhook endpoints (generic JSON or Discord) to receive alerts when jobs complete or permanently fail. Individual event types can be toggled per channel. Test a channel before relying on it via the new "Send test" button.
+- **Settings tabs**: Settings is now split into General, Workers, Notifications, and Upgrade tabs instead of a single long page.
+- **Unsaved-changes guard**: navigating away from Settings while edits are pending now prompts for confirmation before discarding changes.
+
+## Fixes And Stability
+
+- Added `X-Requested-With` CSRF protection for all mutating API endpoints; browser-initiated requests are validated while direct API calls (CLI, test clients) are unaffected.
+- Added HKDF salt to Subber and Pruner credential envelopes, hardening key derivation.
+- Job rows older than the configured retention window are now pruned automatically by a background task.
+- Database migrations add covering indexes and a `not_before` column used for retry backoff.
+- Pre-migration database backups are taken automatically before any schema change.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings → Upgrade**.
+- No database or configuration changes are required when upgrading from 2.2.6.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.2.7`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.2.6...v2.2.7

--- a/packaging/windows/MediaMop.iss
+++ b/packaging/windows/MediaMop.iss
@@ -2,7 +2,7 @@
   #define AppName "MediaMop"
 #endif
 #ifndef AppVersion
-#define AppVersion "2.2.6"
+#define AppVersion "2.2.7"
 #endif
 #ifndef OutputRoot
   #error OutputRoot must be provided to the installer build.


### PR DESCRIPTION
## Summary

- Bumps version to `2.2.7` across `pyproject.toml`, `package.json`, `package-lock.json`, `MediaMop.iss`, and `mediamop-openapi.json`
- Adds `docs/release-notes/v2.2.7.md`

## What's in this release

Changes since v2.2.6 (PR #225):

- Outbound webhook notification channels (generic JSON + Discord) for job completion/failure events
- Settings page refactored into General / Workers / Notifications / Upgrade tabs
- Unsaved-changes guard prompts before discarding in-progress edits
- `X-Requested-With` CSRF protection on all mutating API endpoints
- HKDF salt hardening for Subber/Pruner credential envelopes
- Automatic job-row retention pruning background task
- DB migrations: covering indexes + retry backoff `not_before` column
- Pre-migration automatic database backup

## Test plan

- [ ] CI passes (backend tests, docker-smoke, windows-package-smoke)
- [ ] Merge to main, then tag `v2.2.7` and publish GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)