### PR TITLE
fix: enable ruff I (isort), UP (pyupgrade), SIM (simplify) rule families (closes #232)

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -48,7 +48,7 @@ line-length = 120
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E9", "F63", "F7", "F82", "B", "C4"]
+select = ["E9", "F63", "F7", "F82", "B", "C4", "I", "UP", "SIM"]
 ignore = ["B008"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/apps/backend/src/mediamop/api/factory.py
+++ b/apps/backend/src/mediamop/api/factory.py
@@ -7,22 +7,22 @@ from pathlib import Path
 
 from fastapi import FastAPI, Request
 from fastapi.exception_handlers import http_exception_handler
-from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette import status
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from mediamop import __version__
 from mediamop.api.router import build_v1_router
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.lifespan import lifespan
 from mediamop.platform.health import health_router
-from mediamop.platform.readiness import readiness_router
 from mediamop.platform.http.request_context import RequestContextMiddleware
 from mediamop.platform.http.security_headers import SecurityHeadersMiddleware
 from mediamop.platform.http.xrw_csrf_middleware import XRequestedWithCsrfMiddleware
 from mediamop.platform.metrics.router import router as metrics_router
+from mediamop.platform.readiness import readiness_router
 
 
 def _web_dist_root() -> Path | None:

--- a/apps/backend/src/mediamop/api/router.py
+++ b/apps/backend/src/mediamop/api/router.py
@@ -14,17 +14,17 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from mediamop.modules.dashboard.router import router as dashboard_router
+from mediamop.modules.pruner.router import router as pruner_router
 from mediamop.modules.refiner.router import router as refiner_router
 from mediamop.modules.subber.router import router as subber_router
-from mediamop.modules.pruner.router import router as pruner_router
 from mediamop.platform.activity.router import router as activity_router
+from mediamop.platform.arr_library.http_router import router as arr_library_router
 from mediamop.platform.auth.router import router as auth_router
 from mediamop.platform.local_browse.router import router as local_browse_router
+from mediamop.platform.notifications.router import router as notifications_router
 from mediamop.platform.reconciliation.router import router as reconciliation_router
 from mediamop.platform.suite_settings.router import router as suite_settings_router
-from mediamop.platform.arr_library.http_router import router as arr_library_router
 from mediamop.platform.system_configuration.router import router as system_configuration_router
-from mediamop.platform.notifications.router import router as notifications_router
 
 API_V1_PREFIX = "/api/v1"
 

--- a/apps/backend/src/mediamop/core/alembic_revision_check.py
+++ b/apps/backend/src/mediamop/core/alembic_revision_check.py
@@ -13,12 +13,13 @@ from pathlib import Path
 
 _log = logging.getLogger(__name__)
 
-from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
+
+from alembic import command
 
 
 class DatabaseSchemaMismatch(RuntimeError):

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -7,12 +7,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-from mediamop.core.runtime_paths import (
-    assert_sqlite_db_location_usable,
-    ensure_runtime_directories,
-    resolve_all_runtime_paths,
-    sqlalchemy_sqlite_url,
-)
 from mediamop.core.config_domains import (
     ArrSettings,
     AuthSettings,
@@ -22,13 +16,19 @@ from mediamop.core.config_domains import (
     SessionSettings,
     SubberSettings,
 )
+from mediamop.core.runtime_paths import (
+    assert_sqlite_db_location_usable,
+    ensure_runtime_directories,
+    resolve_all_runtime_paths,
+    sqlalchemy_sqlite_url,
+)
+from mediamop.modules.pruner.worker_limits import clamp_pruner_worker_count
 from mediamop.modules.refiner.refiner_family_intervals import (
     clamp_refiner_min_file_age_seconds,
     clamp_refiner_schedule_interval_seconds,
 )
 from mediamop.modules.refiner.worker_limits import clamp_refiner_worker_count
 from mediamop.modules.subber.worker_limits import clamp_subber_worker_count
-from mediamop.modules.pruner.worker_limits import clamp_pruner_worker_count
 
 
 def _load_backend_dotenv_if_present() -> None:

--- a/apps/backend/src/mediamop/core/datetime_util.py
+++ b/apps/backend/src/mediamop/core/datetime_util.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 
 def as_utc(dt: datetime) -> datetime:
     """Treat naive values as UTC; normalize aware values to UTC."""
 
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)

--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -18,23 +18,22 @@ from mediamop.core.db import (
     dispose_engine,
 )
 from mediamop.core.logging import configure_logging
-from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_handlers
-from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
+from mediamop.modules.pruner.pruner_job_handlers import build_pruner_job_handlers
+from mediamop.modules.pruner.pruner_preview_schedule_enqueue import (
+    start_pruner_preview_schedule_enqueue_tasks,
+    stop_pruner_preview_schedule_enqueue_tasks,
+)
+from mediamop.modules.pruner.worker_loop import (
+    start_pruner_worker_background_tasks,
+    stop_pruner_worker_background_tasks,
+)
 from mediamop.modules.refiner.refiner_crash_recovery import cleanup_refiner_partial_output_files
 from mediamop.modules.refiner.refiner_failure_cleanup_periodic_enqueue import (
     start_refiner_failure_cleanup_enqueue_tasks,
     stop_refiner_failure_cleanup_enqueue_tasks,
 )
-from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
-from mediamop.modules.subber.subber_schedule_enqueue import (
-    start_subber_movies_scan_schedule_enqueue_tasks,
-    start_subber_tv_scan_schedule_enqueue_tasks,
-    start_subber_upgrade_schedule_enqueue_tasks,
-    stop_subber_movies_scan_schedule_enqueue_tasks,
-    stop_subber_tv_scan_schedule_enqueue_tasks,
-    stop_subber_upgrade_schedule_enqueue_tasks,
-)
-from mediamop.modules.pruner.pruner_job_handlers import build_pruner_job_handlers
+from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_handlers
+from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_supplied_payload_evaluation_periodic_enqueue import (
     start_refiner_supplied_payload_evaluation_enqueue_tasks,
     stop_refiner_supplied_payload_evaluation_enqueue_tasks,
@@ -51,34 +50,35 @@ from mediamop.modules.refiner.worker_loop import (
     start_refiner_worker_background_tasks,
     stop_refiner_worker_background_tasks,
 )
+from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
+from mediamop.modules.subber.subber_schedule_enqueue import (
+    start_subber_movies_scan_schedule_enqueue_tasks,
+    start_subber_tv_scan_schedule_enqueue_tasks,
+    start_subber_upgrade_schedule_enqueue_tasks,
+    stop_subber_movies_scan_schedule_enqueue_tasks,
+    stop_subber_tv_scan_schedule_enqueue_tasks,
+    stop_subber_upgrade_schedule_enqueue_tasks,
+)
 from mediamop.modules.subber.worker_loop import (
     start_subber_worker_background_tasks,
     stop_subber_worker_background_tasks,
 )
-from mediamop.modules.pruner.pruner_preview_schedule_enqueue import (
-    start_pruner_preview_schedule_enqueue_tasks,
-    stop_pruner_preview_schedule_enqueue_tasks,
-)
-from mediamop.modules.pruner.worker_loop import (
-    start_pruner_worker_background_tasks,
-    stop_pruner_worker_background_tasks,
-)
 from mediamop.platform.auth.rate_limit import SlidingWindowLimiter
+from mediamop.platform.auth.service import cleanup_inactive_sessions
 from mediamop.platform.auth.session_cleanup import start_session_cleanup_task, stop_session_cleanup_task
 from mediamop.platform.jobs.job_rows_retention_periodic import (
     start_job_rows_retention_tasks,
     stop_job_rows_retention_tasks,
 )
-from mediamop.platform.auth.service import cleanup_inactive_sessions
 from mediamop.platform.jobs.startup_recovery import recover_incomplete_jobs_after_startup
+from mediamop.platform.suite_settings.logs_retention_periodic import (
+    start_log_retention_tasks,
+    stop_log_retention_tasks,
+)
 from mediamop.platform.suite_settings.logs_service import prune_logs_for_retention
 from mediamop.platform.suite_settings.suite_configuration_backup_periodic import (
     start_suite_configuration_backup_tasks,
     stop_suite_configuration_backup_tasks,
-)
-from mediamop.platform.suite_settings.logs_retention_periodic import (
-    start_log_retention_tasks,
-    stop_log_retention_tasks,
 )
 
 _lifespan_log = logging.getLogger(__name__)

--- a/apps/backend/src/mediamop/core/logging.py
+++ b/apps/backend/src/mediamop/core/logging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from datetime import UTC, datetime
@@ -49,10 +50,8 @@ def configure_logging(settings: MediaMopSettings) -> None:
     root.setLevel(level)
     for handler in list(root.handlers):
         root.removeHandler(handler)
-        try:
+        with contextlib.suppress(Exception):
             handler.close()
-        except Exception:
-            pass
 
     shared_filter = MediaMopLogFilter()
 

--- a/apps/backend/src/mediamop/modules/dashboard/service.py
+++ b/apps/backend/src/mediamop/modules/dashboard/service.py
@@ -3,20 +3,25 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
 from mediamop import __version__
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.dashboard.schemas import ActivitySummaryOut, DashboardStatusOut, SystemStatusOut, WorkerLaneHealthOut
-from mediamop.platform.activity.schemas import ActivityEventItemOut
+from mediamop.modules.dashboard.schemas import (
+    ActivitySummaryOut,
+    DashboardStatusOut,
+    SystemStatusOut,
+    WorkerLaneHealthOut,
+)
 from mediamop.platform.activity import service as activity_service
+from mediamop.platform.activity.schemas import ActivityEventItemOut
 from mediamop.platform.jobs.worker_health import build_worker_health_snapshot
 
 
 def _build_activity_summary(db: Session) -> ActivitySummaryOut:
-    since = datetime.now(timezone.utc) - timedelta(hours=24)
+    since = datetime.now(UTC) - timedelta(hours=24)
     n = activity_service.count_activity_events_since(db, since=since)
     latest_row = activity_service.get_latest_activity_event(db)
     latest = ActivityEventItemOut.model_validate(latest_row) if latest_row else None

--- a/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
@@ -27,16 +27,25 @@ from mediamop.modules.pruner.pruner_constants import (
     pruner_apply_operator_label,
 )
 from mediamop.modules.pruner.pruner_credentials_envelope import decrypt_and_parse_envelope
-from mediamop.modules.pruner.pruner_instances_service import get_server_instance
 from mediamop.modules.pruner.pruner_emby_library_delete import emby_delete_library_item
+from mediamop.modules.pruner.pruner_instances_service import get_server_instance
 from mediamop.modules.pruner.pruner_jellyfin_library_delete import jellyfin_delete_library_item
 from mediamop.modules.pruner.pruner_plex_library_delete import plex_delete_library_metadata
 from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
 from mediamop.modules.pruner.worker_loop import PrunerJobWorkContext
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
-from mediamop.platform.observability.operator_messages import activity_detail_envelope, media_scope_label, provider_label
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
+from mediamop.platform.observability.operator_messages import (
+    activity_detail_envelope,
+    media_scope_label,
+    provider_label,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -285,14 +294,13 @@ def make_pruner_candidate_removal_apply_handler(
         evt = C.PRUNER_APPLY_LIBRARY_REMOVAL_COMPLETED
         if removed == 0 and skipped == 0 and failed > 0:
             evt = C.PRUNER_APPLY_LIBRARY_REMOVAL_FAILED
-        with session_factory() as session:
-            with session.begin():
-                record_activity_event(
-                    session,
-                    event_type=evt,
-                    module="pruner",
-                    title=title,
-                    detail=detail,
-                )
+        with session_factory() as session, session.begin():
+            record_activity_event(
+                session,
+                event_type=evt,
+                module="pruner",
+                title=title,
+                detail=detail,
+            )
 
     return _run

--- a/apps/backend/src/mediamop/modules/pruner/pruner_connection_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_connection_job_handler.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -16,7 +16,12 @@ from mediamop.modules.pruner.pruner_media_library import test_emby_jellyfin_conn
 from mediamop.modules.pruner.worker_loop import PrunerJobWorkContext
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, connection_test_title
 
 
@@ -72,7 +77,7 @@ def make_pruner_server_connection_test_handler(
         else:
             ok, detail = False, f"unsupported provider {provider!r}"
 
-        when = datetime.now(timezone.utc)
+        when = datetime.now(UTC)
         title = connection_test_title(module_label="Pruner", name=display_name, provider=provider, ok=ok)
         detail_s = (detail or "")[:10_000]
         result_for_message = DiagnosticResult.SUCCESS if ok else DiagnosticResult.FAILED
@@ -88,25 +93,24 @@ def make_pruner_server_connection_test_handler(
             ),
             "detail": detail_s,
         }
-        with session_factory() as session:
-            with session.begin():
-                inst2 = get_server_instance(session, sid)
-                if inst2 is None:
-                    return
-                inst2.last_connection_test_at = when
-                inst2.last_connection_test_ok = ok
-                inst2.last_connection_test_detail = detail_s
-                evt = (
-                    C.PRUNER_CONNECTION_TEST_SUCCEEDED
-                    if ok
-                    else C.PRUNER_CONNECTION_TEST_FAILED
-                )
-                record_activity_event(
-                    session,
-                    event_type=evt,
-                    module="pruner",
-                    title=title,
-                    detail=json.dumps(activity_detail, separators=(",", ":"))[:10_000],
-                )
+        with session_factory() as session, session.begin():
+            inst2 = get_server_instance(session, sid)
+            if inst2 is None:
+                return
+            inst2.last_connection_test_at = when
+            inst2.last_connection_test_ok = ok
+            inst2.last_connection_test_detail = detail_s
+            evt = (
+                C.PRUNER_CONNECTION_TEST_SUCCEEDED
+                if ok
+                else C.PRUNER_CONNECTION_TEST_FAILED
+            )
+            record_activity_event(
+                session,
+                event_type=evt,
+                module="pruner",
+                title=title,
+                detail=json.dumps(activity_detail, separators=(",", ":"))[:10_000],
+            )
 
     return _run

--- a/apps/backend/src/mediamop/modules/pruner/pruner_genre_filters.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_genre_filters.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 PRUNER_PREVIEW_GENRE_FILTER_MAX_TOKENS = 25
 PRUNER_PREVIEW_GENRE_FILTER_MAX_TOKEN_LEN = 64
@@ -133,7 +134,4 @@ def item_matches_genre_include_filter(
     fl = {str(x).casefold() for x in include_filters if str(x).strip()}
     if not fl:
         return True
-    for g in item_genres:
-        if str(g).casefold() in fl:
-            return True
-    return False
+    return any(str(g).casefold() in fl for g in item_genres)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_http.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_http.py
@@ -10,7 +10,6 @@ from typing import Any
 
 from mediamop.platform.outbound_http import normalize_local_service_base_url
 
-
 DEFAULT_TIMEOUT_SEC = 20.0
 
 

--- a/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
@@ -22,11 +22,6 @@ from mediamop.modules.pruner.pruner_people_filters import (
     plex_leaf_person_tags,
     plex_leaf_person_tags_for_roles,
 )
-from mediamop.modules.pruner.pruner_preview_year_filters import (
-    item_matches_preview_year_filter,
-    jellyfin_emby_item_production_year_int,
-    plex_leaf_release_year_int,
-)
 from mediamop.modules.pruner.pruner_plex_missing_thumb_candidates import (
     _as_list,
     _leaf_type_matches,
@@ -34,6 +29,11 @@ from mediamop.modules.pruner.pruner_plex_missing_thumb_candidates import (
     _plex_headers,
     _rating_key,
     _section_matches_scope,
+)
+from mediamop.modules.pruner.pruner_preview_year_filters import (
+    item_matches_preview_year_filter,
+    jellyfin_emby_item_production_year_int,
+    plex_leaf_release_year_int,
 )
 from mediamop.modules.pruner.pruner_studio_collection_filters import jellyfin_emby_item_studio_names
 
@@ -49,11 +49,7 @@ def _jf_emby_truncated(
     page: int,
 ) -> bool:
     truncated = False
-    if total_hits is not None and candidates_len < total_hits and candidates_len >= max_items:
-        truncated = True
-    elif total_hits is not None and start < total_hits and candidates_len >= max_items:
-        truncated = True
-    elif fetched >= page and candidates_len >= max_items:
+    if total_hits is not None and candidates_len < total_hits and candidates_len >= max_items or total_hits is not None and start < total_hits and candidates_len >= max_items or fetched >= page and candidates_len >= max_items:
         truncated = True
     return truncated
 
@@ -306,10 +302,7 @@ def list_jf_emby_people_match_candidates(
         for it in items:
             if not isinstance(it, dict):
                 continue
-            if roles:
-                names = jellyfin_emby_people_names_for_roles(it, roles)
-            else:
-                names = jellyfin_emby_item_people_names(it)
+            names = jellyfin_emby_people_names_for_roles(it, roles) if roles else jellyfin_emby_item_people_names(it)
             if not item_matches_people_include_filter(names, pf):
                 continue
             iid = str(it.get("Id", "")).strip()
@@ -540,9 +533,7 @@ def _plex_collect_leaf_matches(
                 total_i = start + len(metas)
             start += len(metas)
             if stop_after_page:
-                if start < total_i:
-                    truncated = True
-                elif sec_idx < len(section_keys) - 1:
+                if start < total_i or sec_idx < len(section_keys) - 1:
                     truncated = True
                 break
             if start >= total_i or len(metas) == 0:
@@ -644,10 +635,7 @@ def list_plex_people_match_candidates(
     roles = list(preview_include_people_roles) if preview_include_people_roles is not None else []
 
     def matches(m: dict[str, Any]) -> bool:
-        if roles:
-            tags = plex_leaf_person_tags_for_roles(m, roles)
-        else:
-            tags = plex_leaf_person_tags(m)
+        tags = plex_leaf_person_tags_for_roles(m, roles) if roles else plex_leaf_person_tags(m)
         return item_matches_people_include_filter(tags, pf)
 
     def build(m: dict[str, Any], rk: str) -> dict[str, Any]:

--- a/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
@@ -23,27 +23,15 @@ from mediamop.modules.pruner.pruner_constants import (
     clamp_watched_movie_low_rating_max_jellyfin_emby_community_rating,
     clamp_watched_movie_low_rating_max_plex_audience_rating,
 )
-from mediamop.modules.pruner.pruner_genre_filters import (
-    preview_genre_filters_from_db_column,
-    preview_genre_filters_to_db_column,
-)
-from mediamop.modules.pruner.pruner_studio_collection_filters import (
-    preview_collection_filters_from_db_column,
-    preview_collection_filters_to_db_column,
-    preview_studio_filters_from_db_column,
-    preview_studio_filters_to_db_column,
-)
-from mediamop.modules.pruner.pruner_people_filters import (
-    preview_people_filters_from_db_column,
-    preview_people_filters_to_db_column,
-    preview_people_roles_from_db_column,
-    preview_people_roles_to_db_column,
-)
 from mediamop.modules.pruner.pruner_credentials_envelope import (
     PrunerProvider,
     decrypt_and_parse_envelope,
     encrypt_envelope,
     envelope_secrets_for_provider,
+)
+from mediamop.modules.pruner.pruner_genre_filters import (
+    preview_genre_filters_from_db_column,
+    preview_genre_filters_to_db_column,
 )
 from mediamop.modules.pruner.pruner_instances_service import (
     create_server_instance,
@@ -57,8 +45,14 @@ from mediamop.modules.pruner.pruner_job_kinds import (
     PRUNER_SERVER_CONNECTION_TEST_JOB_KIND,
 )
 from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
-from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
+from mediamop.modules.pruner.pruner_people_filters import (
+    preview_people_filters_from_db_column,
+    preview_people_filters_to_db_column,
+    preview_people_roles_from_db_column,
+    preview_people_roles_to_db_column,
+)
 from mediamop.modules.pruner.pruner_plex_live_eligibility import compute_plex_live_eligibility
+from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
 from mediamop.modules.pruner.pruner_schemas import (
     PrunerApplyEligibilityOut,
     PrunerApplyHttpIn,
@@ -75,10 +69,16 @@ from mediamop.modules.pruner.pruner_schemas import (
     PrunerServerInstancePatchHttpIn,
     PrunerStudiosOut,
 )
-from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
-from mediamop.modules.pruner.pruner_studio_list import list_distinct_studios
 from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
 from mediamop.modules.pruner.pruner_server_instance_model import PrunerServerInstance
+from mediamop.modules.pruner.pruner_studio_collection_filters import (
+    preview_collection_filters_from_db_column,
+    preview_collection_filters_to_db_column,
+    preview_studio_filters_from_db_column,
+    preview_studio_filters_to_db_column,
+)
+from mediamop.modules.pruner.pruner_studio_list import list_distinct_studios
+from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
     current_raw_session_token,

--- a/apps/backend/src/mediamop/modules/pruner/pruner_job_handlers.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_job_handlers.py
@@ -7,9 +7,8 @@ from collections.abc import Callable
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.queue_worker.job_kind_boundaries import validate_pruner_worker_handler_registry
-from mediamop.modules.pruner.pruner_connection_job_handler import make_pruner_server_connection_test_handler
 from mediamop.modules.pruner.pruner_apply_job_handler import make_pruner_candidate_removal_apply_handler
+from mediamop.modules.pruner.pruner_connection_job_handler import make_pruner_server_connection_test_handler
 from mediamop.modules.pruner.pruner_job_kinds import (
     PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
     PRUNER_CANDIDATE_REMOVAL_PLEX_LIVE_JOB_KIND,
@@ -19,6 +18,7 @@ from mediamop.modules.pruner.pruner_job_kinds import (
 from mediamop.modules.pruner.pruner_plex_live_job_handler import make_pruner_plex_live_removal_handler
 from mediamop.modules.pruner.pruner_preview_job_handler import make_pruner_candidate_removal_preview_handler
 from mediamop.modules.pruner.worker_loop import PrunerJobWorkContext
+from mediamop.modules.queue_worker.job_kind_boundaries import validate_pruner_worker_handler_registry
 
 
 def build_pruner_job_handlers(

--- a/apps/backend/src/mediamop/modules/pruner/pruner_jobs_model.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_jobs_model.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from mediamop.core.db import Base
 
 
-class PrunerJobStatus(str, enum.Enum):
+class PrunerJobStatus(enum.StrEnum):
     """Persisted in ``pruner_jobs.status`` (VARCHAR)."""
 
     PENDING = "pending"

--- a/apps/backend/src/mediamop/modules/pruner/pruner_jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_jobs_ops.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from mediamop.modules.queue_worker.job_kind_boundaries import validate_pruner_enqueue_job_kind
 from mediamop.modules.pruner.pruner_jobs_model import PrunerJob, PrunerJobStatus
+from mediamop.modules.queue_worker.job_kind_boundaries import validate_pruner_enqueue_job_kind
 from mediamop.platform.metrics.service import record_module_job_event, set_module_queue_depth
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def _record_pruner_queue_depth(session: Session) -> None:

--- a/apps/backend/src/mediamop/modules/pruner/pruner_media_library.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_media_library.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 import urllib.error
-from datetime import datetime, timedelta, timezone
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from mediamop.modules.pruner.pruner_constants import (
@@ -21,6 +21,12 @@ from mediamop.modules.pruner.pruner_constants import (
     RULE_FAMILY_WATCHED_MOVIES_REPORTED,
     RULE_FAMILY_WATCHED_TV_REPORTED,
     RULE_FAMILY_YEAR_RANGE_MATCH_REPORTED,
+)
+from mediamop.modules.pruner.pruner_http import (
+    PrunerHttpStatusError,
+    http_get_json,
+    http_get_text,
+    join_base_path,
 )
 from mediamop.modules.pruner.pruner_independent_rule_candidates import (
     list_jf_emby_genre_match_candidates,
@@ -38,12 +44,7 @@ from mediamop.modules.pruner.pruner_plex_movie_rule_candidates import (
     list_plex_watched_movie_candidates,
     list_plex_watched_movie_low_rating_candidates,
 )
-from mediamop.modules.pruner.pruner_http import (
-    PrunerHttpStatusError,
-    http_get_json,
-    http_get_text,
-    join_base_path,
-)
+
 
 def jf_emby_pruner_preview_items_fields_csv() -> str:
     """Comma-separated Jellyfin/Emby ``Fields`` for **all** Pruner preview ``Items`` queries in this module.
@@ -160,9 +161,7 @@ def _items_page(
 def _item_missing_primary(item: dict[str, Any]) -> bool:
     if item.get("ImageTags") and isinstance(item["ImageTags"], dict) and item["ImageTags"].get("Primary"):
         return False
-    if item.get("PrimaryImageItemId"):
-        return False
-    return True
+    return not item.get("PrimaryImageItemId")
 
 
 def list_missing_primary_candidates(
@@ -251,9 +250,7 @@ def list_missing_primary_candidates(
             break
 
     truncated = False
-    if total_hits is not None and len(candidates) < total_hits and len(candidates) >= max_items:
-        truncated = True
-    elif total_hits is not None and start < total_hits and len(candidates) >= max_items:
+    if total_hits is not None and len(candidates) < total_hits and len(candidates) >= max_items or total_hits is not None and start < total_hits and len(candidates) >= max_items:
         truncated = True
 
     return candidates, truncated
@@ -272,8 +269,8 @@ def _parse_item_date_created(raw: object) -> datetime | None:
     try:
         dt = datetime.fromisoformat(s)
         if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt.astimezone(timezone.utc)
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
     except ValueError:
         return None
 
@@ -391,9 +388,7 @@ def list_watched_tv_episode_candidates(
         if fetched == 0:
             break
         if len(candidates) >= max_items:
-            if total_hits is not None and start < total_hits:
-                truncated = True
-            elif fetched >= page:
+            if total_hits is not None and start < total_hits or fetched >= page:
                 truncated = True
             break
 
@@ -476,9 +471,7 @@ def list_watched_movie_candidates(
         if fetched == 0:
             break
         if len(candidates) >= max_items:
-            if total_hits is not None and start < total_hits:
-                truncated = True
-            elif fetched >= page:
+            if total_hits is not None and start < total_hits or fetched >= page:
                 truncated = True
             break
 
@@ -572,9 +565,7 @@ def list_watched_movie_low_rating_candidates(
         if fetched == 0:
             break
         if len(candidates) >= max_items:
-            if total_hits is not None and start < total_hits:
-                truncated = True
-            elif fetched >= page:
+            if total_hits is not None and start < total_hits or fetched >= page:
                 truncated = True
             break
 
@@ -601,7 +592,7 @@ def list_unwatched_movie_stale_candidates(
         msg = f"unwatched_movie_stale_reported requires media_scope={MEDIA_SCOPE_MOVIES!r}, got {media_scope!r}"
         raise ValueError(msg)
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=max(1, int(min_age_days)))
+    cutoff = datetime.now(UTC) - timedelta(days=max(1, int(min_age_days)))
     include_types = "Movie"
     candidates: list[dict[str, Any]] = []
     start = 0
@@ -667,9 +658,7 @@ def list_unwatched_movie_stale_candidates(
         if fetched == 0:
             break
         if len(candidates) >= max_items:
-            if total_hits is not None and start < total_hits:
-                truncated = True
-            elif fetched >= page:
+            if total_hits is not None and start < total_hits or fetched >= page:
                 truncated = True
             break
 
@@ -699,7 +688,7 @@ def list_never_played_stale_candidates(
         msg = f"unsupported media_scope: {media_scope!r}"
         raise ValueError(msg)
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=max(1, int(min_age_days)))
+    cutoff = datetime.now(UTC) - timedelta(days=max(1, int(min_age_days)))
     candidates: list[dict[str, Any]] = []
     start = 0
     page = min(100, max(1, max_items * 3))
@@ -778,9 +767,7 @@ def list_never_played_stale_candidates(
         if fetched == 0:
             break
         if len(candidates) >= max_items:
-            if total_hits is not None and start < total_hits:
-                truncated = True
-            elif fetched >= page:
+            if total_hits is not None and start < total_hits or fetched >= page:
                 truncated = True
             break
 

--- a/apps/backend/src/mediamop/modules/pruner/pruner_overview_stats_service.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_overview_stats_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -15,7 +15,7 @@ from mediamop.platform.activity.models import ActivityEvent
 
 def build_pruner_overview_stats(db: Session, *, window_days: int = 30) -> PrunerOverviewStatsOut:
     wd = max(1, int(window_days))
-    since = datetime.now(timezone.utc) - timedelta(days=wd)
+    since = datetime.now(UTC) - timedelta(days=wd)
 
     apply_rows = db.execute(
         select(ActivityEvent.detail).where(

--- a/apps/backend/src/mediamop/modules/pruner/pruner_people_filters.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_people_filters.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from mediamop.modules.pruner.pruner_genre_filters import normalized_genre_filter_tokens
 
@@ -232,7 +233,4 @@ def item_matches_people_include_filter(
     fl = {str(x).casefold() for x in include_filters if str(x).strip()}
     if not fl:
         return True
-    for n in item_people:
-        if str(n).casefold() in fl:
-            return True
-    return False
+    return any(str(n).casefold() in fl for n in item_people)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_plex_missing_thumb_candidates.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_plex_missing_thumb_candidates.py
@@ -61,9 +61,7 @@ def _plex_leaf_missing_thumb(meta: dict[str, Any]) -> bool:
     thumb = meta.get("thumb")
     if thumb is None:
         return True
-    if isinstance(thumb, str) and not thumb.strip():
-        return True
-    return False
+    return bool(isinstance(thumb, str) and not thumb.strip())
 
 
 def _rating_key(meta: dict[str, Any]) -> str:
@@ -178,9 +176,7 @@ def list_plex_missing_thumb_candidates(
                 total_i = start + len(metas)
             start += len(metas)
             if stop_after_page:
-                if start < total_i:
-                    truncated = True
-                elif sec_idx < len(section_keys) - 1:
+                if start < total_i or sec_idx < len(section_keys) - 1:
                     truncated = True
                 break
             if start >= total_i or len(metas) == 0:

--- a/apps/backend/src/mediamop/modules/pruner/pruner_plex_movie_rule_candidates.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_plex_movie_rule_candidates.py
@@ -17,7 +17,7 @@ Supported rule families (Movies scope only):
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Any
 
 from mediamop.modules.pruner.pruner_constants import MEDIA_SCOPE_MOVIES
@@ -87,7 +87,7 @@ def plex_leaf_added_at_utc(meta: dict[str, Any]) -> datetime | None:
     if ts > 10_000_000_000:
         ts = ts // 1000
     try:
-        return datetime.fromtimestamp(ts, tz=timezone.utc)
+        return datetime.fromtimestamp(ts, tz=UTC)
     except (OSError, OverflowError, ValueError):
         return None
 
@@ -178,11 +178,7 @@ def _plex_collect_movie_rows(
                 total_i = start + len(metas)
             start += len(metas)
             if stop_after_page:
-                if start < total_i:
-                    truncated = True
-                elif sec_idx < len(section_keys) - 1:
-                    truncated = True
-                elif page_had_skipped_potential:
+                if start < total_i or sec_idx < len(section_keys) - 1 or page_had_skipped_potential:
                     truncated = True
                 break
             if start >= total_i or len(metas) == 0:
@@ -259,15 +255,13 @@ def list_plex_unwatched_movie_stale_candidates(
     min_age_days: int,
 ) -> tuple[list[dict[str, Any]], bool]:
     age = max(1, int(min_age_days))
-    cutoff = datetime.now(timezone.utc) - timedelta(days=age)
+    cutoff = datetime.now(UTC) - timedelta(days=age)
 
     def pred(m: dict[str, Any]) -> bool:
         if not plex_movie_leaf_unwatched_for_token(m):
             return False
         added = plex_leaf_added_at_utc(m)
-        if added is None or added > cutoff:
-            return False
-        return True
+        return not (added is None or added > cutoff)
 
     def build(m: dict[str, Any], rk: str) -> dict[str, Any]:
         return {

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_item_filters.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_item_filters.py
@@ -42,10 +42,7 @@ def jf_emby_item_passes_preview_filters(
     pf = list(preview_include_people or [])
     if pf:
         roles = list(preview_include_people_roles) if preview_include_people_roles is not None else []
-        if roles:
-            names = jellyfin_emby_people_names_for_roles(it, roles)
-        else:
-            names = jellyfin_emby_item_people_names(it)
+        names = jellyfin_emby_people_names_for_roles(it, roles) if roles else jellyfin_emby_item_people_names(it)
         if not item_matches_people_include_filter(names, pf):
             return False
     if not item_matches_preview_year_filter(
@@ -54,6 +51,4 @@ def jf_emby_item_passes_preview_filters(
         preview_year_max,
     ):
         return False
-    if not item_matches_genre_include_filter(jellyfin_emby_item_studio_names(it), preview_include_studios):
-        return False
-    return True
+    return item_matches_genre_include_filter(jellyfin_emby_item_studio_names(it), preview_include_studios)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
@@ -31,24 +31,29 @@ from mediamop.modules.pruner.pruner_constants import (
 )
 from mediamop.modules.pruner.pruner_credentials_envelope import decrypt_and_parse_envelope
 from mediamop.modules.pruner.pruner_genre_filters import preview_genre_filters_from_db_column
+from mediamop.modules.pruner.pruner_instances_service import get_scope_settings, get_server_instance
+from mediamop.modules.pruner.pruner_job_kinds import PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND
+from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
+from mediamop.modules.pruner.pruner_media_library import preview_payload_json, serialize_candidates
 from mediamop.modules.pruner.pruner_people_filters import (
     preview_people_filters_from_db_column,
     preview_people_roles_from_db_column,
 )
+from mediamop.modules.pruner.pruner_plex_live_eligibility import plex_missing_primary_effective_max_items
+from mediamop.modules.pruner.pruner_preview_service import insert_preview_run
 from mediamop.modules.pruner.pruner_studio_collection_filters import (
     preview_collection_filters_from_db_column,
     preview_studio_filters_from_db_column,
 )
-from mediamop.modules.pruner.pruner_instances_service import get_scope_settings, get_server_instance
-from mediamop.modules.pruner.pruner_job_kinds import PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND
-from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
-from mediamop.modules.pruner.pruner_plex_live_eligibility import plex_missing_primary_effective_max_items
-from mediamop.modules.pruner.pruner_media_library import preview_payload_json, serialize_candidates
-from mediamop.modules.pruner.pruner_preview_service import insert_preview_run
 from mediamop.modules.pruner.worker_loop import PrunerJobWorkContext
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, provider_label, scan_title
 
 logger = logging.getLogger(__name__)
@@ -125,10 +130,9 @@ def make_pruner_candidate_removal_preview_handler(
                 if not bool(sc.watched_movie_low_rating_reported_enabled):
                     msg = "watched_movie_low_rating_reported_enabled is false for this scope"
                     raise ValueError(msg)
-            elif rule_family_id == RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED:
-                if not bool(sc.unwatched_movie_stale_reported_enabled):
-                    msg = "unwatched_movie_stale_reported_enabled is false for this scope"
-                    raise ValueError(msg)
+            elif rule_family_id == RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED and not bool(sc.unwatched_movie_stale_reported_enabled):
+                msg = "unwatched_movie_stale_reported_enabled is false for this scope"
+                raise ValueError(msg)
             max_items = max(1, min(int(sc.preview_max_items), 5000))
             age_days = clamp_never_played_min_age_days(int(sc.never_played_min_age_days))
             unwatched_stale_days = clamp_never_played_min_age_days(int(sc.unwatched_movie_stale_min_age_days))
@@ -246,122 +250,121 @@ def make_pruner_candidate_removal_preview_handler(
             scheduled=is_scheduled,
         )
 
-        with session_factory() as session:
-            with session.begin():
-                insert_preview_run(
-                    session,
-                    preview_run_uuid=run_uuid,
-                    server_instance_id=sid,
+        with session_factory() as session, session.begin():
+            insert_preview_run(
+                session,
+                preview_run_uuid=run_uuid,
+                server_instance_id=sid,
+                media_scope=scope,
+                rule_family_id=rule_family_id,
+                pruner_job_id=int(ctx.id),
+                candidate_count=len(cands),
+                candidates_json=cand_json,
+                truncated=trunc,
+                outcome=outcome,
+                unsupported_detail=unsup,
+                error_message=err,
+            )
+            auto_apply_queued = bool(
+                is_scheduled
+                and auto_apply_enabled
+                and settings.pruner_apply_enabled
+                and outcome == "success"
+                and len(cands) > 0,
+            )
+            detail_obj: dict[str, object] = {
+                **activity_detail_envelope(
+                    module=DiagnosticModule.PRUNER,
+                    action=DiagnosticAction.PREVIEW,
+                    trigger=DiagnosticTrigger.SCHEDULED if is_scheduled else DiagnosticTrigger.MANUAL,
+                    result=result_for_message,
+                    provider=provider,
                     media_scope=scope,
-                    rule_family_id=rule_family_id,
-                    pruner_job_id=int(ctx.id),
-                    candidate_count=len(cands),
-                    candidates_json=cand_json,
-                    truncated=trunc,
-                    outcome=outcome,
-                    unsupported_detail=unsup,
-                    error_message=err,
-                )
-                auto_apply_queued = bool(
-                    is_scheduled
-                    and auto_apply_enabled
-                    and settings.pruner_apply_enabled
-                    and outcome == "success"
-                    and len(cands) > 0,
-                )
-                detail_obj: dict[str, object] = {
-                    **activity_detail_envelope(
-                        module=DiagnosticModule.PRUNER,
-                        action=DiagnosticAction.PREVIEW,
-                        trigger=DiagnosticTrigger.SCHEDULED if is_scheduled else DiagnosticTrigger.MANUAL,
-                        result=result_for_message,
-                        provider=provider,
-                        media_scope=scope,
-                        counts={"checked": len(cands), "found": len(cands), "queued": int(auto_apply_queued)},
-                        user_message=(
-                            f"Pruner checked {label_scope} for {rule_tag} and found {len(cands)} item"
-                            f"{'' if len(cands) == 1 else 's'}."
-                        ),
+                    counts={"checked": len(cands), "found": len(cands), "queued": int(auto_apply_queued)},
+                    user_message=(
+                        f"Pruner checked {label_scope} for {rule_tag} and found {len(cands)} item"
+                        f"{'' if len(cands) == 1 else 's'}."
                     ),
-                    "phase": "preview",
-                    "preview_run_id": run_uuid,
-                    "outcome": outcome,
-                    "candidate_count": len(cands),
-                    "truncated": trunc,
-                    "rule_family_id": rule_family_id,
-                    "trigger": "scheduled" if is_scheduled else "manual",
-                }
-                if preview_genres:
-                    detail_obj["preview_include_genres"] = list(preview_genres)
-                if preview_people:
-                    detail_obj["preview_include_people"] = list(preview_people)
-                if preview_year_min is not None or preview_year_max is not None:
-                    detail_obj["preview_year_min"] = preview_year_min
-                    detail_obj["preview_year_max"] = preview_year_max
-                if preview_studios:
-                    detail_obj["preview_include_studios"] = list(preview_studios)
-                if preview_collections and provider == "plex":
-                    detail_obj["preview_include_collections"] = list(preview_collections)
-                elif preview_collections and provider in ("jellyfin", "emby"):
-                    detail_obj["preview_collections_ignored_note"] = (
-                        "Collection include tokens are stored for this scope but not applied on Jellyfin/Emby previews "
-                        "in this slice — the Items API path does not expose per-item library collection membership "
-                        "without extra calls."
-                    )
-                if outcome == "success" and rule_family_id == RULE_FAMILY_GENRE_MATCH_REPORTED and preview_genres and len(cands) == 0:
-                    detail_obj["preview_genre_rule_zero_candidates_note"] = (
-                        "Zero rows matched your selected genres under the preview cap — the library may still contain "
-                        "other genres, or matches may sit beyond the cap (try raising per-tab preview max)."
-                    )
-                if outcome == "success" and rule_family_id == RULE_FAMILY_PEOPLE_MATCH_REPORTED and preview_people and len(cands) == 0:
-                    detail_obj["preview_people_rule_zero_candidates_note"] = (
-                        "Zero rows matched your entered names under the preview cap — widen names, adjust roles "
-                        "(Jellyfin/Emby), or raise the per-tab preview max if you expected matches."
-                    )
-                if provider == "plex" and rule_family_id == RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED:
-                    detail_obj["plex_missing_primary_item_cap"] = max_items
-                    detail_obj["plex_missing_primary_cap_note"] = (
-                        "Plex missing-primary preview collects at most this many rows per run "
-                        "(min per-scope preview cap, MEDIAMOP_PRUNER_PLEX_LIVE_ABS_MAX_ITEMS, and 5000 ceiling). "
-                        "truncated=true means more matches existed upstream than this cap."
-                    )
-                if outcome == "unsupported" and unsup:
-                    detail_obj["unsupported_detail"] = unsup[:2000]
-                if err:
-                    detail_obj["error"] = err[:2000]
-                if auto_apply_queued:
-                    detail_obj["auto_apply_queued"] = True
-                    detail_obj["max_deletes_per_run"] = max_deletes_per_run
-                elif is_scheduled and auto_apply_enabled and not settings.pruner_apply_enabled:
-                    detail_obj["auto_apply_skipped"] = "Pruner apply is disabled for this MediaMop process."
-                detail = json.dumps(detail_obj, separators=(",", ":"))[:10_000]
-                if outcome == "success":
-                    evt = C.PRUNER_PREVIEW_SUCCEEDED
-                elif outcome == "unsupported":
-                    evt = C.PRUNER_PREVIEW_UNSUPPORTED
-                else:
-                    evt = C.PRUNER_PREVIEW_FAILED
-                record_activity_event(
-                    session,
-                    event_type=evt,
-                    module="pruner",
-                    title=title,
-                    detail=detail,
+                ),
+                "phase": "preview",
+                "preview_run_id": run_uuid,
+                "outcome": outcome,
+                "candidate_count": len(cands),
+                "truncated": trunc,
+                "rule_family_id": rule_family_id,
+                "trigger": "scheduled" if is_scheduled else "manual",
+            }
+            if preview_genres:
+                detail_obj["preview_include_genres"] = list(preview_genres)
+            if preview_people:
+                detail_obj["preview_include_people"] = list(preview_people)
+            if preview_year_min is not None or preview_year_max is not None:
+                detail_obj["preview_year_min"] = preview_year_min
+                detail_obj["preview_year_max"] = preview_year_max
+            if preview_studios:
+                detail_obj["preview_include_studios"] = list(preview_studios)
+            if preview_collections and provider == "plex":
+                detail_obj["preview_include_collections"] = list(preview_collections)
+            elif preview_collections and provider in ("jellyfin", "emby"):
+                detail_obj["preview_collections_ignored_note"] = (
+                    "Collection include tokens are stored for this scope but not applied on Jellyfin/Emby previews "
+                    "in this slice — the Items API path does not expose per-item library collection membership "
+                    "without extra calls."
                 )
-                if auto_apply_queued:
-                    payload = {
-                        "preview_run_uuid": run_uuid,
-                        "server_instance_id": sid,
-                        "media_scope": scope,
-                        "rule_family_id": rule_family_id,
-                        "auto_applied": True,
-                        "max_deletes_per_run": max_deletes_per_run,
-                    }
-                    pruner_enqueue_or_get_job(
-                        session,
-                        dedupe_key=f"pruner:apply:auto:v1:{run_uuid}:{uuid.uuid4()}",
-                        job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                        payload_json=json.dumps(payload, separators=(",", ":")),
-                    )
+            if outcome == "success" and rule_family_id == RULE_FAMILY_GENRE_MATCH_REPORTED and preview_genres and len(cands) == 0:
+                detail_obj["preview_genre_rule_zero_candidates_note"] = (
+                    "Zero rows matched your selected genres under the preview cap — the library may still contain "
+                    "other genres, or matches may sit beyond the cap (try raising per-tab preview max)."
+                )
+            if outcome == "success" and rule_family_id == RULE_FAMILY_PEOPLE_MATCH_REPORTED and preview_people and len(cands) == 0:
+                detail_obj["preview_people_rule_zero_candidates_note"] = (
+                    "Zero rows matched your entered names under the preview cap — widen names, adjust roles "
+                    "(Jellyfin/Emby), or raise the per-tab preview max if you expected matches."
+                )
+            if provider == "plex" and rule_family_id == RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED:
+                detail_obj["plex_missing_primary_item_cap"] = max_items
+                detail_obj["plex_missing_primary_cap_note"] = (
+                    "Plex missing-primary preview collects at most this many rows per run "
+                    "(min per-scope preview cap, MEDIAMOP_PRUNER_PLEX_LIVE_ABS_MAX_ITEMS, and 5000 ceiling). "
+                    "truncated=true means more matches existed upstream than this cap."
+                )
+            if outcome == "unsupported" and unsup:
+                detail_obj["unsupported_detail"] = unsup[:2000]
+            if err:
+                detail_obj["error"] = err[:2000]
+            if auto_apply_queued:
+                detail_obj["auto_apply_queued"] = True
+                detail_obj["max_deletes_per_run"] = max_deletes_per_run
+            elif is_scheduled and auto_apply_enabled and not settings.pruner_apply_enabled:
+                detail_obj["auto_apply_skipped"] = "Pruner apply is disabled for this MediaMop process."
+            detail = json.dumps(detail_obj, separators=(",", ":"))[:10_000]
+            if outcome == "success":
+                evt = C.PRUNER_PREVIEW_SUCCEEDED
+            elif outcome == "unsupported":
+                evt = C.PRUNER_PREVIEW_UNSUPPORTED
+            else:
+                evt = C.PRUNER_PREVIEW_FAILED
+            record_activity_event(
+                session,
+                event_type=evt,
+                module="pruner",
+                title=title,
+                detail=detail,
+            )
+            if auto_apply_queued:
+                payload = {
+                    "preview_run_uuid": run_uuid,
+                    "server_instance_id": sid,
+                    "media_scope": scope,
+                    "rule_family_id": rule_family_id,
+                    "auto_applied": True,
+                    "max_deletes_per_run": max_deletes_per_run,
+                }
+                pruner_enqueue_or_get_job(
+                    session,
+                    dedupe_key=f"pruner:apply:auto:v1:{run_uuid}:{uuid.uuid4()}",
+                    job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+                    payload_json=json.dumps(payload, separators=(",", ":")),
+                )
 
     return _run

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_schedule_enqueue.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_schedule_enqueue.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -34,9 +34,9 @@ from mediamop.modules.pruner.pruner_constants import (
 )
 from mediamop.modules.pruner.pruner_job_kinds import PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND
 from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
-from mediamop.platform.arr_library.schedule_wall_clock import DAY_NAMES, schedule_time_window_active
 from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
 from mediamop.modules.pruner.pruner_server_instance_model import PrunerServerInstance
+from mediamop.platform.arr_library.schedule_wall_clock import DAY_NAMES, schedule_time_window_active
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 
 logger = logging.getLogger(__name__)
@@ -106,12 +106,12 @@ def _scope_row_in_schedule_window(session: Session, sc: PrunerScopeSettings, *, 
 def _scope_row_due(sc: PrunerScopeSettings, *, now: datetime) -> bool:
     """Due using only this row's interval and ``last_scheduled_preview_enqueued_at``."""
 
-    when = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    when = now if now.tzinfo else now.replace(tzinfo=UTC)
     interval = clamp_pruner_scheduled_preview_interval_seconds(int(sc.scheduled_preview_interval_seconds))
     last_at = sc.last_scheduled_preview_enqueued_at
     if last_at is None:
         return True
-    last = last_at if last_at.tzinfo else last_at.replace(tzinfo=timezone.utc)
+    last = last_at if last_at.tzinfo else last_at.replace(tzinfo=UTC)
     return (when - last).total_seconds() >= float(interval)
 
 
@@ -126,7 +126,7 @@ def enqueue_due_scheduled_pruner_previews(session: Session, *, now: datetime) ->
     * row's own due-time vs ``last_scheduled_preview_enqueued_at`` and its interval
     """
 
-    when = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    when = now if now.tzinfo else now.replace(tzinfo=UTC)
     stmt = (
         select(PrunerScopeSettings)
         .join(
@@ -175,12 +175,11 @@ def run_pruner_preview_schedule_enqueue_tick(
     *,
     now: datetime | None = None,
 ) -> int:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    with session_factory() as session:
-        with session.begin():
-            return enqueue_due_scheduled_pruner_previews(session, now=when)
+        when = when.replace(tzinfo=UTC)
+    with session_factory() as session, session.begin():
+        return enqueue_due_scheduled_pruner_previews(session, now=when)
 
 
 async def _run_pruner_preview_schedule_forever(

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_service.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -20,7 +20,7 @@ def apply_latest_preview_denorm(
 ) -> None:
     """Keep ``last_preview_run_id`` aligned with the newest run for (instance, scope)."""
 
-    when = at if at is not None else datetime.now(timezone.utc)
+    when = at if at is not None else datetime.now(UTC)
     scope_row.last_preview_run_id = int(run.id)
     scope_row.last_preview_at = when
     scope_row.last_preview_candidate_count = int(run.candidate_count)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_year_filters.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_year_filters.py
@@ -42,6 +42,4 @@ def item_matches_preview_year_filter(
         return False
     if year_min is not None and year < year_min:
         return False
-    if year_max is not None and year > year_max:
-        return False
-    return True
+    return not (year_max is not None and year > year_max)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_schemas.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_schemas.py
@@ -248,10 +248,9 @@ class PrunerScopePatchIn(BaseModel):
 
     @model_validator(mode="after")
     def _preview_year_bounds_order(self) -> Self:
-        if self.preview_year_min is not None and self.preview_year_max is not None:
-            if self.preview_year_min > self.preview_year_max:
-                msg = "preview_year_min must be less than or equal to preview_year_max when both are set."
-                raise ValueError(msg)
+        if self.preview_year_min is not None and self.preview_year_max is not None and self.preview_year_min > self.preview_year_max:
+            msg = "preview_year_min must be less than or equal to preview_year_max when both are set."
+            raise ValueError(msg)
         return self
 
 

--- a/apps/backend/src/mediamop/modules/pruner/pruner_scope_settings_model.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_scope_settings_model.py
@@ -174,7 +174,7 @@ class PrunerScopeSettings(Base):
         nullable=False,
     )
 
-    server_instance: Mapped["PrunerServerInstance"] = relationship(
+    server_instance: Mapped[PrunerServerInstance] = relationship(
         "PrunerServerInstance",
         back_populates="scope_settings",
     )

--- a/apps/backend/src/mediamop/modules/pruner/pruner_server_instance_model.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_server_instance_model.py
@@ -42,7 +42,7 @@ class PrunerServerInstance(Base):
         nullable=False,
     )
 
-    scope_settings: Mapped[list["PrunerScopeSettings"]] = relationship(
+    scope_settings: Mapped[list[PrunerScopeSettings]] = relationship(
         "PrunerScopeSettings",
         back_populates="server_instance",
         cascade="all, delete-orphan",

--- a/apps/backend/src/mediamop/modules/pruner/pruner_studio_collection_filters.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_studio_collection_filters.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 from mediamop.modules.pruner.pruner_genre_filters import normalized_genre_filter_tokens
 

--- a/apps/backend/src/mediamop/modules/pruner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/pruner/worker_loop.py
@@ -8,24 +8,24 @@ import os
 import socket
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Literal
 
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.http.request_context import job_logging_context
-from mediamop.modules.queue_worker.job_kind_boundaries import (
-    PRUNER_QUEUE_JOB_KIND_PREFIX,
-    job_kind_forbidden_on_pruner_lane,
-    validate_pruner_worker_handler_registry,
-)
 from mediamop.modules.pruner.pruner_jobs_ops import (
     claim_next_eligible_pruner_job,
     complete_claimed_pruner_job,
     fail_claimed_pruner_job,
     fail_leased_pruner_job_after_complete_failure,
 )
+from mediamop.modules.queue_worker.job_kind_boundaries import (
+    PRUNER_QUEUE_JOB_KIND_PREFIX,
+    job_kind_forbidden_on_pruner_lane,
+    validate_pruner_worker_handler_registry,
+)
+from mediamop.platform.http.request_context import job_logging_context
 from mediamop.platform.jobs.worker_health import worker_heartbeat, worker_started, worker_stopped
 from mediamop.platform.notifications.dispatch import dispatch_job_notification
 from mediamop.platform.observability.failure_messages import operator_failure_from_exception
@@ -68,25 +68,24 @@ def process_one_pruner_job(
     lease_seconds: int = DEFAULT_PRUNER_JOB_LEASE_SECONDS,
     now: datetime | None = None,
 ) -> Literal["idle", "processed"]:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     lease_until = when + timedelta(seconds=lease_seconds)
 
-    with session_factory() as session:
-        with session.begin():
-            job = claim_next_eligible_pruner_job(
-                session,
-                lease_owner=lease_owner,
-                lease_expires_at=lease_until,
-                now=when,
-            )
-            if job is None:
-                return "idle"
-            ctx = PrunerJobWorkContext(
-                id=job.id,
-                job_kind=job.job_kind,
-                payload_json=job.payload_json,
-                lease_owner=lease_owner,
-            )
+    with session_factory() as session, session.begin():
+        job = claim_next_eligible_pruner_job(
+            session,
+            lease_owner=lease_owner,
+            lease_expires_at=lease_until,
+            now=when,
+        )
+        if job is None:
+            return "idle"
+        ctx = PrunerJobWorkContext(
+            id=job.id,
+            job_kind=job.job_kind,
+            payload_json=job.payload_json,
+            lease_owner=lease_owner,
+        )
 
     if job_kind_forbidden_on_pruner_lane(ctx.job_kind):
         err_text = (
@@ -94,15 +93,14 @@ def process_one_pruner_job(
             f"{ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_pruner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_pruner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Pruner fail_claimed after cross-lane guard job_id=%s", ctx.id)
         return "processed"
@@ -113,15 +111,14 @@ def process_one_pruner_job(
             f"{ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_pruner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_pruner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Pruner fail_claimed after pruner.* prefix guard job_id=%s", ctx.id)
         return "processed"
@@ -131,15 +128,14 @@ def process_one_pruner_job(
         exc: BaseException = PrunerNoHandlerForJobKind(ctx.job_kind)
         err_text = str(exc)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_pruner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_pruner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Pruner fail_claimed after missing handler job_id=%s", ctx.id)
         return "processed"
@@ -156,15 +152,14 @@ def process_one_pruner_job(
             recoverable=False,
         ).message[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_pruner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_pruner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Pruner fail_claimed_pruner_job failed after handler error job_id=%s", ctx.id)
         dispatch_job_notification(session_factory, module="pruner", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind)
@@ -173,17 +168,16 @@ def process_one_pruner_job(
     complete_ok = True
     complete_err: str | None = None
     try:
-        with session_factory() as session:
-            with session.begin():
-                ok = complete_claimed_pruner_job(
-                    session,
-                    job_id=ctx.id,
-                    lease_owner=ctx.lease_owner,
-                    now=when,
-                )
-                if not ok:
-                    complete_ok = False
-                    complete_err = "complete_claimed_pruner_job refused (lease/state mismatch)"
+        with session_factory() as session, session.begin():
+            ok = complete_claimed_pruner_job(
+                session,
+                job_id=ctx.id,
+                lease_owner=ctx.lease_owner,
+                now=when,
+            )
+            if not ok:
+                complete_ok = False
+                complete_err = "complete_claimed_pruner_job refused (lease/state mismatch)"
     except Exception as exc:
         complete_ok = False
         logger.exception("Pruner complete_claimed_pruner_job failed job_id=%s", ctx.id)
@@ -195,15 +189,14 @@ def process_one_pruner_job(
     if not complete_ok and complete_err is not None:
         bounded = (PRUNER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    recovered = fail_leased_pruner_job_after_complete_failure(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=bounded,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                recovered = fail_leased_pruner_job_after_complete_failure(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=bounded,
+                    now=when,
+                )
             if not recovered:
                 logger.warning(
                     "Pruner terminalization recovery did not apply job_id=%s owner=%s",

--- a/apps/backend/src/mediamop/modules/refiner/arr_queue_plumbing.py
+++ b/apps/backend/src/mediamop/modules/refiner/arr_queue_plumbing.py
@@ -6,7 +6,8 @@ adapters instead.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 
 def normalize_storage_path(path: str) -> str:

--- a/apps/backend/src/mediamop/modules/refiner/domain.py
+++ b/apps/backend/src/mediamop/modules/refiner/domain.py
@@ -9,8 +9,8 @@ ownership from activity.
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Sequence
 
 # Movie release years only; deterministic cutoffs for 4-digit tokens.
 _YEAR_MIN = 1888

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/api.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/api.py
@@ -9,9 +9,9 @@ from fastapi import APIRouter, HTTPException, Request
 from starlette import status
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_path_settings_service import ensure_refiner_path_settings_row
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.schemas_file_remux_pass_manual import (
     RefinerFileRemuxPassManualEnqueueIn,
     RefinerFileRemuxPassManualEnqueueOut,

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
@@ -9,39 +9,38 @@ from typing import Any
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.file_remux_pass.run import run_refiner_file_remux_pass
+from mediamop.modules.refiner.file_remux_pass.visibility import (
+    REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
+    remux_pass_activity_title,
+    remux_pass_result_to_activity_detail,
+)
 from mediamop.modules.refiner.refiner_file_remux_pass_activity import (
     complete_refiner_file_processing_activity,
     record_refiner_file_processing_started,
     record_refiner_file_remux_pass_completed,
     update_refiner_file_processing_progress,
 )
-from mediamop.modules.refiner.file_remux_pass.run import run_refiner_file_remux_pass
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
 from mediamop.modules.refiner.refiner_remux_rules_settings_service import load_refiner_remux_rules_config
-from mediamop.modules.refiner.file_remux_pass.visibility import (
-    REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
-    remux_pass_activity_title,
-    remux_pass_result_to_activity_detail,
-)
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
 
 
 def _record(session_factory: sessionmaker[Session], *, payload: dict[str, Any], activity_id: int | None = None) -> None:
     detail = remux_pass_result_to_activity_detail(payload)
     title = remux_pass_activity_title(payload)
-    with session_factory() as session:
-        with session.begin():
-            if activity_id is not None:
-                updated = complete_refiner_file_processing_activity(
-                    session,
-                    activity_id=activity_id,
-                    title=title,
-                    detail=detail,
-                )
-                if updated:
-                    return
-            record_refiner_file_remux_pass_completed(session, title=title, detail=detail)
+    with session_factory() as session, session.begin():
+        if activity_id is not None:
+            updated = complete_refiner_file_processing_activity(
+                session,
+                activity_id=activity_id,
+                title=title,
+                detail=detail,
+            )
+            if updated:
+                return
+        record_refiner_file_remux_pass_completed(session, title=title, detail=detail)
 
 
 class RefinerActivityProgressReporter:
@@ -52,12 +51,11 @@ class RefinerActivityProgressReporter:
 
     def __call__(self, payload: dict[str, Any]) -> None:
         body = {"job_id": self._job_id, **payload}
-        with self._session_factory() as session:
-            with session.begin():
-                if self.activity_id is None:
-                    self.activity_id = record_refiner_file_processing_started(session, payload=body)
-                else:
-                    update_refiner_file_processing_progress(session, activity_id=self.activity_id, payload=body)
+        with self._session_factory() as session, session.begin():
+            if self.activity_id is None:
+                self.activity_id = record_refiner_file_processing_started(session, payload=body)
+            else:
+                update_refiner_file_processing_progress(session, activity_id=self.activity_id, payload=body)
 
 
 def _make_progress_reporter(session_factory: sessionmaker[Session], *, job_id: int) -> RefinerActivityProgressReporter:

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import shutil
 import time
@@ -22,17 +23,10 @@ from mediamop.modules.refiner.file_remux_pass.visibility import (
     remux_pass_result_to_activity_detail,
     summarize_remux_plan,
 )
-from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_movie_output_cleanup import (
     maybe_run_movie_output_folder_cleanup_after_remux,
 )
-from mediamop.modules.refiner.refiner_tv_output_cleanup import (
-    maybe_run_tv_output_season_folder_cleanup_after_remux,
-)
-from mediamop.modules.refiner.refiner_tv_season_folder_cleanup import (
-    handle_tv_cleanup_after_success,
-    init_tv_season_cleanup_activity_fields,
-)
+from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_remux_mux import (
     build_ffmpeg_argv,
     ffprobe_json,
@@ -52,6 +46,13 @@ from mediamop.modules.refiner.refiner_remux_track_display import (
     audio_before_line_from_probe,
     subtitle_after_line_from_plan,
     subtitle_before_line_from_probe,
+)
+from mediamop.modules.refiner.refiner_tv_output_cleanup import (
+    maybe_run_tv_output_season_folder_cleanup_after_remux,
+)
+from mediamop.modules.refiner.refiner_tv_season_folder_cleanup import (
+    handle_tv_cleanup_after_success,
+    init_tv_season_cleanup_activity_fields,
 )
 from mediamop.platform.file_lifecycle.guardrails import bytes_to_mb, check_minimum_free_disk_space
 from mediamop.platform.file_lifecycle.mutations import safe_copy_to_final, safe_finalize_file, try_hardlink_to_final
@@ -108,19 +109,15 @@ def _probe_duration_seconds(probe: dict[str, Any]) -> float | None:
     candidates: list[float] = []
     fmt = probe.get("format")
     if isinstance(fmt, dict):
-        try:
+        with contextlib.suppress(TypeError, ValueError):
             candidates.append(float(fmt.get("duration") or 0))
-        except (TypeError, ValueError):
-            pass
     streams = probe.get("streams")
     if isinstance(streams, list):
         for stream in streams:
             if not isinstance(stream, dict):
                 continue
-            try:
+            with contextlib.suppress(TypeError, ValueError):
                 candidates.append(float(stream.get("duration") or 0))
-            except (TypeError, ValueError):
-                pass
     valid = [item for item in candidates if item > 0]
     return max(valid) if valid else None
 
@@ -722,10 +719,8 @@ def run_refiner_file_remux_pass(
             required_mb=minimum_free_disk_space_mb,
         )
         if not output_disk.ok:
-            try:
+            with contextlib.suppress(OSError):
                 tmp.unlink(missing_ok=True)
-            except OSError:
-                pass
             return _skip_guardrail(
                 relative_media_path=relative_media_path,
                 inspected_source_path=inspected,

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/visibility.py
@@ -7,7 +7,12 @@ from pathlib import Path
 from typing import Any
 
 from mediamop.modules.refiner.refiner_remux_rules import RemuxPlan
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope
 
 # Persisted on activity detail JSON — keep aligned with web ``REFINER_FILE_REMUX_PASS_EVENT_TYPE`` consumers.

--- a/apps/backend/src/mediamop/modules/refiner/jobs_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_model.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from mediamop.core.db import Base
 
 
-class RefinerJobStatus(str, enum.Enum):
+class RefinerJobStatus(enum.StrEnum):
     """Persisted in ``refiner_jobs.status`` (VARCHAR).
 
     ``failed`` means the handler (or missing-handler path) failed or exhausted retries.

--- a/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
@@ -6,7 +6,7 @@ the one-writer rule. Callers should keep transactions short.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Literal
 
 _REFINER_JOB_DEDUPE_KEY_MAX_LEN = 512
@@ -21,7 +21,7 @@ from mediamop.platform.metrics.service import record_module_job_event, set_modul
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def _record_refiner_queue_depth(session: Session) -> None:

--- a/apps/backend/src/mediamop/modules/refiner/radarr_queue_adapter.py
+++ b/apps/backend/src/mediamop/modules/refiner/radarr_queue_adapter.py
@@ -5,7 +5,8 @@ Does not read ``series``; applicability uses ``outputPath`` and ``movieId`` only
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from mediamop.modules.refiner.arr_queue_plumbing import (
     blocking_suppressed_for_import_wait,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_candidate_gate_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_candidate_gate_handlers.py
@@ -9,11 +9,11 @@ from typing import Any, Literal
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.arr_library import resolve_radarr_http_credentials, resolve_sonarr_http_credentials
 from mediamop.modules.refiner.refiner_candidate_gate_activity import record_refiner_candidate_gate_completed
 from mediamop.modules.refiner.refiner_candidate_gate_evaluate import evaluate_refiner_candidate_gate_from_queue_rows
 from mediamop.modules.refiner.refiner_candidate_gate_queue_fetch import fetch_arr_v3_queue_rows
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
+from mediamop.platform.arr_library import resolve_radarr_http_credentials, resolve_sonarr_http_credentials
 
 
 def _parse_job_payload(payload_json: str | None) -> dict[str, Any]:
@@ -93,8 +93,7 @@ def make_refiner_candidate_gate_handler(
             "reasons": list(outcome.reasons),
         }
         detail = json.dumps(detail_obj, separators=(",", ":"))[:10_000]
-        with session_factory() as session:
-            with session.begin():
-                record_refiner_candidate_gate_completed(session, detail=detail)
+        with session_factory() as session, session.begin():
+            record_refiner_candidate_gate_completed(session, detail=detail)
 
     return _run

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
@@ -13,9 +13,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_candidate_gate_queue_fetch import fetch_arr_v3_queue_rows
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_path_settings_service import (
     effective_tv_work_folder,
     effective_work_folder,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_enqueue.py
@@ -9,8 +9,8 @@ from typing import Literal
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_failure_cleanup_job_kinds import (
     REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY,
     REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_handlers.py
@@ -22,10 +22,7 @@ def _parse_payload(payload_json: str | None, *, default_scope: str) -> str:
     if payload_json and payload_json.strip():
         data = json.loads(payload_json)
         if isinstance(data, dict):
-            if str(data.get("media_scope") or "").strip().lower() == "tv":
-                media_scope = "tv"
-            else:
-                media_scope = "movie"
+            media_scope = "tv" if str(data.get("media_scope") or "").strip().lower() == "tv" else "movie"
     return media_scope
 
 
@@ -37,29 +34,28 @@ def make_refiner_failure_cleanup_handler(
 ) -> Callable[[RefinerJobWorkContext], None]:
     def _run(ctx: RefinerJobWorkContext) -> None:
         media_scope = _parse_payload(ctx.payload_json, default_scope=default_scope)
-        with session_factory() as session:
-            with session.begin():
-                record_refiner_failure_cleanup_sweep_started(
-                    session,
-                    media_scope=media_scope,
-                    detail=json.dumps(
-                        {"job_id": ctx.id, "media_scope": media_scope, "cleanup_run_status": "started"},
-                        separators=(",", ":"),
-                        ensure_ascii=True,
-                    ),
-                )
-                result: dict[str, Any] = run_refiner_failure_cleanup_sweep_for_scope(
-                    session=session,
-                    settings=settings,
-                    media_scope=media_scope,
-                )
-                result["job_id"] = ctx.id
-                detail = json.dumps(result, separators=(",", ":"), ensure_ascii=True)[:10_000]
-                record_refiner_failure_cleanup_sweep_completed(
-                    session,
-                    media_scope=media_scope,
-                    detail=detail,
-                )
+        with session_factory() as session, session.begin():
+            record_refiner_failure_cleanup_sweep_started(
+                session,
+                media_scope=media_scope,
+                detail=json.dumps(
+                    {"job_id": ctx.id, "media_scope": media_scope, "cleanup_run_status": "started"},
+                    separators=(",", ":"),
+                    ensure_ascii=True,
+                ),
+            )
+            result: dict[str, Any] = run_refiner_failure_cleanup_sweep_for_scope(
+                session=session,
+                settings=settings,
+                media_scope=media_scope,
+            )
+            result["job_id"] = ctx.id
+            detail = json.dumps(result, separators=(",", ":"), ensure_ascii=True)[:10_000]
+            record_refiner_failure_cleanup_sweep_completed(
+                session,
+                media_scope=media_scope,
+                detail=detail,
+            )
 
     return _run
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_periodic_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_periodic_enqueue.py
@@ -9,8 +9,8 @@ from typing import Literal
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.refiner.refiner_failure_cleanup_enqueue import enqueue_refiner_failure_cleanup_sweep_job
 from mediamop.modules.refiner.refiner_failure_cleanup_activity import record_refiner_failure_cleanup_sweep_skipped
+from mediamop.modules.refiner.refiner_failure_cleanup_enqueue import enqueue_refiner_failure_cleanup_sweep_job
 
 logger = logging.getLogger(__name__)
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_job_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_job_handlers.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.queue_worker.job_kind_boundaries import validate_refiner_worker_handler_registry
+from mediamop.modules.refiner.file_remux_pass.handlers import make_refiner_file_remux_pass_handler
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_candidate_gate_handlers import make_refiner_candidate_gate_handler
 from mediamop.modules.refiner.refiner_candidate_gate_job_kinds import REFINER_CANDIDATE_GATE_JOB_KIND
 from mediamop.modules.refiner.refiner_failure_cleanup_handlers import make_refiner_failure_cleanup_handler
@@ -15,8 +17,6 @@ from mediamop.modules.refiner.refiner_failure_cleanup_job_kinds import (
     REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND,
     REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND,
 )
-from mediamop.modules.refiner.file_remux_pass.handlers import make_refiner_file_remux_pass_handler
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_supplied_payload_evaluation_handlers import (
     make_refiner_supplied_payload_evaluation_handler,
 )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
@@ -19,10 +19,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.arr_library import resolve_radarr_http_credentials
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
+from mediamop.platform.arr_library import resolve_radarr_http_credentials
 from mediamop.platform.outbound_http import normalize_local_service_base_url
 
 logger = logging.getLogger(__name__)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_api.py
@@ -16,13 +16,13 @@ from mediamop.modules.refiner.schemas_refiner_operator_settings import (
     RefinerOperatorSettingsPutIn,
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
     current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
 )
+from mediamop.platform.auth.deps_auth import UserPublicDep
 
 router = APIRouter(tags=["refiner"])
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
@@ -2,19 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import cast
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
-from mediamop.platform.arr_library.schedule_wall_clock import schedule_time_window_active
 from mediamop.modules.refiner.refiner_operator_settings_model import RefinerOperatorSettingsRow
 from mediamop.modules.refiner.schemas_refiner_operator_settings import (
     RefinerOperatorSettingsOut,
     RefinerOperatorSettingsPutIn,
 )
+from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
+from mediamop.platform.arr_library.schedule_wall_clock import schedule_time_window_active
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 
 
@@ -64,7 +64,7 @@ def refiner_periodic_scope_in_schedule_window(
 ) -> bool:
     """True when a periodic Refiner watched-folder scan may run for this scope."""
 
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if media_scope == "movie":
         if not bool(row.movie_schedule_hours_limited):
             return True

--- a/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.file_remux_pass.visibility import (
     REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN,
     REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED,
 )
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.schemas_refiner_overview_stats import RefinerOverviewStatsOut
 from mediamop.platform.activity import constants as activity_constants
 from mediamop.platform.activity.models import ActivityEvent
@@ -37,7 +37,7 @@ def _json_int(value: object) -> int | None:
 
 
 def build_refiner_overview_stats(db: Session, *, window_days: int = 30) -> RefinerOverviewStatsOut:
-    since = datetime.now(timezone.utc) - timedelta(days=max(1, int(window_days)))
+    since = datetime.now(UTC) - timedelta(days=max(1, int(window_days)))
     failed = int(
         db.scalar(
             select(func.count())

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_api.py
@@ -14,13 +14,13 @@ from mediamop.modules.refiner.refiner_path_settings_service import (
     ensure_refiner_path_settings_row,
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
     current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
 )
+from mediamop.platform.auth.deps_auth import UserPublicDep
 
 router = APIRouter(tags=["refiner"])
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
@@ -10,11 +10,11 @@ import logging
 import os
 import shutil
 import subprocess
-import tempfile
 import sys
+import tempfile
 import time
-from pathlib import Path
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from mediamop.modules.refiner.refiner_remux_rules import RemuxPlan
@@ -222,14 +222,14 @@ def build_ffmpeg_argv(*, ffmpeg_bin: str, src: Path, dst: Path, plan: RemuxPlan)
         args.extend(["-map", f"0:{t.input_index}"])
     args.extend(["-c", "copy"])
     for i, t in enumerate(plan.audio):
-        args.extend(["-disposition:a:%d" % i, "default" if t.default else "0"])
+        args.extend([f"-disposition:a:{i:d}", "default" if t.default else "0"])
     for i, t in enumerate(plan.subtitles):
         flags: list[str] = []
         if t.default:
             flags.append("default")
         if t.forced:
             flags.append("forced")
-        args.extend(["-disposition:s:%d" % i, "+".join(flags) if flags else "0"])
+        args.extend([f"-disposition:s:{i:d}", "+".join(flags) if flags else "0"])
     args.append(str(dst))
     return args
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
@@ -139,9 +139,7 @@ def is_commentary_audio(stream: dict[str, Any]) -> bool:
     title = (tags.get("title") or "").lower()
     if "commentary" in title:
         return True
-    if tags.get("comment") and "commentary" in (tags.get("comment") or "").lower():
-        return True
-    return False
+    return bool(tags.get("comment") and "commentary" in (tags.get("comment") or "").lower())
 
 
 @dataclass(frozen=True)
@@ -207,9 +205,7 @@ def is_remux_required(plan: RemuxPlan, audio_probe: list[dict[str, Any]], sub_pr
         for s in sub_probe
     ]
     new_sub = [(t.input_index, int(t.forced), int(t.default)) for t in plan.subtitles]
-    if old_sub != new_sub:
-        return True
-    return False
+    return old_sub != new_sub
 
 
 def split_streams(probe: dict[str, Any]) -> tuple[list[dict], list[dict], list[dict]]:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_api.py
@@ -16,13 +16,13 @@ from mediamop.modules.refiner.schemas_refiner_remux_rules_settings import (
     RefinerRemuxRulesSettingsPutIn,
 )
 from mediamop.platform.auth.authorization import RequireOperatorDep
-from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.auth.csrf import (
     current_raw_session_token,
     require_session_secret,
     validate_browser_post_origin,
     verify_csrf_token,
 )
+from mediamop.platform.auth.deps_auth import UserPublicDep
 
 router = APIRouter(tags=["refiner"])
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from mediamop.modules.refiner.refiner_remux_rules_settings_model import RefinerRemuxRulesSettingsRow
 from mediamop.modules.refiner.refiner_remux_rules import (
     RefinerRulesConfig,
+    default_refiner_remux_rules_config,
     normalize_audio_preference_mode,
     parse_subtitle_langs_csv,
 )
-from mediamop.modules.refiner.refiner_remux_rules import default_refiner_remux_rules_config
+from mediamop.modules.refiner.refiner_remux_rules_settings_model import RefinerRemuxRulesSettingsRow
 from mediamop.modules.refiner.schemas_refiner_remux_rules_settings import (
     RefinerRemuxRulesScopeOut,
     RefinerRemuxRulesSettingsOut,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_supplied_payload_evaluation_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_supplied_payload_evaluation_handlers.py
@@ -70,8 +70,7 @@ def make_refiner_supplied_payload_evaluation_handler(
             "blocked_upstream": blocked,
         }
         detail = json.dumps(detail_obj, separators=(",", ":"))[:10_000]
-        with session_factory() as session:
-            with session.begin():
-                record_refiner_supplied_payload_evaluation_completed(session, detail=detail)
+        with session_factory() as session, session.begin():
+            record_refiner_supplied_payload_evaluation_completed(session, detail=detail)
 
     return _run

--- a/apps/backend/src/mediamop/modules/refiner/refiner_temp_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_temp_cleanup.py
@@ -16,8 +16,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_path_settings_service import (
     effective_tv_work_folder,
     effective_work_folder,
@@ -46,9 +46,7 @@ def is_refiner_owned_temp_work_file(path: Path) -> bool:
     name = path.name
     if name == REFINER_DRY_RUN_FFMPEG_PLACEHOLDER_NAME:
         return True
-    if ".refiner." in name:
-        return True
-    return False
+    return ".refiner." in name
 
 
 def _resolved_movie_and_tv_work_roots(*, session: Session, settings: MediaMopSettings) -> tuple[Path, Path]:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
@@ -20,11 +20,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.arr_library import resolve_sonarr_http_credentials
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_remux_rules import is_refiner_media_candidate
+from mediamop.platform.arr_library import resolve_sonarr_http_credentials
 from mediamop.platform.outbound_http import normalize_local_service_base_url
 
 logger = logging.getLogger(__name__)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_enqueue.py
@@ -56,10 +56,7 @@ def refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan(
             ),
         ),
     ).all()
-    for job in rows:
-        if _scan_job_media_scope(job.payload_json) == want:
-            return True
-    return False
+    return any(_scan_job_media_scope(job.payload_json) == want for job in rows)
 
 
 def validate_watched_folder_scan_dispatch_prerequisites(

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Literal, Mapping, Sequence
+from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.arr_library import resolve_radarr_http_credentials, resolve_sonarr_http_credentials
 from mediamop.modules.refiner.domain import (
     FileAnchorCandidate,
     RefinerQueueRowView,
@@ -18,6 +18,7 @@ from mediamop.modules.refiner.domain import (
 from mediamop.modules.refiner.radarr_queue_adapter import map_radarr_queue_row_to_refiner_view
 from mediamop.modules.refiner.refiner_candidate_gate_queue_fetch import fetch_arr_v3_queue_rows
 from mediamop.modules.refiner.sonarr_queue_adapter import map_sonarr_queue_row_to_refiner_view
+from mediamop.platform.arr_library import resolve_radarr_http_credentials, resolve_sonarr_http_credentials
 
 Verdict = Literal["proceed", "wait_upstream", "not_held"]
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -12,10 +12,10 @@ from typing import Any
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
-from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
+from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
+from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_evaluate import (
     evaluate_watched_media_file_for_dispatch,
     fetch_radarr_and_sonarr_queue_rows_for_scan,
@@ -111,132 +111,131 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
         rel_this_run: set[str] = set()
         sample_cap = 32
 
-        with session_factory() as session:
-            with session.begin():
-                for file_path in files:
-                    min_size_mb = max(0, int(op_settings.refiner_min_input_file_size_mb))
-                    if min_size_mb > 0:
-                        try:
-                            size_bytes = int(file_path.stat().st_size)
-                        except OSError:
-                            logger.debug("Refiner scan skipped size check because file metadata could not be read: %s", file_path)
-                            continue
-                        if size_bytes < min_size_mb * 1024 * 1024:
-                            summary["skipped_below_minimum_file_size"] += 1
-                            logger.debug(
-                                "Refiner scan skipped %s because it is below the minimum input size (%s MB).",
-                                file_path,
-                                min_size_mb,
-                            )
-                            continue
-
-                    verdict = evaluate_watched_media_file_for_dispatch(
-                        radarr_rows=rad_rows,
-                        sonarr_rows=son_rows,
-                        file_path=file_path,
-                    )
-                    if verdict == "proceed":
-                        summary["verdict_proceed"] += 1
-                    elif verdict == "wait_upstream":
-                        summary["verdict_wait_upstream"] += 1
-                    else:
-                        summary["verdict_not_held"] += 1
-
-                    if verdict != "proceed" or not enqueue_remux_jobs:
+        with session_factory() as session, session.begin():
+            for file_path in files:
+                min_size_mb = max(0, int(op_settings.refiner_min_input_file_size_mb))
+                if min_size_mb > 0:
+                    try:
+                        size_bytes = int(file_path.stat().st_size)
+                    except OSError:
+                        logger.debug("Refiner scan skipped size check because file metadata could not be read: %s", file_path)
+                        continue
+                    if size_bytes < min_size_mb * 1024 * 1024:
+                        summary["skipped_below_minimum_file_size"] += 1
+                        logger.debug(
+                            "Refiner scan skipped %s because it is below the minimum input size (%s MB).",
+                            file_path,
+                            min_size_mb,
+                        )
                         continue
 
-                    rel = relative_posix_path_under_watched(watched_root=watched_path, file_path=file_path)
-                    if rel in rel_this_run:
-                        summary["skipped_duplicate_same_scan"] += 1
-                        continue
-                    rel_this_run.add(rel)
-
-                    if refiner_active_remux_pass_exists_for_relative_path(
-                        session,
-                        relative_posix=rel,
-                        media_scope=media_scope,
-                    ):
-                        summary["skipped_duplicate_active_queue"] += 1
-                        continue
-                    if refiner_completed_remux_output_exists_for_relative_path(
-                        session,
-                        relative_posix=rel,
-                        media_scope=media_scope,
-                        output_root=rt.output_folder,
-                    ):
-                        summary["skipped_existing_completed_output"] += 1
-                        if media_scope == "movie":
-                            summary["completed_source_cleanup_retried"] += 1
-                            cleanup_ok, _cleanup_reason = retry_completed_movie_source_cleanup(
-                                watched_root=watched_path,
-                                file_path=file_path,
-                            )
-                            if cleanup_ok:
-                                summary["completed_source_cleanup_retry_deleted"] += 1
-                            else:
-                                summary["completed_source_cleanup_retry_failed"] += 1
-                                logger.warning(
-                                    "Refiner completed-output source cleanup retry failed for %s",
-                                    file_path,
-                                )
-                        continue
-
-                    payload = json.dumps(
-                        {
-                            "relative_media_path": rel,
-                            "media_scope": media_scope,
-                        },
-                        separators=(",", ":"),
-                    )
-                    dedupe = f"{REFINER_FILE_REMUX_PASS_JOB_KIND}:scan:{uuid.uuid4().hex}"
-                    refiner_enqueue_or_get_job(
-                        session,
-                        dedupe_key=dedupe,
-                        job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
-                        payload_json=payload,
-                    )
-                    summary["remux_jobs_enqueued"] += 1
-                    if len(sample_paths) < sample_cap:
-                        sample_paths.append(rel)
-
-                queued = int(summary["remux_jobs_enqueued"])
-                waiting = int(summary["verdict_wait_upstream"])
-                seen = int(summary["media_candidates_seen"])
-                duplicates = (
-                    int(summary["skipped_duplicate_same_scan"])
-                    + int(summary["skipped_duplicate_active_queue"])
-                    + int(summary["skipped_existing_completed_output"])
+                verdict = evaluate_watched_media_file_for_dispatch(
+                    radarr_rows=rad_rows,
+                    sonarr_rows=son_rows,
+                    file_path=file_path,
                 )
-                if queued:
-                    summary["scan_result_label"] = "files_queued"
-                    summary["user_message"] = (
-                        f"{queued} file{' was' if queued == 1 else 's were'} added to Refiner for processing."
-                    )
-                elif waiting:
-                    summary["scan_result_label"] = "waiting_for_files"
-                    summary["user_message"] = (
-                        f"{waiting} file{' looks' if waiting == 1 else 's look'} like it is still being copied or imported, "
-                        "so MediaMop left it alone for now."
-                    )
-                    summary["waiting_message"] = "MediaMop will check again on the next scheduled scan."
-                elif seen and not enqueue_remux_jobs:
-                    summary["scan_result_label"] = "check_only"
-                    summary["user_message"] = (
-                        f"{seen} media file{' was' if seen == 1 else 's were'} found, but this scan was set to check only."
-                    )
-                elif seen and duplicates:
-                    summary["scan_result_label"] = "already_queued"
-                    summary["user_message"] = (
-                        "MediaMop found matching media files, but they were already waiting for Refiner."
-                    )
-                elif seen:
-                    summary["scan_result_label"] = "nothing_new"
-                    summary["user_message"] = "MediaMop found media files, but there was nothing new to queue."
+                if verdict == "proceed":
+                    summary["verdict_proceed"] += 1
+                elif verdict == "wait_upstream":
+                    summary["verdict_wait_upstream"] += 1
                 else:
-                    summary["scan_result_label"] = "no_media_found"
-                    summary["user_message"] = "MediaMop did not find any media files in this watched folder."
+                    summary["verdict_not_held"] += 1
 
-                # File-level processing events now tell the user what happened. Recording a scan
-                # event here makes Activity look backwards when completed file events arrive first.
+                if verdict != "proceed" or not enqueue_remux_jobs:
+                    continue
+
+                rel = relative_posix_path_under_watched(watched_root=watched_path, file_path=file_path)
+                if rel in rel_this_run:
+                    summary["skipped_duplicate_same_scan"] += 1
+                    continue
+                rel_this_run.add(rel)
+
+                if refiner_active_remux_pass_exists_for_relative_path(
+                    session,
+                    relative_posix=rel,
+                    media_scope=media_scope,
+                ):
+                    summary["skipped_duplicate_active_queue"] += 1
+                    continue
+                if refiner_completed_remux_output_exists_for_relative_path(
+                    session,
+                    relative_posix=rel,
+                    media_scope=media_scope,
+                    output_root=rt.output_folder,
+                ):
+                    summary["skipped_existing_completed_output"] += 1
+                    if media_scope == "movie":
+                        summary["completed_source_cleanup_retried"] += 1
+                        cleanup_ok, _cleanup_reason = retry_completed_movie_source_cleanup(
+                            watched_root=watched_path,
+                            file_path=file_path,
+                        )
+                        if cleanup_ok:
+                            summary["completed_source_cleanup_retry_deleted"] += 1
+                        else:
+                            summary["completed_source_cleanup_retry_failed"] += 1
+                            logger.warning(
+                                "Refiner completed-output source cleanup retry failed for %s",
+                                file_path,
+                            )
+                    continue
+
+                payload = json.dumps(
+                    {
+                        "relative_media_path": rel,
+                        "media_scope": media_scope,
+                    },
+                    separators=(",", ":"),
+                )
+                dedupe = f"{REFINER_FILE_REMUX_PASS_JOB_KIND}:scan:{uuid.uuid4().hex}"
+                refiner_enqueue_or_get_job(
+                    session,
+                    dedupe_key=dedupe,
+                    job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
+                    payload_json=payload,
+                )
+                summary["remux_jobs_enqueued"] += 1
+                if len(sample_paths) < sample_cap:
+                    sample_paths.append(rel)
+
+            queued = int(summary["remux_jobs_enqueued"])
+            waiting = int(summary["verdict_wait_upstream"])
+            seen = int(summary["media_candidates_seen"])
+            duplicates = (
+                int(summary["skipped_duplicate_same_scan"])
+                + int(summary["skipped_duplicate_active_queue"])
+                + int(summary["skipped_existing_completed_output"])
+            )
+            if queued:
+                summary["scan_result_label"] = "files_queued"
+                summary["user_message"] = (
+                    f"{queued} file{' was' if queued == 1 else 's were'} added to Refiner for processing."
+                )
+            elif waiting:
+                summary["scan_result_label"] = "waiting_for_files"
+                summary["user_message"] = (
+                    f"{waiting} file{' looks' if waiting == 1 else 's look'} like it is still being copied or imported, "
+                    "so MediaMop left it alone for now."
+                )
+                summary["waiting_message"] = "MediaMop will check again on the next scheduled scan."
+            elif seen and not enqueue_remux_jobs:
+                summary["scan_result_label"] = "check_only"
+                summary["user_message"] = (
+                    f"{seen} media file{' was' if seen == 1 else 's were'} found, but this scan was set to check only."
+                )
+            elif seen and duplicates:
+                summary["scan_result_label"] = "already_queued"
+                summary["user_message"] = (
+                    "MediaMop found matching media files, but they were already waiting for Refiner."
+                )
+            elif seen:
+                summary["scan_result_label"] = "nothing_new"
+                summary["user_message"] = "MediaMop found media files, but there was nothing new to queue."
+            else:
+                summary["scan_result_label"] = "no_media_found"
+                summary["user_message"] = "MediaMop did not find any media files in this watched folder."
+
+            # File-level processing events now tell the user what happened. Recording a scan
+            # event here makes Activity look backwards when completed file events arrive first.
 
     return _run

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_remux_rules import is_refiner_media_candidate
 from mediamop.platform.activity.models import ActivityEvent
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_work_temp_stale_sweep_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_work_temp_stale_sweep_handlers.py
@@ -43,19 +43,18 @@ def make_refiner_work_temp_stale_sweep_handler(
 
     def _run(ctx: RefinerJobWorkContext) -> None:
         media_scope = _parse_work_temp_stale_sweep_payload(ctx.payload_json)
-        with session_factory() as session:
-            with session.begin():
-                result: dict[str, Any] = run_refiner_work_temp_stale_sweep_for_scope(
-                    session=session,
-                    settings=settings,
-                    media_scope=media_scope,
-                )
-                result["job_id"] = ctx.id
-                detail = json.dumps(result, separators=(",", ":"), ensure_ascii=True)[:10_000]
-                record_refiner_work_temp_stale_sweep_completed(
-                    session,
-                    media_scope=media_scope,
-                    detail=detail,
-                )
+        with session_factory() as session, session.begin():
+            result: dict[str, Any] = run_refiner_work_temp_stale_sweep_for_scope(
+                session=session,
+                settings=settings,
+                media_scope=media_scope,
+            )
+            result["job_id"] = ctx.id
+            detail = json.dumps(result, separators=(",", ":"), ensure_ascii=True)[:10_000]
+            record_refiner_work_temp_stale_sweep_completed(
+                session,
+                media_scope=media_scope,
+                detail=detail,
+            )
 
     return _run

--- a/apps/backend/src/mediamop/modules/refiner/router.py
+++ b/apps/backend/src/mediamop/modules/refiner/router.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from mediamop.modules.refiner.file_remux_pass.api import router as refiner_file_remux_pass_router
 from mediamop.modules.refiner.refiner_candidate_gate_api import router as refiner_candidate_gate_router
 from mediamop.modules.refiner.refiner_jobs_inspection_api import router as refiner_jobs_inspection_router
-from mediamop.modules.refiner.file_remux_pass.api import router as refiner_file_remux_pass_router
 from mediamop.modules.refiner.refiner_operator_settings_api import router as refiner_operator_settings_router
+from mediamop.modules.refiner.refiner_overview_stats_api import router as refiner_overview_stats_router
 from mediamop.modules.refiner.refiner_path_settings_api import router as refiner_path_settings_router
 from mediamop.modules.refiner.refiner_remux_rules_settings_api import router as refiner_remux_rules_settings_router
 from mediamop.modules.refiner.refiner_runtime_settings_api import router as refiner_runtime_settings_router
-from mediamop.modules.refiner.refiner_overview_stats_api import router as refiner_overview_stats_router
 from mediamop.modules.refiner.refiner_supplied_payload_evaluation_api import (
     router as refiner_supplied_payload_evaluation_router,
 )

--- a/apps/backend/src/mediamop/modules/refiner/sonarr_queue_adapter.py
+++ b/apps/backend/src/mediamop/modules/refiner/sonarr_queue_adapter.py
@@ -5,7 +5,8 @@ Does not read ``movie``; applicability uses ``outputPath`` and ``seriesId`` only
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from collections.abc import Mapping
+from typing import Any
 
 from mediamop.modules.refiner.arr_queue_plumbing import (
     blocking_suppressed_for_import_wait,

--- a/apps/backend/src/mediamop/modules/refiner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_loop.py
@@ -12,13 +12,12 @@ import os
 import socket
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Literal
 
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.http.request_context import job_logging_context
 from mediamop.modules.queue_worker.job_kind_boundaries import (
     REFINER_QUEUE_JOB_KIND_PREFIX,
     job_kind_forbidden_on_refiner_lane,
@@ -30,6 +29,7 @@ from mediamop.modules.refiner.jobs_ops import (
     fail_claimed_refiner_job,
     fail_leased_refiner_job_after_complete_failure,
 )
+from mediamop.platform.http.request_context import job_logging_context
 from mediamop.platform.jobs.worker_health import worker_heartbeat, worker_started, worker_stopped
 from mediamop.platform.notifications.dispatch import dispatch_job_notification
 from mediamop.platform.observability.failure_messages import operator_failure_from_exception
@@ -80,25 +80,24 @@ def process_one_refiner_job(
     finished (success or handler failure).
     """
 
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     lease_until = when + timedelta(seconds=lease_seconds)
 
-    with session_factory() as session:
-        with session.begin():
-            job = claim_next_eligible_refiner_job(
-                session,
-                lease_owner=lease_owner,
-                lease_expires_at=lease_until,
-                now=when,
-            )
-            if job is None:
-                return "idle"
-            ctx = RefinerJobWorkContext(
-                id=job.id,
-                job_kind=job.job_kind,
-                payload_json=job.payload_json,
-                lease_owner=lease_owner,
-            )
+    with session_factory() as session, session.begin():
+        job = claim_next_eligible_refiner_job(
+            session,
+            lease_owner=lease_owner,
+            lease_expires_at=lease_until,
+            now=when,
+        )
+        if job is None:
+            return "idle"
+        ctx = RefinerJobWorkContext(
+            id=job.id,
+            job_kind=job.job_kind,
+            payload_json=job.payload_json,
+            lease_owner=lease_owner,
+        )
 
     if job_kind_forbidden_on_refiner_lane(ctx.job_kind):
         err_text = (
@@ -106,15 +105,14 @@ def process_one_refiner_job(
             f"{ctx.job_kind!r} (row id={ctx.id}); use the correct table + workers for that prefix"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_refiner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_refiner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception(
                 "Refiner fail_claimed after cross-lane job_kind guard job_id=%s",
@@ -128,15 +126,14 @@ def process_one_refiner_job(
             f"{ctx.job_kind!r} (row id={ctx.id}); enqueue only refiner-owned kinds"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_refiner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_refiner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception(
                 "Refiner fail_claimed after refiner.* prefix guard job_id=%s",
@@ -149,15 +146,14 @@ def process_one_refiner_job(
         exc: BaseException = RefinerNoHandlerForJobKind(ctx.job_kind)
         err_text = str(exc)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_refiner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_refiner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception(
                 "Refiner fail_claimed_refiner_job failed after missing handler job_id=%s",
@@ -177,15 +173,14 @@ def process_one_refiner_job(
             recoverable=False,
         ).message[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_refiner_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_refiner_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception(
                 "Refiner fail_claimed_refiner_job failed after handler error job_id=%s",
@@ -197,17 +192,16 @@ def process_one_refiner_job(
     complete_ok = True
     complete_err: str | None = None
     try:
-        with session_factory() as session:
-            with session.begin():
-                ok = complete_claimed_refiner_job(
-                    session,
-                    job_id=ctx.id,
-                    lease_owner=ctx.lease_owner,
-                    now=when,
-                )
-                if not ok:
-                    complete_ok = False
-                    complete_err = "complete_claimed_refiner_job refused (lease/state mismatch)"
+        with session_factory() as session, session.begin():
+            ok = complete_claimed_refiner_job(
+                session,
+                job_id=ctx.id,
+                lease_owner=ctx.lease_owner,
+                now=when,
+            )
+            if not ok:
+                complete_ok = False
+                complete_err = "complete_claimed_refiner_job refused (lease/state mismatch)"
     except Exception as exc:
         complete_ok = False
         logger.exception("Refiner complete_claimed_refiner_job failed job_id=%s", ctx.id)
@@ -219,15 +213,14 @@ def process_one_refiner_job(
     if not complete_ok and complete_err is not None:
         bounded = (REFINER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    recovered = fail_leased_refiner_job_after_complete_failure(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=bounded,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                recovered = fail_leased_refiner_job_after_complete_failure(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=bounded,
+                    now=when,
+                )
             if not recovered:
                 logger.warning(
                     "Refiner terminalization recovery did not apply job_id=%s owner=%s",

--- a/apps/backend/src/mediamop/modules/subber/subber_http_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_http_client.py
@@ -7,6 +7,7 @@ import json
 from typing import Any
 
 import httpx
+
 from mediamop.platform.outbound_http import validate_external_provider_url
 
 DEFAULT_USER_AGENT = "MediaMop/1.0"

--- a/apps/backend/src/mediamop/modules/subber/subber_jobs_model.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_jobs_model.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from mediamop.core.db import Base
 
 
-class SubberJobStatus(str, enum.Enum):
+class SubberJobStatus(enum.StrEnum):
     """Persisted in ``subber_jobs.status`` (VARCHAR)."""
 
     PENDING = "pending"

--- a/apps/backend/src/mediamop/modules/subber/subber_jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_jobs_ops.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
@@ -14,7 +14,7 @@ from mediamop.platform.metrics.service import record_module_job_event, set_modul
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def _record_subber_queue_depth(session: Session) -> None:

--- a/apps/backend/src/mediamop/modules/subber/subber_library_scan_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_scan_job_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import Callable
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -21,7 +21,12 @@ from mediamop.modules.subber.subber_settings_service import ensure_subber_settin
 from mediamop.modules.subber.subber_subtitle_state_service import get_missing_for_scope, mark_skipped
 from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, scan_title
 
 
@@ -36,67 +41,66 @@ def make_subber_library_scan_handler(
         payload = json.loads(ctx.payload_json or "{}")
         if str(payload.get("media_scope") or "") != media_scope:
             return
-        when = datetime.now(timezone.utc)
+        when = datetime.now(UTC)
         default_cutoff = when - timedelta(hours=6)
         enqueued = 0
-        with session_factory() as session:
-            with session.begin():
-                settings_row = ensure_subber_settings_row(session)
-                if not settings_row.enabled:
-                    return
-                for row in get_missing_for_scope(session, media_scope):
-                    sc = int(row.search_count or 0)
-                    perm = max(1, int(settings_row.permanent_skip_after_attempts or 10))
-                    if sc >= perm:
-                        mark_skipped(session, int(row.id))
-                        continue
-                    last = row.last_searched_at
-                    if last is not None:
-                        lu = last if last.tzinfo else last.replace(tzinfo=timezone.utc)
-                        if bool(settings_row.adaptive_searching_enabled):
-                            max_att = max(1, int(settings_row.adaptive_searching_max_attempts or 3))
-                            delay_h = max(1, int(settings_row.adaptive_searching_delay_hours or 168))
-                            if sc >= max_att:
-                                if lu > when - timedelta(hours=delay_h):
-                                    continue
-                            elif lu > default_cutoff:
+        with session_factory() as session, session.begin():
+            settings_row = ensure_subber_settings_row(session)
+            if not settings_row.enabled:
+                return
+            for row in get_missing_for_scope(session, media_scope):
+                sc = int(row.search_count or 0)
+                perm = max(1, int(settings_row.permanent_skip_after_attempts or 10))
+                if sc >= perm:
+                    mark_skipped(session, int(row.id))
+                    continue
+                last = row.last_searched_at
+                if last is not None:
+                    lu = last if last.tzinfo else last.replace(tzinfo=UTC)
+                    if bool(settings_row.adaptive_searching_enabled):
+                        max_att = max(1, int(settings_row.adaptive_searching_max_attempts or 3))
+                        delay_h = max(1, int(settings_row.adaptive_searching_delay_hours or 168))
+                        if sc >= max_att:
+                            if lu > when - timedelta(hours=delay_h):
                                 continue
                         elif lu > default_cutoff:
                             continue
-                    dedupe = f"subber:subtitle:{media_scope}:{row.id}:{uuid.uuid4()}"
-                    subber_enqueue_or_get_job(
-                        session,
-                        dedupe_key=dedupe,
-                        job_kind=search_job_kind,
-                        payload_json=json.dumps({"state_id": int(row.id)}, separators=(",", ":")),
-                    )
-                    enqueued += 1
-                subber_activity.record_subber_activity(
+                    elif lu > default_cutoff:
+                        continue
+                dedupe = f"subber:subtitle:{media_scope}:{row.id}:{uuid.uuid4()}"
+                subber_enqueue_or_get_job(
                     session,
-                    event_type=C.SUBBER_LIBRARY_SCAN_ENQUEUED,
-                    title=scan_title(
-                        module_label="Subber",
-                        result=DiagnosticResult.SUCCESS,
-                        count=enqueued,
-                        scope=media_scope,
-                    ),
-                    detail={
-                        **activity_detail_envelope(
-                            module=DiagnosticModule.SUBBER,
-                            action=DiagnosticAction.SCAN,
-                            trigger=DiagnosticTrigger.MANUAL,
-                            result=DiagnosticResult.SUCCESS,
-                            media_scope=media_scope,
-                            counts={"queued": enqueued},
-                            user_message=(
-                                f"Subber queued {enqueued} subtitle search"
-                                f"{'' if enqueued == 1 else 'es'} for {media_scope}."
-                            ),
-                        ),
-                        "enqueued": enqueued,
-                        "media_scope": media_scope,
-                    },
+                    dedupe_key=dedupe,
+                    job_kind=search_job_kind,
+                    payload_json=json.dumps({"state_id": int(row.id)}, separators=(",", ":")),
                 )
+                enqueued += 1
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_LIBRARY_SCAN_ENQUEUED,
+                title=scan_title(
+                    module_label="Subber",
+                    result=DiagnosticResult.SUCCESS,
+                    count=enqueued,
+                    scope=media_scope,
+                ),
+                detail={
+                    **activity_detail_envelope(
+                        module=DiagnosticModule.SUBBER,
+                        action=DiagnosticAction.SCAN,
+                        trigger=DiagnosticTrigger.MANUAL,
+                        result=DiagnosticResult.SUCCESS,
+                        media_scope=media_scope,
+                        counts={"queued": enqueued},
+                        user_message=(
+                            f"Subber queued {enqueued} subtitle search"
+                            f"{'' if enqueued == 1 else 'es'} for {media_scope}."
+                        ),
+                    ),
+                    "enqueued": enqueued,
+                    "media_scope": media_scope,
+                },
+            )
 
     _ = library_job_kind
     return handle

--- a/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
@@ -19,7 +19,10 @@ from mediamop.modules.subber.subber_arr_client import (
     get_sonarr_series,
 )
 from mediamop.modules.subber.subber_credentials_crypto import decrypt_subber_credentials_json
-from mediamop.modules.subber.subber_job_kinds import SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES, SUBBER_JOB_KIND_LIBRARY_SYNC_TV
+from mediamop.modules.subber.subber_job_kinds import (
+    SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
+    SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
+)
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row, language_preferences_list
 from mediamop.modules.subber.subber_subtitle_search_service import apply_path_mapping
@@ -94,71 +97,70 @@ def make_subber_library_sync_movies_handler(
 ) -> Callable[[SubberJobWorkContext], None]:
     def handle(ctx: SubberJobWorkContext) -> None:
         _ = json.loads(ctx.payload_json or "{}")
-        with session_factory() as session:
-            with session.begin():
-                row = ensure_subber_settings_row(session)
-                api_key = _arr_api_key(settings, row, radarr=True)
-                base = (row.radarr_base_url or "").strip()
-                if not base or not api_key:
-                    logger.debug("Subber library sync skipped for movies because Radarr is not configured.")
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                        title="Radarr library sync skipped — not configured",
-                        detail={"reason": "not_configured"},
-                    )
-                    return
-                try:
-                    movies = get_radarr_movies(base, api_key)
-                except SubberArrClientError as e:
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                        title="Radarr library sync failed",
-                        detail={"error": str(e)[:500]},
-                    )
-                    raise
-                langs = language_preferences_list(row)
-                processed = 0
-                found_subs = 0
-                for m in movies:
-                    if not m.get("hasFile"):
-                        continue
-                    mf = m.get("movieFile")
-                    if not isinstance(mf, dict):
-                        continue
-                    fp = str(mf.get("path") or "").strip()
-                    if not fp:
-                        continue
-                    processed += 1
-                    mid = m.get("id")
-                    mid_i = int(mid) if mid is not None and str(mid).strip().isdigit() else None
-                    title = str(m.get("title") or "").strip()
-                    yr = m.get("year")
-                    year_i = int(yr) if yr is not None and str(yr).strip().lstrip("-").isdigit() else None
-                    mapped = _mapped_media_path(row, media_scope="movies", arr_file_path=fp)
-                    for lang in langs:
-                        sub_path, st = _detect_subtitle_path(row, mapped, lang)
-                        if st == "found":
-                            found_subs += 1
-                        upsert_subtitle_state(
-                            session,
-                            media_scope="movies",
-                            file_path=fp,
-                            language_code=lang,
-                            status=st,
-                            subtitle_path=sub_path,
-                            source="sync",
-                            movie_title=title or None,
-                            movie_year=year_i,
-                            radarr_movie_id=mid_i,
-                        )
+        with session_factory() as session, session.begin():
+            row = ensure_subber_settings_row(session)
+            api_key = _arr_api_key(settings, row, radarr=True)
+            base = (row.radarr_base_url or "").strip()
+            if not base or not api_key:
+                logger.debug("Subber library sync skipped for movies because Radarr is not configured.")
                 subber_activity.record_subber_activity(
                     session,
                     event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                    title=f"Radarr library sync complete — {processed} movies processed, {found_subs} subtitles already found",
-                    detail={"movies": processed, "subtitles_found": found_subs},
+                    title="Radarr library sync skipped — not configured",
+                    detail={"reason": "not_configured"},
                 )
+                return
+            try:
+                movies = get_radarr_movies(base, api_key)
+            except SubberArrClientError as e:
+                subber_activity.record_subber_activity(
+                    session,
+                    event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
+                    title="Radarr library sync failed",
+                    detail={"error": str(e)[:500]},
+                )
+                raise
+            langs = language_preferences_list(row)
+            processed = 0
+            found_subs = 0
+            for m in movies:
+                if not m.get("hasFile"):
+                    continue
+                mf = m.get("movieFile")
+                if not isinstance(mf, dict):
+                    continue
+                fp = str(mf.get("path") or "").strip()
+                if not fp:
+                    continue
+                processed += 1
+                mid = m.get("id")
+                mid_i = int(mid) if mid is not None and str(mid).strip().isdigit() else None
+                title = str(m.get("title") or "").strip()
+                yr = m.get("year")
+                year_i = int(yr) if yr is not None and str(yr).strip().lstrip("-").isdigit() else None
+                mapped = _mapped_media_path(row, media_scope="movies", arr_file_path=fp)
+                for lang in langs:
+                    sub_path, st = _detect_subtitle_path(row, mapped, lang)
+                    if st == "found":
+                        found_subs += 1
+                    upsert_subtitle_state(
+                        session,
+                        media_scope="movies",
+                        file_path=fp,
+                        language_code=lang,
+                        status=st,
+                        subtitle_path=sub_path,
+                        source="sync",
+                        movie_title=title or None,
+                        movie_year=year_i,
+                        radarr_movie_id=mid_i,
+                    )
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
+                title=f"Radarr library sync complete — {processed} movies processed, {found_subs} subtitles already found",
+                detail={"movies": processed, "subtitles_found": found_subs},
+            )
 
     return handle
 
@@ -169,109 +171,108 @@ def make_subber_library_sync_tv_handler(
 ) -> Callable[[SubberJobWorkContext], None]:
     def handle(ctx: SubberJobWorkContext) -> None:
         _ = json.loads(ctx.payload_json or "{}")
-        with session_factory() as session:
-            with session.begin():
-                row = ensure_subber_settings_row(session)
-                api_key = _arr_api_key(settings, row, radarr=False)
-                base = (row.sonarr_base_url or "").strip()
-                if not base or not api_key:
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                        title="Sonarr library sync skipped — not configured",
-                        detail={"reason": "not_configured"},
-                    )
-                    return
-                try:
-                    series_list = get_sonarr_series(base, api_key)
-                except SubberArrClientError as e:
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                        title="Sonarr library sync failed",
-                        detail={"error": str(e)[:500]},
-                    )
-                    raise
-                langs = language_preferences_list(row)
-                series_count = 0
-                episodes_processed = 0
-                found_subs = 0
-                for ser in series_list:
-                    sid = ser.get("id")
-                    if sid is None or not str(sid).strip().isdigit():
-                        continue
-                    series_id = int(sid)
-                    series_count += 1
-                    show_title = str(ser.get("title") or "").strip() or None
-                    try:
-                        ep_files = get_sonarr_episode_files(base, api_key, series_id)
-                    except SubberArrClientError as exc:
-                        logger.warning(
-                            "Subber TV library sync could not fetch Sonarr episode files for series_id=%s: %s",
-                            series_id,
-                            exc,
-                        )
-                        ep_files = []
-                    episode_file_id_to_path: dict[int, str] = {}
-                    for ef in ep_files:
-                        if not isinstance(ef, dict):
-                            continue
-                        fid = ef.get("id")
-                        path = str(ef.get("path") or "").strip()
-                        if fid is not None and str(fid).strip().isdigit() and path:
-                            episode_file_id_to_path[int(fid)] = path
-                    try:
-                        episodes = get_sonarr_episodes(base, api_key, series_id)
-                    except SubberArrClientError as exc:
-                        logger.warning(
-                            "Subber TV library sync skipped series_id=%s because Sonarr episodes could not be listed: %s",
-                            series_id,
-                            exc,
-                        )
-                        continue
-                    for ep in episodes:
-                        if not ep.get("hasFile"):
-                            continue
-                        fp = _episode_file_path(ep, episode_file_id_to_path)
-                        if not fp:
-                            continue
-                        episodes_processed += 1
-                        epi_id = ep.get("id")
-                        epi_i = int(epi_id) if epi_id is not None and str(epi_id).strip().isdigit() else None
-                        sn = ep.get("seasonNumber")
-                        en = ep.get("episodeNumber")
-                        son = int(sn) if sn is not None and str(sn).strip().lstrip("-").isdigit() else None
-                        epn = int(en) if en is not None and str(en).strip().lstrip("-").isdigit() else None
-                        et = ep.get("title")
-                        ep_title = str(et).strip() if et is not None else None
-                        mapped = _mapped_media_path(row, media_scope="tv", arr_file_path=fp)
-                        for lang in langs:
-                            sub_path, st = _detect_subtitle_path(row, mapped, lang)
-                            if st == "found":
-                                found_subs += 1
-                            upsert_subtitle_state(
-                                session,
-                                media_scope="tv",
-                                file_path=fp,
-                                language_code=lang,
-                                status=st,
-                                subtitle_path=sub_path,
-                                source="sync",
-                                show_title=show_title,
-                                season_number=son,
-                                episode_number=epn,
-                                episode_title=ep_title,
-                                sonarr_episode_id=epi_i,
-                            )
+        with session_factory() as session, session.begin():
+            row = ensure_subber_settings_row(session)
+            api_key = _arr_api_key(settings, row, radarr=False)
+            base = (row.sonarr_base_url or "").strip()
+            if not base or not api_key:
                 subber_activity.record_subber_activity(
                     session,
                     event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
-                    title=(
-                        f"Sonarr library sync complete — {series_count} series processed, "
-                        f"{episodes_processed} episodes with files, {found_subs} subtitles already found"
-                    ),
-                    detail={"series": series_count, "episodes": episodes_processed, "subtitles_found": found_subs},
+                    title="Sonarr library sync skipped — not configured",
+                    detail={"reason": "not_configured"},
                 )
+                return
+            try:
+                series_list = get_sonarr_series(base, api_key)
+            except SubberArrClientError as e:
+                subber_activity.record_subber_activity(
+                    session,
+                    event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
+                    title="Sonarr library sync failed",
+                    detail={"error": str(e)[:500]},
+                )
+                raise
+            langs = language_preferences_list(row)
+            series_count = 0
+            episodes_processed = 0
+            found_subs = 0
+            for ser in series_list:
+                sid = ser.get("id")
+                if sid is None or not str(sid).strip().isdigit():
+                    continue
+                series_id = int(sid)
+                series_count += 1
+                show_title = str(ser.get("title") or "").strip() or None
+                try:
+                    ep_files = get_sonarr_episode_files(base, api_key, series_id)
+                except SubberArrClientError as exc:
+                    logger.warning(
+                        "Subber TV library sync could not fetch Sonarr episode files for series_id=%s: %s",
+                        series_id,
+                        exc,
+                    )
+                    ep_files = []
+                episode_file_id_to_path: dict[int, str] = {}
+                for ef in ep_files:
+                    if not isinstance(ef, dict):
+                        continue
+                    fid = ef.get("id")
+                    path = str(ef.get("path") or "").strip()
+                    if fid is not None and str(fid).strip().isdigit() and path:
+                        episode_file_id_to_path[int(fid)] = path
+                try:
+                    episodes = get_sonarr_episodes(base, api_key, series_id)
+                except SubberArrClientError as exc:
+                    logger.warning(
+                        "Subber TV library sync skipped series_id=%s because Sonarr episodes could not be listed: %s",
+                        series_id,
+                        exc,
+                    )
+                    continue
+                for ep in episodes:
+                    if not ep.get("hasFile"):
+                        continue
+                    fp = _episode_file_path(ep, episode_file_id_to_path)
+                    if not fp:
+                        continue
+                    episodes_processed += 1
+                    epi_id = ep.get("id")
+                    epi_i = int(epi_id) if epi_id is not None and str(epi_id).strip().isdigit() else None
+                    sn = ep.get("seasonNumber")
+                    en = ep.get("episodeNumber")
+                    son = int(sn) if sn is not None and str(sn).strip().lstrip("-").isdigit() else None
+                    epn = int(en) if en is not None and str(en).strip().lstrip("-").isdigit() else None
+                    et = ep.get("title")
+                    ep_title = str(et).strip() if et is not None else None
+                    mapped = _mapped_media_path(row, media_scope="tv", arr_file_path=fp)
+                    for lang in langs:
+                        sub_path, st = _detect_subtitle_path(row, mapped, lang)
+                        if st == "found":
+                            found_subs += 1
+                        upsert_subtitle_state(
+                            session,
+                            media_scope="tv",
+                            file_path=fp,
+                            language_code=lang,
+                            status=st,
+                            subtitle_path=sub_path,
+                            source="sync",
+                            show_title=show_title,
+                            season_number=son,
+                            episode_number=epn,
+                            episode_title=ep_title,
+                            sonarr_episode_id=epi_i,
+                        )
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_LIBRARY_SYNC_COMPLETED,
+                title=(
+                    f"Sonarr library sync complete — {series_count} series processed, "
+                    f"{episodes_processed} episodes with files, {found_subs} subtitles already found"
+                ),
+                detail={"series": series_count, "episodes": episodes_processed, "subtitles_found": found_subs},
+            )
 
     return handle
 

--- a/apps/backend/src/mediamop/modules/subber/subber_opensubtitles_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_opensubtitles_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import urllib.parse
 from typing import Any
@@ -84,10 +85,8 @@ def fetch_user_info(token: str, api_key: str) -> dict[str, Any]:
 
 
 def logout(token: str, api_key: str) -> None:
-    try:
+    with contextlib.suppress(Exception):
         _request("DELETE", "/logout", api_key=api_key, token=token)
-    except Exception:
-        pass
 
 
 def search(

--- a/apps/backend/src/mediamop/modules/subber/subber_overview_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_overview_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -25,7 +25,7 @@ def _count_state(session: Session, *, media_scope: str | None = None, status: st
 
 def build_subber_overview(session: Session, *, window_days: int = 30) -> SubberOverviewOut:
     wd = max(1, int(window_days))
-    since = datetime.now(timezone.utc) - timedelta(days=wd)
+    since = datetime.now(UTC) - timedelta(days=wd)
 
     subtitles_downloaded = _count_state(session, status="found")
     still_missing = _count_state(session, status="missing")

--- a/apps/backend/src/mediamop/modules/subber/subber_podnapisi_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_podnapisi_client.py
@@ -8,7 +8,12 @@ import urllib.parse
 import zipfile
 from typing import Any
 
-from mediamop.modules.subber.subber_http_client import DEFAULT_USER_AGENT, basic_auth_header, request_bytes, request_json
+from mediamop.modules.subber.subber_http_client import (
+    DEFAULT_USER_AGENT,
+    basic_auth_header,
+    request_bytes,
+    request_json,
+)
 
 USER_AGENT = DEFAULT_USER_AGENT
 LIST_BASE = "https://www.podnapisi.net/api/v2/subtitles/list"
@@ -36,10 +41,7 @@ def _item_hearing_impaired(item: dict[str, Any]) -> bool:
             if str(f).lower() in ("hearing_impaired", "hearing impaired"):
                 return True
     attrs = item.get("attributes")
-    if isinstance(attrs, dict):
-        if attrs.get("hearing_impaired") or attrs.get("from_hearing_impaired"):
-            return True
-    return False
+    return bool(isinstance(attrs, dict) and (attrs.get("hearing_impaired") or attrs.get("from_hearing_impaired")))
 
 
 def _item_id_lang(item: dict[str, Any]) -> tuple[str | None, str]:

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
@@ -8,7 +8,10 @@ from pydantic import BaseModel, Field
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.subber import subber_opensubtitles_client as os_client
-from mediamop.modules.subber.subber_credentials_crypto import decrypt_subber_credentials_json, parse_provider_secrets_json
+from mediamop.modules.subber.subber_credentials_crypto import (
+    decrypt_subber_credentials_json,
+    parse_provider_secrets_json,
+)
 from mediamop.modules.subber.subber_podnapisi_client import LIST_BASE
 from mediamop.modules.subber.subber_provider_registry import (
     ALL_PROVIDER_KEYS,
@@ -25,9 +28,9 @@ from mediamop.modules.subber.subber_providers_service import (
     upsert_provider_settings,
 )
 from mediamop.modules.subber.subber_schemas import SubberProviderOut, SubberProviderPutIn, SubberTestConnectionOut
-from mediamop.platform.outbound_http import validate_external_provider_url
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import current_raw_session_token, verify_csrf_token
+from mediamop.platform.outbound_http import validate_external_provider_url
 
 router = APIRouter(tags=["subber-providers"])
 

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -110,7 +110,7 @@ def upsert_provider_settings(
     row = get_provider_by_key(session, provider_key)
     if row is None:
         raise ValueError(f"Unknown provider_key {provider_key!r}")
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
 
     # Auto-assign priority when enabling; clear when disabling
     if enabled is True and row.priority is None:

--- a/apps/backend/src/mediamop/modules/subber/subber_schedule_enqueue.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_schedule_enqueue.py
@@ -10,12 +10,11 @@ import asyncio
 import json
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.arr_library.schedule_wall_clock import DAY_NAMES, schedule_time_window_active
 from mediamop.modules.subber.subber_job_kinds import (
     SUBBER_JOB_KIND_LIBRARY_SCAN_MOVIES,
     SUBBER_JOB_KIND_LIBRARY_SCAN_TV,
@@ -24,6 +23,7 @@ from mediamop.modules.subber.subber_job_kinds import (
 from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row
+from mediamop.platform.arr_library.schedule_wall_clock import DAY_NAMES, schedule_time_window_active
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ def _branch_due(last_at: datetime | None, interval_seconds: int, *, now: datetim
     iv = _clamp_interval_seconds(interval_seconds)
     if last_at is None:
         return True
-    last = last_at if last_at.tzinfo else last_at.replace(tzinfo=timezone.utc)
+    last = last_at if last_at.tzinfo else last_at.replace(tzinfo=UTC)
     return (now - last).total_seconds() >= float(iv)
 
 
@@ -101,7 +101,7 @@ def _movies_in_window(session: Session, row: SubberSettingsRow, *, when: datetim
 
 
 def enqueue_due_subber_tv_scan(session: Session, *, now: datetime) -> int:
-    when = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    when = now if now.tzinfo else now.replace(tzinfo=UTC)
     row = ensure_subber_settings_row(session)
     if not row.enabled:
         return 0
@@ -126,12 +126,11 @@ def run_subber_tv_scan_tick(
     *,
     now: datetime | None = None,
 ) -> int:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    with session_factory() as session:
-        with session.begin():
-            return enqueue_due_subber_tv_scan(session, now=when)
+        when = when.replace(tzinfo=UTC)
+    with session_factory() as session, session.begin():
+        return enqueue_due_subber_tv_scan(session, now=when)
 
 
 async def _run_subber_tv_scan_forever(
@@ -189,7 +188,7 @@ async def stop_subber_tv_scan_schedule_enqueue_tasks(tasks: list[asyncio.Task[No
 
 
 def enqueue_due_subber_movies_scan(session: Session, *, now: datetime) -> int:
-    when = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    when = now if now.tzinfo else now.replace(tzinfo=UTC)
     row = ensure_subber_settings_row(session)
     if not row.enabled:
         return 0
@@ -214,12 +213,11 @@ def run_subber_movies_scan_tick(
     *,
     now: datetime | None = None,
 ) -> int:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    with session_factory() as session:
-        with session.begin():
-            return enqueue_due_subber_movies_scan(session, now=when)
+        when = when.replace(tzinfo=UTC)
+    with session_factory() as session, session.begin():
+        return enqueue_due_subber_movies_scan(session, now=when)
 
 
 async def _run_subber_movies_scan_forever(
@@ -277,7 +275,7 @@ async def stop_subber_movies_scan_schedule_enqueue_tasks(tasks: list[asyncio.Tas
 
 
 def enqueue_due_subber_upgrade(session: Session, *, now: datetime) -> int:
-    when = now if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    when = now if now.tzinfo else now.replace(tzinfo=UTC)
     row = ensure_subber_settings_row(session)
     if not row.enabled:
         return 0
@@ -302,12 +300,11 @@ def run_subber_upgrade_tick(
     *,
     now: datetime | None = None,
 ) -> int:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    with session_factory() as session:
-        with session.begin():
-            return enqueue_due_subber_upgrade(session, now=when)
+        when = when.replace(tzinfo=UTC)
+    with session_factory() as session, session.begin():
+        return enqueue_due_subber_upgrade(session, now=when)
 
 
 async def _run_subber_upgrade_forever(

--- a/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
@@ -27,7 +27,12 @@ from mediamop.modules.subber.subber_subtitle_state_service import (
 )
 from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope, media_scope_label
 
 logger = logging.getLogger(__name__)
@@ -43,92 +48,91 @@ def make_subber_subtitle_search_handler(
     def handle(ctx: SubberJobWorkContext) -> None:
         payload = json.loads(ctx.payload_json or "{}")
         state_id = int(payload["state_id"])
-        with session_factory() as session:
-            with session.begin():
-                row = get_state_by_id(session, state_id)
-                if row is None:
-                    logger.debug("Subber subtitle search skipped because state_id=%s no longer exists.", state_id)
-                    return
-                if row.status == "found" and row.subtitle_path and os.path.isfile(row.subtitle_path):
-                    logger.debug("Subber subtitle search skipped because state_id=%s already has a subtitle file.", state_id)
-                    return
-                settings_row = ensure_subber_settings_row(session)
-                if not settings_row.enabled:
-                    logger.debug("Subber subtitle search skipped because Subber is disabled (state_id=%s).", state_id)
-                    return
-                if not subber_any_search_configured(settings, settings_row, session):
-                    logger.debug(
-                        "Subber subtitle search skipped because no providers are configured (state_id=%s).",
-                        state_id,
-                    )
-                    return
-                perm = max(1, int(settings_row.permanent_skip_after_attempts or 10))
-                if int(row.search_count or 0) >= perm:
-                    mark_skipped(session, state_id)
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_SUBTITLE_SEARCH_COMPLETED,
-                        title="Subtitle search skipped because the retry limit was reached",
-                        detail={
-                            **activity_detail_envelope(
-                                module=DiagnosticModule.SUBBER,
-                                action=DiagnosticAction.SEARCH,
-                                trigger=DiagnosticTrigger.WORKER,
-                                result=DiagnosticResult.SKIPPED,
-                                media_scope=media_scope,
-                                counts={"checked": 1, "downloaded": 0, "skipped": 1},
-                                user_message="Subber has already searched this item enough times.",
-                                next_action="Change Subber retry settings or manually add a subtitle if this item still needs one.",
-                            ),
-                            "state_id": state_id,
-                            "reason": "search_count",
-                        },
-                    )
-                    return
-                mark_searching(session, state_id)
-                row2 = get_state_by_id(session, state_id)
-                if row2 is None:
-                    logger.debug(
-                        "Subber subtitle search stopped because state_id=%s disappeared after marking searching.",
-                        state_id,
-                    )
-                    return
-                provider_events: list[dict[str, object]] = []
-                ok = search_and_download_subtitle(
-                    settings=settings,
-                    settings_row=settings_row,
-                    state_row=row2,
-                    db=session,
-                    provider_events=provider_events,
+        with session_factory() as session, session.begin():
+            row = get_state_by_id(session, state_id)
+            if row is None:
+                logger.debug("Subber subtitle search skipped because state_id=%s no longer exists.", state_id)
+                return
+            if row.status == "found" and row.subtitle_path and os.path.isfile(row.subtitle_path):
+                logger.debug("Subber subtitle search skipped because state_id=%s already has a subtitle file.", state_id)
+                return
+            settings_row = ensure_subber_settings_row(session)
+            if not settings_row.enabled:
+                logger.debug("Subber subtitle search skipped because Subber is disabled (state_id=%s).", state_id)
+                return
+            if not subber_any_search_configured(settings, settings_row, session):
+                logger.debug(
+                    "Subber subtitle search skipped because no providers are configured (state_id=%s).",
+                    state_id,
                 )
+                return
+            perm = max(1, int(settings_row.permanent_skip_after_attempts or 10))
+            if int(row.search_count or 0) >= perm:
+                mark_skipped(session, state_id)
                 subber_activity.record_subber_activity(
                     session,
                     event_type=C.SUBBER_SUBTITLE_SEARCH_COMPLETED,
-                    title=(
-                        f"Subtitle downloaded for {media_scope_label(media_scope)}"
-                        if ok
-                        else f"No subtitle found for {media_scope_label(media_scope)}"
-                    ),
+                    title="Subtitle search skipped because the retry limit was reached",
                     detail={
                         **activity_detail_envelope(
                             module=DiagnosticModule.SUBBER,
                             action=DiagnosticAction.SEARCH,
                             trigger=DiagnosticTrigger.WORKER,
-                            result=DiagnosticResult.SUCCESS if ok else DiagnosticResult.SKIPPED,
+                            result=DiagnosticResult.SKIPPED,
                             media_scope=media_scope,
-                            counts={"checked": 1, "downloaded": int(bool(ok)), "skipped": int(not ok)},
-                            user_message=(
-                                "Subber downloaded a matching subtitle."
-                                if ok
-                                else "Subber checked the configured providers but did not find a usable subtitle."
-                            ),
+                            counts={"checked": 1, "downloaded": 0, "skipped": 1},
+                            user_message="Subber has already searched this item enough times.",
+                            next_action="Change Subber retry settings or manually add a subtitle if this item still needs one.",
                         ),
                         "state_id": state_id,
-                        "media_scope": media_scope,
-                        "ok": ok,
-                        "provider_events": provider_events,
+                        "reason": "search_count",
                     },
                 )
+                return
+            mark_searching(session, state_id)
+            row2 = get_state_by_id(session, state_id)
+            if row2 is None:
+                logger.debug(
+                    "Subber subtitle search stopped because state_id=%s disappeared after marking searching.",
+                    state_id,
+                )
+                return
+            provider_events: list[dict[str, object]] = []
+            ok = search_and_download_subtitle(
+                settings=settings,
+                settings_row=settings_row,
+                state_row=row2,
+                db=session,
+                provider_events=provider_events,
+            )
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_SUBTITLE_SEARCH_COMPLETED,
+                title=(
+                    f"Subtitle downloaded for {media_scope_label(media_scope)}"
+                    if ok
+                    else f"No subtitle found for {media_scope_label(media_scope)}"
+                ),
+                detail={
+                    **activity_detail_envelope(
+                        module=DiagnosticModule.SUBBER,
+                        action=DiagnosticAction.SEARCH,
+                        trigger=DiagnosticTrigger.WORKER,
+                        result=DiagnosticResult.SUCCESS if ok else DiagnosticResult.SKIPPED,
+                        media_scope=media_scope,
+                        counts={"checked": 1, "downloaded": int(bool(ok)), "skipped": int(not ok)},
+                        user_message=(
+                            "Subber downloaded a matching subtitle."
+                            if ok
+                            else "Subber checked the configured providers but did not find a usable subtitle."
+                        ),
+                    ),
+                    "state_id": state_id,
+                    "media_scope": media_scope,
+                    "ok": ok,
+                    "provider_events": provider_events,
+                },
+            )
 
     _ = job_kind
     return handle

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import json
-import uuid
 import urllib.error
 import urllib.request
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Request, status
@@ -13,11 +13,17 @@ from pydantic import BaseModel, Field
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.core.config import MediaMopSettings
-from mediamop.modules.subber.subber_credentials_crypto import decrypt_subber_credentials_json, encrypt_subber_credentials_json
-from mediamop.modules.subber.subber_job_kinds import SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES, SUBBER_JOB_KIND_LIBRARY_SYNC_TV
+from mediamop.modules.subber import subber_opensubtitles_client as os_client
+from mediamop.modules.subber.subber_credentials_crypto import (
+    decrypt_subber_credentials_json,
+    encrypt_subber_credentials_json,
+)
+from mediamop.modules.subber.subber_job_kinds import (
+    SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
+    SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
+)
 from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_opensubtitles_client import USER_AGENT
-from mediamop.modules.subber import subber_opensubtitles_client as os_client
 from mediamop.modules.subber.subber_overview_service import build_subber_overview
 from mediamop.modules.subber.subber_schemas import (
     SubberArrRootFolderOut,
@@ -34,9 +40,9 @@ from mediamop.modules.subber.subber_settings_service import (
     language_preferences_list,
     set_language_preferences_json,
 )
-from mediamop.platform.outbound_http import normalize_local_service_base_url
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import current_raw_session_token, verify_csrf_token
+from mediamop.platform.outbound_http import normalize_local_service_base_url
 
 router = APIRouter(tags=["subber-settings"])
 
@@ -203,21 +209,19 @@ def put_subber_settings(
     rad_key = _api_key_from_ciphertext(row.radarr_credentials_ciphertext)
     son_configured = bool((row.sonarr_base_url or "").strip()) and bool(son_key)
     rad_configured = bool((row.radarr_base_url or "").strip()) and bool(rad_key)
-    if body.sonarr_base_url is not None or (body.sonarr_api_key is not None and body.sonarr_api_key.strip()):
-        if son_configured:
-            subber_enqueue_or_get_job(
-                db,
-                dedupe_key=f"subber:libsync:settings:tv:{uuid.uuid4()}",
-                job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
-                payload_json="{}",
-            )
-    if body.radarr_base_url is not None or (body.radarr_api_key is not None and body.radarr_api_key.strip()):
-        if rad_configured:
-            subber_enqueue_or_get_job(
-                db,
-                dedupe_key=f"subber:libsync:settings:movies:{uuid.uuid4()}",
-                job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
-                payload_json="{}",
+    if (body.sonarr_base_url is not None or (body.sonarr_api_key is not None and body.sonarr_api_key.strip())) and son_configured:
+        subber_enqueue_or_get_job(
+            db,
+            dedupe_key=f"subber:libsync:settings:tv:{uuid.uuid4()}",
+            job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
+            payload_json="{}",
+        )
+    if (body.radarr_base_url is not None or (body.radarr_api_key is not None and body.radarr_api_key.strip())) and rad_configured:
+        subber_enqueue_or_get_job(
+            db,
+            dedupe_key=f"subber:libsync:settings:movies:{uuid.uuid4()}",
+            job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
+            payload_json="{}",
             )
 
     return _settings_out(db, row, request, settings)

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_service.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from mediamop.platform.arr_library.arr_operator_settings_model import ArrLibraryOperatorSettingsRow
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
+from mediamop.platform.arr_library.arr_operator_settings_model import ArrLibraryOperatorSettingsRow
 
 
 def ensure_subber_settings_row(db: Session) -> SubberSettingsRow:
@@ -44,9 +44,9 @@ def language_preferences_list(row: SubberSettingsRow) -> list[str]:
 def set_language_preferences_json(db: Session, row: SubberSettingsRow, langs: list[str]) -> None:
     norm = [str(x).strip().lower() for x in langs if str(x).strip()]
     row.language_preferences_json = json.dumps(norm or ["en"], separators=(",", ":"))
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)
     db.flush()
 
 
 def touch_updated_at(row: SubberSettingsRow) -> None:
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)

--- a/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subtitle_search_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import io
 import json
 import logging
@@ -14,6 +15,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.subber import subber_gestdown_client as gestdown_client
 from mediamop.modules.subber import subber_opensubtitles_client as os_client
 from mediamop.modules.subber import subber_podnapisi_client as podnapisi_client
@@ -21,7 +23,10 @@ from mediamop.modules.subber import subber_subdl_client as subdl_client
 from mediamop.modules.subber import subber_subf2m_client as subf2m_client
 from mediamop.modules.subber import subber_subsource_client as subsource_client
 from mediamop.modules.subber import subber_yify_client as yify_client
-from mediamop.modules.subber.subber_credentials_crypto import decrypt_subber_credentials_json, parse_provider_secrets_json
+from mediamop.modules.subber.subber_credentials_crypto import (
+    decrypt_subber_credentials_json,
+    parse_provider_secrets_json,
+)
 from mediamop.modules.subber.subber_opensubtitles_client import SubberRateLimitError
 from mediamop.modules.subber.subber_provider_registry import (
     PROVIDER_GESTDOWN,
@@ -33,7 +38,6 @@ from mediamop.modules.subber.subber_provider_registry import (
     PROVIDER_SUBSOURCE,
     PROVIDER_YIFY,
 )
-from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.subber.subber_providers_model import SubberProviderRow
 from mediamop.modules.subber.subber_providers_service import get_enabled_providers_ordered, provider_is_ready_for_search
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
@@ -113,10 +117,7 @@ def opensubtitles_configured(settings: MediaMopSettings, row: SubberSettingsRow)
 def subber_any_search_configured(settings: MediaMopSettings, settings_row: SubberSettingsRow, db: Session) -> bool:
     if opensubtitles_configured(settings, settings_row):
         return True
-    for prow in get_enabled_providers_ordered(db):
-        if provider_is_ready_for_search(settings, prow):
-            return True
-    return False
+    return any(provider_is_ready_for_search(settings, prow) for prow in get_enabled_providers_ordered(db))
 
 
 def _search_query(state_row: SubberSubtitleState) -> str:
@@ -324,17 +325,13 @@ def _try_opensubtitles_provider(
         return True
     except SubberRateLimitError:
         if token:
-            try:
+            with contextlib.suppress(Exception):
                 os_client.logout(token, api_key)
-            except Exception:
-                pass
         raise
     finally:
         if token:
-            try:
+            with contextlib.suppress(Exception):
                 os_client.logout(token, api_key)
-            except Exception:
-                pass
 
 
 def _try_podnapisi(
@@ -703,10 +700,8 @@ def _legacy_opensubtitles_search(
         return False
     finally:
         if token:
-            try:
+            with contextlib.suppress(Exception):
                 os_client.logout(token, api_key)
-            except Exception:
-                pass
 
 
 _PROVIDER_HANDLERS: dict[str, ProviderSearchHandler] = {

--- a/apps/backend/src/mediamop/modules/subber/subber_subtitle_state_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subtitle_state_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -39,7 +39,7 @@ def upsert_subtitle_state(
             SubberSubtitleState.language_code == lang,
         ),
     ).one_or_none()
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     if row is None:
         row = SubberSubtitleState(
             media_scope=media_scope,
@@ -141,7 +141,7 @@ def mark_found(
     row.opensubtitles_file_id = opensubtitles_file_id
     if provider_key is not None:
         row.provider_key = provider_key.strip()[:50] or None
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)
     session.flush()
 
 
@@ -149,17 +149,17 @@ def mark_for_upgrade(session: Session, state_id: int, *, increment_count: bool =
     row = session.scalars(select(SubberSubtitleState).where(SubberSubtitleState.id == state_id)).one_or_none()
     if row is None:
         return
-    row.upgraded_at = datetime.now(timezone.utc)
+    row.upgraded_at = datetime.now(UTC)
     if increment_count:
         row.upgrade_count = int(row.upgrade_count or 0) + 1
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)
     session.flush()
 
 
 def get_candidates_for_upgrade(session: Session, since_days: int) -> list[SubberSubtitleState]:
     from datetime import timedelta
 
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     cutoff = now - timedelta(days=max(1, int(since_days)))
     rows = list(
         session.scalars(
@@ -182,7 +182,7 @@ def get_candidates_for_upgrade(session: Session, since_days: int) -> list[Subber
         if lu is None:
             out.append(r)
             continue
-        luu = lu if lu.tzinfo else lu.replace(tzinfo=timezone.utc)
+        luu = lu if lu.tzinfo else lu.replace(tzinfo=UTC)
         if luu < cutoff:
             out.append(r)
     return out
@@ -194,8 +194,8 @@ def mark_searching(session: Session, state_id: int) -> None:
         return
     row.status = "searching"
     row.search_count = int(row.search_count or 0) + 1
-    row.last_searched_at = datetime.now(timezone.utc)
-    row.updated_at = datetime.now(timezone.utc)
+    row.last_searched_at = datetime.now(UTC)
+    row.updated_at = datetime.now(UTC)
     session.flush()
 
 
@@ -204,7 +204,7 @@ def mark_skipped(session: Session, state_id: int) -> None:
     if row is None:
         return
     row.status = "skipped"
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)
     session.flush()
 
 
@@ -213,5 +213,5 @@ def mark_missing(session: Session, state_id: int) -> None:
     if row is None:
         return
     row.status = "missing"
-    row.updated_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(UTC)
     session.flush()

--- a/apps/backend/src/mediamop/modules/subber/subber_upgrade_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_upgrade_job_handler.py
@@ -10,13 +10,21 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.subber import subber_activity
-from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row
 from mediamop.modules.subber.subber_opensubtitles_client import SubberRateLimitError
-from mediamop.modules.subber.subber_subtitle_search_service import search_and_download_subtitle, subber_any_search_configured
+from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row
+from mediamop.modules.subber.subber_subtitle_search_service import (
+    search_and_download_subtitle,
+    subber_any_search_configured,
+)
 from mediamop.modules.subber.subber_subtitle_state_service import get_candidates_for_upgrade, mark_for_upgrade
 from mediamop.modules.subber.worker_loop import SubberJobWorkContext
 from mediamop.platform.activity import constants as C
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import activity_detail_envelope
 
 logger = logging.getLogger(__name__)
@@ -30,87 +38,86 @@ def make_subber_subtitle_upgrade_handler(
         _ = json.loads(ctx.payload_json or "{}")
         upgraded = 0
         attempted = 0
-        with session_factory() as session:
-            with session.begin():
-                settings_row = ensure_subber_settings_row(session)
-                if not settings_row.enabled or not bool(settings_row.upgrade_enabled):
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_SUBTITLE_UPGRADE_COMPLETED,
-                        title="Subtitle upgrade skipped because it is turned off",
-                        detail={
-                            **activity_detail_envelope(
-                                module=DiagnosticModule.SUBBER,
-                                action=DiagnosticAction.SEARCH,
-                                trigger=DiagnosticTrigger.SCHEDULED,
-                                result=DiagnosticResult.SKIPPED,
-                                counts={"checked": 0, "upgraded": 0, "skipped": 0},
-                                user_message="Subtitle upgrade is turned off in Subber settings.",
-                            ),
-                            "attempted": 0,
-                            "upgraded": 0,
-                        },
-                    )
-                    return
-                if not subber_any_search_configured(settings, settings_row, session):
-                    subber_activity.record_subber_activity(
-                        session,
-                        event_type=C.SUBBER_SUBTITLE_UPGRADE_COMPLETED,
-                        title="Subtitle upgrade skipped because no providers are configured",
-                        detail={
-                            **activity_detail_envelope(
-                                module=DiagnosticModule.SUBBER,
-                                action=DiagnosticAction.SEARCH,
-                                trigger=DiagnosticTrigger.SCHEDULED,
-                                result=DiagnosticResult.SKIPPED,
-                                counts={"checked": 0, "upgraded": 0, "skipped": 0},
-                                user_message="Subber needs at least one subtitle provider before it can upgrade subtitles.",
-                                next_action="Add a subtitle provider in Subber settings.",
-                            ),
-                            "attempted": 0,
-                            "upgraded": 0,
-                        },
-                    )
-                    return
-                interval_sec = max(60, int(settings_row.upgrade_schedule_interval_seconds or 604800))
-                since_days = max(1, int(interval_sec // 86400) or 7)
-                logger.debug("Subber subtitle upgrade scanning candidates from the last %s day(s).", since_days)
-                for row in get_candidates_for_upgrade(session, since_days):
-                    attempted += 1
-                    try:
-                        ok = search_and_download_subtitle(
-                            settings=settings,
-                            settings_row=settings_row,
-                            state_row=row,
-                            db=session,
-                            providers=None,
-                            retain_found_on_failure=True,
-                        )
-                    except SubberRateLimitError:
-                        raise
-                    mark_for_upgrade(session, int(row.id), increment_count=bool(ok))
-                    if ok:
-                        upgraded += 1
+        with session_factory() as session, session.begin():
+            settings_row = ensure_subber_settings_row(session)
+            if not settings_row.enabled or not bool(settings_row.upgrade_enabled):
                 subber_activity.record_subber_activity(
                     session,
                     event_type=C.SUBBER_SUBTITLE_UPGRADE_COMPLETED,
-                    title=f"Subtitle upgrade checked {attempted} item{'' if attempted == 1 else 's'} and improved {upgraded}",
+                    title="Subtitle upgrade skipped because it is turned off",
                     detail={
                         **activity_detail_envelope(
                             module=DiagnosticModule.SUBBER,
                             action=DiagnosticAction.SEARCH,
                             trigger=DiagnosticTrigger.SCHEDULED,
-                            result=DiagnosticResult.SUCCESS,
-                            counts={"checked": attempted, "upgraded": upgraded},
-                            user_message=(
-                                f"Subber checked {attempted} existing subtitle"
-                                f"{'' if attempted == 1 else 's'} and improved {upgraded}."
-                            ),
+                            result=DiagnosticResult.SKIPPED,
+                            counts={"checked": 0, "upgraded": 0, "skipped": 0},
+                            user_message="Subtitle upgrade is turned off in Subber settings.",
                         ),
-                        "attempted": attempted,
-                        "upgraded": upgraded,
+                        "attempted": 0,
+                        "upgraded": 0,
                     },
                 )
+                return
+            if not subber_any_search_configured(settings, settings_row, session):
+                subber_activity.record_subber_activity(
+                    session,
+                    event_type=C.SUBBER_SUBTITLE_UPGRADE_COMPLETED,
+                    title="Subtitle upgrade skipped because no providers are configured",
+                    detail={
+                        **activity_detail_envelope(
+                            module=DiagnosticModule.SUBBER,
+                            action=DiagnosticAction.SEARCH,
+                            trigger=DiagnosticTrigger.SCHEDULED,
+                            result=DiagnosticResult.SKIPPED,
+                            counts={"checked": 0, "upgraded": 0, "skipped": 0},
+                            user_message="Subber needs at least one subtitle provider before it can upgrade subtitles.",
+                            next_action="Add a subtitle provider in Subber settings.",
+                        ),
+                        "attempted": 0,
+                        "upgraded": 0,
+                    },
+                )
+                return
+            interval_sec = max(60, int(settings_row.upgrade_schedule_interval_seconds or 604800))
+            since_days = max(1, int(interval_sec // 86400) or 7)
+            logger.debug("Subber subtitle upgrade scanning candidates from the last %s day(s).", since_days)
+            for row in get_candidates_for_upgrade(session, since_days):
+                attempted += 1
+                try:
+                    ok = search_and_download_subtitle(
+                        settings=settings,
+                        settings_row=settings_row,
+                        state_row=row,
+                        db=session,
+                        providers=None,
+                        retain_found_on_failure=True,
+                    )
+                except SubberRateLimitError:
+                    raise
+                mark_for_upgrade(session, int(row.id), increment_count=bool(ok))
+                if ok:
+                    upgraded += 1
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_SUBTITLE_UPGRADE_COMPLETED,
+                title=f"Subtitle upgrade checked {attempted} item{'' if attempted == 1 else 's'} and improved {upgraded}",
+                detail={
+                    **activity_detail_envelope(
+                        module=DiagnosticModule.SUBBER,
+                        action=DiagnosticAction.SEARCH,
+                        trigger=DiagnosticTrigger.SCHEDULED,
+                        result=DiagnosticResult.SUCCESS,
+                        counts={"checked": attempted, "upgraded": upgraded},
+                        user_message=(
+                            f"Subber checked {attempted} existing subtitle"
+                            f"{'' if attempted == 1 else 's'} and improved {upgraded}."
+                        ),
+                    ),
+                    "attempted": attempted,
+                    "upgraded": upgraded,
+                },
+            )
 
     return handle
 

--- a/apps/backend/src/mediamop/modules/subber/subber_webhook_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_webhook_api.py
@@ -11,7 +11,10 @@ from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
-from mediamop.modules.subber.subber_job_kinds import SUBBER_JOB_KIND_WEBHOOK_IMPORT_MOVIES, SUBBER_JOB_KIND_WEBHOOK_IMPORT_TV
+from mediamop.modules.subber.subber_job_kinds import (
+    SUBBER_JOB_KIND_WEBHOOK_IMPORT_MOVIES,
+    SUBBER_JOB_KIND_WEBHOOK_IMPORT_TV,
+)
 from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 
 router = APIRouter(tags=["subber-webhooks"])

--- a/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_webhook_import_job_handler.py
@@ -57,47 +57,46 @@ def make_subber_webhook_import_handler(
         sonarr_episode_id = int(se_id) if se_id is not None and str(se_id).strip().isdigit() else None
         radarr_movie_id = int(rm_id) if rm_id is not None and str(rm_id).strip().isdigit() else None
         enqueued = 0
-        with session_factory() as session:
-            with session.begin():
-                settings_row = ensure_subber_settings_row(session)
-                if not settings_row.enabled:
-                    logger.debug("Subber webhook import skipped because Subber is disabled (%s).", media_scope)
-                    return
-                for lang in language_preferences_list(settings_row):
-                    st = upsert_subtitle_state(
-                        session,
-                        media_scope=media_scope,
-                        file_path=file_path,
-                        language_code=lang,
-                        status="missing",
-                        source="webhook",
-                        show_title=show_s,
-                        season_number=son,
-                        episode_number=epn,
-                        episode_title=ep_title,
-                        movie_title=title if media_scope == "movies" else None,
-                        movie_year=year_i if media_scope == "movies" else None,
-                        sonarr_episode_id=sonarr_episode_id if media_scope == "tv" else None,
-                        radarr_movie_id=radarr_movie_id if media_scope == "movies" else None,
-                    )
-                    dedupe = f"subber:subtitle:{media_scope}:{st.id}:{uuid.uuid4()}"
-                    subber_enqueue_or_get_job(
-                        session,
-                        dedupe_key=dedupe,
-                        job_kind=search_job_kind,
-                        payload_json=json.dumps({"state_id": int(st.id)}, separators=(",", ":")),
-                    )
-                    enqueued += 1
-                subber_activity.record_subber_activity(
+        with session_factory() as session, session.begin():
+            settings_row = ensure_subber_settings_row(session)
+            if not settings_row.enabled:
+                logger.debug("Subber webhook import skipped because Subber is disabled (%s).", media_scope)
+                return
+            for lang in language_preferences_list(settings_row):
+                st = upsert_subtitle_state(
                     session,
-                    event_type=C.SUBBER_WEBHOOK_IMPORT_ENQUEUED,
-                    title=f"Subber webhook import ({media_scope})",
-                    detail={
-                        "enqueued": enqueued,
-                        "file_path": file_path,
-                        "media_scope": media_scope,
-                    },
+                    media_scope=media_scope,
+                    file_path=file_path,
+                    language_code=lang,
+                    status="missing",
+                    source="webhook",
+                    show_title=show_s,
+                    season_number=son,
+                    episode_number=epn,
+                    episode_title=ep_title,
+                    movie_title=title if media_scope == "movies" else None,
+                    movie_year=year_i if media_scope == "movies" else None,
+                    sonarr_episode_id=sonarr_episode_id if media_scope == "tv" else None,
+                    radarr_movie_id=radarr_movie_id if media_scope == "movies" else None,
                 )
+                dedupe = f"subber:subtitle:{media_scope}:{st.id}:{uuid.uuid4()}"
+                subber_enqueue_or_get_job(
+                    session,
+                    dedupe_key=dedupe,
+                    job_kind=search_job_kind,
+                    payload_json=json.dumps({"state_id": int(st.id)}, separators=(",", ":")),
+                )
+                enqueued += 1
+            subber_activity.record_subber_activity(
+                session,
+                event_type=C.SUBBER_WEBHOOK_IMPORT_ENQUEUED,
+                title=f"Subber webhook import ({media_scope})",
+                detail={
+                    "enqueued": enqueued,
+                    "file_path": file_path,
+                    "media_scope": media_scope,
+                },
+            )
 
     _ = webhook_job_kind
     return handle

--- a/apps/backend/src/mediamop/modules/subber/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/subber/worker_loop.py
@@ -8,13 +8,12 @@ import os
 import socket
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import Literal
 
 from sqlalchemy.orm import Session, sessionmaker
 
 from mediamop.core.config import MediaMopSettings
-from mediamop.platform.http.request_context import job_logging_context
 from mediamop.modules.queue_worker.job_kind_boundaries import (
     SUBBER_QUEUE_JOB_KIND_PREFIX,
     job_kind_forbidden_on_subber_lane,
@@ -26,6 +25,7 @@ from mediamop.modules.subber.subber_jobs_ops import (
     fail_claimed_subber_job,
     fail_leased_subber_job_after_complete_failure,
 )
+from mediamop.platform.http.request_context import job_logging_context
 from mediamop.platform.jobs.worker_health import worker_heartbeat, worker_started, worker_stopped
 from mediamop.platform.notifications.dispatch import dispatch_job_notification
 from mediamop.platform.observability.failure_messages import operator_failure_from_exception
@@ -68,25 +68,24 @@ def process_one_subber_job(
     lease_seconds: int = DEFAULT_SUBBER_JOB_LEASE_SECONDS,
     now: datetime | None = None,
 ) -> Literal["idle", "processed"]:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     lease_until = when + timedelta(seconds=lease_seconds)
 
-    with session_factory() as session:
-        with session.begin():
-            job = claim_next_eligible_subber_job(
-                session,
-                lease_owner=lease_owner,
-                lease_expires_at=lease_until,
-                now=when,
-            )
-            if job is None:
-                return "idle"
-            ctx = SubberJobWorkContext(
-                id=job.id,
-                job_kind=job.job_kind,
-                payload_json=job.payload_json,
-                lease_owner=lease_owner,
-            )
+    with session_factory() as session, session.begin():
+        job = claim_next_eligible_subber_job(
+            session,
+            lease_owner=lease_owner,
+            lease_expires_at=lease_until,
+            now=when,
+        )
+        if job is None:
+            return "idle"
+        ctx = SubberJobWorkContext(
+            id=job.id,
+            job_kind=job.job_kind,
+            payload_json=job.payload_json,
+            lease_owner=lease_owner,
+        )
 
     if job_kind_forbidden_on_subber_lane(ctx.job_kind):
         err_text = (
@@ -94,15 +93,14 @@ def process_one_subber_job(
             f"{ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_subber_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_subber_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Subber fail_claimed after cross-lane guard job_id=%s", ctx.id)
         return "processed"
@@ -113,15 +111,14 @@ def process_one_subber_job(
             f"{ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_subber_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_subber_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Subber fail_claimed after subber.* prefix guard job_id=%s", ctx.id)
         return "processed"
@@ -131,15 +128,14 @@ def process_one_subber_job(
         exc: BaseException = SubberNoHandlerForJobKind(ctx.job_kind)
         err_text = str(exc)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_subber_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_subber_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Subber fail_claimed after missing handler job_id=%s", ctx.id)
         return "processed"
@@ -156,15 +152,14 @@ def process_one_subber_job(
             recoverable=False,
         ).message[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    fail_claimed_subber_job(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=err_text,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                fail_claimed_subber_job(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=err_text,
+                    now=when,
+                )
         except Exception:
             logger.exception("Subber fail_claimed_subber_job failed after handler error job_id=%s", ctx.id)
         dispatch_job_notification(session_factory, module="subber", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind)
@@ -173,17 +168,16 @@ def process_one_subber_job(
     complete_ok = True
     complete_err: str | None = None
     try:
-        with session_factory() as session:
-            with session.begin():
-                ok = complete_claimed_subber_job(
-                    session,
-                    job_id=ctx.id,
-                    lease_owner=ctx.lease_owner,
-                    now=when,
-                )
-                if not ok:
-                    complete_ok = False
-                    complete_err = "complete_claimed_subber_job refused (lease/state mismatch)"
+        with session_factory() as session, session.begin():
+            ok = complete_claimed_subber_job(
+                session,
+                job_id=ctx.id,
+                lease_owner=ctx.lease_owner,
+                now=when,
+            )
+            if not ok:
+                complete_ok = False
+                complete_err = "complete_claimed_subber_job refused (lease/state mismatch)"
     except Exception as exc:
         complete_ok = False
         logger.exception("Subber complete_claimed_subber_job failed job_id=%s", ctx.id)
@@ -195,15 +189,14 @@ def process_one_subber_job(
     if not complete_ok and complete_err is not None:
         bounded = (SUBBER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]
         try:
-            with session_factory() as session:
-                with session.begin():
-                    recovered = fail_leased_subber_job_after_complete_failure(
-                        session,
-                        job_id=ctx.id,
-                        lease_owner=ctx.lease_owner,
-                        error_message=bounded,
-                        now=when,
-                    )
+            with session_factory() as session, session.begin():
+                recovered = fail_leased_subber_job_after_complete_failure(
+                    session,
+                    job_id=ctx.id,
+                    lease_owner=ctx.lease_owner,
+                    error_message=bounded,
+                    now=when,
+                )
             if not recovered:
                 logger.warning(
                     "Subber terminalization recovery did not apply job_id=%s owner=%s",

--- a/apps/backend/src/mediamop/platform/activity/live_stream.py
+++ b/apps/backend/src/mediamop/platform/activity/live_stream.py
@@ -61,7 +61,7 @@ class ActivityLatestNotifier:
             self._waiters.setdefault(loop, set()).add(future)
         try:
             return await asyncio.wait_for(future, timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return None
         finally:
             self._discard_waiter(loop, future)

--- a/apps/backend/src/mediamop/platform/activity/service.py
+++ b/apps/backend/src/mediamop/platform/activity/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import desc, event, func, or_, select
 from sqlalchemy.orm import Session
@@ -20,7 +20,7 @@ _BOOTSTRAP_DENIED_SUPPRESS_SECONDS = 60
 
 
 def _utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def record_activity_event(

--- a/apps/backend/src/mediamop/platform/arr_library/arr_v3_http.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_v3_http.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import urllib.error
 import urllib.parse
@@ -80,10 +81,8 @@ class ArrLibraryV3Client:
                 return json.loads(raw.decode("utf-8"))
         except urllib.error.HTTPError as e:
             body = ""
-            try:
+            with contextlib.suppress(Exception):
                 body = e.read().decode("utf-8", errors="replace")[:500]
-            except Exception:
-                pass
             raise ArrLibraryV3HttpError(f"HTTP {e.code}: {body}") from e
 
     def health_ok(self) -> None:

--- a/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
+++ b/apps/backend/src/mediamop/platform/arr_library/operator_settings_api.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from enum import Enum
+import enum
 
 from fastapi import APIRouter, HTTPException, Request
 from starlette import status
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.core.config import MediaMopSettings
+from mediamop.platform.activity import constants as act_c
+from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.arr_library.arr_http_resolve import (
     preview_radarr_http_credentials_after_put,
     preview_sonarr_http_credentials_after_put,
     resolve_radarr_http_credentials,
     resolve_sonarr_http_credentials,
 )
+from mediamop.platform.arr_library.arr_v3_http import ArrLibraryV3Client, ArrLibraryV3HttpError
 from mediamop.platform.arr_library.operator_settings_schemas import (
     ArrLibraryConnectionPutIn,
     ArrLibraryConnectionTestIn,
@@ -32,9 +35,6 @@ from mediamop.platform.arr_library.operator_settings_service import (
     record_connection_test_result_radarr,
     record_connection_test_result_sonarr,
 )
-from mediamop.platform.arr_library.arr_v3_http import ArrLibraryV3Client, ArrLibraryV3HttpError
-from mediamop.platform.activity import constants as act_c
-from mediamop.platform.activity.service import record_activity_event
 from mediamop.platform.auth.authorization import RequireOperatorDep
 from mediamop.platform.auth.csrf import (
     current_raw_session_token,
@@ -47,7 +47,7 @@ from mediamop.platform.auth.deps_auth import UserPublicDep
 router = APIRouter(tags=["arr-library"])
 
 
-class ArrSearchLaneKey(str, Enum):
+class ArrSearchLaneKey(enum.StrEnum):
     """URL path keys for single-lane search preference saves."""
 
     sonarr_missing = "sonarr_missing"

--- a/apps/backend/src/mediamop/platform/arr_library/operator_settings_service.py
+++ b/apps/backend/src/mediamop/platform/arr_library/operator_settings_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 from sqlalchemy.orm import Session
 
@@ -14,7 +14,6 @@ from mediamop.platform.arr_library.arr_http_resolve import (
 )
 from mediamop.platform.arr_library.arr_operator_settings_model import ArrLibraryOperatorSettingsRow
 from mediamop.platform.arr_library.arr_operator_settings_repo import ensure_arr_library_operator_settings_row
-from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
 from mediamop.platform.arr_library.operator_settings_schemas import (
     ArrLibraryConnectionPanelOut,
     ArrLibraryConnectionPutIn,
@@ -23,6 +22,7 @@ from mediamop.platform.arr_library.operator_settings_schemas import (
     ArrLibrarySearchLaneIn,
     ArrLibrarySearchLaneOut,
 )
+from mediamop.platform.arr_library.schedule_csv_validate import normalize_hhmm, validate_schedule_days_csv
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 
 
@@ -228,7 +228,7 @@ def record_connection_test_result_sonarr(
 ) -> None:
     row = ensure_arr_library_operator_settings_row(session)
     row.sonarr_last_connection_test_ok = ok
-    row.sonarr_last_connection_test_at = datetime.now(timezone.utc)
+    row.sonarr_last_connection_test_at = datetime.now(UTC)
     row.sonarr_last_connection_test_detail = detail[:2000] if detail else None
     session.flush()
 
@@ -241,6 +241,6 @@ def record_connection_test_result_radarr(
 ) -> None:
     row = ensure_arr_library_operator_settings_row(session)
     row.radarr_last_connection_test_ok = ok
-    row.radarr_last_connection_test_at = datetime.now(timezone.utc)
+    row.radarr_last_connection_test_at = datetime.now(UTC)
     row.radarr_last_connection_test_detail = detail[:2000] if detail else None
     session.flush()

--- a/apps/backend/src/mediamop/platform/arr_library/schedule_wall_clock.py
+++ b/apps/backend/src/mediamop/platform/arr_library/schedule_wall_clock.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time, timezone
+from datetime import UTC, datetime, time, timezone
 from zoneinfo import ZoneInfo
 
 DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -49,10 +49,7 @@ def schedule_time_window_active(
     except Exception:
         tz = ZoneInfo("UTC")
     cur = now
-    if cur.tzinfo is None:
-        cur = cur.replace(tzinfo=timezone.utc).astimezone(tz)
-    else:
-        cur = cur.astimezone(tz)
+    cur = cur.replace(tzinfo=UTC).astimezone(tz) if cur.tzinfo is None else cur.astimezone(tz)
     day = DAY_NAMES[cur.weekday()]
     allowed_days = _parse_days(schedule_days)
     if day not in allowed_days:

--- a/apps/backend/src/mediamop/platform/auth/bootstrap_status_db.py
+++ b/apps/backend/src/mediamop/platform/auth/bootstrap_status_db.py
@@ -16,9 +16,7 @@ def _is_sqlite_schema_missing_message(text: str) -> bool:
     lower = text.lower()
     if "no such table" in lower:
         return True
-    if "no such column" in lower:
-        return True
-    return False
+    return "no such column" in lower
 
 
 def _is_missing_relation_or_schema(exc: ProgrammingError) -> bool:
@@ -32,9 +30,7 @@ def _is_missing_relation_or_schema(exc: ProgrammingError) -> bool:
     msg = str(exc).lower()
     if "no such table" in msg:
         return True
-    if "does not exist" in msg and "relation" in msg:
-        return True
-    return False
+    return "does not exist" in msg and "relation" in msg
 
 
 _SCHEMA_NOT_READY = "Local SQLite schema is not ready (run alembic upgrade head)."

--- a/apps/backend/src/mediamop/platform/auth/deps_auth.py
+++ b/apps/backend/src/mediamop/platform/auth/deps_auth.py
@@ -7,8 +7,8 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
-from mediamop.core.config import MediaMopSettings
 from mediamop.api.deps import get_db_session, get_settings
+from mediamop.core.config import MediaMopSettings
 from mediamop.platform.auth import service as auth_service
 from mediamop.platform.auth.models import UserRole
 from mediamop.platform.auth.schemas import UserPublic

--- a/apps/backend/src/mediamop/platform/auth/models.py
+++ b/apps/backend/src/mediamop/platform/auth/models.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from mediamop.core.db import Base
 
 
-class UserRole(str, enum.Enum):
+class UserRole(enum.StrEnum):
     """Values persisted in ``users.role`` (VARCHAR) — authorization checks use these strings."""
 
     admin = "admin"
@@ -53,7 +53,7 @@ class User(Base):
         nullable=False,
     )
 
-    sessions: Mapped[list["UserSession"]] = relationship(
+    sessions: Mapped[list[UserSession]] = relationship(
         "UserSession",
         back_populates="user",
         cascade="all, delete-orphan",
@@ -90,4 +90,4 @@ class UserSession(Base):
     )
     revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    user: Mapped["User"] = relationship("User", back_populates="sessions")
+    user: Mapped[User] = relationship("User", back_populates="sessions")

--- a/apps/backend/src/mediamop/platform/auth/rate_limit.py
+++ b/apps/backend/src/mediamop/platform/auth/rate_limit.py
@@ -11,7 +11,6 @@ import logging
 import threading
 import time
 from collections import OrderedDict, deque
-from typing import Deque
 
 logger = logging.getLogger(__name__)
 _forwarded_without_trust_warned = False
@@ -33,7 +32,7 @@ class SlidingWindowLimiter:
         self.max_keys = max_keys
         self.window_seconds = float(window_seconds)
         self._lock = threading.Lock()
-        self._buckets: OrderedDict[str, Deque[float]] = OrderedDict()
+        self._buckets: OrderedDict[str, deque[float]] = OrderedDict()
 
     def allow(self, key: str) -> bool:
         """Record one event for ``key``. Return True if allowed, False if limited."""

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -9,6 +9,9 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.platform.activity import constants as activity_constants
+from mediamop.platform.activity import service as activity_service
+from mediamop.platform.auth import bootstrap as bootstrap_service
 from mediamop.platform.auth import schemas
 from mediamop.platform.auth import service as auth_service
 from mediamop.platform.auth.abuse import (
@@ -16,7 +19,6 @@ from mediamop.platform.auth.abuse import (
     raise_if_login_rate_limited,
 )
 from mediamop.platform.auth.authorization import RequireAdminDep
-from mediamop.platform.auth import bootstrap as bootstrap_service
 from mediamop.platform.auth.bootstrap_status_db import (
     raise_http_for_bootstrap_status_db,
     raise_http_for_bootstrap_status_sqlalchemy,
@@ -28,8 +30,6 @@ from mediamop.platform.auth.csrf import (
     validate_browser_post_origin,
     verify_csrf_token,
 )
-from mediamop.platform.activity import constants as activity_constants
-from mediamop.platform.activity import service as activity_service
 from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
 

--- a/apps/backend/src/mediamop/platform/auth/service.py
+++ b/apps/backend/src/mediamop/platform/auth/service.py
@@ -25,10 +25,10 @@ from mediamop.platform.auth.sessions import (
     effective_idle_timeout,
     generate_raw_session_token,
     hash_session_token,
+    revoke_session,
     session_invalid_reason,
     touch_last_seen,
     utcnow,
-    revoke_session,
 )
 
 logger = logging.getLogger(__name__)

--- a/apps/backend/src/mediamop/platform/auth/session_cleanup.py
+++ b/apps/backend/src/mediamop/platform/auth/session_cleanup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -22,10 +23,8 @@ async def _session_cleanup_loop(
     interval_seconds: float = _INTERVAL_SECONDS,
 ) -> None:
     while not stop_event.is_set():
-        try:
+        with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
-        except TimeoutError:
-            pass
         if stop_event.is_set():
             break
         try:
@@ -54,7 +53,5 @@ def start_session_cleanup_task(
 
 async def stop_session_cleanup_task(task: asyncio.Task) -> None:
     task.cancel()
-    try:
+    with contextlib.suppress(asyncio.CancelledError):
         await task
-    except asyncio.CancelledError:
-        pass

--- a/apps/backend/src/mediamop/platform/auth/sessions.py
+++ b/apps/backend/src/mediamop/platform/auth/sessions.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from mediamop.core.datetime_util import as_utc
 from mediamop.platform.auth.models import UserSession
@@ -40,7 +40,7 @@ def hash_session_token(raw_token: str) -> str:
 
 
 def utcnow() -> datetime:
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def compute_absolute_expiry(
@@ -96,9 +96,7 @@ def session_is_valid(
         return False
     if is_past_absolute_expiry(session_row, now=n):
         return False
-    if is_idle_expired(session_row, idle=idle, now=n):
-        return False
-    return True
+    return not is_idle_expired(session_row, idle=idle, now=n)
 
 
 def session_invalid_reason(

--- a/apps/backend/src/mediamop/platform/configuration_bundle/service.py
+++ b/apps/backend/src/mediamop/platform/configuration_bundle/service.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any, TypeVar, cast
 
 from sqlalchemy import DateTime, delete, inspect, select
-from sqlalchemy.orm import Mapper
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Mapper, Session
 
 from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
 from mediamop.modules.pruner.pruner_server_instance_model import PrunerServerInstance
@@ -27,7 +26,7 @@ T = TypeVar("T")
 
 def _serialize_cell(value: Any) -> Any:
     if isinstance(value, datetime):
-        return value.astimezone(timezone.utc).isoformat()
+        return value.astimezone(UTC).isoformat()
     return value
 
 

--- a/apps/backend/src/mediamop/platform/file_lifecycle/__init__.py
+++ b/apps/backend/src/mediamop/platform/file_lifecycle/__init__.py
@@ -7,7 +7,12 @@ from mediamop.platform.file_lifecycle.guardrails import (
     mb_to_bytes,
     nearest_existing_parent,
 )
-from mediamop.platform.file_lifecycle.mutations import FileLifecycleError, safe_copy_to_final, safe_finalize_file, safe_unlink
+from mediamop.platform.file_lifecycle.mutations import (
+    FileLifecycleError,
+    safe_copy_to_final,
+    safe_finalize_file,
+    safe_unlink,
+)
 
 __all__ = [
     "DiskSpaceCheck",

--- a/apps/backend/src/mediamop/platform/file_lifecycle/guardrails.py
+++ b/apps/backend/src/mediamop/platform/file_lifecycle/guardrails.py
@@ -6,7 +6,6 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
-
 BYTES_PER_MIB = 1024 * 1024
 
 

--- a/apps/backend/src/mediamop/platform/http/request_context.py
+++ b/apps/backend/src/mediamop/platform/http/request_context.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import time
 import logging
+import time
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from uuid import uuid4

--- a/apps/backend/src/mediamop/platform/jobs/job_rows_retention_periodic.py
+++ b/apps/backend/src/mediamop/platform/jobs/job_rows_retention_periodic.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy import delete
 from sqlalchemy.orm import Session, sessionmaker
@@ -66,10 +66,9 @@ def prune_job_rows(session: Session, *, cutoff: datetime) -> dict[str, int]:
 
 
 def _run_prune_tick(session_factory: sessionmaker[Session], *, settings: MediaMopSettings) -> dict[str, int]:
-    cutoff = datetime.now(timezone.utc) - timedelta(days=settings.job_rows_retention_days)
-    with session_factory() as session:
-        with session.begin():
-            counts = prune_job_rows(session, cutoff=cutoff)
+    cutoff = datetime.now(UTC) - timedelta(days=settings.job_rows_retention_days)
+    with session_factory() as session, session.begin():
+        counts = prune_job_rows(session, cutoff=cutoff)
     return counts
 
 

--- a/apps/backend/src/mediamop/platform/jobs/startup_recovery.py
+++ b/apps/backend/src/mediamop/platform/jobs/startup_recovery.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any
 
 from sqlalchemy import select
@@ -56,7 +56,7 @@ def recover_incomplete_jobs_after_startup(session: Session, *, now: datetime | N
     lease timestamps.
     """
 
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     rr, rf = _recover_table(
         session,
         model=RefinerJob,

--- a/apps/backend/src/mediamop/platform/notifications/dispatch.py
+++ b/apps/backend/src/mediamop/platform/notifications/dispatch.py
@@ -6,12 +6,13 @@ daemon thread. The thread is not joined — callers do not wait.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import threading
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -42,7 +43,7 @@ def _build_webhook_payload(
             "job_kind": job_kind,
             "title": title,
             "detail": detail,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "app": "MediaMop",
         }
     ).encode()
@@ -62,7 +63,7 @@ def _build_discord_payload(*, title: str, detail: str, event: str, module: str, 
                         {"name": "Job ID", "value": str(job_id), "inline": True},
                     ],
                     "footer": {"text": "MediaMop"},
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "timestamp": datetime.now(UTC).isoformat(),
                 }
             ]
         }
@@ -101,7 +102,7 @@ def _post_one(channel: NotificationChannel, *, title: str, detail: str, event: s
         )
 
 
-def _is_permanently_failed(session: "Session", module: str, job_id: int) -> bool:
+def _is_permanently_failed(session: Session, module: str, job_id: int) -> bool:
     """Return True only when the job row has status='failed' (exhausted retries)."""
     from sqlalchemy import text  # local import avoids circular at module level
 
@@ -119,7 +120,7 @@ def _is_permanently_failed(session: "Session", module: str, job_id: int) -> bool
 
 
 def _dispatch_thread(
-    session: "Session",
+    session: Session,
     *,
     event: str,
     module: str,
@@ -144,10 +145,8 @@ def _dispatch_thread(
         session.close()
     except Exception:
         logger.warning("Notification dispatch: failed to read channels for event=%s", event, exc_info=True)
-        try:
+        with contextlib.suppress(Exception):
             session.close()
-        except Exception:
-            pass
         return
 
     for channel in channels:
@@ -155,7 +154,7 @@ def _dispatch_thread(
 
 
 def dispatch_job_notification(
-    session_factory: "sessionmaker[Session]",
+    session_factory: sessionmaker[Session],
     *,
     module: str,
     event_kind: str,

--- a/apps/backend/src/mediamop/platform/observability/diagnostics.py
+++ b/apps/backend/src/mediamop/platform/observability/diagnostics.py
@@ -8,10 +8,9 @@ operator-readable reasons/next actions instead of raw exception-only messages.
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Mapping
-
 
 SECRET_FIELD_FRAGMENTS = ("api_key", "apikey", "authorization", "cookie", "password", "secret", "token")
 SECRET_ASSIGNMENT_RE = re.compile(

--- a/apps/backend/src/mediamop/platform/observability/operator_messages.py
+++ b/apps/backend/src/mediamop/platform/observability/operator_messages.py
@@ -12,7 +12,6 @@ from mediamop.platform.observability.diagnostics import (
     severity_for_result,
 )
 
-
 PROVIDER_LABELS = {
     "emby": "Emby",
     "jellyfin": "Jellyfin",

--- a/apps/backend/src/mediamop/platform/suite_settings/logs_retention_periodic.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/logs_retention_periodic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -31,14 +31,13 @@ def run_log_retention_tick(
     now: datetime | None = None,
 ) -> int:
     global _last_prune_at
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
+        when = when.replace(tzinfo=UTC)
     if _last_prune_at is not None and (when - _last_prune_at).total_seconds() < LOG_RETENTION_MIN_RUN_INTERVAL_SECONDS:
         return 0
-    with session_factory() as session:
-        with session.begin():
-            prune_logs_for_retention(session, settings)
+    with session_factory() as session, session.begin():
+        prune_logs_for_retention(session, settings)
     _last_prune_at = when
     return 1
 

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, RedirectResponse
@@ -19,11 +19,13 @@ from mediamop.platform.auth.csrf import (
 )
 from mediamop.platform.auth.deps_auth import UserPublicDep
 from mediamop.platform.configuration_bundle.service import apply_configuration_bundle, build_configuration_bundle
+from mediamop.platform.metrics.service import build_runtime_metrics_summary
+from mediamop.platform.suite_settings.logs_service import prune_log_file, read_suite_logs
+from mediamop.platform.suite_settings.operational_history import reset_operational_history
 from mediamop.platform.suite_settings.schemas import (
     ConfigurationBundleImportIn,
     SuiteConfigurationBackupItemOut,
     SuiteConfigurationBackupListOut,
-    SuiteUpdateDiagnosticsOut,
     SuiteLogCountsOut,
     SuiteLogEntryOut,
     SuiteLogsOut,
@@ -34,15 +36,17 @@ from mediamop.platform.suite_settings.schemas import (
     SuiteSecurityOverviewOut,
     SuiteSettingsOut,
     SuiteSettingsPutIn,
+    SuiteUpdateDiagnosticsOut,
     SuiteUpdateStartIn,
     SuiteUpdateStartOut,
     SuiteUpdateStatusOut,
 )
-from mediamop.platform.metrics.service import build_runtime_metrics_summary
-from mediamop.platform.suite_settings.operational_history import reset_operational_history
 from mediamop.platform.suite_settings.security_overview import build_suite_security_overview
-from mediamop.platform.suite_settings.logs_service import prune_log_file, read_suite_logs
-from mediamop.platform.suite_settings.service import apply_suite_settings_put, build_suite_settings_out, ensure_suite_settings_row
+from mediamop.platform.suite_settings.service import (
+    apply_suite_settings_put,
+    build_suite_settings_out,
+    ensure_suite_settings_row,
+)
 from mediamop.platform.suite_settings.suite_configuration_backup_service import (
     get_suite_configuration_backup_file_path,
     list_suite_configuration_backups,

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -180,7 +179,7 @@ class SuiteUpdateStatusOut(BaseModel):
     docker_update_command: str | None = None
     in_app_upgrade_supported: bool = False
     in_app_upgrade_summary: str | None = None
-    upgrade: "SuiteUpgradeProgressOut | None" = None
+    upgrade: SuiteUpgradeProgressOut | None = None
 
 
 class SuiteUpdateStartOut(BaseModel):

--- a/apps/backend/src/mediamop/platform/suite_settings/service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/service.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from datetime import time
-from zoneinfo import ZoneInfo
-from zoneinfo import ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, time, timezone, tzinfo
+from datetime import UTC, datetime, time, timezone, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session, sessionmaker
@@ -34,45 +34,44 @@ def run_suite_configuration_backup_tick(
     settings: MediaMopSettings,
     now: datetime | None = None,
 ) -> int:
-    when = now if now is not None else datetime.now(timezone.utc)
+    when = now if now is not None else datetime.now(UTC)
     if when.tzinfo is None:
-        when = when.replace(tzinfo=timezone.utc)
-    with session_factory() as session:
-        with session.begin():
-            suite = ensure_suite_settings_row(session)
-            if not bool(getattr(suite, "configuration_backup_enabled", False)):
+        when = when.replace(tzinfo=UTC)
+    with session_factory() as session, session.begin():
+        suite = ensure_suite_settings_row(session)
+        if not bool(getattr(suite, "configuration_backup_enabled", False)):
+            return 0
+        hours = int(getattr(suite, "configuration_backup_interval_hours", 24) or 24)
+        interval_seconds = max(3600, min(30 * 24 * 3600, hours * 3600))
+        last = getattr(suite, "configuration_backup_last_run_at", None)
+        tz_name = str(getattr(suite, "app_timezone", "") or "UTC").strip() or "UTC"
+        app_tz: tzinfo
+        try:
+            app_tz = ZoneInfo(tz_name)
+        except ZoneInfoNotFoundError:
+            app_tz = UTC
+        preferred_time = _preferred_backup_time(getattr(suite, "configuration_backup_preferred_time", None))
+        local_now = when.astimezone(app_tz)
+        local_target = local_now.replace(
+            hour=preferred_time.hour,
+            minute=preferred_time.minute,
+            second=0,
+            microsecond=0,
+        )
+        if last is not None:
+            last_at = last if last.tzinfo else last.replace(tzinfo=UTC)
+            if (when - last_at).total_seconds() < float(interval_seconds):
                 return 0
-            hours = int(getattr(suite, "configuration_backup_interval_hours", 24) or 24)
-            interval_seconds = max(3600, min(30 * 24 * 3600, hours * 3600))
-            last = getattr(suite, "configuration_backup_last_run_at", None)
-            tz_name = str(getattr(suite, "app_timezone", "") or "UTC").strip() or "UTC"
-            app_tz: tzinfo
-            try:
-                app_tz = ZoneInfo(tz_name)
-            except ZoneInfoNotFoundError:
-                app_tz = timezone.utc
-            preferred_time = _preferred_backup_time(getattr(suite, "configuration_backup_preferred_time", None))
-            local_now = when.astimezone(app_tz)
-            local_target = local_now.replace(
-                hour=preferred_time.hour,
-                minute=preferred_time.minute,
-                second=0,
-                microsecond=0,
-            )
-            if last is not None:
-                last_at = last if last.tzinfo else last.replace(tzinfo=timezone.utc)
-                if (when - last_at).total_seconds() < float(interval_seconds):
+            if hours >= 24:
+                last_local = last_at.astimezone(app_tz)
+                if last_local.date() == local_now.date():
                     return 0
-                if hours >= 24:
-                    last_local = last_at.astimezone(app_tz)
-                    if last_local.date() == local_now.date():
-                        return 0
-            if hours >= 24 and local_now < local_target:
-                return 0
-            create_suite_configuration_backup(session, settings=settings)
-            suite.configuration_backup_last_run_at = when
-            session.flush()
-            return 1
+        if hours >= 24 and local_now < local_target:
+            return 0
+        create_suite_configuration_backup(session, settings=settings)
+        suite.configuration_backup_last_run_at = when
+        session.flush()
+        return 1
 
 
 async def _run_suite_configuration_backup_forever(

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 from sqlalchemy import select
@@ -57,7 +58,7 @@ def get_suite_configuration_backup_file_path(
 def create_suite_configuration_backup(session: Session, *, settings: MediaMopSettings) -> SuiteConfigurationBackupRow:
     backup_root = _backup_dir(settings)
     backup_root.mkdir(parents=True, exist_ok=True)
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     bundle = build_configuration_bundle(session)
     stamp = now.strftime("%Y%m%d-%H%M%S")
     fname = f"suite-configuration-{stamp}.json"
@@ -92,16 +93,12 @@ def _prune_old_backups(session: Session, *, settings: MediaMopSettings) -> None:
     backup_root = _backup_dir(settings)
     keep_names = {r.file_name for r in keep}
     for r in drop:
-        try:
+        with contextlib.suppress(OSError):
             (backup_root / r.file_name).unlink(missing_ok=True)
-        except OSError:
-            pass
         session.delete(r)
     # Clean up orphan files too.
     if backup_root.is_dir():
         for p in backup_root.glob("suite-configuration-*.json"):
             if p.name not in keep_names:
-                try:
+                with contextlib.suppress(OSError):
                     p.unlink(missing_ok=True)
-                except OSError:
-                    pass

--- a/apps/backend/src/mediamop/version.py
+++ b/apps/backend/src/mediamop/version.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 import sys
 import tomllib
-import logging
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-
 
 _DIST_INFO_RE = re.compile(r"^mediamop_backend-(?P<version>\d+(?:\.\d+)*)(?:[^\d].*)?\.dist-info$")
 logger = logging.getLogger(__name__)

--- a/apps/backend/src/mediamop/windows/tray_app.py
+++ b/apps/backend/src/mediamop/windows/tray_app.py
@@ -8,6 +8,7 @@ external-drive access.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import ctypes
 import os
 import secrets
@@ -23,8 +24,9 @@ from pathlib import Path
 from typing import Any
 
 import uvicorn
-from alembic import command
 from alembic.config import Config
+
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.version import __version__
 
@@ -40,9 +42,8 @@ def _append_fallback_log(message: str) -> None:
     path = _fallback_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)
     timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-    with _LOG_LOCK:
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(f"[{timestamp}] {message}\n")
+    with _LOG_LOCK, path.open("a", encoding="utf-8") as handle:
+        handle.write(f"[{timestamp}] {message}\n")
 
 
 def _resource_root() -> Path:
@@ -99,10 +100,8 @@ def _write_private_runtime_token(path: Path, value: str) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(value)
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(path, 0o600)
-        except OSError:
-            pass
 
 
 def _prepare_environment(resource_root: Path, runtime_home: Path) -> Path:
@@ -217,10 +216,8 @@ def _wait_for_health(
         except (OSError, http.client.HTTPException):
             time.sleep(0.25)
         finally:
-            try:
+            with contextlib.suppress(Exception):
                 conn.close()
-            except Exception:
-                pass
     raise RuntimeError("MediaMop did not start listening on localhost in time.")
 
 
@@ -265,9 +262,8 @@ class _MediaMopTrayApp:
 
     def _log(self, message: str) -> None:
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S")
-        with _LOG_LOCK:
-            with self._log_path.open("a", encoding="utf-8") as handle:
-                handle.write(f"[{timestamp}] {message}\n")
+        with _LOG_LOCK, self._log_path.open("a", encoding="utf-8") as handle:
+            handle.write(f"[{timestamp}] {message}\n")
 
     def _open_browser_with_debounce(self, *, source: str) -> None:
         now = time.monotonic()
@@ -363,14 +359,10 @@ class _MediaMopTrayApp:
                         time.sleep(3.0)
                         continue
                     self._log(f"Bundled server host exited unexpectedly with code {exit_code}")
-                    try:
+                    with contextlib.suppress(Exception):
                         self._icon.notify("MediaMop server stopped unexpectedly. Please restart MediaMop.")
-                    except Exception:
-                        pass
-                    try:
+                    with contextlib.suppress(Exception):
                         self._icon.title = "MediaMop (stopped)"
-                    except Exception:
-                        pass
                     return
 
             threading.Thread(

--- a/apps/backend/src/mediamop/windows/updater_service.py
+++ b/apps/backend/src/mediamop/windows/updater_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
 import os
@@ -94,13 +95,13 @@ def _install_root() -> Path:
     if getattr(sys, "frozen", False) and os.name == "nt":
         resolved = _host_path(sys.executable).resolve().parent
         marker = f"frozen:{resolved}"
-        if _LAST_INSTALL_ROOT_LOGGED != marker:
+        if marker != _LAST_INSTALL_ROOT_LOGGED:
             _append_service_log(f"updater_service._install_root resolved to {resolved} (frozen)")
             _LAST_INSTALL_ROOT_LOGGED = marker
         return resolved
     resolved = _runtime_home()
     marker = f"unfrozen:{resolved}"
-    if _LAST_INSTALL_ROOT_LOGGED != marker:
+    if marker != _LAST_INSTALL_ROOT_LOGGED:
         _append_service_log(f"updater_service._install_root resolved to {resolved} (unfrozen)")
         _LAST_INSTALL_ROOT_LOGGED = marker
     return resolved
@@ -1034,10 +1035,8 @@ def _write_private_token(path: Path, value: str) -> None:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
             handle.write(value)
     finally:
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(path, 0o600)
-        except OSError:
-            pass
 
 
 def _load_or_create_token() -> str:
@@ -1883,10 +1882,8 @@ def _reconcile_attempt_worker(attempt_id: str) -> None:
         )
     finally:
         if _RECONCILE_LOCK.locked():
-            try:
+            with contextlib.suppress(RuntimeError):
                 _RECONCILE_LOCK.release()
-            except RuntimeError:
-                pass
 
 
 def _maybe_reconcile_pending_attempt() -> None:

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -7,10 +7,10 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from starlette.testclient import TestClient
 
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.platform.jobs.worker_health import reset_worker_health_for_tests
 from tests.integration_helpers import seed_admin_user, seed_viewer_user

--- a/apps/backend/tests/integration_helpers.py
+++ b/apps/backend/tests/integration_helpers.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
-from mediamop.platform.auth.models import User, UserSession, UserRole
+from mediamop.platform.auth.models import User, UserRole, UserSession
 from mediamop.platform.auth.password import hash_password
 
 

--- a/apps/backend/tests/test_activity_stream.py
+++ b/apps/backend/tests/test_activity_stream.py
@@ -3,25 +3,26 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
-from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 from starlette.testclient import TestClient
 
-from mediamop.api.factory import create_app
 from mediamop.api.deps import get_db_session
+from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.activity import constants as activity_constants
-from mediamop.platform.activity.models import ActivityEvent
-from mediamop.platform.activity.live_stream import activity_latest_notifier
 from mediamop.platform.activity import service as activity_service
+from mediamop.platform.activity.live_stream import activity_latest_notifier
+from mediamop.platform.activity.models import ActivityEvent
 from mediamop.platform.activity.router import get_activity_stream, iter_activity_latest_sse
 from mediamop.platform.suite_settings.service import ensure_suite_settings_row
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _seed_activity_row(*, title: str) -> int:
@@ -96,7 +97,7 @@ def test_record_activity_event_does_not_prune_history_using_log_retention() -> N
             module="refiner",
             title="Old Refiner result that still backs overview history",
             detail="{}",
-            created_at=datetime.now(timezone.utc) - timedelta(days=10),
+            created_at=datetime.now(UTC) - timedelta(days=10),
         )
         db.add(old)
         db.flush()
@@ -192,7 +193,7 @@ async def test_activity_stream_authenticated_emits_latest_format(client_with_adm
         "type": "http",
         "method": "GET",
         "path": "/api/v1/activity/stream",
-        "headers": [(b"cookie", f"{cookie_name}={raw}".encode("utf-8"))],
+        "headers": [(b"cookie", f"{cookie_name}={raw}".encode())],
         "app": app,
     }
 

--- a/apps/backend/tests/test_alembic_revision_startup.py
+++ b/apps/backend/tests/test_alembic_revision_startup.py
@@ -6,14 +6,18 @@ from pathlib import Path
 
 import pytest
 import sqlalchemy as sa
-from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
 from alembic.script import ScriptDirectory
 from starlette.testclient import TestClient
 
+from alembic import command
 from mediamop.api.factory import create_app
-from mediamop.core.alembic_revision_check import DatabaseSchemaMismatch, _script_and_head, ensure_database_at_application_head
+from mediamop.core.alembic_revision_check import (
+    DatabaseSchemaMismatch,
+    _script_and_head,
+    ensure_database_at_application_head,
+)
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine
 
@@ -79,9 +83,8 @@ def test_api_startup_fails_without_migrations(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setenv("MEDIAMOP_HOME", str(isolated))
     MediaMopSettings.load()
 
-    with pytest.raises(DatabaseSchemaMismatch) as excinfo:
-        with TestClient(create_app()):
-            pass
+    with pytest.raises(DatabaseSchemaMismatch) as excinfo, TestClient(create_app()):
+        pass
     assert excinfo.value.kind == "unversioned"
 
 

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,6 +13,7 @@ from starlette.testclient import TestClient
 
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.datetime_util import as_utc
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.activity import constants as activity_constants
 from mediamop.platform.activity.models import ActivityEvent
@@ -20,8 +21,8 @@ from mediamop.platform.auth import service as auth_service
 from mediamop.platform.auth.models import User, UserRole, UserSession
 from mediamop.platform.auth.password import hash_password
 from mediamop.platform.auth.sessions import revoke_session
-from mediamop.core.datetime_util import as_utc
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, reset_user_tables, seed_admin_user
+from tests.integration_helpers import auth_post, reset_user_tables, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def test_login_me_logout_flow(client_with_admin: TestClient) -> None:
@@ -413,15 +414,14 @@ def test_session_limit_ignores_absolute_expired_sessions() -> None:
     settings = MediaMopSettings.load()
     eng = create_db_engine(settings)
     fac = create_session_factory(eng)
-    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
-        with fac() as db:
-            user = db.scalars(select(User).where(User.username == "alice")).one()
-            for _ in range(5):
-                row, _raw = auth_service.create_user_session(db, user, settings=settings)
-                row.absolute_expires_at = base - timedelta(seconds=1)
-            live, _raw = auth_service.create_user_session(db, user, settings=settings)
-            db.commit()
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC)
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base), fac() as db:
+        user = db.scalars(select(User).where(User.username == "alice")).one()
+        for _ in range(5):
+            row, _raw = auth_service.create_user_session(db, user, settings=settings)
+            row.absolute_expires_at = base - timedelta(seconds=1)
+        live, _raw = auth_service.create_user_session(db, user, settings=settings)
+        db.commit()
 
     with fac() as db:
         live_row = db.get(UserSession, live.id)
@@ -758,15 +758,14 @@ def test_load_valid_session_throttles_last_seen_persistence(monkeypatch: pytest.
     settings = MediaMopSettings.load()
     eng = create_db_engine(settings)
     fac = create_session_factory(eng)
-    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC)
     sid: int
     raw: str
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
-        with fac() as db:
-            user = db.scalars(select(User).where(User.username == "alice")).one()
-            row, raw = auth_service.create_user_session(db, user, settings=settings)
-            sid = row.id
-            db.commit()
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base), fac() as db:
+        user = db.scalars(select(User).where(User.username == "alice")).one()
+        row, raw = auth_service.create_user_session(db, user, settings=settings)
+        sid = row.id
+        db.commit()
 
     def read_last_seen() -> datetime:
         with fac() as db:
@@ -779,20 +778,18 @@ def test_load_valid_session_throttles_last_seen_persistence(monkeypatch: pytest.
     with patch(
         "mediamop.platform.auth.service.utcnow",
         return_value=base + timedelta(seconds=30),
-    ):
-        with fac() as db:
-            pair = auth_service.load_valid_session_for_request(db, raw, settings)
-            assert pair is not None
-            db.commit()
+    ), fac() as db:
+        pair = auth_service.load_valid_session_for_request(db, raw, settings)
+        assert pair is not None
+        db.commit()
 
     assert read_last_seen() == base
 
     later = base + timedelta(seconds=61)
-    with patch("mediamop.platform.auth.service.utcnow", return_value=later):
-        with fac() as db:
-            pair = auth_service.load_valid_session_for_request(db, raw, settings)
-            assert pair is not None
-            db.commit()
+    with patch("mediamop.platform.auth.service.utcnow", return_value=later), fac() as db:
+        pair = auth_service.load_valid_session_for_request(db, raw, settings)
+        assert pair is not None
+        db.commit()
 
     assert read_last_seen() == later
 
@@ -803,19 +800,17 @@ def test_expired_session_is_rejected_and_revoked(monkeypatch: pytest.MonkeyPatch
     settings = MediaMopSettings.load()
     eng = create_db_engine(settings)
     fac = create_session_factory(eng)
-    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC)
 
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
-        with fac() as db:
-            user = db.scalars(select(User).where(User.username == "alice")).one()
-            row, raw = auth_service.create_user_session(db, user, settings=settings)
-            sid = row.id
-            db.commit()
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base), fac() as db:
+        user = db.scalars(select(User).where(User.username == "alice")).one()
+        row, raw = auth_service.create_user_session(db, user, settings=settings)
+        sid = row.id
+        db.commit()
 
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base + timedelta(days=settings.session_absolute_days + 1)):
-        with fac() as db:
-            pair = auth_service.load_valid_session_for_request(db, raw, settings)
-            db.commit()
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base + timedelta(days=settings.session_absolute_days + 1)), fac() as db:
+        pair = auth_service.load_valid_session_for_request(db, raw, settings)
+        db.commit()
 
     assert pair is None
     with fac() as db:
@@ -830,17 +825,16 @@ def test_session_cleanup_deletes_revoked_and_expired_sessions(monkeypatch: pytes
     settings = MediaMopSettings.load()
     eng = create_db_engine(settings)
     fac = create_session_factory(eng)
-    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    base = datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC)
 
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base):
-        with fac() as db:
-            user = db.scalars(select(User).where(User.username == "alice")).one()
-            revoked, _ = auth_service.create_user_session(db, user, settings=settings)
-            expired, _ = auth_service.create_user_session(db, user, settings=settings)
-            active, _ = auth_service.create_user_session(db, user, settings=settings)
-            revoke_session(revoked, at=base)
-            expired.absolute_expires_at = base - timedelta(seconds=1)
-            db.commit()
+    with patch("mediamop.platform.auth.service.utcnow", return_value=base), fac() as db:
+        user = db.scalars(select(User).where(User.username == "alice")).one()
+        revoked, _ = auth_service.create_user_session(db, user, settings=settings)
+        expired, _ = auth_service.create_user_session(db, user, settings=settings)
+        active, _ = auth_service.create_user_session(db, user, settings=settings)
+        revoke_session(revoked, at=base)
+        expired.absolute_expires_at = base - timedelta(seconds=1)
+        db.commit()
 
     with fac() as db:
         removed = auth_service.cleanup_inactive_sessions(db, settings=settings, now=base)

--- a/apps/backend/tests/test_auth_service.py
+++ b/apps/backend/tests/test_auth_service.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from mediamop.platform.auth import service
 from mediamop.platform.auth import bootstrap as bootstrap_service
+from mediamop.platform.auth import service
 from mediamop.platform.auth.password import DUMMY_PASSWORD_HASH
 
 

--- a/apps/backend/tests/test_configuration_bundle_api.py
+++ b/apps/backend/tests/test_configuration_bundle_api.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from copy import deepcopy
+
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import tempfile
+from pathlib import Path
 
 import pytest
 from starlette.requests import Request

--- a/apps/backend/tests/test_dashboard_status.py
+++ b/apps/backend/tests/test_dashboard_status.py
@@ -7,7 +7,8 @@ from starlette.testclient import TestClient
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.dashboard.service import build_dashboard_status
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _session_factory():

--- a/apps/backend/tests/test_docker_onboarding_files.py
+++ b/apps/backend/tests/test_docker_onboarding_files.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 

--- a/apps/backend/tests/test_end_to_end_workflows.py
+++ b/apps/backend/tests/test_end_to_end_workflows.py
@@ -2,17 +2,17 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.pruner.pruner_constants import MEDIA_SCOPE_MOVIES, RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED
@@ -28,9 +28,9 @@ from mediamop.modules.pruner.pruner_overview_stats_service import build_pruner_o
 from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
 from mediamop.modules.pruner.worker_loop import process_one_pruner_job
 from mediamop.modules.refiner.file_remux_pass import run as refiner_run
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_handlers
 from mediamop.modules.refiner.refiner_operator_settings_model import RefinerOperatorSettingsRow
 from mediamop.modules.refiner.refiner_overview_stats_service import build_refiner_overview_stats
@@ -96,33 +96,32 @@ def test_refiner_file_reaches_output_cleanup_and_stats(
     source = release / "movie.mkv"
     source.write_bytes(b"x" * 2048)
 
-    with isolated_session_factory() as session:
-        with session.begin():
-            session.merge(
-                RefinerPathSettingsRow(
-                    id=1,
-                    refiner_watched_folder=str(watched),
-                    refiner_work_folder=str(work),
-                    refiner_output_folder=str(output),
-                ),
-            )
-            session.merge(
-                RefinerOperatorSettingsRow(
-                    id=1,
-                    min_file_age_seconds=0,
-                    refiner_min_input_file_size_mb=0,
-                    minimum_free_disk_space_mb=1,
-                ),
-            )
-            refiner_enqueue_or_get_job(
-                session,
-                dedupe_key="e2e-refiner-copy-cleanup",
-                job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
-                payload_json=json.dumps(
-                    {"relative_media_path": "Movie.Release/movie.mkv", "media_scope": "movie"},
-                    separators=(",", ":"),
-                ),
-            )
+    with isolated_session_factory() as session, session.begin():
+        session.merge(
+            RefinerPathSettingsRow(
+                id=1,
+                refiner_watched_folder=str(watched),
+                refiner_work_folder=str(work),
+                refiner_output_folder=str(output),
+            ),
+        )
+        session.merge(
+            RefinerOperatorSettingsRow(
+                id=1,
+                min_file_age_seconds=0,
+                refiner_min_input_file_size_mb=0,
+                minimum_free_disk_space_mb=1,
+            ),
+        )
+        refiner_enqueue_or_get_job(
+            session,
+            dedupe_key="e2e-refiner-copy-cleanup",
+            job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
+            payload_json=json.dumps(
+                {"relative_media_path": "Movie.Release/movie.mkv", "media_scope": "movie"},
+                separators=(",", ":"),
+            ),
+        )
 
     monkeypatch.setattr(refiner_run, "ffprobe_json", lambda path, mediamop_home, **kwargs: _fake_probe())
     monkeypatch.setattr(refiner_run, "resolve_ffprobe_ffmpeg", lambda *, mediamop_home: ("ffprobe", "ffmpeg"))
@@ -134,7 +133,7 @@ def test_refiner_file_reaches_output_cleanup_and_stats(
             isolated_session_factory,
             lease_owner="pytest-refiner",
             job_handlers=handlers,
-            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            now=datetime(2026, 1, 1, tzinfo=UTC),
         )
         == "processed"
     )
@@ -160,31 +159,30 @@ def test_pruner_preview_apply_reaches_terminal_state_and_stats(
     settings = replace(MediaMopSettings.load(), pruner_apply_enabled=True)
     deleted: list[str] = []
 
-    with isolated_session_factory() as session:
-        with session.begin():
-            inst = create_server_instance(
-                session,
-                settings,
-                provider="plex",
-                display_name="Living room",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "plex-token"},
-            )
-            server_instance_id = int(inst.id)
-            pruner_enqueue_or_get_job(
-                session,
-                dedupe_key="e2e-pruner-preview",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                payload_json=json.dumps(
-                    {
-                        "server_instance_id": server_instance_id,
-                        "media_scope": MEDIA_SCOPE_MOVIES,
-                        "rule_family_id": RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                        "trigger": "manual",
-                    },
-                    separators=(",", ":"),
-                ),
-            )
+    with isolated_session_factory() as session, session.begin():
+        inst = create_server_instance(
+            session,
+            settings,
+            provider="plex",
+            display_name="Living room",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "plex-token"},
+        )
+        server_instance_id = int(inst.id)
+        pruner_enqueue_or_get_job(
+            session,
+            dedupe_key="e2e-pruner-preview",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            payload_json=json.dumps(
+                {
+                    "server_instance_id": server_instance_id,
+                    "media_scope": MEDIA_SCOPE_MOVIES,
+                    "rule_family_id": RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+                    "trigger": "manual",
+                },
+                separators=(",", ":"),
+            ),
+        )
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_preview_job_handler.preview_payload_json",
@@ -202,7 +200,7 @@ def test_pruner_preview_apply_reaches_terminal_state_and_stats(
             isolated_session_factory,
             lease_owner="pytest-pruner-preview",
             job_handlers=handlers,
-            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            now=datetime(2026, 1, 1, tzinfo=UTC),
         )
         == "processed"
     )
@@ -237,7 +235,7 @@ def test_pruner_preview_apply_reaches_terminal_state_and_stats(
             isolated_session_factory,
             lease_owner="pytest-pruner-apply",
             job_handlers=handlers,
-            now=datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+            now=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
         )
         == "processed"
     )
@@ -263,36 +261,35 @@ def test_subber_search_downloads_subtitle_and_updates_stats(
     media.parent.mkdir(parents=True)
     media.write_bytes(b"movie")
 
-    with isolated_session_factory() as session:
-        with session.begin():
-            session.merge(
-                RefinerOperatorSettingsRow(
-                    id=1,
-                    min_file_age_seconds=0,
-                    refiner_min_input_file_size_mb=0,
-                    minimum_free_disk_space_mb=1,
-                ),
-            )
-            session.merge(SubberSettingsRow(id=1, enabled=True, language_preferences_json='["en"]'))
-            upsert_provider_settings(session, settings, provider_key=PROVIDER_PODNAPISI, enabled=True, priority=0)
-            state = SubberSubtitleState(
-                media_scope="movies",
-                file_path=str(media),
-                movie_title="Example Movie",
-                movie_year=2026,
-                language_code="en",
-                status="missing",
-                search_count=0,
-            )
-            session.add(state)
-            session.flush()
-            state_id = int(state.id)
-            subber_enqueue_or_get_job(
-                session,
-                dedupe_key="e2e-subber-search",
-                job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_MOVIES,
-                payload_json=json.dumps({"state_id": state_id}, separators=(",", ":")),
-            )
+    with isolated_session_factory() as session, session.begin():
+        session.merge(
+            RefinerOperatorSettingsRow(
+                id=1,
+                min_file_age_seconds=0,
+                refiner_min_input_file_size_mb=0,
+                minimum_free_disk_space_mb=1,
+            ),
+        )
+        session.merge(SubberSettingsRow(id=1, enabled=True, language_preferences_json='["en"]'))
+        upsert_provider_settings(session, settings, provider_key=PROVIDER_PODNAPISI, enabled=True, priority=0)
+        state = SubberSubtitleState(
+            media_scope="movies",
+            file_path=str(media),
+            movie_title="Example Movie",
+            movie_year=2026,
+            language_code="en",
+            status="missing",
+            search_count=0,
+        )
+        session.add(state)
+        session.flush()
+        state_id = int(state.id)
+        subber_enqueue_or_get_job(
+            session,
+            dedupe_key="e2e-subber-search",
+            job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_MOVIES,
+            payload_json=json.dumps({"state_id": state_id}, separators=(",", ":")),
+        )
 
     monkeypatch.setattr(
         "mediamop.modules.subber.subber_subtitle_search_service.podnapisi_client.search",
@@ -309,7 +306,7 @@ def test_subber_search_downloads_subtitle_and_updates_stats(
             isolated_session_factory,
             lease_owner="pytest-subber",
             job_handlers=handlers,
-            now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            now=datetime(2026, 1, 1, tzinfo=UTC),
         )
         == "processed"
     )

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from dataclasses import replace
+from pathlib import Path
 
 from fastapi.testclient import TestClient
 

--- a/apps/backend/tests/test_local_browse_api.py
+++ b/apps/backend/tests/test_local_browse_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_metrics_auth.py
+++ b/apps/backend/tests/test_metrics_auth.py
@@ -2,7 +2,8 @@ import pytest
 from starlette.testclient import TestClient
 
 from mediamop.api.factory import create_app
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_operator_messages.py
+++ b/apps/backend/tests/test_operator_messages.py
@@ -1,4 +1,9 @@
-from mediamop.platform.observability.diagnostics import DiagnosticAction, DiagnosticModule, DiagnosticResult, DiagnosticTrigger
+from mediamop.platform.observability.diagnostics import (
+    DiagnosticAction,
+    DiagnosticModule,
+    DiagnosticResult,
+    DiagnosticTrigger,
+)
 from mediamop.platform.observability.operator_messages import (
     activity_detail_envelope,
     connection_test_title,

--- a/apps/backend/tests/test_pruner_apply_jellyfin.py
+++ b/apps/backend/tests/test_pruner_apply_jellyfin.py
@@ -7,7 +7,6 @@ import uuid
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -19,6 +18,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -39,7 +39,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 @pytest.fixture(autouse=True)
@@ -64,33 +65,32 @@ def _login(client: TestClient) -> None:
 def _jellyfin_preview_run(session_factory: sessionmaker[Session]) -> tuple[int, str]:
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=2,
-                candidates_json=json.dumps(
-                    [{"item_id": "a1", "granularity": "episode"}, {"item_id": "a2", "granularity": "episode"}],
-                ),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=2,
+            candidates_json=json.dumps(
+                [{"item_id": "a1", "granularity": "episode"}, {"item_id": "a2", "granularity": "episode"}],
+            ),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
     return sid, run_uuid
 
 
@@ -141,31 +141,30 @@ def test_apply_post_ok_emby_when_enabled(session_factory: sessionmaker[Session],
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="E",
-                base_url="http://em.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"x"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="E",
+            base_url="http://em.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"x"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:
@@ -185,31 +184,30 @@ def test_apply_accepts_plex_missing_primary_snapshot(session_factory: sessionmak
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="P",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "t"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"x","granularity":"episode"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="P",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "t"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"x","granularity":"episode"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:
@@ -229,31 +227,30 @@ def test_apply_rejects_scope_mismatch_in_url(session_factory: sessionmaker[Sessi
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json="[{\"item_id\":\"x\"}]",
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json="[{\"item_id\":\"x\"}]",
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:
@@ -272,31 +269,30 @@ def test_apply_rejects_non_success_preview(session_factory: sessionmaker[Session
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json="[{\"item_id\":\"x\"}]",
-                truncated=False,
-                outcome="failed",
-                unsupported_detail=None,
-                error_message="x",
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json="[{\"item_id\":\"x\"}]",
+            truncated=False,
+            outcome="failed",
+            unsupported_detail=None,
+            error_message="x",
+        )
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:
@@ -324,42 +320,40 @@ def test_apply_activity_title_uses_operator_label(
         lambda **kw: (404, None),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json="[{\"item_id\":\"gone\"}]",
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json="[{\"item_id\":\"gone\"}]",
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-title-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-title-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -400,42 +394,40 @@ def test_apply_activity_title_emby_names_provider(
         lambda **kw: (404, None),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Emby Lab",
-                base_url="http://emby.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"gone"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Emby Lab",
+            base_url="http://emby.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"gone"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-title-emby-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-title-emby-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -483,42 +475,40 @@ def test_apply_handler_emby_calls_emby_delete_not_jellyfin(
     monkeypatch.setattr("mediamop.modules.pruner.pruner_apply_job_handler.emby_delete_library_item", fake_emby)
     monkeypatch.setattr("mediamop.modules.pruner.pruner_apply_job_handler.jellyfin_delete_library_item", fake_jellyfin)
 
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="E",
-                base_url="http://e.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"e1"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="E",
+            base_url="http://e.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"e1"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-emby-dispatch-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-emby-dispatch-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -547,31 +537,30 @@ def test_get_apply_eligibility_eligible_for_emby_when_enabled(
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="E",
-                base_url="http://em.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"a"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="E",
+            base_url="http://em.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"a"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:
@@ -653,44 +642,42 @@ def test_apply_handler_respects_snapshot_cap(
         fake_delete,
     )
 
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json=json.dumps(
-                    [{"item_id": "only-one"}, {"item_id": "two"}],
-                ),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json=json.dumps(
+                [{"item_id": "only-one"}, {"item_id": "two"}],
+            ),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-cap-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-cap-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND]
@@ -730,44 +717,42 @@ def test_apply_handler_partial_counts(
         fake_delete,
     )
 
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=3,
-                candidates_json=json.dumps(
-                    [{"item_id": "r"}, {"item_id": "s"}, {"item_id": "f"}],
-                ),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=3,
+            candidates_json=json.dumps(
+                [{"item_id": "r"}, {"item_id": "s"}, {"item_id": "f"}],
+            ),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-partial-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-partial-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](

--- a/apps/backend/tests/test_pruner_genre_filters.py
+++ b/apps/backend/tests/test_pruner_genre_filters.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -20,6 +19,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -40,7 +40,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_patch, auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_patch, auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 @pytest.fixture(autouse=True)
@@ -143,24 +144,23 @@ def session_factory(_iso) -> sessionmaker[Session]:
 
 def test_scope_row_persists_genre_filters(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="G",
-                base_url="http://g.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            row = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
-                ),
-            ).one()
-            row.preview_include_genres_json = preview_genre_filters_to_db_column(["Noir"])
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="G",
+            base_url="http://g.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        row = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
+            ),
+        ).one()
+        row.preview_include_genres_json = preview_genre_filters_to_db_column(["Noir"])
     with session_factory() as s:
         row2 = s.scalars(
             select(PrunerScopeSettings).where(

--- a/apps/backend/tests/test_pruner_instances_api.py
+++ b/apps/backend/tests/test_pruner_instances_api.py
@@ -4,16 +4,22 @@ from __future__ import annotations
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from starlette.testclient import TestClient
 
+import mediamop.modules.pruner.pruner_jobs_model  # noqa: F401
+import mediamop.modules.pruner.pruner_preview_run_model  # noqa: F401
+import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
+import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -23,14 +29,14 @@ from mediamop.modules.pruner.pruner_constants import (
     RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
     RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED,
 )
+from mediamop.modules.pruner.pruner_instances_service import get_scope_settings, normalize_server_base_url
 from mediamop.modules.pruner.pruner_job_kinds import (
     PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
     PRUNER_SERVER_CONNECTION_TEST_JOB_KIND,
 )
 from mediamop.modules.pruner.pruner_jobs_model import PrunerJob
-from mediamop.modules.pruner.pruner_instances_service import get_scope_settings, normalize_server_base_url
-from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
 from mediamop.modules.pruner.pruner_preview_service import insert_preview_run
+from mediamop.modules.pruner.pruner_scope_settings_model import PrunerScopeSettings
 from mediamop.modules.pruner.pruner_server_instance_model import PrunerServerInstance
 from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_in_process_workers,
@@ -40,17 +46,12 @@ from tests.integration_app_runtime_quiesce import (
 from tests.integration_helpers import (
     auth_patch,
     auth_post,
-    csrf as fetch_csrf,
     seed_admin_user,
     seed_viewer_user,
 )
-
-import mediamop.modules.pruner.pruner_jobs_model  # noqa: F401
-import mediamop.modules.pruner.pruner_preview_run_model  # noqa: F401
-import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
-import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
+from tests.integration_helpers import (
+    csrf as fetch_csrf,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -541,7 +542,7 @@ def test_post_pruner_preview_does_not_touch_last_scheduled_preview_enqueued_at(
     )
     assert r0.status_code == 200, r0.text
     iid = int(r0.json()["id"])
-    t0 = datetime(2026, 4, 10, 8, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 8, 0, 0, tzinfo=UTC)
     fac = _fac()
     with fac() as db:
         sc = get_scope_settings(db, server_instance_id=iid, media_scope=MEDIA_SCOPE_TV)
@@ -564,7 +565,7 @@ def test_post_pruner_preview_does_not_touch_last_scheduled_preview_enqueued_at(
         assert sc2 is not None
         last = sc2.last_scheduled_preview_enqueued_at
         assert last is not None
-        last_utc = last if last.tzinfo else last.replace(tzinfo=timezone.utc)
+        last_utc = last if last.tzinfo else last.replace(tzinfo=UTC)
         assert last_utc == t0
 
 

--- a/apps/backend/tests/test_pruner_movie_low_rating_unwatched_stale.py
+++ b/apps/backend/tests/test_pruner_movie_low_rating_unwatched_stale.py
@@ -9,9 +9,9 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from pydantic import ValidationError
+from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 from starlette.testclient import TestClient
 
@@ -21,11 +21,10 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
-from sqlalchemy import select
-
 from mediamop.modules.pruner.pruner_constants import (
     MEDIA_SCOPE_MOVIES,
     MEDIA_SCOPE_TV,
@@ -49,7 +48,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_patch, auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_patch, auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def test_jf_emby_pruner_preview_items_fields_csv_includes_people_and_rating() -> None:
@@ -369,41 +369,39 @@ def test_apply_jellyfin_low_rating_movies_skips_404(
         "mediamop.modules.pruner.pruner_apply_job_handler.jellyfin_delete_library_item",
         lambda **kw: (404, None),
     )
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf-apply.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_MOVIES,
-                rule_family_id=RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"gone"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-low-rating",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf-apply.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_MOVIES,
+            rule_family_id=RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"gone"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-low-rating",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](

--- a/apps/backend/tests/test_pruner_multi_instance_isolation.py
+++ b/apps/backend/tests/test_pruner_multi_instance_isolation.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -18,6 +17,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.pruner.pruner_constants import MEDIA_SCOPE_TV, RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED
@@ -47,25 +47,24 @@ def session_factory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sessionm
 
 def test_two_emby_connection_tests_hit_distinct_base_urls(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            a = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Emby A",
-                base_url="http://emby-a.test",
-                credentials_secrets={"api_key": "k-a"},
-            )
-            b = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Emby B",
-                base_url="http://emby-b.test",
-                credentials_secrets={"api_key": "k-b"},
-            )
-            id_a, id_b = int(a.id), int(b.id)
+    with session_factory() as s, s.begin():
+        a = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Emby A",
+            base_url="http://emby-a.test",
+            credentials_secrets={"api_key": "k-a"},
+        )
+        b = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Emby B",
+            base_url="http://emby-b.test",
+            credentials_secrets={"api_key": "k-b"},
+        )
+        id_a, id_b = int(a.id), int(b.id)
 
     urls: list[str] = []
 
@@ -96,25 +95,24 @@ def test_two_emby_connection_tests_hit_distinct_base_urls(session_factory: sessi
 
 def test_two_jellyfin_connection_tests_hit_distinct_base_urls(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            a = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF A",
-                base_url="http://jf-a.test",
-                credentials_secrets={"api_key": "k-a"},
-            )
-            b = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF B",
-                base_url="http://jf-b.test",
-                credentials_secrets={"api_key": "k-b"},
-            )
-            id_a, id_b = int(a.id), int(b.id)
+    with session_factory() as s, s.begin():
+        a = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF A",
+            base_url="http://jf-a.test",
+            credentials_secrets={"api_key": "k-a"},
+        )
+        b = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF B",
+            base_url="http://jf-b.test",
+            credentials_secrets={"api_key": "k-b"},
+        )
+        id_a, id_b = int(a.id), int(b.id)
 
     urls: list[str] = []
 
@@ -145,25 +143,24 @@ def test_two_jellyfin_connection_tests_hit_distinct_base_urls(session_factory: s
 
 def test_preview_denorm_only_updates_matching_instance_scope(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            a = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="A",
-                base_url="http://a.test",
-                credentials_secrets={"api_key": "x"},
-            )
-            b = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="B",
-                base_url="http://b.test",
-                credentials_secrets={"api_key": "y"},
-            )
-            id_a, id_b = int(a.id), int(b.id)
+    with session_factory() as s, s.begin():
+        a = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="A",
+            base_url="http://a.test",
+            credentials_secrets={"api_key": "x"},
+        )
+        b = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="B",
+            base_url="http://b.test",
+            credentials_secrets={"api_key": "y"},
+        )
+        id_a, id_b = int(a.id), int(b.id)
 
     with session_factory() as s:
         with s.begin():

--- a/apps/backend/tests/test_pruner_overview_stats_api.py
+++ b/apps/backend/tests/test_pruner_overview_stats_api.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> None:

--- a/apps/backend/tests/test_pruner_people_filters.py
+++ b/apps/backend/tests/test_pruner_people_filters.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,6 +20,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -53,7 +53,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_patch, auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_patch, auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def test_preview_people_filters_roundtrip_matches_genre_normalization() -> None:
@@ -300,24 +301,23 @@ def session_factory(_iso) -> sessionmaker[Session]:
 
 def test_scope_row_persists_people_filters(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="P",
-                base_url="http://p.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            row = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
-                ),
-            ).one()
-            row.preview_include_people_json = preview_people_filters_to_db_column(["Ada Lovelace"])
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="P",
+            base_url="http://p.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        row = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
+            ),
+        ).one()
+        row.preview_include_people_json = preview_people_filters_to_db_column(["Ada Lovelace"])
     with session_factory() as s:
         row2 = s.scalars(
             select(PrunerScopeSettings).where(
@@ -437,49 +437,48 @@ def test_plex_apply_does_not_call_candidate_collector_with_people_filters_on_sco
 ) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="Plex",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "tok"},
-            )
-            sid = int(inst.id)
-            row = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
-                ),
-            ).one()
-            row.preview_include_people_json = preview_people_filters_to_db_column(["Anyone"])
-            run_uuid = str(uuid.uuid4())
-            from mediamop.modules.pruner.pruner_preview_service import insert_preview_run
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="Plex",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "tok"},
+        )
+        sid = int(inst.id)
+        row = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_TV,
+            ),
+        ).one()
+        row.preview_include_people_json = preview_people_filters_to_db_column(["Anyone"])
+        run_uuid = str(uuid.uuid4())
+        from mediamop.modules.pruner.pruner_preview_service import insert_preview_run
 
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json=json.dumps([{"item_id": "1", "granularity": "episode"}]),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-            job_row = PrunerJob(
-                dedupe_key="plex-apply-people-scope-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json=json.dumps([{"item_id": "1", "granularity": "episode"}]),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+        job_row = PrunerJob(
+            dedupe_key="plex-apply-people-scope-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     calls: list[str] = []
 

--- a/apps/backend/tests/test_pruner_plex_live_removal.py
+++ b/apps/backend/tests/test_pruner_plex_live_removal.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy.orm import Session, sessionmaker
 from starlette.testclient import TestClient
@@ -16,6 +15,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -32,7 +32,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> None:
@@ -62,17 +63,16 @@ def session_factory(_iso) -> sessionmaker[Session]:
 
 def _plex_sid(session_factory: sessionmaker[Session]) -> int:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="Plex",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "tok"},
-            )
-            return int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="Plex",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "tok"},
+        )
+        return int(inst.id)
 
 
 def test_plex_live_eligibility_is_always_ineligible_with_deprecation_notes(
@@ -102,17 +102,16 @@ def test_plex_live_eligibility_is_always_ineligible_with_deprecation_notes(
 def test_plex_live_post_rejects_jellyfin_instance(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
     seed_admin_user()
     app = create_app()
     with TestClient(app) as client:

--- a/apps/backend/tests/test_pruner_plex_movie_rule_candidates.py
+++ b/apps/backend/tests/test_pruner_plex_movie_rule_candidates.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -45,7 +45,7 @@ def test_plex_leaf_audience_rating_float() -> None:
 def test_plex_leaf_added_at_utc_seconds_and_ms() -> None:
     dt = plex_leaf_added_at_utc({"addedAt": 1_450_147_195})
     assert dt is not None
-    assert dt.tzinfo == timezone.utc
+    assert dt.tzinfo == UTC
     dt_ms = plex_leaf_added_at_utc({"addedAt": 1_450_147_195_000})
     assert dt_ms is not None
     assert abs((dt_ms - dt).total_seconds()) < 2
@@ -165,7 +165,7 @@ def test_list_plex_low_rating_requires_audience_rating() -> None:
 
 
 def test_list_plex_unwatched_stale_uses_added_at() -> None:
-    old_ts = int((datetime.now(timezone.utc) - timedelta(days=100)).timestamp())
+    old_ts = int((datetime.now(UTC) - timedelta(days=100)).timestamp())
 
     def fake_get_json(url: str, headers: dict[str, str]) -> tuple[int, dict]:  # noqa: ARG001
         if "allLeaves" not in url:

--- a/apps/backend/tests/test_pruner_plex_preview_apply.py
+++ b/apps/backend/tests/test_pruner_plex_preview_apply.py
@@ -7,7 +7,6 @@ import uuid
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -18,6 +17,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.pruner.pruner_apply_eligibility import compute_apply_eligibility
@@ -61,17 +61,16 @@ def session_factory(_iso) -> sessionmaker[Session]:
 
 def _plex_instance(session_factory: sessionmaker[Session], *, label: str = "Plex") -> int:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name=label,
-                base_url=f"http://plex-{label.lower().replace(' ', '-')}.test:32400",
-                credentials_secrets={"auth_token": "tok"},
-            )
-            return int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name=label,
+            base_url=f"http://plex-{label.lower().replace(' ', '-')}.test:32400",
+            credentials_secrets={"auth_token": "tok"},
+        )
+        return int(inst.id)
 
 
 def test_plex_apply_does_not_call_candidate_collector(
@@ -110,35 +109,34 @@ def test_plex_apply_does_not_call_candidate_collector(
         _delete,
     )
 
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=2,
-                candidates_json=json.dumps(
-                    [
-                        {"item_id": "1", "granularity": "episode"},
-                        {"item_id": "2", "granularity": "episode"},
-                    ],
-                ),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-            job_row = PrunerJob(
-                dedupe_key="plex-apply-test",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=2,
+            candidates_json=json.dumps(
+                [
+                    {"item_id": "1", "granularity": "episode"},
+                    {"item_id": "2", "granularity": "episode"},
+                ],
+            ),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+        job_row = PrunerJob(
+            dedupe_key="plex-apply-test",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -177,22 +175,21 @@ def test_plex_apply_preview_run_must_match_instance(
     sid_a = _plex_instance(session_factory, label="A")
     sid_b = _plex_instance(session_factory, label="B")
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid_b,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json=json.dumps([{"item_id": "9", "granularity": "episode"}]),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid_b,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json=json.dumps([{"item_id": "9", "granularity": "episode"}]),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND]
@@ -222,22 +219,21 @@ def test_plex_apply_rejects_scope_mismatch_with_snapshot(
     settings = MediaMopSettings.load()
     sid = _plex_instance(session_factory)
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_MOVIES,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json=json.dumps([{"item_id": "m1", "granularity": "movie_item"}]),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_MOVIES,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json=json.dumps([{"item_id": "m1", "granularity": "movie_item"}]),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND]
@@ -305,22 +301,21 @@ def test_candidates_json_cap_does_not_widen_apply_set(
     sid = _plex_instance(session_factory)
     run_uuid = str(uuid.uuid4())
     wide = [{"item_id": str(i), "granularity": "episode"} for i in range(5)]
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=2,
-                candidates_json=json.dumps(wide),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=2,
+            candidates_json=json.dumps(wide),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     deleted: list[str] = []
 
@@ -361,22 +356,21 @@ def test_auto_apply_payload_enforces_max_deletes_per_run(
     sid = _plex_instance(session_factory)
     run_uuid = str(uuid.uuid4())
     candidates = [{"item_id": str(i), "granularity": "episode"} for i in range(5)]
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
-                pruner_job_id=None,
-                candidate_count=5,
-                candidates_json=json.dumps(candidates),
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
+            pruner_job_id=None,
+            candidate_count=5,
+            candidates_json=json.dumps(candidates),
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     deleted: list[str] = []
 
@@ -455,16 +449,15 @@ def test_plex_preview_job_passes_effective_cap_to_collector(
         sc.preview_max_items = 500
         s.commit()
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="plex-cap-preview",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="plex-cap-preview",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND](

--- a/apps/backend/tests/test_pruner_preview_activity_events.py
+++ b/apps/backend/tests/test_pruner_preview_activity_events.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -17,6 +16,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.pruner.pruner_constants import (
@@ -62,33 +62,31 @@ def test_plex_preview_missing_primary_records_success_activity(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="Plex",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "t"},
-            )
-            sid = int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="Plex",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "t"},
+        )
+        sid = int(inst.id)
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_media_library.list_plex_missing_thumb_candidates",
         lambda **_kw: ([{"item_id": "42", "granularity": "episode", "episode_title": "Pilot"}], False),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-activity-test-job",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-activity-test-job",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND]
@@ -127,33 +125,31 @@ def test_scheduled_preview_activity_title_and_detail_trigger(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="Plex Sched",
-                base_url="http://plex-sched.test:32400",
-                credentials_secrets={"auth_token": "t"},
-            )
-            sid = int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="Plex Sched",
+            base_url="http://plex-sched.test:32400",
+            credentials_secrets={"auth_token": "t"},
+        )
+        sid = int(inst.id)
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_media_library.list_plex_missing_thumb_candidates",
         lambda **_kw: ([], False),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-activity-scheduled-job",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-activity-scheduled-job",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND]
@@ -185,40 +181,38 @@ def test_scheduled_preview_accepts_non_missing_primary_rule_family(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF Sched",
-                base_url="http://jf-sched.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            row_m = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
-                ),
-            ).one()
-            row_m.watched_movies_reported_enabled = True
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF Sched",
+            base_url="http://jf-sched.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        row_m = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
+            ),
+        ).one()
+        row_m.watched_movies_reported_enabled = True
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_preview_job_handler.preview_payload_json",
         lambda **kwargs: ("success", "", [{"granularity": "movie_item", "item_id": "9"}], False),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-activity-scheduled-watched-movies",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-activity-scheduled-watched-movies",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND]
@@ -257,25 +251,24 @@ def test_scheduled_preview_auto_apply_enqueues_snapshot_apply_job(
 ) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF Auto",
-                base_url="http://jf-auto.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            row_m = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
-                ),
-            ).one()
-            row_m.auto_apply_enabled = True
-            row_m.max_deletes_per_run = 3
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF Auto",
+            base_url="http://jf-auto.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        row_m = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
+            ),
+        ).one()
+        row_m.auto_apply_enabled = True
+        row_m.max_deletes_per_run = 3
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_preview_job_handler.preview_payload_json",
@@ -287,16 +280,15 @@ def test_scheduled_preview_auto_apply_enqueues_snapshot_apply_job(
         ),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-auto-apply-scheduled",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-auto-apply-scheduled",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND](
@@ -333,40 +325,38 @@ def test_plex_preview_zero_candidates_with_genres_records_operator_note(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="plex",
-                display_name="Plex",
-                base_url="http://plex.test:32400",
-                credentials_secrets={"auth_token": "t"},
-            )
-            sid = int(inst.id)
-            row = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == "tv",
-                ),
-            ).one()
-            row.preview_include_genres_json = preview_genre_filters_to_db_column(["Drama"])
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="plex",
+            display_name="Plex",
+            base_url="http://plex.test:32400",
+            credentials_secrets={"auth_token": "t"},
+        )
+        sid = int(inst.id)
+        row = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == "tv",
+            ),
+        ).one()
+        row.preview_include_genres_json = preview_genre_filters_to_db_column(["Drama"])
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_media_library.list_plex_missing_thumb_candidates",
         lambda **_kw: ([], False),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-activity-genre-zero",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-activity-genre-zero",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND]
@@ -399,40 +389,38 @@ def test_jellyfin_preview_activity_collection_ignored_note_when_tokens_stored(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF Coll Note",
-                base_url="http://jf-coll-note.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            row = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == "movies",
-                ),
-            ).one()
-            row.preview_include_collections_json = '["MCU"]'
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF Coll Note",
+            base_url="http://jf-coll-note.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        row = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == "movies",
+            ),
+        ).one()
+        row.preview_include_collections_json = '["MCU"]'
 
     monkeypatch.setattr(
         "mediamop.modules.pruner.pruner_preview_job_handler.preview_payload_json",
         lambda **kwargs: ("success", "", [], False),
     )
 
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="preview-activity-jf-coll-ignored",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="preview-activity-jf-coll-ignored",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     fn = handlers[PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND]

--- a/apps/backend/tests/test_pruner_preview_schedule.py
+++ b/apps/backend/tests/test_pruner_preview_schedule.py
@@ -3,15 +3,14 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 
 def _as_utc(dt: datetime) -> datetime:
-    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -22,6 +21,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.pruner.pruner_constants import (
@@ -67,79 +67,76 @@ def _scope(
 
 def test_scheduled_tick_skips_disabled_instance(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Off",
-                base_url="http://off.test",
-                credentials_secrets={"api_key": "x"},
-            )
-            inst.enabled = False
-            sid = int(inst.id)
-            tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
-            tv.scheduled_preview_enabled = True
-            tv.scheduled_preview_interval_seconds = 60
-            tv.last_scheduled_preview_enqueued_at = None
-    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(timezone.utc))
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Off",
+            base_url="http://off.test",
+            credentials_secrets={"api_key": "x"},
+        )
+        inst.enabled = False
+        sid = int(inst.id)
+        tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
+        tv.scheduled_preview_enabled = True
+        tv.scheduled_preview_interval_seconds = 60
+        tv.last_scheduled_preview_enqueued_at = None
+    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(UTC))
     assert n == 0
 
 
 def test_scheduled_tick_skips_when_rule_disabled(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="On",
-                base_url="http://on.test",
-                credentials_secrets={"api_key": "x"},
-            )
-            sid = int(inst.id)
-            tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
-            tv.scheduled_preview_enabled = True
-            tv.scheduled_preview_interval_seconds = 60
-            tv.missing_primary_media_reported_enabled = False
-            tv.last_scheduled_preview_enqueued_at = None
-    assert run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(timezone.utc)) == 0
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="On",
+            base_url="http://on.test",
+            credentials_secrets={"api_key": "x"},
+        )
+        sid = int(inst.id)
+        tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
+        tv.scheduled_preview_enabled = True
+        tv.scheduled_preview_interval_seconds = 60
+        tv.missing_primary_media_reported_enabled = False
+        tv.last_scheduled_preview_enqueued_at = None
+    assert run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(UTC)) == 0
 
 
 def test_two_same_provider_instances_independent_due(session_factory: sessionmaker[Session]) -> None:
     """Instance B not due must not block instance A from enqueueing."""
 
     settings = MediaMopSettings.load()
