### PR TITLE
fix: narrow session_cookie_samesite to Literal type, remove auth router type: ignore (closes #233)

### DIFF
--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 from urllib.parse import urlparse
 
 from mediamop.core.config_domains import (
@@ -118,7 +119,7 @@ class MediaMopSettings:
     previous_credentials_secrets: tuple[str, ...]
     session_cookie_name: str
     session_cookie_secure: bool
-    session_cookie_samesite: str
+    session_cookie_samesite: Literal["strict", "lax", "none"]
     session_idle_minutes: int
     session_absolute_days: int
     session_trusted_idle_minutes: int
@@ -325,11 +326,12 @@ class MediaMopSettings:
             (os.environ.get("MEDIAMOP_SESSION_COOKIE_NAME") or "").strip()
             or "mediamop_session"
         )
-        samesite = (
+        _samesite_raw = (
             (os.environ.get("MEDIAMOP_SESSION_COOKIE_SAMESITE") or "lax").strip().lower()
         )
-        if samesite not in ("lax", "strict", "none"):
-            samesite = "lax"
+        if _samesite_raw not in ("lax", "strict", "none"):
+            _samesite_raw = "lax"
+        samesite = cast(Literal["strict", "lax", "none"], _samesite_raw)
         secure = _env_bool(
             "MEDIAMOP_SESSION_COOKIE_SECURE",
             default=(env == "production"),

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -113,7 +113,7 @@ def post_login(
         max_age=auth_service.session_public(session_row, settings=settings)["absolute_timeout_days"] * 86400,
         httponly=True,
         secure=settings.session_cookie_secure,
-        samesite=settings.session_cookie_samesite,  # type: ignore[arg-type]
+        samesite=settings.session_cookie_samesite,
         path="/",
     )
     response.headers.setdefault("Cache-Control", "no-store, private")
@@ -299,7 +299,7 @@ def post_logout(
         path="/",
         httponly=True,
         secure=settings.session_cookie_secure,
-        samesite=settings.session_cookie_samesite,  # type: ignore[arg-type]
+        samesite=settings.session_cookie_samesite,
     )
     response.headers.setdefault("Cache-Control", "no-store, private")
     response.status_code = status.HTTP_204_NO_CONTENT


### PR DESCRIPTION
Rebased cleanly on main. Narrows `session_cookie_samesite` from `str` to `Literal["strict","lax","none"]` via a cast after the validation guard, removing the two `# type: ignore[arg-type]` comments in `auth/router.py`. mypy clean, 87 auth tests pass.