### PR TITLE
feat: expose storage-savings metrics for Refiner and Pruner (closes #234)

### DIFF
--- a/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
@@ -35,6 +35,7 @@ from mediamop.modules.pruner.pruner_preview_run_model import PrunerPreviewRun
 from mediamop.modules.pruner.worker_loop import PrunerJobWorkContext
 from mediamop.platform.activity import constants as C
 from mediamop.platform.activity.service import record_activity_event
+from mediamop.platform.metrics.service import record_module_savings
 from mediamop.platform.observability.diagnostics import (
     DiagnosticAction,
     DiagnosticModule,
@@ -197,6 +198,7 @@ def make_pruner_candidate_removal_apply_handler(
         removed = 0
         skipped = 0
         failed = 0
+        total_bytes_freed = 0
         for c in candidates:
             item_id = str(c.get("item_id", "")).strip()
             if not item_id:
@@ -231,6 +233,12 @@ def make_pruner_candidate_removal_apply_handler(
                 )
             if status in (200, 204):
                 removed += 1
+                try:
+                    sz = int(c.get("size_bytes") or 0)
+                    if sz > 0:
+                        total_bytes_freed += sz
+                except (TypeError, ValueError):
+                    pass
             elif status == 404:
                 logger.debug(
                     "Pruner apply skipped item_id=%s because it was already absent on provider=%s.",
@@ -246,6 +254,9 @@ def make_pruner_candidate_removal_apply_handler(
                     status,
                 )
                 failed += 1
+
+        if total_bytes_freed > 0:
+            record_module_savings(module="pruner", bytes_saved=total_bytes_freed)
 
         label = _scope_label(scope)
         provider_s = provider_label(provider_for_delete) or provider_for_delete

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -56,6 +56,7 @@ from mediamop.modules.refiner.refiner_tv_season_folder_cleanup import (
 )
 from mediamop.platform.file_lifecycle.guardrails import bytes_to_mb, check_minimum_free_disk_space
 from mediamop.platform.file_lifecycle.mutations import safe_copy_to_final, safe_finalize_file, try_hardlink_to_final
+from mediamop.platform.metrics.service import record_module_savings
 
 logger = logging.getLogger(__name__)
 
@@ -790,6 +791,14 @@ def run_refiner_file_remux_pass(
         "Live remux finished; before = source probe; after = planned disposition (copy remux — "
         "ffprobe of the written file was used for validation only)."
     )
+    try:
+        _src_sz = int(src.stat().st_size)
+        _out_sz = int(final.stat().st_size)
+        _saved = _src_sz - _out_sz
+        if _saved > 0:
+            record_module_savings(module="refiner", bytes_saved=_saved)
+    except OSError:
+        pass
     if progress_reporter is not None:
         progress_reporter(
             {

--- a/apps/backend/src/mediamop/platform/metrics/service.py
+++ b/apps/backend/src/mediamop/platform/metrics/service.py
@@ -30,6 +30,7 @@ class RuntimeMetricsSummary(TypedDict):
     busiest_routes: list[RouteSummary]
     module_job_counts: dict[str, dict[str, int]]
     module_queue_depths: dict[str, int]
+    module_savings_bytes: dict[str, int]
 
 
 class RuntimeMetricsStore:
@@ -43,6 +44,7 @@ class RuntimeMetricsStore:
         self.log_counts: Counter[str] = Counter()
         self.module_job_counts: Counter[tuple[str, str]] = Counter()
         self.module_queue_depths: dict[str, int] = defaultdict(int)
+        self.module_savings_bytes: Counter[str] = Counter()
 
     def record_request(self, *, method: str, route: str, status_code: int, duration_ms: float) -> None:
         bucket = f"{status_code // 100}xx"
@@ -72,6 +74,14 @@ class RuntimeMetricsStore:
             return
         with self._lock:
             self.module_queue_depths[module] = max(0, int(depth))
+
+    def record_module_savings(self, *, module: str, bytes_saved: int) -> None:
+        if not module:
+            return
+        if bytes_saved <= 0:
+            return
+        with self._lock:
+            self.module_savings_bytes[module] += int(bytes_saved)
 
     def summary(self) -> RuntimeMetricsSummary:
         with self._lock:
@@ -106,6 +116,7 @@ class RuntimeMetricsStore:
                 ],
                 "module_job_counts": module_job_counts,
                 "module_queue_depths": dict(self.module_queue_depths),
+                "module_savings_bytes": {m: int(v) for m, v in self.module_savings_bytes.items()},
             }
 
     def render_prometheus(self) -> str:
@@ -133,6 +144,14 @@ class RuntimeMetricsStore:
                 lines.append(f'mediamop_module_jobs_total{{module="{module}",event="{event}"}} {count}')
         for module, depth in summary["module_queue_depths"].items():
             lines.append(f'mediamop_module_queue_depth{{module="{module}"}} {depth}')
+        savings = summary["module_savings_bytes"]
+        if savings:
+            lines.append(
+                "# HELP mediamop_module_savings_bytes_total Bytes saved by each module (Refiner remux, Pruner removal)."
+            )
+            lines.append("# TYPE mediamop_module_savings_bytes_total counter")
+            for module, total in sorted(savings.items()):
+                lines.append(f'mediamop_module_savings_bytes_total{{module="{module}"}} {total}')
         return "\n".join(lines) + "\n"
 
 
@@ -153,6 +172,10 @@ def record_module_job_event(*, module: str, event: str) -> None:
 
 def set_module_queue_depth(*, module: str, depth: int) -> None:
     runtime_metrics.set_module_queue_depth(module=module, depth=depth)
+
+
+def record_module_savings(*, module: str, bytes_saved: int) -> None:
+    runtime_metrics.record_module_savings(module=module, bytes_saved=bytes_saved)
 
 
 def build_runtime_metrics_summary() -> RuntimeMetricsSummary:

--- a/apps/backend/tests/test_runtime_metrics_service.py
+++ b/apps/backend/tests/test_runtime_metrics_service.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from mediamop.platform.metrics.service import (
+    build_runtime_metrics_summary,
     record_http_request,
     record_log_record,
     record_module_job_event,
+    record_module_savings,
     render_prometheus_metrics,
     reset_runtime_metrics_for_tests,
     set_module_queue_depth,
@@ -30,3 +32,57 @@ def test_runtime_metrics_summary_and_prometheus_include_module_job_metrics() -> 
     assert 'mediamop_module_queue_depth{module="refiner"} 3' in output
     assert 'mediamop_module_queue_depth{module="subber"} 1' in output
     assert "mediamop_http_requests_total 2" in output
+
+
+def test_record_module_savings_increments_correctly() -> None:
+    reset_runtime_metrics_for_tests()
+
+    record_module_savings(module="refiner", bytes_saved=1_000_000)
+    record_module_savings(module="refiner", bytes_saved=500_000)
+    record_module_savings(module="pruner", bytes_saved=2_000_000)
+
+    summary = build_runtime_metrics_summary()
+    assert summary["module_savings_bytes"]["refiner"] == 1_500_000
+    assert summary["module_savings_bytes"]["pruner"] == 2_000_000
+
+
+def test_record_module_savings_ignores_nonpositive() -> None:
+    reset_runtime_metrics_for_tests()
+
+    record_module_savings(module="refiner", bytes_saved=0)
+    record_module_savings(module="refiner", bytes_saved=-100)
+
+    summary = build_runtime_metrics_summary()
+    assert "refiner" not in summary["module_savings_bytes"]
+
+
+def test_summary_includes_module_savings_bytes() -> None:
+    reset_runtime_metrics_for_tests()
+
+    record_module_savings(module="refiner", bytes_saved=12_345_678)
+
+    summary = build_runtime_metrics_summary()
+    assert "module_savings_bytes" in summary
+    assert summary["module_savings_bytes"] == {"refiner": 12_345_678}
+
+
+def test_render_prometheus_includes_savings_metric() -> None:
+    reset_runtime_metrics_for_tests()
+
+    record_module_savings(module="refiner", bytes_saved=12_345_678)
+    record_module_savings(module="pruner", bytes_saved=9_876_543)
+
+    output = render_prometheus_metrics()
+
+    assert "# HELP mediamop_module_savings_bytes_total" in output
+    assert "# TYPE mediamop_module_savings_bytes_total counter" in output
+    assert 'mediamop_module_savings_bytes_total{module="refiner"} 12345678' in output
+    assert 'mediamop_module_savings_bytes_total{module="pruner"} 9876543' in output
+
+
+def test_render_prometheus_omits_savings_section_when_empty() -> None:
+    reset_runtime_metrics_for_tests()
+
+    output = render_prometheus_metrics()
+
+    assert "mediamop_module_savings_bytes_total" not in output


### PR DESCRIPTION
## Summary

- Adds `module_savings_bytes: Counter[str]` to `RuntimeMetricsStore` and a new `record_module_savings(*, module, bytes_saved)` method + module-level helper
- Extends `RuntimeMetricsSummary` TypedDict with `module_savings_bytes: dict[str, int]`
- `render_prometheus()` now emits `mediamop_module_savings_bytes_total{module="..."}` (HELP + TYPE headers included, section omitted when empty)
- Refiner's `run_refiner_file_remux_pass` records `source_size - output_size` after a successful live ffmpeg remux pass
- Pruner's apply handler accumulates `size_bytes` from candidate dicts (forward-compatible; current snapshots don't include sizes yet, so pruner savings will be 0 until candidate builders are extended)

## Test plan

- [ ] `test_record_module_savings_increments_correctly` — counter accumulates across calls
- [ ] `test_record_module_savings_ignores_nonpositive` — zero/negative bytes_saved are silently ignored
- [ ] `test_summary_includes_module_savings_bytes` — `summary()` returns the new key
- [ ] `test_render_prometheus_includes_savings_metric` — correct HELP/TYPE headers and label values
- [ ] `test_render_prometheus_omits_savings_section_when_empty` — no stray metric lines when nothing recorded
- [ ] All 12 metrics-related tests pass; mypy reports no issues in 132 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)