-    t0 = datetime(2026, 4, 17, 12, 0, 0, tzinfo=timezone.utc)
-    with session_factory() as s:
-        with s.begin():
-            a = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="A",
-                base_url="http://a.test",
-                credentials_secrets={"api_key": "a"},
-            )
-            b = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="B",
-                base_url="http://b.test",
-                credentials_secrets={"api_key": "b"},
-            )
-            id_a, id_b = int(a.id), int(b.id)
-            tv_a = _scope(s, instance_id=id_a, media_scope=MEDIA_SCOPE_TV)
-            tv_a.scheduled_preview_enabled = True
-            tv_a.scheduled_preview_interval_seconds = 60
-            tv_a.last_scheduled_preview_enqueued_at = None
-            tv_b = _scope(s, instance_id=id_b, media_scope=MEDIA_SCOPE_TV)
-            tv_b.scheduled_preview_enabled = True
-            tv_b.scheduled_preview_interval_seconds = 3600
-            tv_b.last_scheduled_preview_enqueued_at = t0
+    t0 = datetime(2026, 4, 17, 12, 0, 0, tzinfo=UTC)
+    with session_factory() as s, s.begin():
+        a = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="A",
+            base_url="http://a.test",
+            credentials_secrets={"api_key": "a"},
+        )
+        b = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="B",
+            base_url="http://b.test",
+            credentials_secrets={"api_key": "b"},
+        )
+        id_a, id_b = int(a.id), int(b.id)
+        tv_a = _scope(s, instance_id=id_a, media_scope=MEDIA_SCOPE_TV)
+        tv_a.scheduled_preview_enabled = True
+        tv_a.scheduled_preview_interval_seconds = 60
+        tv_a.last_scheduled_preview_enqueued_at = None
+        tv_b = _scope(s, instance_id=id_b, media_scope=MEDIA_SCOPE_TV)
+        tv_b.scheduled_preview_enabled = True
+        tv_b.scheduled_preview_interval_seconds = 3600
+        tv_b.last_scheduled_preview_enqueued_at = t0
 
     now = t0.replace(hour=12, minute=2)
     n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=now)
