### PR TITLE
chore: security cleanup — remove leaked local settings and machine path

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git remote *)",
-      "Bash(gh label *)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ apps/web/tmp-*.cjs
 
 # Build-time downloaded Windows FFmpeg runtime
 packaging/windows/vendor/
+
+# Claude Code local settings (machine-specific, never commit)
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,6 @@ This file is the short entry point for coding agents. Keep detailed rules in lin
 
 ## Repository Boundaries
 
-- Canonical checkout: `C:\Users\User\Projects\MediaMop`.
 - Do not use old duplicate checkouts or copied source trees.
 - Treat `main` as protected. Use short-lived branches and pull requests.
 - Never revert user changes unless the user explicitly asks for that exact revert.


### PR DESCRIPTION
## What was exposed

Two issues found during a public repo audit:

**1. `.claude/settings.local.json` committed to repo**
This is a personal/machine-specific Claude Code settings file that should never be in source control. Content was harmless (just tool permission allow-list) but the file type is explicitly "local" and should not be tracked.

**2. `AGENTS.md` contained local Windows path**
`Canonical checkout: C:\Users\User\Projects\MediaMop` was hardcoded — this exposes the machine username publicly.

## Changes

- **Deleted** `.claude/settings.local.json`
- **Updated** `.gitignore` — added `.claude/settings.local.json` so it can never be accidentally committed again
- **Updated** `AGENTS.md` — removed the hardcoded local machine path line

🤖 Generated with [Claude Code](https://claude.com/claude-code)