### PR TITLE
chore: apply ruff format to backend (pre-existing drift)

### DIFF
--- a/apps/backend/src/mediamop/core/alembic_revision_check.py
+++ b/apps/backend/src/mediamop/core/alembic_revision_check.py
@@ -100,7 +100,7 @@ def _backup_database_before_migration(engine: Engine) -> None:
     db_url = str(engine.url)
     if not db_url.startswith("sqlite:///"):
         return
-    db_path = Path(db_url[len("sqlite:///"):])
+    db_path = Path(db_url[len("sqlite:///") :])
     if not db_path.is_file():
         return
     ts = time.strftime("%Y%m%dT%H%M%S")
@@ -122,8 +122,7 @@ def _run_alembic_upgrade_head(engine: Engine) -> None:
     except Exception as exc:
         raise DatabaseSchemaMismatch(
             f"Alembic upgrade to head failed: {exc}. "
-            "Fix the error above, or restore a database backup. "
-            + _manual_migration_instructions(),
+            "Fix the error above, or restore a database backup. " + _manual_migration_instructions(),
             kind="upgrade_failed",
         ) from exc
 
@@ -146,8 +145,7 @@ def ensure_database_at_application_head(engine: Engine) -> None:
     if current is None:
         raise DatabaseSchemaMismatch(
             "No Alembic revision is recorded for this database (migrations have not been applied). "
-            f"This build requires schema revision {head!r}. "
-            + migrate_hint,
+            f"This build requires schema revision {head!r}. " + migrate_hint,
             kind="unversioned",
         )
 
@@ -167,8 +165,7 @@ def ensure_database_at_application_head(engine: Engine) -> None:
         after = _current_revision(engine)
         if after != head:
             raise DatabaseSchemaMismatch(
-                f"After upgrade, database revision is {after!r}, expected {head!r}. "
-                + migrate_hint,
+                f"After upgrade, database revision is {after!r}, expected {head!r}. " + migrate_hint,
                 kind="upgrade_failed",
             )
         return

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -322,13 +322,8 @@ class MediaMopSettings:
             for item in _parse_csv_urls(os.environ.get("MEDIAMOP_PREVIOUS_CREDENTIALS_SECRETS") or "")
             if item and item != credentials_secret
         )
-        cookie_name = (
-            (os.environ.get("MEDIAMOP_SESSION_COOKIE_NAME") or "").strip()
-            or "mediamop_session"
-        )
-        _samesite_raw = (
-            (os.environ.get("MEDIAMOP_SESSION_COOKIE_SAMESITE") or "lax").strip().lower()
-        )
+        cookie_name = (os.environ.get("MEDIAMOP_SESSION_COOKIE_NAME") or "").strip() or "mediamop_session"
+        _samesite_raw = (os.environ.get("MEDIAMOP_SESSION_COOKIE_SAMESITE") or "lax").strip().lower()
         if _samesite_raw not in ("lax", "strict", "none"):
             _samesite_raw = "lax"
         samesite = cast(Literal["strict", "lax", "none"], _samesite_raw)
@@ -387,6 +382,7 @@ class MediaMopSettings:
             min(300, _env_int("MEDIAMOP_SUBBER_LIBRARY_SCAN_SCHEDULE_SCAN_INTERVAL_SECONDS", 45)),
         )
         subber_upgrade_sched_enq = _env_bool("MEDIAMOP_SUBBER_UPGRADE_SCHEDULE_ENQUEUE_ENABLED", True)
+
         def _refiner_supplied_payload_eval_schedule_enabled() -> bool:
             new_k = "MEDIAMOP_REFINER_SUPPLIED_PAYLOAD_EVALUATION_SCHEDULE_ENABLED"
             old_k = "MEDIAMOP_REFINER_LIBRARY_AUDIT_PASS_SCHEDULE_ENABLED"

--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -341,7 +341,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         )
         await _stop_task_group(
             "refiner_watched_folder_scan_dispatch_stop",
-            lambda: stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(refiner_watched_folder_scan_dispatch_tasks),
+            lambda: stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
+                refiner_watched_folder_scan_dispatch_tasks
+            ),
         )
         await _stop_task_group(
             "refiner_work_temp_stale_sweep_stop",
@@ -351,7 +353,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             "refiner_failure_cleanup_stop",
             lambda: stop_refiner_failure_cleanup_enqueue_tasks(refiner_failure_cleanup_tasks),
         )