@@ -162,24 +159,23 @@ def test_two_same_provider_instances_independent_due(session_factory: sessionmak
 
 def test_tv_and_movies_same_instance_both_enqueue_when_due(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="Dual",
-                base_url="http://dual.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            for scope in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-                row = _scope(s, instance_id=sid, media_scope=scope)
-                row.scheduled_preview_enabled = True
-                row.scheduled_preview_interval_seconds = 60
-                row.last_scheduled_preview_enqueued_at = None
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="Dual",
+            base_url="http://dual.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        for scope in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
+            row = _scope(s, instance_id=sid, media_scope=scope)
+            row.scheduled_preview_enabled = True
+            row.scheduled_preview_interval_seconds = 60
+            row.last_scheduled_preview_enqueued_at = None
 
-    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(timezone.utc))
+    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(UTC))
     assert n == 2
     with session_factory() as s:
         jobs = s.scalars(select(PrunerJob).where(PrunerJob.job_kind == PRUNER_CANDIDATE_REMOVAL_PREVIEW_JOB_KIND)).all()
@@ -191,25 +187,24 @@ def test_tv_and_movies_same_instance_both_enqueue_when_due(session_factory: sess
 
 def test_scheduled_tick_enqueues_non_missing_primary_rule_family(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="Movies",
-                base_url="http://movies.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            movies = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_MOVIES)
-            movies.scheduled_preview_enabled = True
-            movies.scheduled_preview_interval_seconds = 60
-            movies.missing_primary_media_reported_enabled = False
-            movies.watched_movies_reported_enabled = True
-            movies.last_scheduled_preview_enqueued_at = None
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="Movies",
+            base_url="http://movies.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        movies = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_MOVIES)
+        movies.scheduled_preview_enabled = True
+        movies.scheduled_preview_interval_seconds = 60
+        movies.missing_primary_media_reported_enabled = False
+        movies.watched_movies_reported_enabled = True
+        movies.last_scheduled_preview_enqueued_at = None
 
-    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(timezone.utc))
+    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(UTC))
 
     assert n == 1
     with session_factory() as s:
