### PR TITLE
fix: remove mypy overrides for refiner and windows modules (closes #231)

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -62,9 +62,3 @@ check_untyped_defs = true
 warn_unused_ignores = true
 ignore_errors = false
 
-[[tool.mypy.overrides]]
-module = [
-  "mediamop.modules.refiner.*",
-  "mediamop.windows.*",
-]
-ignore_errors = true

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
@@ -152,14 +152,14 @@ def make_refiner_file_remux_pass_handler(
                 settings,
                 media_scope=media_scope,
             )
-            if path_err is not None:
+            if path_err is not None or path_runtime is None:
                 _record(
                     session_factory,
                     payload={
                         "job_id": ctx.id,
                         "ok": False,
                         "outcome": REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
-                        "reason": path_err,
+                        "reason": path_err or "path runtime unavailable",
                         "relative_media_path": rel.strip(),
                     },
                 )

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -109,7 +109,9 @@ def _probe_duration_seconds(probe: dict[str, Any]) -> float | None:
     fmt = probe.get("format")
     if isinstance(fmt, dict):
         try:
-            candidates.append(float(fmt.get("duration")))
+            dur = fmt.get("duration")
+            if dur is not None:
+                candidates.append(float(dur))
         except (TypeError, ValueError):
             pass
     streams = probe.get("streams")
@@ -118,7 +120,9 @@ def _probe_duration_seconds(probe: dict[str, Any]) -> float | None:
             if not isinstance(stream, dict):
                 continue
             try:
-                candidates.append(float(stream.get("duration")))
+                dur = stream.get("duration")
+                if dur is not None:
+                    candidates.append(float(dur))
             except (TypeError, ValueError):
                 pass
     valid = [item for item in candidates if item > 0]
@@ -336,7 +340,7 @@ def _handle_refiner_cleanup_after_success(
         return
 
     out["source_folder_path"] = str(movie_folder)
-    cascade: list[str] = out["cascade_folders_deleted"]  # type: ignore[assignment]
+    cascade: list[str] = out["cascade_folders_deleted"]
 
     out_dir = Path(path_runtime.output_folder).resolve()
     if not str(path_runtime.output_folder).strip():

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_api.py
@@ -1,7 +1,5 @@
 """Compatibility alias for the Refiner file remux pass API."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import api as _api
-
-sys.modules[__name__] = _api
+from mediamop.modules.refiner.file_remux_pass.api import (
+    router as router,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_handlers.py
@@ -1,7 +1,6 @@
 """Compatibility alias for Refiner file remux pass handlers."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import handlers as _handlers
-
-sys.modules[__name__] = _handlers
+from mediamop.modules.refiner.file_remux_pass.handlers import (
+    make_refiner_file_remux_pass_handler as make_refiner_file_remux_pass_handler,
+    RefinerActivityProgressReporter as RefinerActivityProgressReporter,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_job_kinds.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_job_kinds.py
@@ -1,7 +1,5 @@
 """Compatibility alias for the Refiner file remux pass job kinds."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import job_kinds as _job_kinds
-
-sys.modules[__name__] = _job_kinds
+from mediamop.modules.refiner.file_remux_pass.job_kinds import (
+    REFINER_FILE_REMUX_PASS_JOB_KIND as REFINER_FILE_REMUX_PASS_JOB_KIND,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_paths.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_paths.py
@@ -1,7 +1,5 @@
 """Compatibility alias for the Refiner file remux pass path helpers."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import paths as _paths
-
-sys.modules[__name__] = _paths
+from mediamop.modules.refiner.file_remux_pass.paths import (
+    resolve_media_file_under_refiner_root as resolve_media_file_under_refiner_root,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_run.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_run.py
@@ -1,7 +1,5 @@
 """Compatibility alias for the Refiner file remux pass runner."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import run as _run
-
-sys.modules[__name__] = _run
+from mediamop.modules.refiner.file_remux_pass.run import (
+    run_refiner_file_remux_pass as run_refiner_file_remux_pass,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_remux_pass_visibility.py
@@ -1,7 +1,13 @@
 """Compatibility alias for Refiner file remux pass visibility helpers."""
 
-import sys
-
-from mediamop.modules.refiner.file_remux_pass import visibility as _visibility
-
-sys.modules[__name__] = _visibility
+from mediamop.modules.refiner.file_remux_pass.visibility import (
+    REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION as REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
+    REMUX_PASS_OUTCOME_FAILED_DURING_EXECUTION as REMUX_PASS_OUTCOME_FAILED_DURING_EXECUTION,
+    REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN as REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN,
+    REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED as REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED,
+    REMUX_PASS_OUTCOME_SKIPPED_GUARDRAIL as REMUX_PASS_OUTCOME_SKIPPED_GUARDRAIL,
+    clip_remux_pass_payload_for_activity as clip_remux_pass_payload_for_activity,
+    remux_pass_activity_title as remux_pass_activity_title,
+    remux_pass_result_to_activity_detail as remux_pass_result_to_activity_detail,
+    summarize_remux_plan as summarize_remux_plan,
+)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
@@ -386,7 +386,7 @@ def maybe_run_movie_output_folder_cleanup_after_remux(
         "Radarr reports no library movie file paths inside this folder, so Refiner treated it as safe to remove under the other gates."
     )
 
-    cascade: list[str] = out["movie_output_cascade_folders_deleted"]  # type: ignore[assignment]
+    cascade: list[str] = out["movie_output_cascade_folders_deleted"]
 
     try:
         shutil.rmtree(output_movie_folder)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
@@ -223,14 +223,14 @@ def build_refiner_path_settings_get_out(*, row: RefinerPathSettingsRow, settings
     default_tv_work = resolved_default_refiner_tv_work_folder(mediamop_home=settings.mediamop_home)
     return {
         "refiner_watched_folder": row.refiner_watched_folder,
-        "refiner_watched_folder_exists": bool((row.refiner_watched_folder or "").strip() and Path(row.refiner_watched_folder).is_dir()),
+        "refiner_watched_folder_exists": bool((row.refiner_watched_folder or "").strip() and Path(row.refiner_watched_folder or "").is_dir()),
         "refiner_work_folder": row.refiner_work_folder,
         "refiner_output_folder": (row.refiner_output_folder or "").strip() or None,
         "resolved_default_work_folder": default_work,
         "effective_work_folder": work_eff,
         "refiner_tv_watched_folder": row.refiner_tv_watched_folder,
         "refiner_tv_watched_folder_exists": bool(
-            (row.refiner_tv_watched_folder or "").strip() and Path(row.refiner_tv_watched_folder).is_dir()
+            (row.refiner_tv_watched_folder or "").strip() and Path(row.refiner_tv_watched_folder or "").is_dir()
         ),
         "refiner_tv_work_folder": row.refiner_tv_work_folder,
         "refiner_tv_output_folder": (row.refiner_tv_output_folder or "").strip() or None,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
@@ -107,7 +107,7 @@ def _scope_out(
         subtitle_langs_csv=subtitle_langs_csv or "",
         preserve_forced_subs=bool(preserve_forced_subs),
         preserve_default_subs=bool(preserve_default_subs),
-        audio_preference_mode=normalize_audio_preference_mode(audio_preference_mode),  # type: ignore[arg-type]
+        audio_preference_mode=normalize_audio_preference_mode(audio_preference_mode),
     )
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
@@ -440,7 +440,7 @@ def maybe_run_tv_output_season_folder_cleanup_after_remux(
         "Sonarr reports no library episode file paths inside this season folder, so Refiner treated it as safe to remove under the other gates."
     )
 
-    cascade: list[str] = out["tv_output_cascade_folders_deleted"]  # type: ignore[assignment]
+    cascade: list[str] = out["tv_output_cascade_folders_deleted"]
 
     try:
         shutil.rmtree(output_season_folder)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_season_folder_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_season_folder_cleanup.py
@@ -210,9 +210,9 @@ def handle_tv_cleanup_after_success(
     """After a successful live TV pass: optional whole-season-folder removal + show cascade (gates in docstring)."""
 
     init_tv_season_cleanup_activity_fields(out)
-    summary: list[str] = out["tv_episode_check_summary"]  # type: ignore[assignment]
-    completeness: dict[str, str] = out["tv_output_completeness_check"]  # type: ignore[assignment]
-    cascade: list[str] = out["tv_cascade_folders_deleted"]  # type: ignore[assignment]
+    summary: list[str] = out["tv_episode_check_summary"]
+    completeness: dict[str, str] = out["tv_output_completeness_check"]
+    cascade: list[str] = out["tv_cascade_folders_deleted"]
 
     watched_resolved = watched_root.resolve()
     src_resolved = src.resolve()
@@ -317,7 +317,7 @@ def handle_tv_cleanup_after_success(
                 else:
                     expected_out = (out_dir / Path(rel)).resolve()
             chk = _check_output_file_completeness_tv(output_file=expected_out, source_file=ep)
-            completeness[name] = chk["output_completeness_check"]  # type: ignore[index]
+            completeness[name] = chk["output_completeness_check"]
             if chk["output_completeness_check"] != "passed":
                 out["tv_season_folder_skip_reason"] = (
                     chk.get("output_completeness_note")
@@ -335,7 +335,7 @@ def handle_tv_cleanup_after_success(
         elif _activity_documents_tv_live_success(session, relative_posix=rel):
             expected_out = out_dir / Path(rel)
             chk = _check_output_file_completeness_tv(output_file=expected_out, source_file=ep)
-            completeness[name] = chk["output_completeness_check"]  # type: ignore[index]
+            completeness[name] = chk["output_completeness_check"]
             if chk["output_completeness_check"] != "passed":
                 out["tv_season_folder_skip_reason"] = (
                     chk.get("output_completeness_note")

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -154,7 +154,7 @@ class _WindowsSingleInstanceGuard:
     def acquire(self) -> bool:
         if os.name != "nt":
             return True
-        kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+        kernel32 = ctypes.windll.kernel32
         kernel32.SetLastError(0)
         handle = kernel32.CreateMutexW(None, False, self._name)
         if not handle:
@@ -168,7 +168,7 @@ class _WindowsSingleInstanceGuard:
         if self._handle is None:
             return
         try:
-            ctypes.windll.kernel32.CloseHandle(self._handle)  # type: ignore[attr-defined]
+            ctypes.windll.kernel32.CloseHandle(self._handle)
         finally:
             self._handle = None
 
@@ -261,7 +261,7 @@ class _MediaMopTrayApp:
         self._browser_open_lock = threading.Lock()
         executable_dir = Path(sys.executable).resolve().parent
         self._server_exe = executable_dir / "MediaMopServer.exe"
-        self._server_process: subprocess.Popen[str] | None = None
+        self._server_process: subprocess.Popen[Any] | None = None
 
     def _log(self, message: str) -> None:
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
@@ -286,7 +286,7 @@ class _MediaMopTrayApp:
         self._open_browser_with_debounce(source="tray")
 
     def _handle_open_data_folder(self, icon: Any, item: Any) -> None:  # noqa: ARG002
-        os.startfile(str(self._runtime_home))  # type: ignore[attr-defined]
+        os.startfile(str(self._runtime_home))
 
     def _handle_quit(self, icon: Any, item: Any) -> None:  # noqa: ARG002
         self._log("Quit requested from tray icon")
@@ -314,12 +314,13 @@ class _MediaMopTrayApp:
             raise RuntimeError(f"Bundled server host is missing: {self._server_exe}")
         self._log(f"Starting bundled server host: {self._server_exe}")
         creationflags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
-        self._server_process = subprocess.Popen(
+        proc = subprocess.Popen(
             [str(self._server_exe), "--serve", "--port", str(self._port)],
             cwd=str(self._server_exe.parent),
             creationflags=creationflags,
         )
-        self._log(f"Bundled server host pid={self._server_process.pid}")
+        self._server_process = proc
+        self._log(f"Bundled server host pid={proc.pid}")
 
     def _stop_server_process(self) -> None:
         proc = self._server_process

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -160,7 +160,7 @@ def _bool_env(name: str) -> bool:
 
 def _pid_is_running(pid: object) -> bool:
     try:
-        numeric = int(pid)
+        numeric = int(str(pid))
     except (TypeError, ValueError):
         return False
     if numeric <= 0:
@@ -187,7 +187,7 @@ def _normalize_executable_path(raw: object) -> str | None:
 
 def _read_process_snapshot(pid: object) -> dict[str, object] | None:
     try:
-        numeric = int(pid)
+        numeric = int(str(pid))
     except (TypeError, ValueError):
         return None
     if numeric <= 0:
@@ -746,7 +746,8 @@ def _write_state(**updates: object) -> dict[str, object]:
         state = _read_state_unlocked()
         diagnostics_update = updates.pop("diagnostics", None)
         if diagnostics_update is not None:
-            merged = dict(state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {})
+            _existing_diag = state.get("diagnostics")
+            merged = dict(_existing_diag) if isinstance(_existing_diag, dict) else {}
             if isinstance(diagnostics_update, dict):
                 merged.update(diagnostics_update)
             else:
@@ -963,7 +964,8 @@ def _archive_superseded_terminal_attempt() -> None:
         )
         merged_diagnostics = dict(install_diagnostics)
 
-    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    _diag_raw = state.get("diagnostics")
+    diagnostics: dict[str, object] = dict(_diag_raw) if isinstance(_diag_raw, dict) else {}
     attempt_id = str(state.get("attempt_id") or "").strip() or None
     archived_diagnostics = dict(diagnostics)
     archived_diagnostics.update(merged_diagnostics)
@@ -1331,7 +1333,7 @@ def _start_packaged_tray_in_active_session(*, open_browser: bool = False) -> int
 
 def _terminate_pid(pid: object) -> str | None:
     try:
-        numeric = int(pid)
+        numeric = int(str(pid))
     except (TypeError, ValueError):
         return "Invalid PID."
     if numeric <= 0:
@@ -1520,9 +1522,9 @@ def _verify_install(target_version: str) -> tuple[bool, dict[str, object], str]:
                 )
                 diagnostics["mismatch_restart"] = restart_diag
                 if restart_diag.get("restarted_tray_pid"):
-                    restarted_tray_pid = int(restart_diag["restarted_tray_pid"])
+                    restarted_tray_pid = int(str(restart_diag["restarted_tray_pid"]))
                 if restart_diag.get("restarted_server_pid"):
-                    started_server_pid = int(restart_diag["restarted_server_pid"])
+                    started_server_pid = int(str(restart_diag["restarted_server_pid"]))
                 if restart_diag.get("restart_error"):
                     mismatch_restart_error = str(restart_diag["restart_error"])
                 else:
@@ -1992,7 +1994,8 @@ def _maybe_reconcile_pending_attempt() -> None:
 
 def _status_view() -> dict[str, object]:
     state = _read_state()
-    diagnostics = state.get("diagnostics") if isinstance(state.get("diagnostics"), dict) else {}
+    _diag_val = state.get("diagnostics")
+    diagnostics: dict[str, object] = dict(_diag_val) if isinstance(_diag_val, dict) else {}
     raw_phase = (
         str(diagnostics.get("reconciled_from_phase") or state.get("phase") or "unknown").strip().lower()
         or "unknown"

--- a/apps/backend/tests/test_end_to_end_workflows.py
+++ b/apps/backend/tests/test_end_to_end_workflows.py
@@ -27,7 +27,7 @@ from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
 from mediamop.modules.pruner.pruner_overview_stats_service import build_pruner_overview_stats
 from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
 from mediamop.modules.pruner.worker_loop import process_one_pruner_job
-from mediamop.modules.refiner import refiner_file_remux_pass_run as refiner_run
+from mediamop.modules.refiner.file_remux_pass import run as refiner_run
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_file_remux_pass_job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND

--- a/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
-from mediamop.modules.refiner import refiner_file_remux_pass_handlers as handler_mod
+from mediamop.modules.refiner.file_remux_pass import handlers as handler_mod
 from mediamop.modules.refiner.refiner_file_remux_pass_visibility import REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
 from mediamop.platform.activity import constants as activity_constants

--- a/apps/backend/tests/test_refiner_file_remux_pass_run.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_run.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.refiner import refiner_file_remux_pass_run as runmod
+from mediamop.modules.refiner.file_remux_pass import run as runmod
 from mediamop.modules.refiner.refiner_remux_rules import PlannedTrack, RemuxPlan
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_file_remux_pass_visibility import (


### PR DESCRIPTION
## Summary

- Removes the `[[tool.mypy.overrides]]` block in `pyproject.toml` that suppressed all mypy errors for `mediamop.modules.refiner.*` and `mediamop.windows.*`
- Converts 6 `sys.modules[__name__] = _module` compat shims in the refiner module into proper explicit re-exports that mypy can type-check
- Fixes all 54 type errors that surfaced across 17 files

## Type errors fixed

- **6 compat shims** (`refiner_file_remux_pass_{api,handlers,job_kinds,paths,run,visibility}.py`): replaced `sys.modules` trick with explicit `from ... import X as X` re-exports
- **`file_remux_pass/handlers.py`**: add `or path_runtime is None` guard to narrow `RefinerPathRuntime | None` to non-None after early return
- **`file_remux_pass/run.py`**: guard `float()` calls with `if dur is not None`; remove stale `type: ignore[assignment]`
- **`refiner_path_settings_service.py`**: use `Path(x or "")` to avoid `Path(str | None)`
- **`refiner_remux_rules_settings_service.py`**: remove now-redundant `type: ignore[arg-type]`
- **`refiner_movie_output_cleanup.py`, `refiner_tv_output_cleanup.py`, `refiner_tv_season_folder_cleanup.py`**: remove stale `type: ignore` comments
- **`updater_service.py`**: use `int(str(pid))` for `object`-typed PIDs; extract `isinstance(x, dict)` checks into local vars before calling `dict()` on them; annotate local `diagnostics` as `dict[str, object]`
- **`tray_app.py`**: change `Popen[str]` to `Popen[Any]`; use local var before `.pid` access; remove stale `type: ignore[attr-defined]`
- **3 test files**: update imports from compat shim aliases to canonical `file_remux_pass` subpackage so `monkeypatch.setattr` targets the correct module namespace

## Test results

```
870 passed, 2 skipped, 1 known pre-existing failure (test_local_browse_api::test_system_directories_returns_not_found)
```

## Final mypy output

```
Success: no issues found in 94 source files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)