-        await _stop_task_group("subber_tv_scan_schedule_stop", lambda: stop_subber_tv_scan_schedule_enqueue_tasks(subber_tv_scan_tasks))
+        await _stop_task_group(
+            "subber_tv_scan_schedule_stop", lambda: stop_subber_tv_scan_schedule_enqueue_tasks(subber_tv_scan_tasks)
+        )
         await _stop_task_group(
             "subber_movies_scan_schedule_stop",
             lambda: stop_subber_movies_scan_schedule_enqueue_tasks(subber_movies_scan_tasks),

--- a/apps/backend/src/mediamop/modules/pruner/pruner_apply_eligibility.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_apply_eligibility.py
@@ -143,7 +143,9 @@ def compute_apply_eligibility(
             reasons.append(
                 f"{apply_label} is not enabled for this scope (watched movies rule toggle).",
             )
-        elif rid == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED and not bool(sc.watched_movie_low_rating_reported_enabled):
+        elif rid == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED and not bool(
+            sc.watched_movie_low_rating_reported_enabled
+        ):
             reasons.append(
                 f"{apply_label} is not enabled for this scope (watched low-rating movies rule toggle).",
             )

--- a/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_apply_job_handler.py
@@ -139,7 +139,10 @@ def make_pruner_candidate_removal_apply_handler(
             if snap_rule == RULE_FAMILY_WATCHED_MOVIES_REPORTED and str(run.media_scope) != MEDIA_SCOPE_MOVIES:
                 msg = "watched_movies_reported apply requires a Movies scope preview snapshot"
                 raise ValueError(msg)
-            if snap_rule == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED and str(run.media_scope) != MEDIA_SCOPE_MOVIES:
+            if (
+                snap_rule == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED
+                and str(run.media_scope) != MEDIA_SCOPE_MOVIES
+            ):
                 msg = "watched_movie_low_rating_reported apply requires a Movies scope preview snapshot"
                 raise ValueError(msg)
             if snap_rule == RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED and str(run.media_scope) != MEDIA_SCOPE_MOVIES:
@@ -261,7 +264,9 @@ def make_pruner_candidate_removal_apply_handler(
         label = _scope_label(scope)
         provider_s = provider_label(provider_for_delete) or provider_for_delete
         scope_s = media_scope_label(scope) or label
-        result_for_message = DiagnosticResult.FAILED if removed == 0 and skipped == 0 and failed > 0 else DiagnosticResult.SUCCESS
+        result_for_message = (
+            DiagnosticResult.FAILED if removed == 0 and skipped == 0 and failed > 0 else DiagnosticResult.SUCCESS
+        )
         if auto_applied:
             title = (
                 f"{action_label}: Pruner automatically removed {removed} {scope_s} item"

--- a/apps/backend/src/mediamop/modules/pruner/pruner_connection_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_connection_job_handler.py
@@ -100,11 +100,7 @@ def make_pruner_server_connection_test_handler(
             inst2.last_connection_test_at = when
             inst2.last_connection_test_ok = ok
             inst2.last_connection_test_detail = detail_s
-            evt = (
-                C.PRUNER_CONNECTION_TEST_SUCCEEDED
-                if ok
-                else C.PRUNER_CONNECTION_TEST_FAILED
-            )
+            evt = C.PRUNER_CONNECTION_TEST_SUCCEEDED if ok else C.PRUNER_CONNECTION_TEST_FAILED
             record_activity_event(
                 session,
                 event_type=evt,

--- a/apps/backend/src/mediamop/modules/pruner/pruner_constants.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_constants.py
@@ -139,5 +139,6 @@ def clamp_pruner_scheduled_preview_interval_seconds(raw: int) -> int:
         min(PRUNER_SCHEDULED_PREVIEW_INTERVAL_MAX_SECONDS, int(raw)),
     )
 
+
 # TV preview: one row per **episode** missing a primary image (honest granularity for UI + removal).
 # Movies preview: one row per **movie library item** missing a primary image.

--- a/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_credentials_crypto.py
@@ -107,7 +107,8 @@ def decrypt_pruner_credentials_json(settings: MediaMopSettings, ciphertext: str)
                 except Exception:
                     salt = None
             fernets = credential_secret_candidates(
-                settings, lambda s, _salt=salt: _fernet_for_secret_hkdf(s, salt=_salt)  # type: ignore[misc]
+                settings,
+                lambda s, _salt=salt: _fernet_for_secret_hkdf(s, salt=_salt),  # type: ignore[misc]
             )
         elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_independent_rule_candidates.py
@@ -39,6 +39,7 @@ from mediamop.modules.pruner.pruner_studio_collection_filters import jellyfin_em
 
 logger = logging.getLogger(__name__)
 
+
 def _jf_emby_truncated(
     *,
     total_hits: int | None,
@@ -49,7 +50,16 @@ def _jf_emby_truncated(
     page: int,
 ) -> bool:
     truncated = False
-    if total_hits is not None and candidates_len < total_hits and candidates_len >= max_items or total_hits is not None and start < total_hits and candidates_len >= max_items or fetched >= page and candidates_len >= max_items:
+    if (
+        total_hits is not None
+        and candidates_len < total_hits
+        and candidates_len >= max_items
+        or total_hits is not None
+        and start < total_hits
+        and candidates_len >= max_items
+        or fetched >= page
+        and candidates_len >= max_items
+    ):
         truncated = True
     return truncated
 

--- a/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_instances_api.py
@@ -120,7 +120,9 @@ def _scope_row_out(session: Session, row: PrunerScopeSettings) -> PrunerScopeSum
         preview_year_min=clamp_preview_year_bound(row.preview_year_min),
         preview_year_max=clamp_preview_year_bound(row.preview_year_max),
         preview_include_studios=preview_studio_filters_from_db_column(str(row.preview_include_studios_json)),
-        preview_include_collections=preview_collection_filters_from_db_column(str(row.preview_include_collections_json)),
+        preview_include_collections=preview_collection_filters_from_db_column(
+            str(row.preview_include_collections_json)
+        ),
         scheduled_preview_enabled=bool(row.scheduled_preview_enabled),
         scheduled_preview_interval_seconds=clamp_pruner_scheduled_preview_interval_seconds(
             int(row.scheduled_preview_interval_seconds),
@@ -328,7 +330,9 @@ def get_pruner_scope(
     db: DbSessionDep,
 ) -> PrunerScopeSummaryOut:
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     sc = get_scope_settings(db, server_instance_id=instance_id, media_scope=media_scope)
     if sc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scope not found.")
@@ -350,7 +354,9 @@ def patch_pruner_scope(
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     sc = get_scope_settings(db, server_instance_id=instance_id, media_scope=media_scope)
     if sc is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Scope not found.")
@@ -379,7 +385,9 @@ def patch_pruner_scope(
     if body.unwatched_movie_stale_reported_enabled is not None:
         sc.unwatched_movie_stale_reported_enabled = bool(body.unwatched_movie_stale_reported_enabled)
     if body.unwatched_movie_stale_min_age_days is not None:
-        sc.unwatched_movie_stale_min_age_days = clamp_never_played_min_age_days(int(body.unwatched_movie_stale_min_age_days))
+        sc.unwatched_movie_stale_min_age_days = clamp_never_played_min_age_days(
+            int(body.unwatched_movie_stale_min_age_days)
+        )
     if body.preview_max_items is not None:
         sc.preview_max_items = int(body.preview_max_items)
     if body.preview_include_genres is not None:
@@ -447,7 +455,9 @@ def list_pruner_preview_runs(
     instance_id: Annotated[int, Path(ge=1)],
     _user: UserPublicDep,
     db: DbSessionDep,
-    media_scope: Annotated[str | None, Query(description="`tv` or `movies`; omit for all scopes on this instance.")] = None,
+    media_scope: Annotated[
+        str | None, Query(description="`tv` or `movies`; omit for all scopes on this instance.")
+    ] = None,
     limit: Annotated[int, Query(ge=1, le=50)] = 20,
 ) -> list[PrunerPreviewRunListItemOut]:
     if get_server_instance(db, instance_id) is None:
@@ -505,7 +515,9 @@ def get_pruner_apply_eligibility(
     settings: SettingsDep,
 ) -> PrunerApplyEligibilityOut:
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     if get_server_instance(db, instance_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")
     return compute_apply_eligibility(
@@ -537,7 +549,9 @@ def post_pruner_apply_from_preview(
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     if get_server_instance(db, instance_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")
     elig = compute_apply_eligibility(
@@ -581,7 +595,9 @@ def get_pruner_plex_live_removal_eligibility(
     settings: SettingsDep,
 ) -> PrunerPlexLiveEligibilityOut:
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     if get_server_instance(db, instance_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")
     return compute_plex_live_eligibility(
@@ -611,7 +627,9 @@ def post_pruner_plex_live_removal(
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     if media_scope not in (MEDIA_SCOPE_TV, MEDIA_SCOPE_MOVIES):
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies.")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="media_scope must be tv or movies."
+        )
     inst = get_server_instance(db, instance_id)
     if inst is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Instance not found.")

--- a/apps/backend/src/mediamop/modules/pruner/pruner_jobs_inspection_service.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_jobs_inspection_service.py
@@ -27,10 +27,7 @@ def list_pruner_jobs_for_inspection(
 ) -> PrunerJobsInspectionOut:
     if statuses:
         stmt = (
-            select(PrunerJob)
-            .where(PrunerJob.status.in_(statuses))
-            .order_by(PrunerJob.updated_at.desc())
-            .limit(limit)
+            select(PrunerJob).where(PrunerJob.status.in_(statuses)).order_by(PrunerJob.updated_at.desc()).limit(limit)
         )
         default_recent_slice = False
     else:

--- a/apps/backend/src/mediamop/modules/pruner/pruner_media_library.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_media_library.py
@@ -250,7 +250,14 @@ def list_missing_primary_candidates(
             break
 
     truncated = False
-    if total_hits is not None and len(candidates) < total_hits and len(candidates) >= max_items or total_hits is not None and start < total_hits and len(candidates) >= max_items:
+    if (
+        total_hits is not None
+        and len(candidates) < total_hits
+        and len(candidates) >= max_items
+        or total_hits is not None
+        and start < total_hits
+        and len(candidates) >= max_items
+    ):
         truncated = True
 
     return candidates, truncated

--- a/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_preview_job_handler.py
@@ -94,10 +94,14 @@ def make_pruner_candidate_removal_preview_handler(
         if rule_family_id == RULE_FAMILY_WATCHED_MOVIES_REPORTED and scope != MEDIA_SCOPE_MOVIES:
             msg = "watched_movies_reported preview requires media_scope=movies"
             raise ValueError(msg)
-        if rule_family_id in (
-            RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
-            RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED,
-        ) and scope != MEDIA_SCOPE_MOVIES:
+        if (
+            rule_family_id
+            in (
+                RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED,
+                RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED,
+            )
+            and scope != MEDIA_SCOPE_MOVIES
+        ):
             msg = f"{rule_family_id} preview requires media_scope=movies"
             raise ValueError(msg)
 
@@ -130,7 +134,9 @@ def make_pruner_candidate_removal_preview_handler(
                 if not bool(sc.watched_movie_low_rating_reported_enabled):
                     msg = "watched_movie_low_rating_reported_enabled is false for this scope"
                     raise ValueError(msg)
-            elif rule_family_id == RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED and not bool(sc.unwatched_movie_stale_reported_enabled):
+            elif rule_family_id == RULE_FAMILY_UNWATCHED_MOVIE_STALE_REPORTED and not bool(
+                sc.unwatched_movie_stale_reported_enabled
+            ):
                 msg = "unwatched_movie_stale_reported_enabled is false for this scope"
                 raise ValueError(msg)
             max_items = max(1, min(int(sc.preview_max_items), 5000))
@@ -176,7 +182,9 @@ def make_pruner_candidate_removal_preview_handler(
                 secrets=secrets,
                 max_items=max_items,
                 rule_family_id=rule_family_id,
-                never_played_min_age_days=age_days if rule_family_id == RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED else None,
+                never_played_min_age_days=age_days
+                if rule_family_id == RULE_FAMILY_NEVER_PLAYED_STALE_REPORTED
+                else None,
                 preview_include_genres=preview_genres,
                 preview_include_people=preview_people,
                 preview_include_people_roles=preview_people_roles,
@@ -311,12 +319,22 @@ def make_pruner_candidate_removal_preview_handler(
                     "in this slice — the Items API path does not expose per-item library collection membership "
                     "without extra calls."
                 )
-            if outcome == "success" and rule_family_id == RULE_FAMILY_GENRE_MATCH_REPORTED and preview_genres and len(cands) == 0:
+            if (
+                outcome == "success"
+                and rule_family_id == RULE_FAMILY_GENRE_MATCH_REPORTED
+                and preview_genres
+                and len(cands) == 0
+            ):
                 detail_obj["preview_genre_rule_zero_candidates_note"] = (
                     "Zero rows matched your selected genres under the preview cap — the library may still contain "
                     "other genres, or matches may sit beyond the cap (try raising per-tab preview max)."
                 )
-            if outcome == "success" and rule_family_id == RULE_FAMILY_PEOPLE_MATCH_REPORTED and preview_people and len(cands) == 0:
+            if (
+                outcome == "success"
+                and rule_family_id == RULE_FAMILY_PEOPLE_MATCH_REPORTED
+                and preview_people
+                and len(cands) == 0
+            ):
                 detail_obj["preview_people_rule_zero_candidates_note"] = (
                     "Zero rows matched your entered names under the preview cap — widen names, adjust roles "
                     "(Jellyfin/Emby), or raise the per-tab preview max if you expected matches."

--- a/apps/backend/src/mediamop/modules/pruner/pruner_schemas.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_schemas.py
@@ -76,9 +76,7 @@ class PrunerScopeSummaryOut(BaseModel):
     )
     preview_year_max: int | None = Field(
         default=None,
-        description=(
-            "Optional inclusive maximum year for preview narrowing (same semantics as ``preview_year_min``)."
-        ),
+        description=("Optional inclusive maximum year for preview narrowing (same semantics as ``preview_year_min``)."),
     )
     preview_include_studios: list[str] = Field(
         default_factory=list,
@@ -248,7 +246,11 @@ class PrunerScopePatchIn(BaseModel):
 
     @model_validator(mode="after")
     def _preview_year_bounds_order(self) -> Self:
-        if self.preview_year_min is not None and self.preview_year_max is not None and self.preview_year_min > self.preview_year_max:
+        if (
+            self.preview_year_min is not None
+            and self.preview_year_max is not None
+            and self.preview_year_min > self.preview_year_max
+        ):
             msg = "preview_year_min must be less than or equal to preview_year_max when both are set."
             raise ValueError(msg)
         return self
@@ -285,7 +287,10 @@ class PrunerPreviewEnqueueIn(BaseModel):
         if self.rule_family_id == RULE_FAMILY_WATCHED_MOVIES_REPORTED and self.media_scope != MEDIA_SCOPE_MOVIES:
             msg = "watched_movies_reported preview is only available for the Movies tab (media_scope must be movies)."
             raise ValueError(msg)
-        if self.rule_family_id == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED and self.media_scope != MEDIA_SCOPE_MOVIES:
+        if (
+            self.rule_family_id == RULE_FAMILY_WATCHED_MOVIE_LOW_RATING_REPORTED
+            and self.media_scope != MEDIA_SCOPE_MOVIES
+        ):
             msg = (
                 "watched_movie_low_rating_reported preview is only available for the Movies tab "
                 "(media_scope must be movies)."
@@ -313,12 +318,7 @@ class PrunerServerInstancePatchHttpIn(PrunerServerInstancePatchIn):
 
     @model_validator(mode="after")
     def _at_least_one_field(self) -> PrunerServerInstancePatchHttpIn:
-        if (
-            self.display_name is None
-            and self.base_url is None
-            and self.enabled is None
-            and self.credentials is None
-        ):
+        if self.display_name is None and self.base_url is None and self.enabled is None and self.credentials is None:
             msg = "At least one of display_name, base_url, enabled, or credentials must be provided."
             raise ValueError(msg)
         return self

--- a/apps/backend/src/mediamop/modules/pruner/pruner_server_instance_model.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_server_instance_model.py
@@ -18,7 +18,9 @@ class PrunerServerInstance(Base):
     """Operator-registered server; credentials stored as encrypted JSON (see ``pruner_credentials``)."""
 
     __tablename__ = "pruner_server_instances"
-    __table_args__ = (UniqueConstraint("provider", "normalized_base_url", name="uq_pruner_server_provider_normalized_url"),)
+    __table_args__ = (
+        UniqueConstraint("provider", "normalized_base_url", name="uq_pruner_server_provider_normalized_url"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     provider: Mapped[str] = mapped_column(String(16), nullable=False)

--- a/apps/backend/src/mediamop/modules/pruner/pruner_studio_list.py
+++ b/apps/backend/src/mediamop/modules/pruner/pruner_studio_list.py
@@ -151,7 +151,9 @@ def _list_distinct_studios_plex(
             }
             leaves_url = join_base_path(base_url, f"library/sections/{sec_key}/allLeaves", params)
             try:
-                st, page = http_get_json(leaves_url, headers=_plex_headers(auth_token), timeout_sec=min(10.0, remaining))
+                st, page = http_get_json(
+                    leaves_url, headers=_plex_headers(auth_token), timeout_sec=min(10.0, remaining)
+                )
             except (urllib.error.URLError, TimeoutError, OSError, ValueError, TypeError):
                 return []
             except Exception:  # noqa: BLE001
@@ -234,4 +236,3 @@ def list_distinct_studios(
     except Exception:  # noqa: BLE001
         return []
     return []
-

--- a/apps/backend/src/mediamop/modules/pruner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/pruner/worker_loop.py
@@ -89,8 +89,7 @@ def process_one_pruner_job(
 
     if job_kind_forbidden_on_pruner_lane(ctx.job_kind):
         err_text = (
-            "pruner worker refused job_kind reserved for another module lane: "
-            f"{ctx.job_kind!r} (row id={ctx.id})"
+            f"pruner worker refused job_kind reserved for another module lane: {ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
             with session_factory() as session, session.begin():
@@ -107,8 +106,7 @@ def process_one_pruner_job(
 
     if not ctx.job_kind.startswith(PRUNER_QUEUE_JOB_KIND_PREFIX):
         err_text = (
-            "pruner worker refused job_kind missing required pruner.* prefix: "
-            f"{ctx.job_kind!r} (row id={ctx.id})"
+            f"pruner worker refused job_kind missing required pruner.* prefix: {ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
             with session_factory() as session, session.begin():
@@ -162,7 +160,9 @@ def process_one_pruner_job(
                 )
         except Exception:
             logger.exception("Pruner fail_claimed_pruner_job failed after handler error job_id=%s", ctx.id)
-        dispatch_job_notification(session_factory, module="pruner", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="pruner", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
         return "processed"
 
     complete_ok = True
@@ -184,7 +184,9 @@ def process_one_pruner_job(
         complete_err = str(exc)
 
     if complete_ok:
-        dispatch_job_notification(session_factory, module="pruner", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="pruner", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
 
     if not complete_ok and complete_err is not None:
         bounded = (PRUNER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]

--- a/apps/backend/src/mediamop/modules/refiner/domain.py
+++ b/apps/backend/src/mediamop/modules/refiner/domain.py
@@ -233,12 +233,7 @@ def extract_title_year_anchor(
 
 def title_year_anchors_match(a: TitleYearAnchor, b: TitleYearAnchor) -> bool:
     """True when both anchors are usable and agree on title tokens and year."""
-    return (
-        a.is_usable_for_match()
-        and b.is_usable_for_match()
-        and a.title_tokens == b.title_tokens
-        and a.year == b.year
-    )
+    return a.is_usable_for_match() and b.is_usable_for_match() and a.title_tokens == b.title_tokens and a.year == b.year
 
 
 def _row_anchor(row: RefinerQueueRowView) -> TitleYearAnchor | None:

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -309,7 +309,9 @@ def _handle_refiner_cleanup_after_success(
     try:
         src_resolved.relative_to(watched_resolved)
     except ValueError:
-        out["source_folder_skip_reason"] = "The video file is not under the saved watched folder, so nothing was removed."
+        out["source_folder_skip_reason"] = (
+            "The video file is not under the saved watched folder, so nothing was removed."
+        )
         logger.warning("Refiner Movies cleanup: source not under watched root (%s).", src_resolved)
         out["source_deleted_after_success"] = False
         return
@@ -339,7 +341,9 @@ def _handle_refiner_cleanup_after_success(
     out_dir = Path(path_runtime.output_folder).resolve()
     if not str(path_runtime.output_folder).strip():
         out["output_completeness_check"] = "skipped"
-        out["source_folder_skip_reason"] = "No output folder is configured for Movies, so the release folder was not removed."
+        out["source_folder_skip_reason"] = (
+            "No output folder is configured for Movies, so the release folder was not removed."
+        )
         out["output_completeness_note"] = out["source_folder_skip_reason"]
         out["source_deleted_after_success"] = False
         logger.warning("Refiner Movies cleanup: missing output folder configuration.")
@@ -440,7 +444,11 @@ def run_refiner_file_remux_pass(
             )
     min_age = max(
         0,
-        int(settings.refiner_watched_folder_min_file_age_seconds if min_file_age_seconds is None else min_file_age_seconds),
+        int(
+            settings.refiner_watched_folder_min_file_age_seconds
+            if min_file_age_seconds is None
+            else min_file_age_seconds
+        ),
     )
     if min_age > 0:
         try:
@@ -597,7 +605,9 @@ def run_refiner_file_remux_pass(
                 remux_required=remux_needed,
             )
         try:
-            _copied, output_replaced_existing, unchanged_output_method = _copy_unchanged_source_to_output(src=src, final=final_skip)
+            _copied, output_replaced_existing, unchanged_output_method = _copy_unchanged_source_to_output(
+                src=src, final=final_skip
+            )
         except Exception as exc:
             if progress_reporter is not None:
                 progress_reporter(
@@ -811,7 +821,7 @@ def run_refiner_file_remux_pass(
                 "media_scope": scope,
                 "message": "The cleaned-up file was written. Refiner is doing final safety checks.",
             }
-    )
+        )
     _handle_refiner_cleanup_after_success(
         src=src,
         watched_root=watched_root,

--- a/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
@@ -28,7 +28,9 @@ def _record_refiner_queue_depth(session: Session) -> None:
     depth = session.scalar(
         select(func.count())
         .select_from(RefinerJob)
-        .where(or_(RefinerJob.status == RefinerJobStatus.PENDING.value, RefinerJob.status == RefinerJobStatus.LEASED.value))
+        .where(
+            or_(RefinerJob.status == RefinerJobStatus.PENDING.value, RefinerJob.status == RefinerJobStatus.LEASED.value)
+        )
     )
     set_module_queue_depth(module="refiner", depth=int(depth or 0))
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup.py
@@ -163,7 +163,9 @@ def _failed_jobs_for_scope(
         try:
             rel, scope, legacy_dry_run = _parse_payload(row.payload_json)
         except (ValueError, json.JSONDecodeError):
-            logger.debug("Refiner failure cleanup ignored malformed failed-job payload job_id=%s", row.id, exc_info=True)
+            logger.debug(
+                "Refiner failure cleanup ignored malformed failed-job payload job_id=%s", row.id, exc_info=True
+            )
             continue
         if scope != media_scope:
             continue
@@ -204,11 +206,15 @@ def run_refiner_failure_cleanup_sweep_for_scope(
     )
     older_than = now - timedelta(seconds=max(0, grace))
     row = ensure_refiner_path_settings_row(session)
-    work_root = Path(
-        effective_tv_work_folder(row=row, mediamop_home=settings.mediamop_home)[0]
-        if ms == "tv"
-        else effective_work_folder(row=row, mediamop_home=settings.mediamop_home)[0]
-    ).expanduser().resolve()
+    work_root = (
+        Path(
+            effective_tv_work_folder(row=row, mediamop_home=settings.mediamop_home)[0]
+            if ms == "tv"
+            else effective_work_folder(row=row, mediamop_home=settings.mediamop_home)[0]
+        )
+        .expanduser()
+        .resolve()
+    )
     watched_raw = (row.refiner_tv_watched_folder if ms == "tv" else row.refiner_watched_folder) or ""
     output_raw = (row.refiner_tv_output_folder if ms == "tv" else row.refiner_output_folder) or ""
     out: dict[str, Any] = {
@@ -261,12 +267,12 @@ def run_refiner_failure_cleanup_sweep_for_scope(
         detail: dict[str, Any] = {
             "job_id": int(job.id),
             "relative_media_path": rel_norm,
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_ran": False,
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_skip_reason": None,
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_dry_run": bool(legacy_dry_run),
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_queue_check": "skipped",
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_temp_files_deleted": [],
-            f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_cascade_folders_deleted": [],
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_ran": False,
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_skip_reason": None,
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_dry_run": bool(legacy_dry_run),
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_queue_check": "skipped",
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_temp_files_deleted": [],
+            f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_cascade_folders_deleted": [],
         }
         out["processed_failed_jobs"] += 1
         out["jobs"].append(detail)
@@ -276,13 +282,13 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                 job.id,
                 rel_norm,
             )
-            detail[f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_skip_reason"] = (
+            detail[f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_skip_reason"] = (
                 "Skipped for compatibility: this failed remux row uses legacy dry_run payload format, "
                 "which is not a current Refiner mode."
             )
             continue
         if queue_unreachable:
-            detail[f"{'tv' if ms=='tv' else 'movie'}_failure_cleanup_skip_reason"] = (
+            detail[f"{'tv' if ms == 'tv' else 'movie'}_failure_cleanup_skip_reason"] = (
                 f"ARR queue check was unavailable ({queue_unreachable}), so nothing was removed."
             )
             continue
@@ -296,7 +302,9 @@ def run_refiner_failure_cleanup_sweep_for_scope(
             detail["movie_failure_cleanup_output_folder_path"] = str(out_folder)
             if _movie_queue_contains(radarr_rows=radarr_rows, src_file=src_file):
                 detail["movie_failure_cleanup_queue_check"] = "blocked_in_queue"
-                detail["movie_failure_cleanup_skip_reason"] = "File is still in Radarr queue, so failure cleanup skipped."
+                detail["movie_failure_cleanup_skip_reason"] = (
+                    "File is still in Radarr queue, so failure cleanup skipped."
+                )
                 continue
             detail["movie_failure_cleanup_queue_check"] = "passed_not_in_queue"
             detail["movie_failure_cleanup_ran"] = True
@@ -432,4 +440,3 @@ def run_refiner_failure_cleanup_sweep_for_scope(
                     detail["tv_failure_cleanup_temp_files_deleted"].append(str(temp))
     out["cleanup_run_status"] = "completed"
     return out
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_activity.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_activity.py
@@ -59,4 +59,3 @@ def record_refiner_failure_cleanup_sweep_skipped(
         title=f"Refiner cleanup skipped for {label}",
         detail=detail,
     )
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_enqueue.py
@@ -28,7 +28,9 @@ def enqueue_refiner_failure_cleanup_sweep_job(
 ) -> tuple[RefinerJob, bool]:
     ms = "tv" if str(media_scope).strip().lower() == "tv" else "movie"
     job_kind = REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND if ms == "tv" else REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND
-    dedupe_base = REFINER_TV_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY if ms == "tv" else REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY
+    dedupe_base = (
+        REFINER_TV_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY if ms == "tv" else REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY
+    )
     active = session.scalars(
         select(RefinerJob)
         .where(
@@ -48,4 +50,3 @@ def enqueue_refiner_failure_cleanup_sweep_job(
         payload_json=payload_json,
     )
     return job, True
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_handlers.py
@@ -58,4 +58,3 @@ def make_refiner_failure_cleanup_handler(
             )
 
     return _run
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_job_kinds.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_job_kinds.py
@@ -7,4 +7,3 @@ REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND = "refiner.tv_failure_cleanup_sweep.v1
 
 REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY = "refiner.movie_failure_cleanup_sweep:v1"
 REFINER_TV_FAILURE_CLEANUP_SWEEP_DEDUPE_KEY = "refiner.tv_failure_cleanup_sweep:v1"
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_periodic_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_failure_cleanup_periodic_enqueue.py
@@ -106,4 +106,3 @@ async def stop_refiner_failure_cleanup_enqueue_tasks(tasks: list[asyncio.Task[No
             t.cancel()
     if tasks:
         await asyncio.gather(*tasks, return_exceptions=True)
-

--- a/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_movie_output_cleanup.py
@@ -247,7 +247,9 @@ def maybe_run_movie_output_folder_cleanup_after_remux(
 
     out_root_raw = (path_runtime.output_folder or "").strip()
     if not out_root_raw:
-        out["movie_output_folder_skip_reason"] = "No Movies output folder is configured, so Refiner did not evaluate output-folder cleanup."
+        out["movie_output_folder_skip_reason"] = (
+            "No Movies output folder is configured, so Refiner did not evaluate output-folder cleanup."
+        )
         out["movie_output_truth_check"] = "skipped"
         out["movie_output_truth_note"] = out["movie_output_folder_skip_reason"]
         return
@@ -261,7 +263,9 @@ def maybe_run_movie_output_folder_cleanup_after_remux(
         return
 
     if not output_root.is_dir():
-        out["movie_output_folder_skip_reason"] = "The Movies output folder is missing on disk, so output-folder cleanup was skipped."
+        out["movie_output_folder_skip_reason"] = (
+            "The Movies output folder is missing on disk, so output-folder cleanup was skipped."
+        )
         out["movie_output_truth_check"] = "skipped"
         out["movie_output_truth_note"] = out["movie_output_folder_skip_reason"]
         return

--- a/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_overview_stats_service.py
@@ -97,7 +97,9 @@ def build_refiner_overview_stats(db: Session, *, window_days: int = 30) -> Refin
     terminal = completed + failed
     rate = round((completed / terminal) * 100.0, 1) if terminal > 0 else 0.0
     net_space_saved_bytes = total_source_bytes - total_output_bytes
-    net_space_saved_percent = round((net_space_saved_bytes / total_source_bytes) * 100.0, 1) if total_source_bytes > 0 else 0.0
+    net_space_saved_percent = (
+        round((net_space_saved_bytes / total_source_bytes) * 100.0, 1) if total_source_bytes > 0 else 0.0
+    )
 
     return RefinerOverviewStatsOut(
         window_days=max(1, int(window_days)),

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
@@ -216,14 +216,18 @@ def resolve_refiner_path_runtime_for_remux(
     )
 
 
-def build_refiner_path_settings_get_out(*, row: RefinerPathSettingsRow, settings: MediaMopSettings) -> dict[str, object]:
+def build_refiner_path_settings_get_out(
+    *, row: RefinerPathSettingsRow, settings: MediaMopSettings
+) -> dict[str, object]:
     work_eff, _is_def = effective_work_folder(row=row, mediamop_home=settings.mediamop_home)
     default_work = resolved_default_refiner_work_folder(mediamop_home=settings.mediamop_home)
     tv_work_eff, _tv_def = effective_tv_work_folder(row=row, mediamop_home=settings.mediamop_home)
     default_tv_work = resolved_default_refiner_tv_work_folder(mediamop_home=settings.mediamop_home)
     return {
         "refiner_watched_folder": row.refiner_watched_folder,
-        "refiner_watched_folder_exists": bool((row.refiner_watched_folder or "").strip() and Path(row.refiner_watched_folder or "").is_dir()),
+        "refiner_watched_folder_exists": bool(
+            (row.refiner_watched_folder or "").strip() and Path(row.refiner_watched_folder or "").is_dir()
+        ),
         "refiner_work_folder": row.refiner_work_folder,
         "refiner_output_folder": (row.refiner_output_folder or "").strip() or None,
         "resolved_default_work_folder": default_work,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
@@ -67,9 +67,7 @@ def normalize_audio_preference_mode(raw: str | None) -> AudioSelectionPolicy:
 _MEDIA_EXTENSIONS = frozenset({".mkv", ".mp4", ".m4v", ".webm", ".avi"})
 
 # Historical allowlist marker kept for candidate classification docs/tests.
-REFINER_SOURCE_SIDECAR_CLEANUP_SUFFIXES: frozenset[str] = frozenset(
-    {".par2", ".sfv", ".nzb", ".nfo"}
-)
+REFINER_SOURCE_SIDECAR_CLEANUP_SUFFIXES: frozenset[str] = frozenset({".par2", ".sfv", ".nzb", ".nfo"})
 
 
 def is_refiner_media_candidate(path: Path) -> bool:
@@ -351,9 +349,7 @@ def _select_audio_winner(
             )
             return None, removed_audio, notes
         w = _pick_best(pool, preferred_set=preferred_set, use_fallback_penalty=False)
-        notes.append(
-            f"Selected {_describe_candidate(w)} using primary language only (strict policy)."
-        )
+        notes.append(f"Selected {_describe_candidate(w)} using primary language only (strict policy).")
         return w, removed_audio, notes
 
     # preferred_langs_quality — tier walk then fallback
@@ -406,9 +402,7 @@ def plan_remux(
             tags = _stream_tags(s)
             lang_raw = normalize_lang(tags.get("language"))
             removed_audio.append(f"{lang_raw or 'und'} (commentary excluded — remove commentary enabled)")
-            notes.append(
-                f"Excluded commentary track (stream {int(s['index'])}) because remove commentary is enabled."
-            )
+            notes.append(f"Excluded commentary track (stream {int(s['index'])}) because remove commentary is enabled.")
             continue
         c = _candidate_from_stream(s)
         if c is None:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules_settings_service.py
@@ -141,7 +141,9 @@ def build_refiner_remux_rules_settings_out(row: RefinerRemuxRulesSettingsRow) ->
     )
 
 
-def apply_refiner_remux_rules_settings_put(db: Session, body: RefinerRemuxRulesSettingsPutIn) -> RefinerRemuxRulesSettingsRow:
+def apply_refiner_remux_rules_settings_put(
+    db: Session, body: RefinerRemuxRulesSettingsPutIn
+) -> RefinerRemuxRulesSettingsRow:
     row = ensure_refiner_remux_rules_settings_row(db)
     if body.subtitle_mode == "keep_selected" and not (body.subtitle_langs_csv or "").strip():
         raise ValueError("When keeping subtitles, set at least one language in subtitle_langs_csv.")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_temp_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_temp_cleanup.py
@@ -183,9 +183,7 @@ def run_refiner_work_temp_stale_sweep_for_scope(
             path.unlink()
             out["temp_cleanup_files_deleted"].append(str(path))
         except OSError as exc:
-            human = (
-                f"{path} — could not remove this file because the system reported it is in use or locked ({exc})."
-            )
+            human = f"{path} — could not remove this file because the system reported it is in use or locked ({exc})."
             out["temp_cleanup_files_skipped"].append(human)
             logger.warning("Refiner work temp sweep (%s): %s", ms, human)
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_output_cleanup.py
@@ -446,9 +446,7 @@ def maybe_run_tv_output_season_folder_cleanup_after_remux(
         shutil.rmtree(output_season_folder)
     except OSError as exc:
         locked = getattr(exc, "filename", None)
-        human = (
-            f"Refiner could not remove the TV season output folder because a file or folder was in use or blocked ({exc})."
-        )
+        human = f"Refiner could not remove the TV season output folder because a file or folder was in use or blocked ({exc})."
         if locked:
             human += f" Problem path reported by the system: {locked}."
         out["tv_output_season_folder_skip_reason"] = human

--- a/apps/backend/src/mediamop/modules/refiner/refiner_tv_season_folder_cleanup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_tv_season_folder_cleanup.py
@@ -175,7 +175,9 @@ def _tv_cascade_delete_empty_parents(
         try:
             cur.relative_to(root)
         except ValueError:
-            logger.warning("Refiner TV cleanup: stopped cascade because a folder is outside the TV watched folder (%s).", cur)
+            logger.warning(
+                "Refiner TV cleanup: stopped cascade because a folder is outside the TV watched folder (%s).", cur
+            )
             break
         if not cur.is_dir():
             break
@@ -219,7 +221,9 @@ def handle_tv_cleanup_after_success(
     try:
         src_resolved.relative_to(watched_resolved)
     except ValueError:
-        out["tv_season_folder_skip_reason"] = "The video file is not under the saved TV watched folder, so nothing was removed."
+        out["tv_season_folder_skip_reason"] = (
+            "The video file is not under the saved TV watched folder, so nothing was removed."
+        )
         summary.append("Stopped: the processed file is not under the TV watched folder.")
         return
 
@@ -227,7 +231,9 @@ def handle_tv_cleanup_after_success(
     try:
         season_folder.relative_to(watched_resolved)
     except ValueError:
-        out["tv_season_folder_skip_reason"] = "The season folder would sit outside the TV watched folder, so Refiner did nothing."
+        out["tv_season_folder_skip_reason"] = (
+            "The season folder would sit outside the TV watched folder, so Refiner did nothing."
+        )
         summary.append("Stopped: season folder is outside the TV watched folder.")
         return
 
@@ -253,7 +259,9 @@ def handle_tv_cleanup_after_success(
 
     episodes = get_tv_episode_set_media_files(season_folder=season_folder)
     if not episodes:
-        out["tv_season_folder_skip_reason"] = "This season folder has no direct video files Refiner treats as episodes, so nothing was removed."
+        out["tv_season_folder_skip_reason"] = (
+            "This season folder has no direct video files Refiner treats as episodes, so nothing was removed."
+        )
         summary.append("Stopped: no episode media files found as direct children of the season folder.")
         return
 
@@ -291,10 +299,14 @@ def handle_tv_cleanup_after_success(
                 "so the whole season folder was left in place."
             )
             out["tv_season_folder_skip_reason"] = msg
-            line_parts.append("Active Refiner TV job check failed — a TV remux job is pending or running for this path.")
+            line_parts.append(
+                "Active Refiner TV job check failed — a TV remux job is pending or running for this path."
+            )
             summary.append(" ".join(line_parts))
             return
-        line_parts.append("Active Refiner TV job check passed — no other pending or running TV remux job for this path.")
+        line_parts.append(
+            "Active Refiner TV job check passed — no other pending or running TV remux job for this path."
+        )
 
         rel_eq = rel == str(remux_context.get("relative_media_path") or "").strip()
         live_ok = (

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_api.py
@@ -65,9 +65,7 @@ def post_refiner_watched_folder_remux_scan_dispatch_enqueue(
         if err == "missing_output_for_live_remux":
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "enqueue_remux_jobs requires a saved output folder for this media scope."
-                ),
+                detail=("enqueue_remux_jobs requires a saved output folder for this media scope."),
             )
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid scan prerequisites.")
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -118,7 +118,9 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                     try:
                         size_bytes = int(file_path.stat().st_size)
                     except OSError:
-                        logger.debug("Refiner scan skipped size check because file metadata could not be read: %s", file_path)
+                        logger.debug(
+                            "Refiner scan skipped size check because file metadata could not be read: %s", file_path
+                        )
                         continue
                     if size_bytes < min_size_mb * 1024 * 1024:
                         summary["skipped_below_minimum_file_size"] += 1

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -226,6 +226,12 @@ def retry_completed_movie_source_cleanup(
     except OSError as exc:
         locked = getattr(exc, "filename", None)
         if locked:
-            return False, f"Source cleanup retry could not remove the release folder because this path is still locked: {locked}."
-        return False, f"Source cleanup retry could not remove the release folder because it is still locked or blocked ({exc})."
+            return (
+                False,
+                f"Source cleanup retry could not remove the release folder because this path is still locked: {locked}.",
+            )
+        return (
+            False,
+            f"Source cleanup retry could not remove the release folder because it is still locked or blocked ({exc}).",
+        )
     return True, None

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_remux_rules_settings.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_remux_rules_settings.py
@@ -27,6 +27,8 @@ class RefinerRemuxRulesScopeOut(BaseModel):
         "preferred_langs_strict",
         "quality_all_languages",
     ]
+
+
 class RefinerRemuxRulesSettingsOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/backend/src/mediamop/modules/refiner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_loop.py
@@ -186,7 +186,9 @@ def process_one_refiner_job(
                 "Refiner fail_claimed_refiner_job failed after handler error job_id=%s",
                 ctx.id,
             )
-        dispatch_job_notification(session_factory, module="refiner", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="refiner", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
         return "processed"
 
     complete_ok = True
@@ -208,7 +210,9 @@ def process_one_refiner_job(
         complete_err = str(exc)
 
     if complete_ok:
-        dispatch_job_notification(session_factory, module="refiner", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="refiner", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
 
     if not complete_ok and complete_err is not None:
         bounded = (REFINER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]

--- a/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_credentials_crypto.py
@@ -106,7 +106,8 @@ def decrypt_subber_credentials_json(settings: MediaMopSettings, ciphertext: str)
                 except Exception:
                     salt = None
             fernets = credential_secret_candidates(
-                settings, lambda s, _salt=salt: _fernet_for_secret_hkdf(s, salt=_salt)  # type: ignore[misc]
+                settings,
+                lambda s, _salt=salt: _fernet_for_secret_hkdf(s, salt=_salt),  # type: ignore[misc]
             )
         elif key_id == _CREDENTIALS_KEY_ID_LEGACY:
             fernets = credential_secret_candidates(settings, _fernet_for_secret_legacy)

--- a/apps/backend/src/mediamop/modules/subber/subber_jobs_inspection_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_jobs_inspection_service.py
@@ -37,10 +37,7 @@ def list_subber_jobs_for_inspection(
 ) -> SubberJobsInspectionOut:
     if statuses:
         stmt = (
-            select(SubberJob)
-            .where(SubberJob.status.in_(statuses))
-            .order_by(SubberJob.updated_at.desc())
-            .limit(limit)
+            select(SubberJob).where(SubberJob.status.in_(statuses)).order_by(SubberJob.updated_at.desc()).limit(limit)
         )
         default_recent_slice = False
     else:

--- a/apps/backend/src/mediamop/modules/subber/subber_podnapisi_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_podnapisi_client.py
@@ -21,7 +21,9 @@ LIST_BASE = "https://www.podnapisi.net/api/v2/subtitles/list"
 logger = logging.getLogger(__name__)
 
 
-def _request_json(url: str, *, username: str | None = None, password: str | None = None) -> dict[str, Any] | list[Any] | None:
+def _request_json(
+    url: str, *, username: str | None = None, password: str | None = None
+) -> dict[str, Any] | list[Any] | None:
     headers = {"User-Agent": USER_AGENT, "Accept": "application/json"}
     auth = basic_auth_header(username, password)
     if auth:

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_api.py
@@ -98,8 +98,10 @@ def put_subber_provider(
             detail=availability_note or "Provider is not available in this version.",
         )
     creds: dict[str, str | None] | None = None
-    if body.username is not None or (body.password is not None and body.password.strip()) or (
-        body.api_key is not None and body.api_key.strip()
+    if (
+        body.username is not None
+        or (body.password is not None and body.password.strip())
+        or (body.api_key is not None and body.api_key.strip())
     ):
         row0 = get_provider_by_key(db, pk)
         raw_existing = decrypt_subber_credentials_json(settings, row0.credentials_ciphertext or "") if row0 else "{}"

--- a/apps/backend/src/mediamop/modules/subber/subber_providers_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_providers_service.py
@@ -71,7 +71,9 @@ def get_enabled_providers_ordered(session: Session) -> list[SubberProviderRow]:
 
 def get_provider_by_key(session: Session, provider_key: str) -> SubberProviderRow | None:
     ensure_all_provider_rows(session)
-    return session.scalars(select(SubberProviderRow).where(SubberProviderRow.provider_key == provider_key)).one_or_none()
+    return session.scalars(
+        select(SubberProviderRow).where(SubberProviderRow.provider_key == provider_key)
+    ).one_or_none()
 
 
 def provider_has_stored_credentials(settings: MediaMopSettings, row: SubberProviderRow) -> bool:

--- a/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_search_job_handler.py
@@ -54,7 +54,9 @@ def make_subber_subtitle_search_handler(
                 logger.debug("Subber subtitle search skipped because state_id=%s no longer exists.", state_id)
                 return
             if row.status == "found" and row.subtitle_path and os.path.isfile(row.subtitle_path):
-                logger.debug("Subber subtitle search skipped because state_id=%s already has a subtitle file.", state_id)
+                logger.debug(
+                    "Subber subtitle search skipped because state_id=%s already has a subtitle file.", state_id
+                )
                 return
             settings_row = ensure_subber_settings_row(session)
             if not settings_row.enabled:

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
@@ -209,20 +209,24 @@ def put_subber_settings(
     rad_key = _api_key_from_ciphertext(row.radarr_credentials_ciphertext)
     son_configured = bool((row.sonarr_base_url or "").strip()) and bool(son_key)
     rad_configured = bool((row.radarr_base_url or "").strip()) and bool(rad_key)
-    if (body.sonarr_base_url is not None or (body.sonarr_api_key is not None and body.sonarr_api_key.strip())) and son_configured:
+    if (
+        body.sonarr_base_url is not None or (body.sonarr_api_key is not None and body.sonarr_api_key.strip())
+    ) and son_configured:
         subber_enqueue_or_get_job(
             db,
             dedupe_key=f"subber:libsync:settings:tv:{uuid.uuid4()}",
             job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
             payload_json="{}",
         )
-    if (body.radarr_base_url is not None or (body.radarr_api_key is not None and body.radarr_api_key.strip())) and rad_configured:
+    if (
+        body.radarr_base_url is not None or (body.radarr_api_key is not None and body.radarr_api_key.strip())
+    ) and rad_configured:
         subber_enqueue_or_get_job(
             db,
             dedupe_key=f"subber:libsync:settings:movies:{uuid.uuid4()}",
             job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_MOVIES,
             payload_json="{}",
-            )
+        )
 
     return _settings_out(db, row, request, settings)
 

--- a/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subdl_client.py
@@ -66,5 +66,7 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle zip/srt from SubDL."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
+    _code, data = request_bytes(
+        download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True
+    )
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_subf2m_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subf2m_client.py
@@ -62,5 +62,7 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle from Subf2m."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
+    _code, data = request_bytes(
+        download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True
+    )
     return data

--- a/apps/backend/src/mediamop/modules/subber/subber_subsource_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_subsource_client.py
@@ -62,7 +62,13 @@ def search(
         dl = s.get("download_url") or s.get("url") or s.get("downloadLink") or ""
         lang = str(s.get("lang") or s.get("language") or "").lower()[:10]
         if dl:
-            out.append({"download_url": str(dl), "language": lang, "hearing_impaired": bool(s.get("hi") or s.get("hearing_impaired"))})
+            out.append(
+                {
+                    "download_url": str(dl),
+                    "language": lang,
+                    "hearing_impaired": bool(s.get("hi") or s.get("hearing_impaired")),
+                }
+            )
     return out
 
 

--- a/apps/backend/src/mediamop/modules/subber/subber_yify_client.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_yify_client.py
@@ -56,5 +56,7 @@ def search(
 
 def download(*, download_url: str) -> bytes:
     """Download subtitle from YifySubtitles."""
-    _code, data = request_bytes(download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True)
+    _code, data = request_bytes(
+        download_url, headers={"User-Agent": USER_AGENT}, timeout=60, validate_provider_url=True
+    )
     return data

--- a/apps/backend/src/mediamop/modules/subber/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/subber/worker_loop.py
@@ -89,8 +89,7 @@ def process_one_subber_job(
 
     if job_kind_forbidden_on_subber_lane(ctx.job_kind):
         err_text = (
-            "subber worker refused job_kind reserved for another module lane: "
-            f"{ctx.job_kind!r} (row id={ctx.id})"
+            f"subber worker refused job_kind reserved for another module lane: {ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
             with session_factory() as session, session.begin():
@@ -107,8 +106,7 @@ def process_one_subber_job(
 
     if not ctx.job_kind.startswith(SUBBER_QUEUE_JOB_KIND_PREFIX):
         err_text = (
-            "subber worker refused job_kind missing required subber.* prefix: "
-            f"{ctx.job_kind!r} (row id={ctx.id})"
+            f"subber worker refused job_kind missing required subber.* prefix: {ctx.job_kind!r} (row id={ctx.id})"
         )[:10_000]
         try:
             with session_factory() as session, session.begin():
@@ -162,7 +160,9 @@ def process_one_subber_job(
                 )
         except Exception:
             logger.exception("Subber fail_claimed_subber_job failed after handler error job_id=%s", ctx.id)
-        dispatch_job_notification(session_factory, module="subber", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="subber", event_kind="failed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
         return "processed"
 
     complete_ok = True
@@ -184,7 +184,9 @@ def process_one_subber_job(
         complete_err = str(exc)
 
     if complete_ok:
-        dispatch_job_notification(session_factory, module="subber", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind)
+        dispatch_job_notification(
+            session_factory, module="subber", event_kind="completed", job_id=ctx.id, job_kind=ctx.job_kind
+        )
 
     if not complete_ok and complete_err is not None:
         bounded = (SUBBER_TERMINALIZATION_FAILURE_PREFIX + complete_err)[:10_000]

--- a/apps/backend/src/mediamop/platform/activity/service.py
+++ b/apps/backend/src/mediamop/platform/activity/service.py
@@ -80,6 +80,7 @@ def _publish_committed_activity_events(session: Session) -> None:
 def _clear_pending_activity_events(session: Session) -> None:
     session.info.pop(_PENDING_ACTIVITY_IDS_INFO_KEY, None)
 
+
 def maybe_record_login_failed(db: Session, *, username: str) -> None:
     """One failed-login event per username per short window to limit brute-force noise."""
 
@@ -186,13 +187,17 @@ def count_activity_events(
     date_from: datetime | None = None,
     date_to: datetime | None = None,
 ) -> int:
-    stmt = _filtered_activity_stmt(
-        module=module,
-        event_type=event_type,
-        search=search,
-        date_from=date_from,
-        date_to=date_to,
-    ).with_only_columns(func.count()).order_by(None)
+    stmt = (
+        _filtered_activity_stmt(
+            module=module,
+            event_type=event_type,
+            search=search,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        .with_only_columns(func.count())
+        .order_by(None)
+    )
     return int(db.scalar(stmt) or 0)
 
 

--- a/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_connection_crypto.py
@@ -15,9 +15,7 @@ from mediamop.core.config import MediaMopSettings
 from mediamop.core.credentials_rotation import credential_secret_candidates
 
 # Frozen KDF domain bytes (legacy install compatibility). Do not change.
-_ARR_API_KEY_KDF_PEPPER = binascii.a2b_hex(
-    "6d656469616d6f702e666574636865722e6172725f6170695f6b65792e76317c"
-)
+_ARR_API_KEY_KDF_PEPPER = binascii.a2b_hex("6d656469616d6f702e666574636865722e6172725f6170695f6b65792e76317c")
 _ARR_API_KEY_KDF_ITERATIONS = 390_000
 _ENVELOPE_VERSION = 2
 _CREDENTIALS_KEY_ID: Literal["credentials:v1"] = "credentials:v1"

--- a/apps/backend/src/mediamop/platform/arr_library/arr_operator_settings_model.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_operator_settings_model.py
@@ -20,7 +20,9 @@ class ArrLibraryOperatorSettingsRow(Base):
 
     sonarr_missing_search_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     sonarr_missing_search_max_items_per_run: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
-    sonarr_missing_search_retry_delay_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1440")
+    sonarr_missing_search_retry_delay_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1440"
+    )
     sonarr_missing_search_schedule_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     sonarr_missing_search_schedule_days: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     sonarr_missing_search_schedule_start: Mapped[str] = mapped_column(Text, nullable=False, server_default="00:00")
@@ -31,7 +33,9 @@ class ArrLibraryOperatorSettingsRow(Base):
 
     sonarr_upgrade_search_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     sonarr_upgrade_search_max_items_per_run: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
-    sonarr_upgrade_search_retry_delay_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1440")
+    sonarr_upgrade_search_retry_delay_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1440"
+    )
     sonarr_upgrade_search_schedule_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     sonarr_upgrade_search_schedule_days: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     sonarr_upgrade_search_schedule_start: Mapped[str] = mapped_column(Text, nullable=False, server_default="00:00")
@@ -42,7 +46,9 @@ class ArrLibraryOperatorSettingsRow(Base):
 
     radarr_missing_search_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     radarr_missing_search_max_items_per_run: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
-    radarr_missing_search_retry_delay_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1440")
+    radarr_missing_search_retry_delay_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1440"
+    )
     radarr_missing_search_schedule_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     radarr_missing_search_schedule_days: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     radarr_missing_search_schedule_start: Mapped[str] = mapped_column(Text, nullable=False, server_default="00:00")
@@ -53,7 +59,9 @@ class ArrLibraryOperatorSettingsRow(Base):
 
     radarr_upgrade_search_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     radarr_upgrade_search_max_items_per_run: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
-    radarr_upgrade_search_retry_delay_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1440")
+    radarr_upgrade_search_retry_delay_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1440"
+    )
     radarr_upgrade_search_schedule_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     radarr_upgrade_search_schedule_days: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     radarr_upgrade_search_schedule_start: Mapped[str] = mapped_column(Text, nullable=False, server_default="00:00")

--- a/apps/backend/src/mediamop/platform/arr_library/arr_operator_settings_repo.py
+++ b/apps/backend/src/mediamop/platform/arr_library/arr_operator_settings_repo.py
@@ -7,7 +7,9 @@ from mediamop.platform.arr_library.arr_operator_settings_model import ArrLibrary
 
 
 def ensure_arr_library_operator_settings_row(session: Session) -> ArrLibraryOperatorSettingsRow:
-    row = session.scalars(select(ArrLibraryOperatorSettingsRow).where(ArrLibraryOperatorSettingsRow.id == 1)).one_or_none()
+    row = session.scalars(
+        select(ArrLibraryOperatorSettingsRow).where(ArrLibraryOperatorSettingsRow.id == 1)
+    ).one_or_none()
     if row is None:
         row = ArrLibraryOperatorSettingsRow(id=1)
         session.add(row)

--- a/apps/backend/src/mediamop/platform/arr_library/operator_settings_service.py
+++ b/apps/backend/src/mediamop/platform/arr_library/operator_settings_service.py
@@ -67,7 +67,9 @@ def _lane_out_from_row(row: ArrLibraryOperatorSettingsRow, prefix: str) -> ArrLi
     )
 
 
-def _sonarr_panel(session: Session, settings: MediaMopSettings, row: ArrLibraryOperatorSettingsRow) -> ArrLibraryConnectionPanelOut:
+def _sonarr_panel(
+    session: Session, settings: MediaMopSettings, row: ArrLibraryOperatorSettingsRow
+) -> ArrLibraryConnectionPanelOut:
     eff_b, _eff_k = resolve_sonarr_http_credentials(session, settings)
     return ArrLibraryConnectionPanelOut(
         enabled=bool(row.sonarr_connection_enabled),
@@ -85,7 +87,9 @@ def _sonarr_panel(session: Session, settings: MediaMopSettings, row: ArrLibraryO
     )
 
 
-def _radarr_panel(session: Session, settings: MediaMopSettings, row: ArrLibraryOperatorSettingsRow) -> ArrLibraryConnectionPanelOut:
+def _radarr_panel(
+    session: Session, settings: MediaMopSettings, row: ArrLibraryOperatorSettingsRow
+) -> ArrLibraryConnectionPanelOut:
     eff_b, _eff_k = resolve_radarr_http_credentials(session, settings)
     return ArrLibraryConnectionPanelOut(
         enabled=bool(row.radarr_connection_enabled),
@@ -103,7 +107,9 @@ def _radarr_panel(session: Session, settings: MediaMopSettings, row: ArrLibraryO
     )
 
 
-def build_arr_library_operator_settings_out(session: Session, settings: MediaMopSettings) -> ArrLibraryOperatorSettingsOut:
+def build_arr_library_operator_settings_out(
+    session: Session, settings: MediaMopSettings
+) -> ArrLibraryOperatorSettingsOut:
     row = ensure_arr_library_operator_settings_row(session)
     suite_row = ensure_suite_settings_row(session)
     sb, sk = resolve_sonarr_http_credentials(session, settings)

--- a/apps/backend/src/mediamop/platform/auth/csrf.py
+++ b/apps/backend/src/mediamop/platform/auth/csrf.py
@@ -50,11 +50,7 @@ def issue_csrf_token(secret: str, raw_session_token: str | None = None) -> str:
     if not secret.strip():
         raise ValueError("session secret required for CSRF")
     bound_session = (raw_session_token or "").strip()
-    payload = (
-        _session_subject_payload(bound_session)
-        if bound_session
-        else CSRF_SUBJECT_ANONYMOUS
-    )
+    payload = _session_subject_payload(bound_session) if bound_session else CSRF_SUBJECT_ANONYMOUS
     return _signer(secret).sign(payload.encode("utf-8")).decode("utf-8")
 
 

--- a/apps/backend/src/mediamop/platform/auth/router.py
+++ b/apps/backend/src/mediamop/platform/auth/router.py
@@ -269,7 +269,9 @@ def post_logout(
     validate_browser_post_origin(request, settings)
     token = _csrf_from_header_or_body(x_csrf_token, body.csrf_token if body else None)
     raw_session_token = current_raw_session_token(request, settings)
-    if not verify_csrf_token(secret, token, raw_session_token=raw_session_token, allow_anonymous=raw_session_token is None):
+    if not verify_csrf_token(
+        secret, token, raw_session_token=raw_session_token, allow_anonymous=raw_session_token is None
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid or expired CSRF token.",

--- a/apps/backend/src/mediamop/platform/auth/service.py
+++ b/apps/backend/src/mediamop/platform/auth/service.py
@@ -95,15 +95,18 @@ def enforce_session_limit_for_user(
     if max_active_sessions < 1:
         max_active_sessions = 1
     now = utcnow()
-    active_count = db.scalar(
-        select(func.count())
-        .select_from(UserSession)
-        .where(
-            UserSession.user_id == user_id,
-            UserSession.revoked_at.is_(None),
-            UserSession.absolute_expires_at > now,
+    active_count = (
+        db.scalar(
+            select(func.count())
+            .select_from(UserSession)
+            .where(
+                UserSession.user_id == user_id,
+                UserSession.revoked_at.is_(None),
+                UserSession.absolute_expires_at > now,
+            )
         )
-    ) or 0
+        or 0
+    )
     overflow = int(active_count) - max_active_sessions
     if overflow <= 0:
         return 0
@@ -134,11 +137,7 @@ def create_user_session(
     raw = generate_raw_session_token()
     th = hash_session_token(raw)
     abs_ttl = timedelta(
-        days=(
-            settings.session_trusted_absolute_days
-            if trusted_device
-            else settings.session_absolute_days
-        )
+        days=(settings.session_trusted_absolute_days if trusted_device else settings.session_absolute_days)
     )
     now = utcnow()
     row = UserSession(
@@ -242,15 +241,9 @@ def user_public(user: User) -> dict:
 
 
 def session_public(session: UserSession, *, settings: MediaMopSettings) -> dict:
-    idle_minutes = (
-        settings.session_trusted_idle_minutes
-        if session.is_trusted_device
-        else settings.session_idle_minutes
-    )
+    idle_minutes = settings.session_trusted_idle_minutes if session.is_trusted_device else settings.session_idle_minutes
     absolute_days = (
-        settings.session_trusted_absolute_days
-        if session.is_trusted_device
-        else settings.session_absolute_days
+        settings.session_trusted_absolute_days if session.is_trusted_device else settings.session_absolute_days
     )
     return {
         "trusted_device": session.is_trusted_device,

--- a/apps/backend/src/mediamop/platform/auth/sessions.py
+++ b/apps/backend/src/mediamop/platform/auth/sessions.py
@@ -77,11 +77,7 @@ def is_idle_expired(
 
 
 def effective_idle_timeout(session_row: UserSession, *, settings) -> timedelta:
-    minutes = (
-        settings.session_trusted_idle_minutes
-        if session_row.is_trusted_device
-        else settings.session_idle_minutes
-    )
+    minutes = settings.session_trusted_idle_minutes if session_row.is_trusted_device else settings.session_idle_minutes
     return timedelta(minutes=minutes)
 
 

--- a/apps/backend/src/mediamop/platform/http/security_headers.py
+++ b/apps/backend/src/mediamop/platform/http/security_headers.py
@@ -16,12 +16,7 @@ from starlette.responses import Response
 from mediamop.core.config import MediaMopSettings
 
 # API baseline: no scripts, no frames, no base-tag surprises, no forms to third parties.
-_API_CSP = (
-    "default-src 'none'; "
-    "base-uri 'none'; "
-    "frame-ancestors 'none'; "
-    "form-action 'none'"
-)
+_API_CSP = "default-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'"
 
 # HTML baseline for the bundled SPA shell/static assets.
 # Keep this narrow and first-party only; the web app self-hosts its fonts.

--- a/apps/backend/src/mediamop/platform/http/xrw_csrf_middleware.py
+++ b/apps/backend/src/mediamop/platform/http/xrw_csrf_middleware.py
@@ -39,7 +39,9 @@ class XRequestedWithCsrfMiddleware(BaseHTTPMiddleware):
             xrw = (request.headers.get("X-Requested-With") or "").strip()
             if xrw.lower() != "xmlhttprequest":
                 return JSONResponse(
-                    {"detail": "Missing X-Requested-With header. This endpoint requires an authenticated browser session."},
+                    {
+                        "detail": "Missing X-Requested-With header. This endpoint requires an authenticated browser session."
+                    },
                     status_code=403,
                 )
         return await call_next(request)

--- a/apps/backend/src/mediamop/platform/jobs/worker_health.py
+++ b/apps/backend/src/mediamop/platform/jobs/worker_health.py
@@ -104,16 +104,17 @@ def build_worker_health_snapshot(
                 ),
             )
             continue
-        active = sum(1 for row in module_rows if row.status == "running" and now - row.last_seen_at <= stale_after_seconds)
-        stale = sum(1 for row in module_rows if row.status == "running" and now - row.last_seen_at > stale_after_seconds)
+        active = sum(
+            1 for row in module_rows if row.status == "running" and now - row.last_seen_at <= stale_after_seconds
+        )
+        stale = sum(
+            1 for row in module_rows if row.status == "running" and now - row.last_seen_at > stale_after_seconds
+        )
         stopped = sum(1 for row in module_rows if row.status == "stopped")
         missing = max(0, expected - len(module_rows))
         degraded = stale + stopped + missing
         if degraded:
-            detail = (
-                f"{module.title()} expected {expected} worker(s), but "
-                f"{degraded} are stale, stopped, or missing."
-            )
+            detail = f"{module.title()} expected {expected} worker(s), but {degraded} are stale, stopped, or missing."
             status = "degraded"
         else:
             detail = f"{module.title()} worker heartbeats are current."

--- a/apps/backend/src/mediamop/platform/local_browse/__init__.py
+++ b/apps/backend/src/mediamop/platform/local_browse/__init__.py
@@ -1,2 +1,1 @@
 """Local desktop browse helpers."""
-

--- a/apps/backend/src/mediamop/platform/local_browse/router.py
+++ b/apps/backend/src/mediamop/platform/local_browse/router.py
@@ -86,7 +86,9 @@ def _list_root_entries() -> list[DirectoryBrowseEntry]:
                 }.get(int(drive_type), "Drive")
             except Exception:
                 description = "Drive"
-            entries.append(DirectoryBrowseEntry(name=root.rstrip("\\"), path=root, kind="root", description=description))
+            entries.append(
+                DirectoryBrowseEntry(name=root.rstrip("\\"), path=root, kind="root", description=description)
+            )
         return entries
     return [DirectoryBrowseEntry(name="/", path="/", kind="root", description="Filesystem root")]
 
@@ -134,7 +136,6 @@ def get_system_directories(
             detail="Path must begin at the filesystem root.",
         )
 
-
     if not os.path.isdir(normalized):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="The requested directory does not exist.")
 
@@ -157,9 +158,13 @@ def get_system_directories(
                 ),
             )
     except PermissionError as exc:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="MediaMop cannot access this folder.") from exc
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="MediaMop cannot access this folder."
+        ) from exc
     except OSError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="The requested directory cannot be accessed.") from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="The requested directory cannot be accessed."
+        ) from exc
 
     entries.sort(key=lambda entry: entry.name.lower())
     return DirectoryBrowseOut(current_path=normalized, parent_path=parent_path, entries=entries)

--- a/apps/backend/src/mediamop/platform/metrics/__init__.py
+++ b/apps/backend/src/mediamop/platform/metrics/__init__.py
@@ -1,2 +1,1 @@
 """Runtime metrics services."""
-

--- a/apps/backend/src/mediamop/platform/notifications/dispatch.py
+++ b/apps/backend/src/mediamop/platform/notifications/dispatch.py
@@ -70,12 +70,16 @@ def _build_discord_payload(*, title: str, detail: str, event: str, module: str, 
     ).encode()
 
 
-def _post_one(channel: NotificationChannel, *, title: str, detail: str, event: str, module: str, job_id: int, job_kind: str) -> None:
+def _post_one(
+    channel: NotificationChannel, *, title: str, detail: str, event: str, module: str, job_id: int, job_kind: str
+) -> None:
     try:
         if channel.provider == "discord":
             body = _build_discord_payload(title=title, detail=detail, event=event, module=module, job_id=job_id)
         else:
-            body = _build_webhook_payload(event=event, module=module, job_id=job_id, job_kind=job_kind, title=title, detail=detail)
+            body = _build_webhook_payload(
+                event=event, module=module, job_id=job_id, job_kind=job_kind, title=title, detail=detail
+            )
         req = urllib.request.Request(
             channel.url,
             data=body,

--- a/apps/backend/src/mediamop/platform/notifications/model.py
+++ b/apps/backend/src/mediamop/platform/notifications/model.py
@@ -34,9 +34,7 @@ class NotificationChannel(Base):
     url: Mapped[str] = mapped_column(Text, nullable=False)
     events_json: Mapped[str] = mapped_column(Text, nullable=False, server_default='["job_failed"]')
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), nullable=False
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )

--- a/apps/backend/src/mediamop/platform/notifications/ops.py
+++ b/apps/backend/src/mediamop/platform/notifications/ops.py
@@ -47,9 +47,7 @@ def list_notification_channels(session: Session) -> list[NotificationChannel]:
 
 
 def get_notification_channel(session: Session, channel_id: int) -> NotificationChannel | None:
-    return session.scalars(
-        select(NotificationChannel).where(NotificationChannel.id == channel_id)
-    ).one_or_none()
+    return session.scalars(select(NotificationChannel).where(NotificationChannel.id == channel_id)).one_or_none()
 
 
 def create_notification_channel(
@@ -111,9 +109,7 @@ def delete_notification_channel(
 
 def get_channels_for_event(session: Session, event: str) -> list[NotificationChannel]:
     """Return enabled channels whose events_json includes *event* or its wildcard counterpart."""
-    rows = session.scalars(
-        select(NotificationChannel).where(NotificationChannel.enabled.is_(True))
-    ).all()
+    rows = session.scalars(select(NotificationChannel).where(NotificationChannel.enabled.is_(True))).all()
     result = []
     for row in rows:
         subscribed = _parse_events(row.events_json)

--- a/apps/backend/src/mediamop/platform/notifications/router.py
+++ b/apps/backend/src/mediamop/platform/notifications/router.py
@@ -74,7 +74,10 @@ def post_notification_channel(
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Your confirmation token expired. Refresh the page and try again.")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Your confirmation token expired. Refresh the page and try again.",
+        )
     try:
         row = create_notification_channel(
             db,
@@ -102,7 +105,10 @@ def put_notification_channel(
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Your confirmation token expired. Refresh the page and try again.")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Your confirmation token expired. Refresh the page and try again.",
+        )
     try:
         row = update_notification_channel(
             db,
@@ -148,7 +154,10 @@ def post_notification_channel_test(
     validate_browser_post_origin(request, settings)
     secret = require_session_secret(settings)
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Your confirmation token expired. Refresh the page and try again.")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Your confirmation token expired. Refresh the page and try again.",
+        )
     row = get_notification_channel(db, channel_id)
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification channel not found.")

--- a/apps/backend/src/mediamop/platform/reconciliation/__init__.py
+++ b/apps/backend/src/mediamop/platform/reconciliation/__init__.py
@@ -1,2 +1,1 @@
 """Filesystem/database reconciliation support."""
-

--- a/apps/backend/src/mediamop/platform/suite_settings/release_catalog.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/release_catalog.py
@@ -92,9 +92,7 @@ def _coerce_release_asset(payload: dict[str, Any]) -> GitHubReleaseAsset:
         api_url=api_url,
         browser_download_url=str(payload.get("browser_download_url") or "").strip(),
         size_bytes=int(payload.get("size") or 0),
-        content_type=(
-            str(payload.get("content_type") or "").strip() or None
-        ),
+        content_type=(str(payload.get("content_type") or "").strip() or None),
     )
 
 
@@ -108,9 +106,7 @@ def _coerce_release_payload(payload: dict[str, Any]) -> GitHubReleaseRecord:
     published_at_raw = payload.get("published_at")
     published_at = None
     if isinstance(published_at_raw, str) and published_at_raw.strip():
-        published_at = datetime.fromisoformat(
-            published_at_raw.strip().replace("Z", "+00:00")
-        )
+        published_at = datetime.fromisoformat(published_at_raw.strip().replace("Z", "+00:00"))
     assets_raw = payload.get("assets")
     assets: list[GitHubReleaseAsset] = []
     if isinstance(assets_raw, list):
@@ -155,12 +151,7 @@ def fetch_release_record_by_version(
         response.raise_for_status()
         record = _coerce_release_payload(response.json())
     if record.tag_name != tag:
-        raise ValueError(
-            f"Release tag mismatch for MediaMop update: expected {tag}, got {record.tag_name}."
-        )
+        raise ValueError(f"Release tag mismatch for MediaMop update: expected {tag}, got {record.tag_name}.")
     if record.draft or record.prerelease:
-        raise ValueError(
-            f"MediaMop update {tag} is not a stable published release."
-        )
+        raise ValueError(f"MediaMop update {tag} is not a stable published release.")
     return record
-

--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -145,7 +145,9 @@ def put_configuration_bundle(
 
 
 @router.get("/suite/configuration-backups", response_model=SuiteConfigurationBackupListOut)
-def get_configuration_backups(_user: RequireOperatorDep, db: DbSessionDep, settings: SettingsDep) -> SuiteConfigurationBackupListOut:
+def get_configuration_backups(
+    _user: RequireOperatorDep, db: DbSessionDep, settings: SettingsDep
+) -> SuiteConfigurationBackupListOut:
     directory, rows = list_suite_configuration_backups(db, settings=settings)
     return SuiteConfigurationBackupListOut(
         directory=directory,
@@ -191,7 +193,6 @@ def get_suite_update_status(_user: UserPublicDep, settings: SettingsDep) -> Suit
     """Read-only update check for the signed-in Settings page."""
 
     return build_suite_update_status(settings)
-
 
 
 @router.post("/suite/operational-history/reset", response_model=SuiteOperationalHistoryResetOut)

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -140,7 +140,9 @@ class SuiteSecurityOverviewOut(BaseModel):
     extra_https_hardening_enabled: bool = Field(
         description="Whether strict transport (HSTS) extra protection is enabled for browser responses.",
     )
-    sign_in_attempt_limit: int = Field(ge=1, description="How many failed sign-in tries are allowed before cooling off.")
+    sign_in_attempt_limit: int = Field(
+        ge=1, description="How many failed sign-in tries are allowed before cooling off."
+    )
     sign_in_attempt_window_plain: str = Field(
         description="How long the sign-in try window lasts, in everyday wording.",
     )

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_periodic.py
@@ -83,6 +83,7 @@ async def _run_suite_configuration_backup_forever(
     loop = asyncio.get_running_loop()
     scan_iv = 60.0
     while not stop_event.is_set():
+
         def _once() -> int:
             return run_suite_configuration_backup_tick(session_factory, settings=settings)
 

--- a/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/suite_configuration_backup_service.py
@@ -21,7 +21,9 @@ def _backup_dir(settings: MediaMopSettings) -> Path:
     return (Path(settings.backup_dir) / "suite-configuration").resolve()
 
 
-def list_suite_configuration_backups(session: Session, *, settings: MediaMopSettings) -> tuple[str, list[SuiteConfigurationBackupRow]]:
+def list_suite_configuration_backups(
+    session: Session, *, settings: MediaMopSettings
+) -> tuple[str, list[SuiteConfigurationBackupRow]]:
     rows = list(
         session.scalars(
             select(SuiteConfigurationBackupRow).order_by(

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -79,9 +79,7 @@ def _build_release_status(
 
     current_parsed = parse_version_key(current_version)
     latest_parsed = parse_version_key(release.version)
-    update_available = bool(
-        current_parsed and latest_parsed and latest_parsed > current_parsed
-    )
+    update_available = bool(current_parsed and latest_parsed and latest_parsed > current_parsed)
 
     if not release.version:
         status = "unavailable"
@@ -114,9 +112,7 @@ def _build_release_status(
         docker_update_command=docker_update_command,
         in_app_upgrade_supported=install_type == "windows",
         in_app_upgrade_summary=(
-            "Updates are managed by the MediaMop desktop app via Velopack."
-            if install_type == "windows"
-            else None
+            "Updates are managed by the MediaMop desktop app via Velopack." if install_type == "windows" else None
         ),
     )
 

--- a/apps/backend/src/mediamop/platform/system_configuration/router.py
+++ b/apps/backend/src/mediamop/platform/system_configuration/router.py
@@ -60,7 +60,9 @@ def put_suite_configuration_bundle(
 
 
 @router.get("/suite-configuration-backups", response_model=SuiteConfigurationBackupListOut)
-def get_suite_configuration_backups(_user: RequireOperatorDep, db: DbSessionDep, settings: SettingsDep) -> SuiteConfigurationBackupListOut:
+def get_suite_configuration_backups(
+    _user: RequireOperatorDep, db: DbSessionDep, settings: SettingsDep
+) -> SuiteConfigurationBackupListOut:
     directory, rows = list_suite_configuration_backups(db, settings=settings)
     return SuiteConfigurationBackupListOut(
         directory=directory,

--- a/apps/backend/src/mediamop/windows/__init__.py
+++ b/apps/backend/src/mediamop/windows/__init__.py
@@ -1,2 +1,1 @@
 """Windows desktop packaging helpers for MediaMop."""
-

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -164,7 +164,9 @@ def test_login_failed_persisted_throttled_per_username(client_with_admin: TestCl
         db.commit()
     with fac() as db:
         before = db.scalar(
-            select(func.count()).select_from(ActivityEvent).where(
+            select(func.count())
+            .select_from(ActivityEvent)
+            .where(
                 ActivityEvent.event_type == activity_constants.AUTH_LOGIN_FAILED,
                 ActivityEvent.detail == "alice",
             ),
@@ -183,7 +185,9 @@ def test_login_failed_persisted_throttled_per_username(client_with_admin: TestCl
         assert r.status_code == 401
     with fac() as db:
         after = db.scalar(
-            select(func.count()).select_from(ActivityEvent).where(
+            select(func.count())
+            .select_from(ActivityEvent)
+            .where(
                 ActivityEvent.event_type == activity_constants.AUTH_LOGIN_FAILED,
                 ActivityEvent.detail == "alice",
             ),
@@ -606,7 +610,9 @@ def test_bootstrap_denied_persisted_throttled(client_with_admin: TestClient) -> 
         db.commit()
     with fac() as db:
         before = db.scalar(
-            select(func.count()).select_from(ActivityEvent).where(
+            select(func.count())
+            .select_from(ActivityEvent)
+            .where(
                 ActivityEvent.event_type == activity_constants.AUTH_BOOTSTRAP_DENIED,
             ),
         )
@@ -634,7 +640,9 @@ def test_bootstrap_denied_persisted_throttled(client_with_admin: TestClient) -> 
     assert r2.status_code == 403
     with fac() as db:
         after = db.scalar(
-            select(func.count()).select_from(ActivityEvent).where(
+            select(func.count())
+            .select_from(ActivityEvent)
+            .where(
                 ActivityEvent.event_type == activity_constants.AUTH_BOOTSTRAP_DENIED,
             ),
         )
@@ -706,9 +714,7 @@ def test_activity_recent_includes_login_event(client_with_admin: TestClient) -> 
     r_act = client_with_admin.get("/api/v1/activity/recent")
     assert r_act.status_code == 200, r_act.text
     items = r_act.json()["items"]
-    assert any(
-        x.get("event_type") == "auth.login_succeeded" and x.get("detail") == "alice" for x in items
-    )
+    assert any(x.get("event_type") == "auth.login_succeeded" and x.get("detail") == "alice" for x in items)
 
 
 def test_activity_recent_includes_logout_event(client_with_admin: TestClient) -> None:
@@ -775,10 +781,13 @@ def test_load_valid_session_throttles_last_seen_persistence(monkeypatch: pytest.
 
     assert read_last_seen() == base
 
-    with patch(
-        "mediamop.platform.auth.service.utcnow",
-        return_value=base + timedelta(seconds=30),
-    ), fac() as db:
+    with (
+        patch(
+            "mediamop.platform.auth.service.utcnow",
+            return_value=base + timedelta(seconds=30),
+        ),
+        fac() as db,
+    ):
         pair = auth_service.load_valid_session_for_request(db, raw, settings)
         assert pair is not None
         db.commit()
@@ -808,7 +817,13 @@ def test_expired_session_is_rejected_and_revoked(monkeypatch: pytest.MonkeyPatch
         sid = row.id
         db.commit()
 
-    with patch("mediamop.platform.auth.service.utcnow", return_value=base + timedelta(days=settings.session_absolute_days + 1)), fac() as db:
+    with (
+        patch(
+            "mediamop.platform.auth.service.utcnow",
+            return_value=base + timedelta(days=settings.session_absolute_days + 1),
+        ),
+        fac() as db,
+    ):
         pair = auth_service.load_valid_session_for_request(db, raw, settings)
         db.commit()
 

--- a/apps/backend/tests/test_configuration_bundle_api.py
+++ b/apps/backend/tests/test_configuration_bundle_api.py
@@ -68,7 +68,9 @@ def test_configuration_bundle_round_trip_suite_name(client_with_admin: TestClien
         headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
     )
     assert r_restore.status_code == 200, r_restore.text
-    assert r_restore.json()["suite_settings"]["product_display_name"] == bundle["suite_settings"]["product_display_name"]
+    assert (
+        r_restore.json()["suite_settings"]["product_display_name"] == bundle["suite_settings"]["product_display_name"]
+    )
 
 
 def test_configuration_bundle_put_rejects_bad_version(client_with_admin: TestClient) -> None:

--- a/apps/backend/tests/test_credentials_secret_crypto.py
+++ b/apps/backend/tests/test_credentials_secret_crypto.py
@@ -31,13 +31,17 @@ def _settings(monkeypatch, *, session: str, credentials: str | None) -> MediaMop
 
 def test_credentials_secret_decouples_pruner_subber_and_arr_from_session_rotation(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("MEDIAMOP_HOME", str(tmp_path))
-    s1 = _settings(monkeypatch, session="session-secret-a-abcdefghijklmnopqrstuvwxyz", credentials="credentials-secret-a")
+    s1 = _settings(
+        monkeypatch, session="session-secret-a-abcdefghijklmnopqrstuvwxyz", credentials="credentials-secret-a"
+    )
 
     pruner = encrypt_pruner_credentials_json(s1, '{"api_key":"p"}')
     subber = encrypt_subber_credentials_json(s1, '{"api_key":"s"}')
     arr = encrypt_arr_api_key(s1, "arr-key")
 
-    s2 = _settings(monkeypatch, session="session-secret-b-abcdefghijklmnopqrstuvwxyz", credentials="credentials-secret-a")
+    s2 = _settings(
+        monkeypatch, session="session-secret-b-abcdefghijklmnopqrstuvwxyz", credentials="credentials-secret-a"
+    )
 
     assert decrypt_pruner_credentials_json(s2, pruner) == '{"api_key":"p"}'
     assert decrypt_subber_credentials_json(s2, subber) == '{"api_key":"s"}'
@@ -83,7 +87,9 @@ def test_legacy_session_secret_ciphertexts_can_be_rewrapped(monkeypatch, tmp_pat
 
 def test_previous_credentials_secret_allows_safe_secret_rotation(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("MEDIAMOP_HOME", str(tmp_path))
-    old = _settings(monkeypatch, session="session-secret-a-abcdefghijklmnopqrstuvwxyz", credentials="old-credentials-secret")
+    old = _settings(
+        monkeypatch, session="session-secret-a-abcdefghijklmnopqrstuvwxyz", credentials="old-credentials-secret"
+    )
 
     pruner = encrypt_pruner_credentials_json(old, '{"api_key":"p"}')
     subber = encrypt_subber_credentials_json(old, '{"api_key":"s"}')

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -62,7 +62,9 @@ def test_readiness_reports_failed_when_worker_heartbeat_missing() -> None:
         startup_ready = True
         engine = None
         session_factory = None
-        settings = replace(MediaMopSettings.load(), refiner_worker_count=1, pruner_worker_count=0, subber_worker_count=0)
+        settings = replace(
+            MediaMopSettings.load(), refiner_worker_count=1, pruner_worker_count=0, subber_worker_count=0
+        )
 
     payload = build_readiness(State())
 

--- a/apps/backend/tests/test_operator_messages.py
+++ b/apps/backend/tests/test_operator_messages.py
@@ -17,14 +17,17 @@ from mediamop.platform.observability.operator_messages import (
 def test_operator_message_labels_are_plain_language() -> None:
     assert provider_label("jellyfin") == "Jellyfin"
     assert media_scope_label("tv") == "TV episodes"
-    assert scan_title(
-        module_label="Pruner preview",
-        result=DiagnosticResult.SUCCESS,
-        count=2,
-        scope="movies",
-        source="Living room (Jellyfin)",
-        scheduled=True,
-    ) == "Scheduled Pruner preview scan found 2 Movies needing action from Living room (Jellyfin)"
+    assert (
+        scan_title(
+            module_label="Pruner preview",
+            result=DiagnosticResult.SUCCESS,
+            count=2,
+            scope="movies",
+            source="Living room (Jellyfin)",
+            scheduled=True,
+        )
+        == "Scheduled Pruner preview scan found 2 Movies needing action from Living room (Jellyfin)"
+    )
     assert connection_test_title(module_label="Pruner", name="Living room", provider="plex", ok=False) == (
         "Pruner connection test failed for Living room (Plex)"
     )

--- a/apps/backend/tests/test_pruner_apply_jellyfin.py
+++ b/apps/backend/tests/test_pruner_apply_jellyfin.py
@@ -137,7 +137,9 @@ def test_apply_post_ok_when_enabled(session_factory: sessionmaker[Session], monk
         assert "pruner_job_id" in r.json()
 
 
-def test_apply_post_ok_emby_when_enabled(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_post_ok_emby_when_enabled(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
@@ -180,7 +182,9 @@ def test_apply_post_ok_emby_when_enabled(session_factory: sessionmaker[Session],
         assert "pruner_job_id" in r.json()
 
 
-def test_apply_accepts_plex_missing_primary_snapshot(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_accepts_plex_missing_primary_snapshot(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
@@ -223,7 +227,9 @@ def test_apply_accepts_plex_missing_primary_snapshot(session_factory: sessionmak
         assert "pruner_job_id" in r.json()
 
 
-def test_apply_rejects_scope_mismatch_in_url(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_rejects_scope_mismatch_in_url(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
@@ -245,7 +251,7 @@ def test_apply_rejects_scope_mismatch_in_url(session_factory: sessionmaker[Sessi
             rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
             pruner_job_id=None,
             candidate_count=1,
-            candidates_json="[{\"item_id\":\"x\"}]",
+            candidates_json='[{"item_id":"x"}]',
             truncated=False,
             outcome="success",
             unsupported_detail=None,
@@ -265,7 +271,9 @@ def test_apply_rejects_scope_mismatch_in_url(session_factory: sessionmaker[Sessi
         assert r.status_code == 422, r.text
 
 
-def test_apply_rejects_non_success_preview(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_apply_rejects_non_success_preview(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     run_uuid = str(uuid.uuid4())
@@ -287,7 +295,7 @@ def test_apply_rejects_non_success_preview(session_factory: sessionmaker[Session
             rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
             pruner_job_id=None,
             candidate_count=1,
-            candidates_json="[{\"item_id\":\"x\"}]",
+            candidates_json='[{"item_id":"x"}]',
             truncated=False,
             outcome="failed",
             unsupported_detail=None,
@@ -338,7 +346,7 @@ def test_apply_activity_title_uses_operator_label(
             rule_family_id=RULE_FAMILY_MISSING_PRIMARY_MEDIA_REPORTED,
             pruner_job_id=None,
             candidate_count=1,
-            candidates_json="[{\"item_id\":\"gone\"}]",
+            candidates_json='[{"item_id":"gone"}]',
             truncated=False,
             outcome="success",
             unsupported_detail=None,

--- a/apps/backend/tests/test_pruner_instances_api.py
+++ b/apps/backend/tests/test_pruner_instances_api.py
@@ -737,7 +737,9 @@ def test_get_pruner_instance_studios_not_found(client_with_admin: TestClient) ->
     assert r.status_code == 404
 
 
-def test_get_pruner_instance_studios_returns_list(client_with_admin: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_pruner_instance_studios_returns_list(
+    client_with_admin: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _login_admin(client_with_admin)
     tok = fetch_csrf(client_with_admin)
     r0 = auth_post(

--- a/apps/backend/tests/test_pruner_people_filters.py
+++ b/apps/backend/tests/test_pruner_people_filters.py
@@ -122,37 +122,46 @@ def test_jellyfin_emby_people_names_for_roles_filters_by_type() -> None:
 
 def test_jf_emby_preview_people_roles_cast_vs_director() -> None:
     item = {"Genres": [], "People": [{"Name": "Pat", "Type": "Director"}], "ProductionYear": None, "Studios": []}
-    assert jf_emby_item_passes_preview_filters(
-        item,
-        preview_include_genres=[],
-        preview_include_people=["pat"],
-        preview_include_people_roles=["cast"],
-        preview_year_min=None,
-        preview_year_max=None,
-        preview_include_studios=[],
-    ) is False
-    assert jf_emby_item_passes_preview_filters(
-        item,
-        preview_include_genres=[],
-        preview_include_people=["pat"],
-        preview_include_people_roles=["director"],
-        preview_year_min=None,
-        preview_year_max=None,
-        preview_include_studios=[],
-    ) is True
+    assert (
+        jf_emby_item_passes_preview_filters(
+            item,
+            preview_include_genres=[],
+            preview_include_people=["pat"],
+            preview_include_people_roles=["cast"],
+            preview_year_min=None,
+            preview_year_max=None,
+            preview_include_studios=[],
+        )
+        is False
+    )
+    assert (
+        jf_emby_item_passes_preview_filters(
+            item,
+            preview_include_genres=[],
+            preview_include_people=["pat"],
+            preview_include_people_roles=["director"],
+            preview_year_min=None,
+            preview_year_max=None,
+            preview_include_studios=[],
+        )
+        is True
+    )
 
 
 def test_jf_emby_preview_people_roles_empty_searches_all_credits() -> None:
     item = {"Genres": [], "People": [{"Name": "Pat", "Type": "Director"}], "ProductionYear": None, "Studios": []}
-    assert jf_emby_item_passes_preview_filters(
-        item,
-        preview_include_genres=[],
-        preview_include_people=["pat"],
-        preview_include_people_roles=[],
-        preview_year_min=None,
-        preview_year_max=None,
-        preview_include_studios=[],
-    ) is True
+    assert (
+        jf_emby_item_passes_preview_filters(
+            item,
+            preview_include_genres=[],
+            preview_include_people=["pat"],
+            preview_include_people_roles=[],
+            preview_year_min=None,
+            preview_year_max=None,
+            preview_include_studios=[],
+        )
+        is True
+    )
 
 
 def test_preview_people_roles_roundtrip() -> None:

--- a/apps/backend/tests/test_pruner_plex_live_removal.py
+++ b/apps/backend/tests/test_pruner_plex_live_removal.py
@@ -99,7 +99,9 @@ def test_plex_live_eligibility_is_always_ineligible_with_deprecation_notes(
         assert data["live_max_items_cap"] == 2
 
 
-def test_plex_live_post_rejects_jellyfin_instance(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_plex_live_post_rejects_jellyfin_instance(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     settings = MediaMopSettings.load()
     with session_factory() as s, s.begin():
@@ -126,7 +128,9 @@ def test_plex_live_post_rejects_jellyfin_instance(session_factory: sessionmaker[
         assert r.status_code == 422, r.text
 
 
-def test_plex_live_post_plex_always_422_retired(session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_plex_live_post_plex_always_422_retired(
+    session_factory: sessionmaker[Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("MEDIAMOP_PRUNER_APPLY_ENABLED", "1")
     monkeypatch.setenv("MEDIAMOP_PRUNER_PLEX_LIVE_REMOVAL_ENABLED", "1")
     sid = _plex_sid(session_factory)

--- a/apps/backend/tests/test_pruner_preview_activity_events.py
+++ b/apps/backend/tests/test_pruner_preview_activity_events.py
@@ -101,9 +101,7 @@ def test_plex_preview_missing_primary_records_success_activity(
 
     with session_factory() as s:
         evt = s.scalars(
-            select(ActivityEvent)
-            .where(ActivityEvent.module == "pruner")
-            .order_by(ActivityEvent.id.desc()),
+            select(ActivityEvent).where(ActivityEvent.module == "pruner").order_by(ActivityEvent.id.desc()),
         ).first()
         assert evt is not None
         assert evt.event_type == C.PRUNER_PREVIEW_SUCCEEDED
@@ -166,9 +164,7 @@ def test_scheduled_preview_activity_title_and_detail_trigger(
 
     with session_factory() as s:
         evt = s.scalars(
-            select(ActivityEvent)
-            .where(ActivityEvent.module == "pruner")
-            .order_by(ActivityEvent.id.desc()),
+            select(ActivityEvent).where(ActivityEvent.module == "pruner").order_by(ActivityEvent.id.desc()),
         ).first()
         assert evt is not None
         assert evt.title.startswith("Scheduled Pruner preview scan found")
@@ -234,9 +230,7 @@ def test_scheduled_preview_accepts_non_missing_primary_rule_family(
 
     with session_factory() as s:
         evt = s.scalars(
-            select(ActivityEvent)
-            .where(ActivityEvent.module == "pruner")
-            .order_by(ActivityEvent.id.desc()),
+            select(ActivityEvent).where(ActivityEvent.module == "pruner").order_by(ActivityEvent.id.desc()),
         ).first()
         assert evt is not None
         assert evt.title.startswith("Scheduled Pruner preview scan found")
@@ -371,9 +365,7 @@ def test_plex_preview_zero_candidates_with_genres_records_operator_note(
 
     with session_factory() as s:
         evt = s.scalars(
-            select(ActivityEvent)
-            .where(ActivityEvent.module == "pruner")
-            .order_by(ActivityEvent.id.desc()),
+            select(ActivityEvent).where(ActivityEvent.module == "pruner").order_by(ActivityEvent.id.desc()),
         ).first()
         assert evt is not None
         assert evt.event_type == C.PRUNER_PREVIEW_SUCCEEDED
@@ -435,9 +427,7 @@ def test_jellyfin_preview_activity_collection_ignored_note_when_tokens_stored(
 
     with session_factory() as s:
         evt = s.scalars(
-            select(ActivityEvent)
-            .where(ActivityEvent.module == "pruner")
-            .order_by(ActivityEvent.id.desc()),
+            select(ActivityEvent).where(ActivityEvent.module == "pruner").order_by(ActivityEvent.id.desc()),
         ).first()
         assert evt is not None
         detail = json.loads(evt.detail or "{}")

--- a/apps/backend/tests/test_pruner_preview_schedule.py
+++ b/apps/backend/tests/test_pruner_preview_schedule.py
@@ -8,6 +8,8 @@ from datetime import UTC, datetime, timezone
 
 def _as_utc(dt: datetime) -> datetime:
     return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
 from pathlib import Path
 
 import pytest

--- a/apps/backend/tests/test_refiner_failure_cleanup.py
+++ b/apps/backend/tests/test_refiner_failure_cleanup.py
@@ -55,7 +55,9 @@ def _add_failed(session: Session, *, rel: str, scope: str, dry_run: bool = False
         dedupe_key=f"x:{scope}:{rel}",
         job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
         status=RefinerJobStatus.FAILED.value,
-        payload_json=json.dumps({"relative_media_path": rel, "media_scope": scope, "dry_run": dry_run}, separators=(",", ":")),
+        payload_json=json.dumps(
+            {"relative_media_path": rel, "media_scope": scope, "dry_run": dry_run}, separators=(",", ":")
+        ),
     )
     session.add(row)
     session.flush()
@@ -91,7 +93,7 @@ def test_failed_movie_older_than_grace_cleans_source_output_and_temp(tmp_path: P
     out.parent.mkdir(parents=True, exist_ok=True)
     src.write_bytes(b"a")
     out.write_bytes(b"b")
-    temp = (tmp_path / "mwork" / "Film.refiner.tmp.mkv")
+    temp = tmp_path / "mwork" / "Film.refiner.tmp.mkv"
     temp.write_bytes(b"c")
     _seed_paths(session, mw=mw, mo=mo, tw=tw, to=to)
     _add_failed(session, rel=rel, scope="movie")
@@ -464,4 +466,3 @@ def test_failure_cleanup_handler_records_started_and_no_eligible_activity(tmp_pa
         titles = [row.title for row in db.query(ActivityEvent).order_by(ActivityEvent.id.asc()).all()]
     assert "Refiner cleanup started for Movies" in titles
     assert "Refiner cleanup checked Movies: no eligible files" in titles
-

--- a/apps/backend/tests/test_refiner_ffprobe_log_levels.py
+++ b/apps/backend/tests/test_refiner_ffprobe_log_levels.py
@@ -12,8 +12,12 @@ def test_ffprobe_success_diagnostics_are_debug_not_warning(tmp_path: Path, monke
     debug_messages: list[str] = []
     warning_messages: list[str] = []
     monkeypatch.setattr(refiner_remux_mux, "resolve_ffprobe_ffmpeg", lambda *, mediamop_home: ("ffprobe", "ffmpeg"))
-    monkeypatch.setattr(refiner_remux_mux.logger, "debug", lambda msg, *args, **kwargs: debug_messages.append(msg % args))
-    monkeypatch.setattr(refiner_remux_mux.logger, "warning", lambda msg, *args, **kwargs: warning_messages.append(msg % args))
+    monkeypatch.setattr(
+        refiner_remux_mux.logger, "debug", lambda msg, *args, **kwargs: debug_messages.append(msg % args)
+    )
+    monkeypatch.setattr(
+        refiner_remux_mux.logger, "warning", lambda msg, *args, **kwargs: warning_messages.append(msg % args)
+    )
     monkeypatch.setattr(
         refiner_remux_mux.subprocess,
         "run",
@@ -34,7 +38,9 @@ def test_ffprobe_failure_result_still_warns(tmp_path: Path, monkeypatch) -> None
     warning_messages: list[str] = []
     monkeypatch.setattr(refiner_remux_mux, "resolve_ffprobe_ffmpeg", lambda *, mediamop_home: ("ffprobe", "ffmpeg"))
     monkeypatch.setattr(refiner_remux_mux.logger, "debug", lambda *args, **kwargs: None)
-    monkeypatch.setattr(refiner_remux_mux.logger, "warning", lambda msg, *args, **kwargs: warning_messages.append(msg % args))
+    monkeypatch.setattr(
+        refiner_remux_mux.logger, "warning", lambda msg, *args, **kwargs: warning_messages.append(msg % args)
+    )
     monkeypatch.setattr(
         refiner_remux_mux.subprocess,
         "run",

--- a/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_activity_handler.py
@@ -41,7 +41,9 @@ def test_refiner_remux_handler_updates_progress_row_to_completed_activity(
         ),
     )
     monkeypatch.setattr(handler_mod, "load_refiner_remux_rules_config", lambda _session, *, media_scope: object())
-    monkeypatch.setattr(handler_mod, "resolve_refiner_path_runtime_for_remux", lambda *_args, **_kwargs: (object(), None))
+    monkeypatch.setattr(
+        handler_mod, "resolve_refiner_path_runtime_for_remux", lambda *_args, **_kwargs: (object(), None)
+    )
 
     def _fake_run_refiner_file_remux_pass(**kwargs: Any) -> dict[str, Any]:
         progress_reporter = kwargs["progress_reporter"]

--- a/apps/backend/tests/test_refiner_file_remux_pass_run.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_run.py
@@ -75,6 +75,7 @@ def test_run_fails_when_watched_root_missing(tmp_path: Path) -> None:
     assert r["preflight_status"] == "failed"
     assert "watched folder" in r["reason"].lower()
 
+
 def test_live_skips_when_no_remux_required_copies_to_output_and_deletes_release_folder(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -194,6 +195,7 @@ def test_live_skips_when_no_remux_required_replaces_existing_output_before_clean
     assert r.get("output_replaced_existing") is True
     assert existing.read_bytes() == b"x" * 2000
     assert r.get("source_folder_deleted") is True
+
 
 def test_live_fails_during_ffmpeg_surfaces_outcome(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home = tmp_path / "home"
@@ -563,7 +565,9 @@ def test_preflight_failure_contract_for_age_gate_has_no_cleanup_mutations(tmp_pa
     src.write_bytes(b"x" * 200)
     out = tmp_path / "out"
     out.mkdir()
-    settings = replace(MediaMopSettings.load(), mediamop_home=str(home), refiner_watched_folder_min_file_age_seconds=999_999)
+    settings = replace(
+        MediaMopSettings.load(), mediamop_home=str(home), refiner_watched_folder_min_file_age_seconds=999_999
+    )
     rt = _runtime(media=media, home=home, out=out)
 
     r = runmod.run_refiner_file_remux_pass(
@@ -728,5 +732,3 @@ def test_guardrail_skips_before_unchanged_copy_when_output_disk_low(
     assert "insufficient disk space" in r["reason"]
     assert src.exists()
     assert not (out / "copy.mkv").exists()
-
-

--- a/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
+++ b/apps/backend/tests/test_refiner_file_remux_pass_visibility.py
@@ -36,12 +36,18 @@ def test_summarize_remux_plan_includes_streams() -> None:
 
 def test_activity_title_per_outcome() -> None:
     base = {"relative_media_path": "movies/foo.mkv"}
-    assert "processed successfully" in remux_pass_activity_title(
-        {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN},
-    ).lower()
-    assert "no changes needed" in remux_pass_activity_title(
-        {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED},
-    ).lower()
+    assert (
+        "processed successfully"
+        in remux_pass_activity_title(
+            {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_OUTPUT_WRITTEN},
+        ).lower()
+    )
+    assert (
+        "no changes needed"
+        in remux_pass_activity_title(
+            {**base, "outcome": REMUX_PASS_OUTCOME_LIVE_SKIPPED_NOT_REQUIRED},
+        ).lower()
+    )
 
 
 def test_clip_argv_for_activity_truncates_long_lists() -> None:

--- a/apps/backend/tests/test_refiner_movie_output_cleanup.py
+++ b/apps/backend/tests/test_refiner_movie_output_cleanup.py
@@ -525,7 +525,9 @@ def test_rmtree_lock_skips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     assert "could not remove" in (out.get("movie_output_folder_skip_reason") or "").lower()
 
 
-def test_live_cleanup_runs_even_when_legacy_dry_run_flag_passed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_cleanup_runs_even_when_legacy_dry_run_flag_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _session(tmp_path)
     radarr_calls: list[int] = []
 

--- a/apps/backend/tests/test_refiner_path_settings_api.py
+++ b/apps/backend/tests/test_refiner_path_settings_api.py
@@ -196,9 +196,7 @@ def test_resolve_refiner_path_runtime_fails_without_watched_folder(client_with_a
         row = ensure_refiner_path_settings_row(db)
         prev = row.refiner_watched_folder
         db.execute(
-            update(RefinerPathSettingsRow)
-            .where(RefinerPathSettingsRow.id == 1)
-            .values(refiner_watched_folder=None),
+            update(RefinerPathSettingsRow).where(RefinerPathSettingsRow.id == 1).values(refiner_watched_folder=None),
         )
         db.commit()
     try:

--- a/apps/backend/tests/test_refiner_probe_controls.py
+++ b/apps/backend/tests/test_refiner_probe_controls.py
@@ -51,4 +51,3 @@ def test_resolve_ffprobe_ffmpeg_uses_explicit_tool_dir(monkeypatch: pytest.Monke
     monkeypatch.setenv("MEDIAMOP_FFMPEG_DIR", str(tool_dir))
 
     assert resolve_ffprobe_ffmpeg(mediamop_home=str(tmp_path / "home")) == (str(ffprobe), str(ffmpeg))
-

--- a/apps/backend/tests/test_refiner_supplied_payload_evaluation_lane.py
+++ b/apps/backend/tests/test_refiner_supplied_payload_evaluation_lane.py
@@ -149,8 +149,13 @@ def test_refiner_supplied_payload_evaluation_periodic_module_only_imports_core_a
     import mediamop.modules.refiner.refiner_supplied_payload_evaluation_periodic_enqueue as mod
 
     def _allowed_from(m: str) -> bool:
-        return m == "__future__" or m == "mediamop.core.config" or m.startswith("mediamop.modules.refiner.") or m.startswith(
-            "sqlalchemy.",
+        return (
+            m == "__future__"
+            or m == "mediamop.core.config"
+            or m.startswith("mediamop.modules.refiner.")
+            or m.startswith(
+                "sqlalchemy.",
+            )
         )
 
     tree = ast.parse(Path(mod.__file__).read_text(encoding="utf-8"))

--- a/apps/backend/tests/test_refiner_tv_output_cleanup.py
+++ b/apps/backend/tests/test_refiner_tv_output_cleanup.py
@@ -491,7 +491,9 @@ def test_active_movie_job_does_not_block_tv_output(tmp_path: Path, monkeypatch: 
     assert out["tv_output_season_folder_deleted"] is True
 
 
-def test_live_cleanup_runs_even_when_legacy_dry_run_flag_passed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_live_cleanup_runs_even_when_legacy_dry_run_flag_passed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _session(tmp_path)
     calls: list[int] = []
 

--- a/apps/backend/tests/test_refiner_tv_season_folder_cleanup.py
+++ b/apps/backend/tests/test_refiner_tv_season_folder_cleanup.py
@@ -186,7 +186,9 @@ def test_tv_cleanup_not_blocked_by_movie_scope_job_same_path(tmp_path: Path, mon
         RefinerJob(
             dedupe_key="km",
             job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
-            payload_json=json.dumps({"relative_media_path": "Serie/S01/e.mkv", "dry_run": False, "media_scope": "movie"}),
+            payload_json=json.dumps(
+                {"relative_media_path": "Serie/S01/e.mkv", "dry_run": False, "media_scope": "movie"}
+            ),
             status=RefinerJobStatus.PENDING.value,
             max_attempts=3,
         ),
@@ -379,7 +381,9 @@ def test_tv_cleanup_blocked_output_too_small_for_prior_pass(tmp_path: Path, monk
     assert sdir.exists()
 
 
-def test_tv_cleanup_blocked_when_sonarr_queue_holds_sibling_episode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tv_cleanup_blocked_when_sonarr_queue_holds_sibling_episode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _sqlite_session(tmp_path)
     home = tmp_path / "h"
     home.mkdir()
@@ -530,7 +534,9 @@ def test_tv_cleanup_check4_blocked_when_min_age_not_met(tmp_path: Path, monkeypa
     assert sdir.exists()
 
 
-def test_tv_cleanup_activity_movie_scope_ignored_for_prior_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tv_cleanup_activity_movie_scope_ignored_for_prior_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _sqlite_session(tmp_path)
     home = tmp_path / "h"
     home.mkdir()
@@ -660,7 +666,9 @@ def test_tv_cleanup_failed_tv_activity_does_not_clear_episode(tmp_path: Path, mo
     assert sdir.exists()
 
 
-def test_tv_cleanup_dry_run_activity_row_does_not_count_as_tv_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tv_cleanup_dry_run_activity_row_does_not_count_as_tv_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _sqlite_session(tmp_path)
     home = tmp_path / "h"
     home.mkdir()
@@ -726,7 +734,9 @@ def test_tv_cleanup_dry_run_activity_row_does_not_count_as_tv_success(tmp_path: 
     assert sdir.exists()
 
 
-def test_tv_cleanup_blocked_when_prior_tv_success_but_output_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_tv_cleanup_blocked_when_prior_tv_success_but_output_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     _, session = _sqlite_session(tmp_path)
     home = tmp_path / "h"
     home.mkdir()

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_evaluate.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_evaluate.py
@@ -17,7 +17,9 @@ def test_verdict_proceeds_when_no_queue_rows(tmp_path) -> None:
     f = d / "Gate Test 2001.mkv"
     f.write_bytes(b"1")
     v = merge_queue_views_for_watched_file(radarr_rows=[], sonarr_rows=[], file_path=f)
-    assert verdict_for_watched_scan_file(v, candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "proceed"
+    assert (
+        verdict_for_watched_scan_file(v, candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "proceed"
+    )
 
 
 def test_verdict_proceeds_when_unrelated_queue_row_exists() -> None:
@@ -29,7 +31,10 @@ def test_verdict_proceeds_when_unrelated_queue_row_exists() -> None:
         queue_title="Different Movie",
         queue_year=2001,
     )
-    assert verdict_for_watched_scan_file([row], candidate=FileAnchorCandidate(title="Gate Test 2001", year=None)) == "proceed"
+    assert (
+        verdict_for_watched_scan_file([row], candidate=FileAnchorCandidate(title="Gate Test 2001", year=None))
+        == "proceed"
+    )
 
 
 def test_verdict_proceed_when_owned_and_not_blocked() -> None:

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_lane.py
@@ -206,11 +206,7 @@ def test_scan_handler_enqueues_remux_without_arr_connections(
         )
 
     with session_factory() as s:
-        remux = [
-            j
-            for j in s.scalars(select(RefinerJob)).all()
-            if j.job_kind == "refiner.file.remux_pass.v1"
-        ]
+        remux = [j for j in s.scalars(select(RefinerJob)).all() if j.job_kind == "refiner.file.remux_pass.v1"]
         assert len(remux) == 1
         body = json.loads(remux[0].payload_json or "{}")
         assert body.get("relative_media_path") == "Standalone Movie 2026.mkv"
@@ -299,11 +295,7 @@ def test_scan_handler_skips_file_when_previous_success_output_still_exists(
         )
 
     with session_factory() as s:
-        remux = [
-            j
-            for j in s.scalars(select(RefinerJob)).all()
-            if j.job_kind == "refiner.file.remux_pass.v1"
-        ]
+        remux = [j for j in s.scalars(select(RefinerJob)).all() if j.job_kind == "refiner.file.remux_pass.v1"]
         assert remux == []
     assert watch.exists()
     assert not release.exists()

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_manual_enqueue_api.py
@@ -74,7 +74,9 @@ def test_watched_folder_scan_enqueue_ok(client_with_admin: TestClient, tmp_path:
     assert body["job_kind"] == REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND
 
 
-def test_watched_folder_scan_enqueue_defaults_to_processing_files(client_with_admin: TestClient, tmp_path: Path) -> None:
+def test_watched_folder_scan_enqueue_defaults_to_processing_files(
+    client_with_admin: TestClient, tmp_path: Path
+) -> None:
     _login_admin(client_with_admin)
     w = tmp_path / "w_scan_api_default"
     w.mkdir()

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -66,24 +66,33 @@ def test_periodic_scheduler_reports_missed_due_intervals() -> None:
 
 
 def test_periodic_scheduler_sleeps_until_nearest_scope_due() -> None:
-    assert _next_scheduler_sleep_seconds(
-        now_loop=100.0,
-        next_run_movie=104.0,
-        next_run_tv=180.0,
-        poll_seconds=300.0,
-    ) == 4.0
-    assert _next_scheduler_sleep_seconds(
-        now_loop=100.0,
-        next_run_movie=100.0,
-        next_run_tv=180.0,
-        poll_seconds=300.0,
-    ) == 0.25
-    assert _next_scheduler_sleep_seconds(
-        now_loop=100.0,
-        next_run_movie=500.0,
-        next_run_tv=600.0,
-        poll_seconds=60.0,
-    ) == 60.0
+    assert (
+        _next_scheduler_sleep_seconds(
+            now_loop=100.0,
+            next_run_movie=104.0,
+            next_run_tv=180.0,
+            poll_seconds=300.0,
+        )
+        == 4.0
+    )
+    assert (
+        _next_scheduler_sleep_seconds(
+            now_loop=100.0,
+            next_run_movie=100.0,
+            next_run_tv=180.0,
+            poll_seconds=300.0,
+        )
+        == 0.25
+    )
+    assert (
+        _next_scheduler_sleep_seconds(
+            now_loop=100.0,
+            next_run_movie=500.0,
+            next_run_tv=600.0,
+            poll_seconds=60.0,
+        )
+        == 60.0
+    )
 
 
 def test_periodic_scheduler_scope_failure_does_not_block_other_scope(

--- a/apps/backend/tests/test_startup_crash_recovery.py
+++ b/apps/backend/tests/test_startup_crash_recovery.py
@@ -25,7 +25,9 @@ def _session_factory(tmp_path: Path) -> sessionmaker[Session]:
         future=True,
     )
     Base.metadata.create_all(engine)
-    return sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
+    return sessionmaker(
+        bind=engine, class_=Session, autoflush=False, autocommit=False, expire_on_commit=False, future=True
+    )
 
 
 def test_startup_recovery_requeues_leased_jobs_with_attempts_remaining(tmp_path: Path) -> None:
@@ -124,7 +126,11 @@ def test_startup_refiner_recovery_removes_hidden_partial_outputs(tmp_path: Path)
 
     settings = MediaMopSettings.load()
     with factory() as session, session.begin():
-        session.add(RefinerPathSettingsRow(id=1, refiner_output_folder=str(output), refiner_work_folder="", refiner_watched_folder=""))
+        session.add(
+            RefinerPathSettingsRow(
+                id=1, refiner_output_folder=str(output), refiner_work_folder="", refiner_watched_folder=""
+            )
+        )
 
     with factory() as session:
         removed = cleanup_refiner_partial_output_files(session, settings)

--- a/apps/backend/tests/test_subber_library_sync_job_handler.py
+++ b/apps/backend/tests/test_subber_library_sync_job_handler.py
@@ -99,7 +99,9 @@ def test_library_sync_movies_upserts_and_detects_srt(session_factory, tmp_path: 
 
     handlers = build_subber_job_handlers(settings, session_factory)
     t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
-    with patch("mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload):
+    with patch(
+        "mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload
+    ):
         assert (
             process_one_subber_job(
                 session_factory,
@@ -251,7 +253,9 @@ def test_upsert_does_not_downgrade_found_to_missing(session_factory) -> None:
 
     handlers = build_subber_job_handlers(settings, session_factory)
     t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
-    with patch("mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload):
+    with patch(
+        "mediamop.modules.subber.subber_library_sync_job_handler.get_radarr_movies", return_value=movies_payload
+    ):
         process_one_subber_job(session_factory, lease_owner="ls4", job_handlers=handlers, now=t0, lease_seconds=600)
 
     with session_factory() as s:
@@ -294,7 +298,9 @@ def test_library_sync_tv_resolves_path_via_episode_file_table(session_factory, t
     with (
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_series", return_value=series),
         patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episodes", return_value=episodes),
-        patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episode_files", return_value=ep_files),
+        patch(
+            "mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episode_files", return_value=ep_files
+        ),
     ):
         process_one_subber_job(session_factory, lease_owner="ls5", job_handlers=handlers, now=t0, lease_seconds=600)
 

--- a/apps/backend/tests/test_subber_opensubtitles_client.py
+++ b/apps/backend/tests/test_subber_opensubtitles_client.py
@@ -21,5 +21,8 @@ def test_request_429_raises_subber_rate_limit_error() -> None:
     request = httpx.Request("GET", "https://api.opensubtitles.com/api/v1/x")
     response = httpx.Response(429, request=request, content=io.BytesIO().getvalue())
     err = httpx.HTTPStatusError("Too Many Requests", request=request, response=response)
-    with patch("mediamop.modules.subber.subber_opensubtitles_client.request_json", side_effect=err), pytest.raises(SubberRateLimitError):
+    with (
+        patch("mediamop.modules.subber.subber_opensubtitles_client.request_json", side_effect=err),
+        pytest.raises(SubberRateLimitError),
+    ):
         _request("GET", "/subtitles?query=x", api_key="key", token=None)

--- a/apps/backend/tests/test_subber_provider_http_client.py
+++ b/apps/backend/tests/test_subber_provider_http_client.py
@@ -58,4 +58,7 @@ def test_safe_provider_url_blocks_local_targets() -> None:
 
 
 def test_safe_provider_url_allows_public_https_targets() -> None:
-    assert subber_http_client.safe_provider_url("https://subtitles.example/file.srt") == "https://subtitles.example/file.srt"
+    assert (
+        subber_http_client.safe_provider_url("https://subtitles.example/file.srt")
+        == "https://subtitles.example/file.srt"
+    )

--- a/apps/backend/tests/test_subber_settings_api.py
+++ b/apps/backend/tests/test_subber_settings_api.py
@@ -393,7 +393,9 @@ def test_sonarr_root_folders_uses_saved_connection(client_admin: TestClient) -> 
     _login_admin(client_admin)
     _put_settings(client_admin, {"sonarr_base_url": "http://sonarr.local", "sonarr_api_key": "son-key"})
     tok = csrf(client_admin)
-    with patch("urllib.request.urlopen", return_value=_JsonResponse('[{"path":"/tv","freeSpace":1073741824},{"path":"/tv"}]')) as mocked:
+    with patch(
+        "urllib.request.urlopen", return_value=_JsonResponse('[{"path":"/tv","freeSpace":1073741824},{"path":"/tv"}]')
+    ) as mocked:
         r = client_admin.post(
             "/api/v1/subber/settings/sonarr-root-folders",
             json={"csrf_token": tok},

--- a/apps/backend/tests/test_suite_operational_history.py
+++ b/apps/backend/tests/test_suite_operational_history.py
@@ -57,8 +57,16 @@ def test_operational_history_reset_clears_history_but_keeps_active_work(client_w
         )
         db.add_all(
             [
-                RefinerJob(dedupe_key="refiner-done", job_kind="refiner.file.remux_pass.v1", status=RefinerJobStatus.COMPLETED.value),
-                RefinerJob(dedupe_key="refiner-pending", job_kind="refiner.file.remux_pass.v1", status=RefinerJobStatus.PENDING.value),
+                RefinerJob(
+                    dedupe_key="refiner-done",
+                    job_kind="refiner.file.remux_pass.v1",
+                    status=RefinerJobStatus.COMPLETED.value,
+                ),
+                RefinerJob(
+                    dedupe_key="refiner-pending",
+                    job_kind="refiner.file.remux_pass.v1",
+                    status=RefinerJobStatus.PENDING.value,
+                ),
                 PrunerJob(dedupe_key="pruner-done", job_kind="pruner.preview", status=PrunerJobStatus.FAILED.value),
                 PrunerJob(dedupe_key="pruner-pending", job_kind="pruner.preview", status=PrunerJobStatus.PENDING.value),
                 SubberJob(dedupe_key="subber-done", job_kind="subber.search", status=SubberJobStatus.COMPLETED.value),

--- a/apps/backend/tests/test_suite_settings_api.py
+++ b/apps/backend/tests/test_suite_settings_api.py
@@ -126,8 +126,7 @@ def test_ensure_suite_settings_row_defaults_to_skipped_for_existing_install() ->
         assert row.setup_wizard_state == "skipped"
 
 
-def test_bootstrap_explicitly_keeps_setup_wizard_pending_for_true_first_run(
-) -> None:
+def test_bootstrap_explicitly_keeps_setup_wizard_pending_for_true_first_run() -> None:
     reset_user_tables()
     with TestClient(create_app()) as client:
         bootstrap_csrf = fetch_csrf(client)

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -45,7 +45,7 @@ def test_server_spec_uses_dedicated_entry_point_and_assets() -> None:
     assert (repo / "packaging" / "windows" / "assets" / "mediamop-tray-icon.ico").is_file()
     assert 'TRAY_ICON_PNG = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.png"' in text
     assert 'TRAY_ICON_ICO = ROOT / "packaging" / "windows" / "assets" / "mediamop-tray-icon.ico"' in text
-    assert "(str(THIRD_PARTY_NOTICES), \".\")" in text
+    assert '(str(THIRD_PARTY_NOTICES), ".")' in text
     assert 'copy_metadata("mediamop-backend")' in text
     assert "icon=str(TRAY_ICON_ICO)" in text
     assert 'name="MediaMopServer"' in text
@@ -66,7 +66,7 @@ def test_velopack_build_script_includes_ffmpeg_and_version_validation() -> None:
     assert "ffmpeg-N-124254-g397c7c7524-win64-lgpl.zip" in build_text
     assert "Get-FileHash" in build_text
     assert "MEDIAMOP_BUILD_VERSION" in build_text
-    assert "$buildVersion.StartsWith(\"v\")" in build_text
+    assert '$buildVersion.StartsWith("v")' in build_text
     assert "does not match backend project version" in build_text
     assert "MediaMopServer.exe reports version" in build_text
     assert "vpk" in build_text
@@ -80,7 +80,7 @@ def test_release_workflow_uses_velopack_and_normalized_semver() -> None:
     assert "MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}" in text
     assert 'scripts/smoke-windows-package.ps1 -ExpectedVersion "${{ steps.version.outputs.plain }}"' in text
     assert "SHA256SUMS.txt" in text
-    assert 'id: codesign' in text
+    assert "id: codesign" in text
     assert "steps.codesign.outputs.enabled == 'true'" in text
     assert "if: ${{ secrets." not in text
     assert "Get-AuthenticodeSignature" in text

--- a/apps/backend/tests/test_worker_health.py
+++ b/apps/backend/tests/test_worker_health.py
@@ -39,7 +39,9 @@ def session_factory(tmp_path: Path) -> sessionmaker[Session]:
         future=True,
     )
     Base.metadata.create_all(engine)
-    return sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
+    return sessionmaker(
+        bind=engine, class_=Session, autoflush=False, autocommit=False, expire_on_commit=False, future=True
+    )
 
 
 def test_worker_health_detects_missing_stale_and_stopped_workers() -> None:
@@ -96,7 +98,9 @@ def test_readiness_fails_when_expected_worker_has_no_heartbeat(session_factory) 
     class State:
         startup_started_at = 0.0
         startup_ready = True
-        settings = replace(MediaMopSettings.load(), refiner_worker_count=1, pruner_worker_count=0, subber_worker_count=0)
+        settings = replace(
+            MediaMopSettings.load(), refiner_worker_count=1, pruner_worker_count=0, subber_worker_count=0
+        )
         engine = object()
         session_factory = object()
 


### PR DESCRIPTION
## Summary

- Runs `ruff format src tests` across the entire backend — 114 files reformatted, 311 untouched
- No logic changes; purely whitespace/style normalization
- Clears the pre-push hook's `ruff format --check` gate so future pushes pass without `--no-verify`

## Test plan

- [ ] CI `ruff check` passes (only gate in CI)
- [ ] No test failures

🤖 Generated with [Claude Code](https://claude.ai/claude-code)