@@ -225,25 +220,24 @@ def test_scheduled_tick_enqueues_non_missing_primary_rule_family(session_factory
 
 def test_scheduled_tick_enqueues_one_job_per_enabled_rule_family(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="Multi",
-                base_url="http://multi.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            movies = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_MOVIES)
-            movies.scheduled_preview_enabled = True
-            movies.scheduled_preview_interval_seconds = 60
-            movies.missing_primary_media_reported_enabled = True
-            movies.watched_movies_reported_enabled = True
-            movies.last_scheduled_preview_enqueued_at = None
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="Multi",
+            base_url="http://multi.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        movies = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_MOVIES)
+        movies.scheduled_preview_enabled = True
+        movies.scheduled_preview_interval_seconds = 60
+        movies.missing_primary_media_reported_enabled = True
+        movies.watched_movies_reported_enabled = True
+        movies.last_scheduled_preview_enqueued_at = None
 
-    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(timezone.utc))
+    n = run_pruner_preview_schedule_enqueue_tick(session_factory, now=datetime.now(UTC))
 
     assert n == 2
     with session_factory() as s:
@@ -254,22 +248,21 @@ def test_scheduled_tick_enqueues_one_job_per_enabled_rule_family(session_factory
 
 def test_second_tick_not_due_until_own_interval_elapses(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    t0 = datetime(2026, 4, 17, 10, 0, 0, tzinfo=timezone.utc)
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Cadence",
-                base_url="http://cad.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
-            tv.scheduled_preview_enabled = True
-            tv.scheduled_preview_interval_seconds = 120
-            tv.last_scheduled_preview_enqueued_at = None
+    t0 = datetime(2026, 4, 17, 10, 0, 0, tzinfo=UTC)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Cadence",
+            base_url="http://cad.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        tv = _scope(s, instance_id=sid, media_scope=MEDIA_SCOPE_TV)
+        tv.scheduled_preview_enabled = True
+        tv.scheduled_preview_interval_seconds = 120
+        tv.last_scheduled_preview_enqueued_at = None
 
     assert run_pruner_preview_schedule_enqueue_tick(session_factory, now=t0) == 1
     assert run_pruner_preview_schedule_enqueue_tick(session_factory, now=t0.replace(minute=1)) == 0

--- a/apps/backend/tests/test_pruner_preview_year_studio_collection.py
+++ b/apps/backend/tests/test_pruner_preview_year_studio_collection.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 
 import mediamop.modules.pruner.pruner_jobs_model  # noqa: F401
@@ -16,6 +15,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.modules.pruner.pruner_constants import MEDIA_SCOPE_MOVIES, RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED
 from mediamop.modules.pruner.pruner_genre_filters import plex_leaf_collection_tags, plex_leaf_studio_tags
 from mediamop.modules.pruner.pruner_media_library import jf_emby_pruner_preview_items_fields_csv, preview_payload_json
@@ -35,6 +35,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
+
+
 @pytest.fixture(autouse=True)
 def _iso(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     integration_test_set_home(tmp_path, monkeypatch, "mmhome_pruner_ysc_filters")

--- a/apps/backend/tests/test_pruner_watched_movies.py
+++ b/apps/backend/tests/test_pruner_watched_movies.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,6 +20,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -44,7 +44,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:
@@ -179,41 +180,39 @@ def test_apply_jellyfin_watched_movies_skips_404(
         "mediamop.modules.pruner.pruner_apply_job_handler.jellyfin_delete_library_item",
         lambda **kw: (404, None),
     )
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF Movies",
-                base_url="http://jf-movies.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_MOVIES,
-                rule_family_id=RULE_FAMILY_WATCHED_MOVIES_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"gone-m"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-watched-movies-jf",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF Movies",
+            base_url="http://jf-movies.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_MOVIES,
+            rule_family_id=RULE_FAMILY_WATCHED_MOVIES_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"gone-m"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-watched-movies-jf",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -247,38 +246,37 @@ def test_compute_apply_eligibility_watched_movies_requires_toggle(
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF",
-                base_url="http://jf-elig.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            movies = s.scalars(
-                select(PrunerScopeSettings).where(
-                    PrunerScopeSettings.server_instance_id == sid,
-                    PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
-                ),
-            ).one()
-            movies.watched_movies_reported_enabled = False
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_MOVIES,
-                rule_family_id=RULE_FAMILY_WATCHED_MOVIES_REPORTED,
-                pruner_job_id=None,
-                candidate_count=2,
-                candidates_json="[]",
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF",
+            base_url="http://jf-elig.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        movies = s.scalars(
+            select(PrunerScopeSettings).where(
+                PrunerScopeSettings.server_instance_id == sid,
+                PrunerScopeSettings.media_scope == MEDIA_SCOPE_MOVIES,
+            ),
+        ).one()
+        movies.watched_movies_reported_enabled = False
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_MOVIES,
+            rule_family_id=RULE_FAMILY_WATCHED_MOVIES_REPORTED,
+            pruner_job_id=None,
+            candidate_count=2,
+            candidates_json="[]",
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     settings2 = MediaMopSettings.load()
     with session_factory() as s:

--- a/apps/backend/tests/test_pruner_watched_tv.py
+++ b/apps/backend/tests/test_pruner_watched_tv.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
@@ -21,6 +20,7 @@ import mediamop.modules.pruner.pruner_scope_settings_model  # noqa: F401
 import mediamop.modules.pruner.pruner_server_instance_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -43,7 +43,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, seed_admin_user
+from tests.integration_helpers import auth_post, seed_admin_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:
@@ -205,43 +206,41 @@ def test_watched_tv_preview_denorm_only_affects_target_instance(
     session_factory: sessionmaker[Session],
 ) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            a = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="A",
-                base_url="http://jf-a-w.test",
-                credentials_secrets={"api_key": "a"},
-            )
-            b = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="B",
-                base_url="http://jf-b-w.test",
-                credentials_secrets={"api_key": "b"},
-            )
-            id_a, id_b = int(a.id), int(b.id)
+    with session_factory() as s, s.begin():
+        a = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="A",
+            base_url="http://jf-a-w.test",
+            credentials_secrets={"api_key": "a"},
+        )
+        b = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="B",
+            base_url="http://jf-b-w.test",
+            credentials_secrets={"api_key": "b"},
+        )
+        id_a, id_b = int(a.id), int(b.id)
 
     uid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=uid,
-                server_instance_id=id_a,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
-                pruner_job_id=None,
-                candidate_count=3,
-                candidates_json="[]",
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=uid,
+            server_instance_id=id_a,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
+            pruner_job_id=None,
+            candidate_count=3,
+            candidates_json="[]",
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     with session_factory() as s:
         tv_b = s.scalars(
@@ -255,35 +254,33 @@ def test_watched_tv_preview_denorm_only_affects_target_instance(
 
 def test_watched_tv_preview_denorm_only_updates_tv_scope_row(session_factory: sessionmaker[Session]) -> None:
     settings = MediaMopSettings.load()
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="One",
-                base_url="http://jf-one.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="One",
+            base_url="http://jf-one.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
 
     uid = str(uuid.uuid4())
-    with session_factory() as s:
-        with s.begin():
-            insert_preview_run(
-                s,
-                preview_run_uuid=uid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json="[]",
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
+    with session_factory() as s, s.begin():
+        insert_preview_run(
+            s,
+            preview_run_uuid=uid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json="[]",
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
 
     with session_factory() as s:
         tv = s.scalars(
@@ -314,41 +311,39 @@ def test_apply_jellyfin_watched_tv_activity_wording(
         "mediamop.modules.pruner.pruner_apply_job_handler.jellyfin_delete_library_item",
         lambda **kw: (204, None),
     )
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="jellyfin",
-                display_name="JF Watch",
-                base_url="http://jf-watch.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"ep-x","granularity":"episode"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-watched-jf",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="jellyfin",
+            display_name="JF Watch",
+            base_url="http://jf-watch.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"ep-x","granularity":"episode"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-watched-jf",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](
@@ -392,41 +387,39 @@ def test_apply_emby_watched_tv_activity_names_emby(
         "mediamop.modules.pruner.pruner_apply_job_handler.emby_delete_library_item",
         lambda **kw: (204, None),
     )
-    with session_factory() as s:
-        with s.begin():
-            inst = create_server_instance(
-                s,
-                settings,
-                provider="emby",
-                display_name="Emby Watch",
-                base_url="http://emby-watch.test",
-                credentials_secrets={"api_key": "k"},
-            )
-            sid = int(inst.id)
-            insert_preview_run(
-                s,
-                preview_run_uuid=run_uuid,
-                server_instance_id=sid,
-                media_scope=MEDIA_SCOPE_TV,
-                rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
-                pruner_job_id=None,
-                candidate_count=1,
-                candidates_json='[{"item_id":"e1"}]',
-                truncated=False,
-                outcome="success",
-                unsupported_detail=None,
-                error_message=None,
-            )
-    with session_factory() as s:
-        with s.begin():
-            job_row = PrunerJob(
-                dedupe_key="apply-watched-emby",
-                job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
-                status=PrunerJobStatus.COMPLETED.value,
-            )
-            s.add(job_row)
-            s.flush()
-            job_id = int(job_row.id)
+    with session_factory() as s, s.begin():
+        inst = create_server_instance(
+            s,
+            settings,
+            provider="emby",
+            display_name="Emby Watch",
+            base_url="http://emby-watch.test",
+            credentials_secrets={"api_key": "k"},
+        )
+        sid = int(inst.id)
+        insert_preview_run(
+            s,
+            preview_run_uuid=run_uuid,
+            server_instance_id=sid,
+            media_scope=MEDIA_SCOPE_TV,
+            rule_family_id=RULE_FAMILY_WATCHED_TV_REPORTED,
+            pruner_job_id=None,
+            candidate_count=1,
+            candidates_json='[{"item_id":"e1"}]',
+            truncated=False,
+            outcome="success",
+            unsupported_detail=None,
+            error_message=None,
+        )
+    with session_factory() as s, s.begin():
+        job_row = PrunerJob(
+            dedupe_key="apply-watched-emby",
+            job_kind=PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND,
+            status=PrunerJobStatus.COMPLETED.value,
+        )
+        s.add(job_row)
+        s.flush()
+        job_id = int(job_row.id)
 
     handlers = build_pruner_job_handlers(settings, session_factory)
     handlers[PRUNER_CANDIDATE_REMOVAL_APPLY_JOB_KIND](

--- a/apps/backend/tests/test_queue_job_kind_boundaries.py
+++ b/apps/backend/tests/test_queue_job_kind_boundaries.py
@@ -3,18 +3,28 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.pruner.pruner_jobs_model  # noqa: F401
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import Base
+from mediamop.modules.pruner.pruner_job_handlers import build_pruner_job_handlers
+from mediamop.modules.pruner.pruner_jobs_model import PrunerJob, PrunerJobStatus
+from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
+from mediamop.modules.pruner.worker_loop import process_one_pruner_job
 from mediamop.modules.queue_worker.job_kind_boundaries import (
     job_kind_forbidden_on_refiner_lane,
+    validate_pruner_worker_handler_registry,
     validate_refiner_worker_handler_registry,
     validate_subber_worker_handler_registry,
-    validate_pruner_worker_handler_registry,
 )
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
@@ -27,17 +37,6 @@ from mediamop.modules.subber.subber_job_kinds import SUBBER_JOB_KIND_SUBTITLE_SE
 from mediamop.modules.subber.subber_jobs_model import SubberJob, SubberJobStatus
 from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.worker_loop import process_one_subber_job
-from mediamop.modules.pruner.pruner_job_handlers import build_pruner_job_handlers
-from mediamop.modules.pruner.pruner_jobs_model import PrunerJob, PrunerJobStatus
-from mediamop.modules.pruner.pruner_jobs_ops import pruner_enqueue_or_get_job
-from mediamop.modules.pruner.worker_loop import process_one_pruner_job
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.pruner.pruner_jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
-from mediamop.core.db import Base
 
 # Legacy lane prefix still blocked on sibling queues (see ``job_kind_boundaries``).
 _LEGACY_TRIMMER_JOB = "trimmer.radarr.cleanup_drive.v1"
@@ -76,25 +75,21 @@ def test_default_refiner_handler_registry_has_no_foreign_lane_keys() -> None:
 
 
 def test_refiner_enqueue_rejects_foreign_namespaces(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
-            refiner_enqueue_or_get_job(s, dedupe_key="t", job_kind="pruner.probe.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
-            refiner_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
-            refiner_enqueue_or_get_job(
-                s,
-                dedupe_key="s",
-                job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_TV,
-            )
+    with session_factory() as s, pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
+        refiner_enqueue_or_get_job(s, dedupe_key="t", job_kind="pruner.probe.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
+        refiner_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="refiner_enqueue_or_get_job refuses"):
+        refiner_enqueue_or_get_job(
+            s,
+            dedupe_key="s",
+            job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_TV,
+        )
 
 
 def test_refiner_enqueue_rejects_unprefixed_job_kind(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="refiner_enqueue_or_get_job requires job_kind"):
-            refiner_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
+    with session_factory() as s, pytest.raises(ValueError, match="refiner_enqueue_or_get_job requires job_kind"):
+        refiner_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
 
 
 def test_validate_refiner_worker_handler_registry_rejects_foreign_lane_keys() -> None:
@@ -151,7 +146,7 @@ def test_process_one_refiner_job_fails_claimed_row_in_foreign_lane_without_handl
 def test_process_one_refiner_job_rejects_unprefixed_job_kind_row(session_factory) -> None:
     """Direct-insert legacy rows without ``refiner.*`` must fail safe on the Refiner worker."""
 
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(
             RefinerJob(
@@ -179,32 +174,27 @@ def test_process_one_refiner_job_rejects_unprefixed_job_kind_row(session_factory
 
 
 def test_pruner_enqueue_rejects_foreign_namespaces(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
-            pruner_enqueue_or_get_job(s, dedupe_key="x", job_kind="refiner.compact.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
-            pruner_enqueue_or_get_job(
-                s,
-                dedupe_key="y",
-                job_kind=_LEGACY_TRIMMER_JOB,
-            )
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
-            pruner_enqueue_or_get_job(
-                s,
-                dedupe_key="z",
-                job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_TV,
-            )
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
-            pruner_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
+        pruner_enqueue_or_get_job(s, dedupe_key="x", job_kind="refiner.compact.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
+        pruner_enqueue_or_get_job(
+            s,
+            dedupe_key="y",
+            job_kind=_LEGACY_TRIMMER_JOB,
+        )
+    with session_factory() as s, pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
+        pruner_enqueue_or_get_job(
+            s,
+            dedupe_key="z",
+            job_kind=SUBBER_JOB_KIND_SUBTITLE_SEARCH_TV,
+        )
+    with session_factory() as s, pytest.raises(ValueError, match="pruner_enqueue_or_get_job refuses"):
+        pruner_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
 
 
 def test_pruner_enqueue_rejects_unprefixed_job_kind(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="pruner_enqueue_or_get_job requires job_kind"):
-            pruner_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
+    with session_factory() as s, pytest.raises(ValueError, match="pruner_enqueue_or_get_job requires job_kind"):
+        pruner_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
 
 
 def test_validate_pruner_worker_handler_registry_rejects_foreign_lane_keys() -> None:
@@ -231,7 +221,7 @@ def test_process_one_pruner_job_fails_claimed_row_with_foreign_lane_job_kind(
 ) -> None:
     """Mis-placed ``pruner_jobs`` rows stamped with another module's prefix must not execute."""
 
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(
             PrunerJob(
@@ -263,7 +253,7 @@ def test_process_one_pruner_job_fails_claimed_row_with_foreign_lane_job_kind(
 def test_process_one_pruner_job_rejects_unprefixed_job_kind_row(session_factory, tmp_path) -> None:
     """Direct-insert rows without ``pruner.*`` must fail safe on the Pruner worker."""
 
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(
             PrunerJob(
@@ -293,28 +283,23 @@ def test_process_one_pruner_job_rejects_unprefixed_job_kind_row(session_factory,
 
 
 def test_subber_enqueue_rejects_foreign_namespaces(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
-            subber_enqueue_or_get_job(s, dedupe_key="x", job_kind="refiner.compact.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
-            subber_enqueue_or_get_job(s, dedupe_key="t", job_kind="pruner.probe.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
-            subber_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
-            subber_enqueue_or_get_job(
-                s,
-                dedupe_key="f",
-                job_kind=_LEGACY_TRIMMER_JOB,
-            )
+    with session_factory() as s, pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
+        subber_enqueue_or_get_job(s, dedupe_key="x", job_kind="refiner.compact.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
+        subber_enqueue_or_get_job(s, dedupe_key="t", job_kind="pruner.probe.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
+        subber_enqueue_or_get_job(s, dedupe_key="legacy", job_kind="trimmer.legacy.v1")
+    with session_factory() as s, pytest.raises(ValueError, match="subber_enqueue_or_get_job refuses"):
+        subber_enqueue_or_get_job(
+            s,
+            dedupe_key="f",
+            job_kind=_LEGACY_TRIMMER_JOB,
+        )
 
 
 def test_subber_enqueue_rejects_unprefixed_job_kind(session_factory) -> None:
-    with session_factory() as s:
-        with pytest.raises(ValueError, match="subber_enqueue_or_get_job requires job_kind"):
-            subber_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
+    with session_factory() as s, pytest.raises(ValueError, match="subber_enqueue_or_get_job requires job_kind"):
+        subber_enqueue_or_get_job(s, dedupe_key="u", job_kind="bare.kind")
 
 
 def test_validate_subber_worker_handler_registry_rejects_foreign_lane_keys() -> None:
@@ -344,7 +329,7 @@ def test_process_one_subber_job_fails_claimed_row_with_foreign_lane_job_kind(
 ) -> None:
     """Mis-placed ``subber_jobs`` rows stamped with another module's prefix must not execute."""
 
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(
             SubberJob(
@@ -375,7 +360,7 @@ def test_process_one_subber_job_fails_claimed_row_with_foreign_lane_job_kind(
 def test_process_one_subber_job_rejects_unprefixed_job_kind_row(session_factory) -> None:
     """Direct-insert rows without ``subber.*`` must fail safe on the Subber worker."""
 
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(
             SubberJob(

--- a/apps/backend/tests/test_reconciliation_service.py
+++ b/apps/backend/tests/test_reconciliation_service.py
@@ -13,7 +13,8 @@ from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.refiner.refiner_path_settings_model import RefinerPathSettingsRow
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
 from mediamop.platform.reconciliation.service import build_reconciliation_report, repair_reconciliation_issue
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _fac():

--- a/apps/backend/tests/test_refiner_candidate_gate_lane.py
+++ b/apps/backend/tests/test_refiner_candidate_gate_lane.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +11,9 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
@@ -20,10 +23,6 @@ from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_hand
 from mediamop.modules.refiner.worker_loop import process_one_refiner_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -69,7 +68,7 @@ def test_candidate_gate_handler_uses_live_queue_shape(
     def _fake_fetch(**_kwargs):
         return fake_rows
 
-    t0 = datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
     payload = {
         "target": "radarr",
         "release_title": "Gate Test",

--- a/apps/backend/tests/test_refiner_candidate_gate_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_candidate_gate_manual_enqueue_api.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 from sqlalchemy import delete, select
 from starlette.testclient import TestClient
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.refiner.jobs_model import RefinerJob
 from mediamop.modules.refiner.refiner_candidate_gate_job_kinds import REFINER_CANDIDATE_GATE_JOB_KIND
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _fac():

--- a/apps/backend/tests/test_refiner_failure_cleanup.py
+++ b/apps/backend/tests/test_refiner_failure_cleanup.py
@@ -14,11 +14,11 @@ from sqlalchemy.orm import Session, sessionmaker
 import mediamop.modules.refiner.jobs_model  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
-from mediamop.modules.refiner.refiner_failure_cleanup_enqueue import enqueue_refiner_failure_cleanup_sweep_job
-from mediamop.modules.refiner.refiner_failure_cleanup import run_refiner_failure_cleanup_sweep_for_scope
-from mediamop.modules.refiner.refiner_failure_cleanup_handlers import make_refiner_failure_cleanup_handler
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.refiner_failure_cleanup import run_refiner_failure_cleanup_sweep_for_scope
+from mediamop.modules.refiner.refiner_failure_cleanup_enqueue import enqueue_refiner_failure_cleanup_sweep_job
+from mediamop.modules.refiner.refiner_failure_cleanup_handlers import make_refiner_failure_cleanup_handler
 from mediamop.modules.refiner.refiner_path_settings_model import RefinerPathSettingsRow
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
 from mediamop.platform.activity.models import ActivityEvent

--- a/apps/backend/tests/test_refiner_file_remux_pass_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_manual_enqueue_api.py
@@ -7,15 +7,15 @@ from pathlib import Path
 from sqlalchemy import delete, select
 from starlette.testclient import TestClient
 
-from mediamop.core.config import MediaMopSettings
-from mediamop.core.db import create_db_engine, create_session_factory
-from mediamop.modules.refiner.jobs_model import RefinerJob
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
-
 import mediamop.modules.refiner.jobs_model  # noqa: F401
 import mediamop.platform.activity.models  # noqa: F401
 import mediamop.platform.auth.models  # noqa: F401
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import create_db_engine, create_session_factory
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _fac():

--- a/apps/backend/tests/test_refiner_file_remux_pass_run.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_run.py
@@ -11,14 +11,14 @@ import pytest
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.refiner.file_remux_pass import run as runmod
-from mediamop.modules.refiner.refiner_remux_rules import PlannedTrack, RemuxPlan
-from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.file_remux_pass.visibility import (
     REMUX_PASS_OUTCOME_FAILED_BEFORE_EXECUTION,
     REMUX_PASS_OUTCOME_FAILED_DURING_EXECUTION,
     REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED,
     REMUX_PASS_OUTCOME_SKIPPED_GUARDRAIL,
 )
+from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
+from mediamop.modules.refiner.refiner_remux_rules import PlannedTrack, RemuxPlan
 from mediamop.platform.file_lifecycle.guardrails import DiskSpaceCheck
 
 from .test_refiner_tv_season_folder_cleanup import _sqlite_session

--- a/apps/backend/tests/test_refiner_jobs_claim.py
+++ b/apps/backend/tests/test_refiner_jobs_claim.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import threading
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+# Register all ORM tables on Base.metadata (create_all parity with Alembic surface).
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.db import Base
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.jobs_ops import (
@@ -20,11 +24,6 @@ from mediamop.modules.refiner.jobs_ops import (
     recover_handler_ok_finalize_failed_to_completed,
     refiner_enqueue_or_get_job,
 )
-
-# Register all ORM tables on Base.metadata (create_all parity with Alembic surface).
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -52,7 +51,7 @@ def session_factory(jobs_engine):
 
 
 def _t0() -> datetime:
-    return datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    return datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
 
 
 def test_enqueue_duplicate_dedupe_key_returns_same_row(session_factory):

--- a/apps/backend/tests/test_refiner_jobs_inspection_api.py
+++ b/apps/backend/tests/test_refiner_jobs_inspection_api.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import delete
 from starlette.testclient import TestClient
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
@@ -20,11 +23,8 @@ from tests.integration_app_runtime_quiesce import (
     integration_test_quiesce_periodic_enqueue,
     integration_test_set_home,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, seed_admin_user, seed_viewer_user
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
+from tests.integration_helpers import auth_post, seed_admin_user, seed_viewer_user
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 @pytest.fixture(autouse=True)
@@ -87,9 +87,9 @@ def _login_viewer(client: TestClient) -> None:
 
 
 def _seed_mixed_status_rows() -> None:
-    t0 = datetime(2026, 4, 11, 10, 0, 0, tzinfo=timezone.utc)
-    t1 = datetime(2026, 4, 11, 11, 0, 0, tzinfo=timezone.utc)
-    t2 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 10, 0, 0, tzinfo=UTC)
+    t1 = datetime(2026, 4, 11, 11, 0, 0, tzinfo=UTC)
+    t2 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     fac = _fac()
     with fac() as db:
         db.execute(delete(RefinerJob))
@@ -238,7 +238,7 @@ def test_refiner_job_cancel_pending_refuses_leased(client_with_admin: TestClient
             job_kind="refiner.candidate_gate.v1",
             status=RefinerJobStatus.LEASED.value,
             lease_owner="w",
-            lease_expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            lease_expires_at=datetime(2099, 1, 1, tzinfo=UTC),
             attempt_count=1,
         )
         db.add(row)

--- a/apps/backend/tests/test_refiner_movie_output_cleanup.py
+++ b/apps/backend/tests/test_refiner_movie_output_cleanup.py
@@ -16,8 +16,8 @@ from sqlalchemy.orm import Session, sessionmaker
 import mediamop.modules.refiner.jobs_model  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_movie_output_cleanup import (
     maybe_run_movie_output_folder_cleanup_after_remux,
     normalize_relative_media_path_for_match,

--- a/apps/backend/tests/test_refiner_operator_settings_api.py
+++ b/apps/backend/tests/test_refiner_operator_settings_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_overview_stats_api.py
+++ b/apps/backend/tests/test_refiner_overview_stats_api.py
@@ -9,11 +9,12 @@ from starlette.testclient import TestClient
 
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.platform.activity import constants as activity_constants
 from mediamop.platform.activity.models import ActivityEvent
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_path_settings_api.py
+++ b/apps/backend/tests/test_refiner_path_settings_api.py
@@ -16,8 +16,8 @@ from mediamop.modules.refiner.refiner_path_settings_service import (
     resolved_default_refiner_tv_work_folder,
     resolved_default_refiner_work_folder,
 )
-
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_remux_rules_settings_api.py
+++ b/apps/backend/tests/test_refiner_remux_rules_settings_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_runtime_settings_api.py
+++ b/apps/backend/tests/test_refiner_runtime_settings_api.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_supplied_payload_evaluation_lane.py
+++ b/apps/backend/tests/test_refiner_supplied_payload_evaluation_lane.py
@@ -3,29 +3,32 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_candidate_gate_job_kinds import REFINER_CANDIDATE_GATE_JOB_KIND
-from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.refiner_failure_cleanup_job_kinds import (
     REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND,
     REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND,
 )
 from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_handlers
-from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
-    REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
-)
 from mediamop.modules.refiner.refiner_supplied_payload_evaluation_job_kinds import (
     REFINER_SUPPLIED_PAYLOAD_EVALUATION_JOB_KIND,
+)
+from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
+    REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
 )
 from mediamop.modules.refiner.refiner_work_temp_stale_sweep_job_kinds import (
     REFINER_WORK_TEMP_STALE_SWEEP_JOB_KIND,
@@ -33,10 +36,6 @@ from mediamop.modules.refiner.refiner_work_temp_stale_sweep_job_kinds import (
 from mediamop.modules.refiner.worker_loop import process_one_refiner_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -79,7 +78,7 @@ def test_build_refiner_job_handlers_registry_is_refiner_prefixed_only(session_fa
 
 
 def test_supplied_payload_evaluation_runs_on_refiner_lane_records_activity(session_factory) -> None:
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     payload = {
         "rows": [
             {

--- a/apps/backend/tests/test_refiner_supplied_payload_evaluation_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_supplied_payload_evaluation_manual_enqueue_api.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from sqlalchemy import delete, select
 from starlette.testclient import TestClient
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.refiner.jobs_model import RefinerJob
@@ -12,11 +15,8 @@ from mediamop.modules.refiner.refiner_supplied_payload_evaluation_job_kinds impo
     REFINER_SUPPLIED_PAYLOAD_EVALUATION_DEDUPE_KEY,
     REFINER_SUPPLIED_PAYLOAD_EVALUATION_JOB_KIND,
 )
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _fac():

--- a/apps/backend/tests/test_refiner_temp_cleanup.py
+++ b/apps/backend/tests/test_refiner_temp_cleanup.py
@@ -16,8 +16,8 @@ import mediamop.modules.refiner.jobs_model  # noqa: F401
 import mediamop.modules.refiner.refiner_temp_cleanup as refiner_temp_cleanup
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_temp_cleanup import (
     is_refiner_owned_temp_work_file,
     refiner_file_remux_pass_job_active_for_scope,
@@ -333,13 +333,12 @@ def test_file_lock_skip_continues_movie_scope(tmp_path: Path) -> None:
             raise PermissionError("locked")
         return real_unlink(self, *a, **kw)
 
-    with _patch_roots(w_m, w_t):
-        with patch.object(Path, "unlink", _unlink):
-            out = run_refiner_work_temp_stale_sweep_for_scope(
-                session=session,
-                settings=settings,
-                media_scope="movie",
-            )
+    with _patch_roots(w_m, w_t), patch.object(Path, "unlink", _unlink):
+        out = run_refiner_work_temp_stale_sweep_for_scope(
+            session=session,
+            settings=settings,
+            media_scope="movie",
+        )
     assert f1.exists()
     assert not f2.exists()
     assert len(out["temp_cleanup_files_deleted"]) == 1

--- a/apps/backend/tests/test_refiner_tv_output_cleanup.py
+++ b/apps/backend/tests/test_refiner_tv_output_cleanup.py
@@ -15,8 +15,8 @@ from sqlalchemy.orm import Session, sessionmaker
 import mediamop.modules.refiner.jobs_model  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_tv_output_cleanup import (
     iter_direct_child_refiner_media_candidates,

--- a/apps/backend/tests/test_refiner_tv_season_folder_cleanup.py
+++ b/apps/backend/tests/test_refiner_tv_season_folder_cleanup.py
@@ -5,21 +5,23 @@ from __future__ import annotations
 import json
 import os
 import time
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from dataclasses import replace
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.file_remux_pass.visibility import (
     REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN,
     REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED,
 )
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_path_settings_service import RefinerPathRuntime
 from mediamop.modules.refiner.refiner_tv_season_folder_cleanup import (
     get_tv_episode_set_media_files,
@@ -27,9 +29,6 @@ from mediamop.modules.refiner.refiner_tv_season_folder_cleanup import (
 )
 from mediamop.platform.activity import constants as activity_c
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
 
 
 def _sqlite_session(tmp_path: Path) -> tuple[sessionmaker[Session], Session]:

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +11,10 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_path_settings_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
@@ -23,11 +27,6 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kin
 )
 from mediamop.modules.refiner.worker_loop import process_one_refiner_job
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.modules.refiner.refiner_path_settings_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -82,7 +81,7 @@ def test_scan_handler_enqueues_remux_when_requested(
     def _fake_fetch(_session: Session, _settings: MediaMopSettings):
         return fake_rad, [], None, None
 
-    t0 = datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC)
 
     with session_factory() as s:
         s.merge(
@@ -200,7 +199,7 @@ def test_scan_handler_enqueues_remux_without_arr_connections(
                 session_factory,
                 lease_owner="scan-test",
                 job_handlers=handlers,
-                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC),
                 lease_seconds=3600,
             )
             == "processed"
@@ -293,7 +292,7 @@ def test_scan_handler_skips_file_when_previous_success_output_still_exists(
                 session_factory,
                 lease_owner="scan-test",
                 job_handlers=handlers,
-                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC),
                 lease_seconds=3600,
             )
             == "processed"
@@ -355,7 +354,7 @@ def test_scan_handler_does_not_record_activity_when_no_files_are_queued(
                 session_factory,
                 lease_owner="scan-test",
                 job_handlers=handlers,
-                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=timezone.utc),
+                now=datetime(2026, 4, 12, 12, 0, 0, tzinfo=UTC),
                 lease_seconds=3600,
             )
             == "processed"

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
@@ -12,8 +12,8 @@ from mediamop.modules.refiner.jobs_model import RefinerJob
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
     REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
 )
-
-from tests.integration_helpers import auth_post, csrf as fetch_csrf, trusted_browser_origin_headers
+from tests.integration_helpers import auth_post, trusted_browser_origin_headers
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login_admin(client: TestClient) -> None:

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -7,9 +7,11 @@ import json
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
 from mediamop.core.db import Base
-from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops import (
     iter_watched_folder_media_candidate_files,
     refiner_active_remux_pass_exists_for_relative_path,
@@ -18,9 +20,6 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops imp
     retry_completed_movie_source_cleanup,
 )
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
 
 
 def test_iter_watched_folder_media_candidates_sorted(tmp_path) -> None:

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -10,6 +10,11 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy import delete, select, update
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_path_settings_model  # noqa: F401
+import mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue as periodic_enqueue
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
@@ -18,7 +23,6 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_enqueue
     refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan,
     try_enqueue_periodic_watched_folder_remux_scan_dispatch,
 )
-import mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue as periodic_enqueue
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
     REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
 )
@@ -27,11 +31,6 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodi
     _next_scheduler_sleep_seconds,
     _watched_folder_scan_interval_seconds,
 )
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.modules.refiner.refiner_path_settings_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 def _fac():

--- a/apps/backend/tests/test_refiner_worker_loop.py
+++ b/apps/backend/tests/test_refiner_worker_loop.py
@@ -4,29 +4,28 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from unittest.mock import patch
 
 import pytest
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import Base
+from mediamop.modules.refiner import worker_loop as refiner_worker_loop_mod
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.jobs_ops import complete_claimed_refiner_job as real_complete_claimed
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.worker_limits import clamp_refiner_worker_count
-from mediamop.modules.refiner import worker_loop as refiner_worker_loop_mod
-from mediamop.modules.refiner.jobs_ops import complete_claimed_refiner_job as real_complete_claimed
 from mediamop.modules.refiner.worker_loop import (
     process_one_refiner_job,
     refiner_worker_run_forever,
     start_refiner_worker_background_tasks,
     stop_refiner_worker_background_tasks,
 )
-
-import mediamop.modules.refiner.jobs_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
-from mediamop.core.db import Base
 
 
 @pytest.fixture
@@ -152,7 +151,7 @@ def test_process_one_idle_when_no_jobs(session_factory) -> None:
 
 
 def test_process_one_completes_with_success_handler(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="d1", job_kind="refiner.test.ok.v1", max_attempts=3)
         s.commit()
@@ -174,7 +173,7 @@ def test_process_one_completes_with_success_handler(session_factory) -> None:
 
 
 def test_process_one_fail_path_on_handler_error(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(
             s,
@@ -203,7 +202,7 @@ def test_process_one_fail_path_on_handler_error(session_factory) -> None:
 
 
 def test_process_one_missing_handler_fails_claimed_job(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="d3", job_kind="refiner.test.unknown.v1")
         s.commit()
@@ -227,7 +226,7 @@ def test_refiner_worker_loop_processes_one_job_then_stops(session_factory, monke
         "mediamop.modules.refiner.worker_loop.REFINER_WORKER_IDLE_SLEEP_SECONDS",
         0.05,
     )
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="loop1", job_kind="refiner.test.loop_ok.v1")
         s.commit()
@@ -314,7 +313,7 @@ def test_worker_survives_tick_exception_then_processes_idle(
 
 
 def test_process_one_survives_complete_claim_raises(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="d-complete-raise", job_kind="refiner.test.ok.v1", max_attempts=3)
         s.commit()
@@ -345,7 +344,7 @@ def test_process_one_survives_complete_claim_raises(session_factory) -> None:
 
 
 def test_process_one_complete_refused_triggers_terminalization(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="d-complete-false", job_kind="refiner.test.ok.v1", max_attempts=3)
         s.commit()
@@ -374,7 +373,7 @@ def test_process_one_complete_refused_triggers_terminalization(session_factory) 
 
 
 def test_terminalization_of_first_job_does_not_block_second_job_completion(session_factory) -> None:
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="seq-a", job_kind="refiner.test.ok.v1", max_attempts=3)
         refiner_enqueue_or_get_job(s, dedupe_key="seq-b", job_kind="refiner.test.ok.v1", max_attempts=3)
@@ -436,7 +435,7 @@ def test_worker_stays_alive_after_complete_failure_terminalization(
         "REFINER_WORKER_IDLE_SLEEP_SECONDS",
         0.05,
     )
-    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 10, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         refiner_enqueue_or_get_job(s, dedupe_key="w-term", job_kind="refiner.test.term.v1", max_attempts=3)
         s.commit()

--- a/apps/backend/tests/test_release_catalog.py
+++ b/apps/backend/tests/test_release_catalog.py
@@ -30,7 +30,7 @@ def test_fetch_release_record_by_version_rejects_wrong_returned_tag(monkeypatch:
             return payload
 
     class _Client:
-        def __enter__(self) -> "_Client":
+        def __enter__(self) -> _Client:
             return self
 
         def __exit__(self, exc_type, exc, tb) -> None:
@@ -67,7 +67,7 @@ def test_fetch_release_record_by_version_rejects_prerelease(monkeypatch: pytest.
             return payload
 
     class _Client:
-        def __enter__(self) -> "_Client":
+        def __enter__(self) -> _Client:
             return self
 
         def __exit__(self, exc_type, exc, tb) -> None:

--- a/apps/backend/tests/test_sqlite_foundation.py
+++ b/apps/backend/tests/test_sqlite_foundation.py
@@ -7,12 +7,11 @@ import sqlite3
 import stat
 import sys
 import warnings
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
 import pytest
-
 from sqlalchemy.engine import Engine
 
 from mediamop.core import db as db_module
@@ -82,7 +81,7 @@ def test_create_db_engine_registers_sqlite_datetime_adapter(
             warnings.simplefilter("always", DeprecationWarning)
             with sqlite3.connect(":memory:") as conn:
                 conn.execute("create table t(v text)")
-                conn.execute("insert into t(v) values (?)", (datetime.now(timezone.utc),))
+                conn.execute("insert into t(v) values (?)", (datetime.now(UTC),))
                 conn.commit()
         assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
     finally:

--- a/apps/backend/tests/test_startup_crash_recovery.py
+++ b/apps/backend/tests/test_startup_crash_recovery.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 from sqlalchemy import create_engine
@@ -30,44 +30,42 @@ def _session_factory(tmp_path: Path) -> sessionmaker[Session]:
 
 def test_startup_recovery_requeues_leased_jobs_with_attempts_remaining(tmp_path: Path) -> None:
     factory = _session_factory(tmp_path)
-    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
-    with factory() as session:
-        with session.begin():
-            session.add_all(
-                [
-                    RefinerJob(
-                        dedupe_key="refiner-recover",
-                        job_kind="refiner.test.v1",
-                        status=RefinerJobStatus.LEASED.value,
-                        lease_owner="dead-refiner",
-                        lease_expires_at=now + timedelta(hours=1),
-                        attempt_count=1,
-                        max_attempts=3,
-                    ),
-                    PrunerJob(
-                        dedupe_key="pruner-recover",
-                        job_kind="pruner.test.v1",
-                        status=PrunerJobStatus.LEASED.value,
-                        lease_owner="dead-pruner",
-                        lease_expires_at=now + timedelta(hours=1),
-                        attempt_count=1,
-                        max_attempts=2,
-                    ),
-                    SubberJob(
-                        dedupe_key="subber-recover",
-                        job_kind="subber.test.v1",
-                        status=SubberJobStatus.LEASED.value,
-                        lease_owner="dead-subber",
-                        lease_expires_at=now + timedelta(hours=1),
-                        attempt_count=0,
-                        max_attempts=1,
-                    ),
-                ],
-            )
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=UTC)
+    with factory() as session, session.begin():
+        session.add_all(
+            [
+                RefinerJob(
+                    dedupe_key="refiner-recover",
+                    job_kind="refiner.test.v1",
+                    status=RefinerJobStatus.LEASED.value,
+                    lease_owner="dead-refiner",
+                    lease_expires_at=now + timedelta(hours=1),
+                    attempt_count=1,
+                    max_attempts=3,
+                ),
+                PrunerJob(
+                    dedupe_key="pruner-recover",
+                    job_kind="pruner.test.v1",
+                    status=PrunerJobStatus.LEASED.value,
+                    lease_owner="dead-pruner",
+                    lease_expires_at=now + timedelta(hours=1),
+                    attempt_count=1,
+                    max_attempts=2,
+                ),
+                SubberJob(
+                    dedupe_key="subber-recover",
+                    job_kind="subber.test.v1",
+                    status=SubberJobStatus.LEASED.value,
+                    lease_owner="dead-subber",
+                    lease_expires_at=now + timedelta(hours=1),
+                    attempt_count=0,
+                    max_attempts=1,
+                ),
+            ],
+        )
 
-    with factory() as session:
-        with session.begin():
-            result = recover_incomplete_jobs_after_startup(session, now=now)
+    with factory() as session, session.begin():
+        result = recover_incomplete_jobs_after_startup(session, now=now)
 
     assert result.refiner_requeued == 1
     assert result.pruner_requeued == 1
@@ -87,24 +85,22 @@ def test_startup_recovery_requeues_leased_jobs_with_attempts_remaining(tmp_path:
 
 def test_startup_recovery_fails_leased_jobs_after_final_attempt(tmp_path: Path) -> None:
     factory = _session_factory(tmp_path)
-    now = datetime(2026, 4, 29, 12, 0, tzinfo=timezone.utc)
-    with factory() as session:
-        with session.begin():
-            session.add(
-                RefinerJob(
-                    dedupe_key="refiner-final",
-                    job_kind="refiner.test.v1",
-                    status=RefinerJobStatus.LEASED.value,
-                    lease_owner="dead-refiner",
-                    lease_expires_at=now + timedelta(hours=1),
-                    attempt_count=3,
-                    max_attempts=3,
-                ),
-            )
+    now = datetime(2026, 4, 29, 12, 0, tzinfo=UTC)
+    with factory() as session, session.begin():
+        session.add(
+            RefinerJob(
+                dedupe_key="refiner-final",
+                job_kind="refiner.test.v1",
+                status=RefinerJobStatus.LEASED.value,
+                lease_owner="dead-refiner",
+                lease_expires_at=now + timedelta(hours=1),
+                attempt_count=3,
+                max_attempts=3,
+            ),
+        )
 
-    with factory() as session:
-        with session.begin():
-            result = recover_incomplete_jobs_after_startup(session, now=now)
+    with factory() as session, session.begin():
+        result = recover_incomplete_jobs_after_startup(session, now=now)
 
     assert result.refiner_failed == 1
     with factory() as session:
@@ -127,9 +123,8 @@ def test_startup_refiner_recovery_removes_hidden_partial_outputs(tmp_path: Path)
     final.write_bytes(b"complete")
 
     settings = MediaMopSettings.load()
-    with factory() as session:
-        with session.begin():
-            session.add(RefinerPathSettingsRow(id=1, refiner_output_folder=str(output), refiner_work_folder="", refiner_watched_folder=""))
+    with factory() as session, session.begin():
+        session.add(RefinerPathSettingsRow(id=1, refiner_output_folder=str(output), refiner_work_folder="", refiner_watched_folder=""))
 
     with factory() as session:
         removed = cleanup_refiner_partial_output_files(session, settings)

--- a/apps/backend/tests/test_subber_jobs_lane.py
+++ b/apps/backend/tests/test_subber_jobs_lane.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.queue_worker.job_kind_boundaries import validate_subber_worker_handler_registry
@@ -27,12 +32,6 @@ from mediamop.modules.subber.worker_loop import process_one_subber_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
 from mediamop.platform.metrics.service import build_runtime_metrics_summary, reset_runtime_metrics_for_tests
-
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -69,7 +68,7 @@ def test_build_subber_job_handlers_registry_matches_production_kinds(session_fac
 
 def test_webhook_import_tv_runs_on_subber_lane_records_activity(session_factory) -> None:
     reset_runtime_metrics_for_tests()
-    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 11, 12, 0, 0, tzinfo=UTC)
     settings = MediaMopSettings.load()
     payload = {
         "file_path": "/media/tv/Pilot.mkv",

--- a/apps/backend/tests/test_subber_library_api.py
+++ b/apps/backend/tests/test_subber_library_api.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from starlette.testclient import TestClient
 
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.modules.subber.subber_job_kinds import (

--- a/apps/backend/tests/test_subber_library_scan_job_handler.py
+++ b/apps/backend/tests/test_subber_library_scan_job_handler.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
@@ -19,12 +24,6 @@ from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
 from mediamop.modules.subber.worker_loop import process_one_subber_job
-
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -58,7 +57,7 @@ def test_library_scan_enqueues_missing_not_recent(session_factory) -> None:
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="ls1", job_handlers=handlers, now=t0, lease_seconds=600)
     with session_factory() as s:
         jobs = list(s.scalars(select(SubberJob).order_by(SubberJob.id.asc())).all())
@@ -67,7 +66,7 @@ def test_library_scan_enqueues_missing_not_recent(session_factory) -> None:
 
 
 def test_library_scan_skips_recently_searched(session_factory) -> None:
-    recent = datetime(2026, 6, 1, 11, 0, 0, tzinfo=timezone.utc)
+    recent = datetime(2026, 6, 1, 11, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         s.add(SubberSettingsRow(id=1, enabled=True))
         s.add(
@@ -90,7 +89,7 @@ def test_library_scan_skips_recently_searched(session_factory) -> None:
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="ls2", job_handlers=handlers, now=t0, lease_seconds=600)
     with session_factory() as s:
         jobs = list(s.scalars(select(SubberJob)).all())

--- a/apps/backend/tests/test_subber_library_sync_job_handler.py
+++ b/apps/backend/tests/test_subber_library_sync_job_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,11 +11,19 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.subber.subber_credentials_crypto import encrypt_subber_credentials_json
 from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
-from mediamop.modules.subber.subber_job_kinds import SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES, SUBBER_JOB_KIND_LIBRARY_SYNC_TV
+from mediamop.modules.subber.subber_job_kinds import (
+    SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
+    SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
+)
 from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
@@ -23,12 +31,6 @@ from mediamop.modules.subber.subber_subtitle_state_service import upsert_subtitl
 from mediamop.modules.subber.worker_loop import process_one_subber_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -96,7 +98,7 @@ def test_library_sync_movies_upserts_and_detects_srt(session_factory, tmp_path: 
         s.commit()
 
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     with patch("mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload):
         assert (
             process_one_subber_job(
@@ -156,7 +158,7 @@ def test_library_sync_tv_upserts_and_detects_srt(session_factory, tmp_path: Path
     ]
 
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     with (
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_series", return_value=series),
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episodes", return_value=episodes),
@@ -197,7 +199,7 @@ def test_library_sync_movies_skips_without_credentials(session_factory) -> None:
         s.commit()
 
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     with patch("mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies") as m:
         assert (
             process_one_subber_job(
@@ -248,7 +250,7 @@ def test_upsert_does_not_downgrade_found_to_missing(session_factory) -> None:
         s.commit()
 
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     with patch("mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload):
         process_one_subber_job(session_factory, lease_owner="ls4", job_handlers=handlers, now=t0, lease_seconds=600)
 
@@ -288,7 +290,7 @@ def test_library_sync_tv_resolves_path_via_episode_file_table(session_factory, t
     ep_files = [{"id": 555, "path": str(mkv), "seriesId": 1}]
 
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
     with (
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_series", return_value=series),
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episodes", return_value=episodes),

--- a/apps/backend/tests/test_subber_opensubtitles_client.py
+++ b/apps/backend/tests/test_subber_opensubtitles_client.py
@@ -21,6 +21,5 @@ def test_request_429_raises_subber_rate_limit_error() -> None:
     request = httpx.Request("GET", "https://api.opensubtitles.com/api/v1/x")
     response = httpx.Response(429, request=request, content=io.BytesIO().getvalue())
     err = httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
-    with patch("mediamop.modules.subber.subber_opensubtitles_client.request_json", side_effect=err):
-        with pytest.raises(SubberRateLimitError):
-            _request("GET", "/subtitles?query=x", api_key="key", token=None)
+    with patch("mediamop.modules.subber.subber_opensubtitles_client.request_json", side_effect=err), pytest.raises(SubberRateLimitError):
+        _request("GET", "/subtitles?query=x", api_key="key", token=None)

--- a/apps/backend/tests/test_subber_overview_api.py
+++ b/apps/backend/tests/test_subber_overview_api.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> None:

--- a/apps/backend/tests/test_subber_schedule_enqueue.py
+++ b/apps/backend/tests/test_subber_schedule_enqueue.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -10,6 +10,9 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.db import Base
 from mediamop.modules.subber.subber_job_kinds import (
     SUBBER_JOB_KIND_LIBRARY_SCAN_MOVIES,
@@ -17,15 +20,12 @@ from mediamop.modules.subber.subber_job_kinds import (
     SUBBER_JOB_KIND_SUBTITLE_UPGRADE,
 )
 from mediamop.modules.subber.subber_jobs_model import SubberJob
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
 from mediamop.modules.subber.subber_schedule_enqueue import (
     enqueue_due_subber_movies_scan,
     enqueue_due_subber_tv_scan,
     enqueue_due_subber_upgrade,
 )
 from mediamop.modules.subber.subber_settings_service import ensure_subber_settings_row
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def _job_kinds(session_factory) -> list[str]:
 
 
 def test_tv_scan_fires_when_enabled(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         with s.begin():
             row = ensure_subber_settings_row(s)
@@ -59,7 +59,7 @@ def test_tv_scan_fires_when_enabled(session_factory) -> None:
 
 
 def test_tv_scan_does_not_fire_when_disabled(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         with s.begin():
             row = ensure_subber_settings_row(s)
@@ -73,7 +73,7 @@ def test_tv_scan_does_not_fire_when_disabled(session_factory) -> None:
 
 
 def test_tv_scan_does_not_fire_before_interval(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     last = t0 - timedelta(seconds=30)
     with session_factory() as s:
         with s.begin():
@@ -89,24 +89,23 @@ def test_tv_scan_does_not_fire_before_interval(session_factory) -> None:
 
 
 def test_movies_scan_fires_independently_of_tv(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
-    with session_factory() as s:
-        with s.begin():
-            row = ensure_subber_settings_row(s)
-            row.enabled = True
-            row.tv_schedule_enabled = False
-            row.movies_schedule_enabled = True
-            row.movies_schedule_interval_seconds = 60
-            row.movies_last_scheduled_scan_enqueued_at = None
-            row.movies_schedule_hours_limited = False
-            assert enqueue_due_subber_tv_scan(s, now=t0) == 0
-            assert enqueue_due_subber_movies_scan(s, now=t0) == 1
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+    with session_factory() as s, s.begin():
+        row = ensure_subber_settings_row(s)
+        row.enabled = True
+        row.tv_schedule_enabled = False
+        row.movies_schedule_enabled = True
+        row.movies_schedule_interval_seconds = 60
+        row.movies_last_scheduled_scan_enqueued_at = None
+        row.movies_schedule_hours_limited = False
+        assert enqueue_due_subber_tv_scan(s, now=t0) == 0
+        assert enqueue_due_subber_movies_scan(s, now=t0) == 1
     kinds = _job_kinds(session_factory)
     assert kinds == [SUBBER_JOB_KIND_LIBRARY_SCAN_MOVIES]
 
 
 def test_upgrade_scan_fires_when_both_flags_enabled(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         with s.begin():
             row = ensure_subber_settings_row(s)
@@ -123,7 +122,7 @@ def test_upgrade_scan_fires_when_both_flags_enabled(session_factory) -> None:
 
 
 def test_upgrade_scan_does_not_fire_when_upgrade_disabled(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         with s.begin():
             row = ensure_subber_settings_row(s)
@@ -139,7 +138,7 @@ def test_upgrade_scan_does_not_fire_when_upgrade_disabled(session_factory) -> No
 
 
 def test_upgrade_scan_does_not_fire_when_schedule_disabled(session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
     with session_factory() as s:
         with s.begin():
             row = ensure_subber_settings_row(s)
@@ -159,17 +158,16 @@ def test_upgrade_scan_does_not_fire_when_schedule_disabled(session_factory) -> N
     side_effect=RuntimeError("tv tick failed"),
 )
 def test_tv_crash_does_not_affect_movies_enqueue(mock_tv: object, session_factory) -> None:
-    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
-    with session_factory() as s:
-        with s.begin():
-            row = ensure_subber_settings_row(s)
-            row.enabled = True
-            row.tv_schedule_enabled = False
-            row.movies_schedule_enabled = True
-            row.movies_schedule_interval_seconds = 60
-            row.movies_last_scheduled_scan_enqueued_at = None
-            row.movies_schedule_hours_limited = False
-            assert enqueue_due_subber_movies_scan(s, now=t0) == 1
+    t0 = datetime(2026, 4, 1, 12, 0, 0, tzinfo=UTC)
+    with session_factory() as s, s.begin():
+        row = ensure_subber_settings_row(s)
+        row.enabled = True
+        row.tv_schedule_enabled = False
+        row.movies_schedule_enabled = True
+        row.movies_schedule_interval_seconds = 60
+        row.movies_last_scheduled_scan_enqueued_at = None
+        row.movies_schedule_hours_limited = False
+        assert enqueue_due_subber_movies_scan(s, now=t0) == 1
     assert mock_tv.call_count == 0
     kinds = _job_kinds(session_factory)
     assert kinds == [SUBBER_JOB_KIND_LIBRARY_SCAN_MOVIES]

--- a/apps/backend/tests/test_subber_search_job_handler.py
+++ b/apps/backend/tests/test_subber_search_job_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +11,11 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
@@ -20,12 +25,6 @@ from mediamop.modules.subber.subber_jobs_ops import subber_enqueue_or_get_job
 from mediamop.modules.subber.subber_settings_model import SubberSettingsRow
 from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleState
 from mediamop.modules.subber.worker_loop import process_one_subber_job
-
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -67,7 +66,7 @@ def test_subtitle_search_skips_when_found_and_file_exists(session_factory, tmp_p
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
     assert (
         process_one_subber_job(
             session_factory,
@@ -108,7 +107,7 @@ def test_subtitle_search_marks_skipped_at_search_cap(_mock_cfg, session_factory)
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="u2", job_handlers=handlers, now=t0, lease_seconds=600)
     with session_factory() as s:
         row = s.get(SubberSubtitleState, sid)
@@ -142,6 +141,6 @@ def test_subtitle_search_calls_download(mock_dl, _mock_os_cfg, session_factory) 
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="u3", job_handlers=handlers, now=t0, lease_seconds=600)
     assert mock_dl.called

--- a/apps/backend/tests/test_subber_settings_api.py
+++ b/apps/backend/tests/test_subber_settings_api.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
+import urllib.error
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import urllib.error
-from alembic import command
 from alembic.config import Config
 from starlette.testclient import TestClient
 
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.modules.subber.subber_settings_api import _load_secrets_envelope
 from tests.integration_app_runtime_quiesce import (
@@ -379,7 +379,7 @@ class _JsonResponse:
     def __init__(self, payload: str) -> None:
         self._payload = payload
 
-    def __enter__(self) -> "_JsonResponse":
+    def __enter__(self) -> _JsonResponse:
         return self
 
     def __exit__(self, *_args: object) -> None:

--- a/apps/backend/tests/test_subber_upgrade_job_handler.py
+++ b/apps/backend/tests/test_subber_upgrade_job_handler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -11,6 +11,11 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
+import mediamop.modules.subber.subber_jobs_model  # noqa: F401
+import mediamop.modules.subber.subber_settings_model  # noqa: F401
+import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.auth.models  # noqa: F401
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.subber.subber_job_handlers import build_subber_job_handlers
@@ -22,12 +27,6 @@ from mediamop.modules.subber.subber_subtitle_state_model import SubberSubtitleSt
 from mediamop.modules.subber.worker_loop import process_one_subber_job
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.models import ActivityEvent
-
-import mediamop.modules.subber.subber_jobs_model  # noqa: F401
-import mediamop.modules.subber.subber_settings_model  # noqa: F401
-import mediamop.modules.subber.subber_subtitle_state_model  # noqa: F401
-import mediamop.platform.activity.models  # noqa: F401
-import mediamop.platform.auth.models  # noqa: F401
 
 
 @pytest.fixture
@@ -52,7 +51,7 @@ def test_upgrade_job_noop_when_disabled(mock_dl, session_factory) -> None:
         s.commit()
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="u1", job_handlers=handlers, now=t0, lease_seconds=600)
     assert not mock_dl.called
 
@@ -86,7 +85,7 @@ def test_upgrade_runs_when_enabled(mock_dl, _mock_cfg, mock_cand, session_factor
         s.commit()
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 1, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="u2", job_handlers=handlers, now=t0, lease_seconds=600)
     assert mock_dl.called
     assert mock_cand.called
@@ -115,7 +114,7 @@ def test_upgrade_handler_skips_when_subber_disabled(mock_dl, session_factory) ->
         s.commit()
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 2, tzinfo=UTC)
     process_one_subber_job(session_factory, lease_owner="u3", job_handlers=handlers, now=t0, lease_seconds=600)
     assert not mock_dl.called
     with session_factory() as s:
@@ -167,7 +166,7 @@ def test_upgrade_handler_runs_when_enabled_with_candidates(session_factory, tmp_
 
     settings = MediaMopSettings.load()
     handlers = build_subber_job_handlers(settings, session_factory)
-    t0 = datetime(2026, 1, 3, tzinfo=timezone.utc)
+    t0 = datetime(2026, 1, 3, tzinfo=UTC)
     with (
         patch(
             "mediamop.modules.subber.subber_upgrade_job_handler.search_and_download_subtitle",

--- a/apps/backend/tests/test_subber_webhook_api.py
+++ b/apps/backend/tests/test_subber_webhook_api.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from alembic import command
 from alembic.config import Config
 from sqlalchemy import select
 from starlette.testclient import TestClient
 
+from alembic import command
 from mediamop.api.factory import create_app
 from mediamop.modules.subber.subber_jobs_model import SubberJob
 from tests.integration_app_runtime_quiesce import (

--- a/apps/backend/tests/test_suite_configuration_backup_security.py
+++ b/apps/backend/tests/test_suite_configuration_backup_security.py
@@ -20,6 +20,5 @@ def test_configuration_backup_download_rejects_path_traversal_file_name() -> Non
         db.commit()
         backup_id = row.id
 
-    with factory() as db:
-        with pytest.raises(ValueError, match="file name is invalid"):
-            get_suite_configuration_backup_file_path(db, settings=settings, backup_id=backup_id)
+    with factory() as db, pytest.raises(ValueError, match="file name is invalid"):
+        get_suite_configuration_backup_file_path(db, settings=settings, backup_id=backup_id)

--- a/apps/backend/tests/test_suite_operational_history.py
+++ b/apps/backend/tests/test_suite_operational_history.py
@@ -12,7 +12,8 @@ from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.subber.subber_jobs_model import SubberJob, SubberJobStatus
 from mediamop.platform.activity import constants as activity_constants
 from mediamop.platform.activity.models import ActivityEvent
-from tests.integration_helpers import auth_post, csrf as fetch_csrf
+from tests.integration_helpers import auth_post
+from tests.integration_helpers import csrf as fetch_csrf
 
 
 def _login(client: TestClient) -> str:

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -16,28 +16,29 @@ from mediamop.core.db import create_db_engine, create_session_factory
 from mediamop.platform.activity import constants as act_c
 from mediamop.platform.activity.models import ActivityEvent
 from mediamop.platform.activity.service import record_activity_event
-from mediamop.platform.suite_settings.release_catalog import (
-    GitHubReleaseAsset,
-    GitHubReleaseRecord,
-)
-from mediamop.platform.suite_settings.model import SuiteSettingsRow
-from mediamop.platform.suite_settings.service import apply_suite_settings_put, ensure_suite_settings_row
 from mediamop.platform.auth.models import User
 from mediamop.platform.auth.password import hash_password
-from mediamop.platform.suite_settings.suite_configuration_backup_periodic import run_suite_configuration_backup_tick
-from mediamop.platform.suite_settings.suite_configuration_backup_service import list_suite_configuration_backups
 from mediamop.platform.suite_settings.logs_retention_periodic import (
     reset_log_retention_periodic_state_for_tests,
     run_log_retention_tick,
 )
 from mediamop.platform.suite_settings.logs_service import ParsedLogEntry
+from mediamop.platform.suite_settings.model import SuiteSettingsRow
+from mediamop.platform.suite_settings.release_catalog import (
+    GitHubReleaseAsset,
+    GitHubReleaseRecord,
+)
+from mediamop.platform.suite_settings.service import apply_suite_settings_put, ensure_suite_settings_row
+from mediamop.platform.suite_settings.suite_configuration_backup_periodic import run_suite_configuration_backup_tick
+from mediamop.platform.suite_settings.suite_configuration_backup_service import list_suite_configuration_backups
 from mediamop.platform.suite_settings.update_service import start_suite_update_now
-
 from tests.integration_helpers import (
     auth_post,
-    csrf as fetch_csrf,
     reset_user_tables,
     trusted_browser_origin_headers,
+)
+from tests.integration_helpers import (
+    csrf as fetch_csrf,
 )
 
 
@@ -342,7 +343,7 @@ def test_log_retention_does_not_prune_activity_history(client_with_admin: TestCl
         assert old is not None
         from datetime import datetime, timedelta, timezone
 
-        old.created_at = datetime.now(timezone.utc) - timedelta(days=40)
+        old.created_at = datetime.now(UTC) - timedelta(days=40)
         db.commit()
 
     tok = fetch_csrf(client_with_admin)

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pathlib import Path
 import re
 import threading
+from pathlib import Path
 
 from mediamop.windows import tray_app
 

--- a/apps/backend/tests/test_windows_updater_service.py
+++ b/apps/backend/tests/test_windows_updater_service.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-import time
 import threading
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 

--- a/apps/backend/tests/test_worker_health.py
+++ b/apps/backend/tests/test_worker_health.py
@@ -12,7 +12,10 @@ from mediamop.core.config import MediaMopSettings
 from mediamop.core.db import Base
 from mediamop.modules.dashboard.service import build_dashboard_status
 from mediamop.modules.refiner import worker_loop as refiner_worker_loop
-from mediamop.modules.refiner.worker_loop import start_refiner_worker_background_tasks, stop_refiner_worker_background_tasks
+from mediamop.modules.refiner.worker_loop import (
+    start_refiner_worker_background_tasks,
+    stop_refiner_worker_background_tasks,
+)
 from mediamop.platform.jobs.worker_health import (
     build_worker_health_snapshot,
     reset_worker_health_for_tests,


### PR DESCRIPTION
## Summary

- Adds `"I"`, `"UP"`, and `"SIM"` to `[tool.ruff.lint] select` in `apps/backend/pyproject.toml`
- Applied all auto-fixable violations, then manually fixed the remainder

## Fix counts

| Rule family | Auto-fixed | Manually fixed |
|---|---|---|
| I (isort) | 140 I001 unsorted imports | 0 |
| UP (pyupgrade) | 164 (UP017 datetime UTC, UP037 quoted annotations, UP006, UP012, UP041) | 8 (UP042 StrEnum ×5, UP031 f-strings ×2, UP035 typing.Deque ×1) |
| SIM (simplify) | 150 (SIM114, SIM300, SIM117 partial) | ~60 (SIM105 contextlib.suppress, SIM103 needless-bool, SIM108 ternary, SIM110 any(), SIM117 merged with-statements, SIM102 collapsible-if) |

## Test results

- 868 passed, 2 skipped
- Pre-existing known failure `test_local_browse_api::test_system_directories_returns_not_found` excluded (not related to this change)
- `ruff check src/mediamop tests` exits 0 with the new select list

🤖 Generated with [Claude Code](https://claude.com/claude-code)