### PR TITLE
feat: add update mode selector to Settings > Upgrade tab

### DIFF
--- a/apps/backend/src/mediamop/platform/suite_settings/router.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/router.py
@@ -37,6 +37,8 @@ from mediamop.platform.suite_settings.schemas import (
     SuiteSettingsOut,
     SuiteSettingsPutIn,
     SuiteUpdateStatusOut,
+    UpdateSettingsOut,
+    UpdateSettingsPutIn,
 )
 from mediamop.platform.suite_settings.security_overview import build_suite_security_overview
 from mediamop.platform.suite_settings.service import (
@@ -50,6 +52,8 @@ from mediamop.platform.suite_settings.suite_configuration_backup_service import 
 )
 from mediamop.platform.suite_settings.update_service import (
     build_suite_update_status,
+    get_update_settings,
+    put_update_settings,
 )
 
 router = APIRouter(tags=["suite"])
@@ -193,6 +197,32 @@ def get_suite_update_status(_user: UserPublicDep, settings: SettingsDep) -> Suit
     """Read-only update check for the signed-in Settings page."""
 
     return build_suite_update_status(settings)
+
+
+@router.get("/suite/update-settings", response_model=UpdateSettingsOut)
+def get_suite_update_settings(_user: UserPublicDep, settings: SettingsDep) -> UpdateSettingsOut:
+    """Read the tray update-mode preferences from update-settings.json."""
+
+    return get_update_settings(settings)
+
+
+@router.put("/suite/update-settings", response_model=UpdateSettingsOut)
+def put_suite_update_settings(
+    body: UpdateSettingsPutIn,
+    request: Request,
+    _user: RequireOperatorDep,
+    settings: SettingsDep,
+) -> UpdateSettingsOut:
+    """Persist tray update-mode preferences to update-settings.json."""
+
+    validate_browser_post_origin(request, settings)
+    secret = require_session_secret(settings)
+    if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Your confirmation token expired. Refresh the page and try again.",
+        )
+    return put_update_settings(settings, body.mode, body.check_on_startup, body.check_interval_minutes)
 
 
 @router.post("/suite/operational-history/reset", response_model=SuiteOperationalHistoryResetOut)

--- a/apps/backend/src/mediamop/platform/suite_settings/schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/schemas.py
@@ -183,6 +183,27 @@ class SuiteUpdateStatusOut(BaseModel):
     in_app_upgrade_summary: str | None = None
 
 
+class UpdateSettingsOut(BaseModel):
+    """Tray update behaviour persisted in update-settings.json."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mode: str = Field(description="Auto, DownloadOnly, or NotifyOnly")
+    check_on_startup: bool = True
+    check_interval_minutes: int = Field(ge=1, le=10080)
+
+
+class UpdateSettingsPutIn(BaseModel):
+    """Body for PUT /suite/update-settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)
+    mode: str = Field(..., pattern="^(Auto|DownloadOnly|NotifyOnly)$")
+    check_on_startup: bool = True
+    check_interval_minutes: int = Field(default=60, ge=1, le=10080)
+
+
 class SuiteOperationalHistoryResetIn(BaseModel):
     """Body for ``POST /suite/operational-history/reset``."""
 

--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -7,6 +7,7 @@ Settings page can show current vs. latest.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
@@ -23,6 +24,7 @@ from mediamop.platform.suite_settings.release_catalog import (
 )
 from mediamop.platform.suite_settings.schemas import (
     SuiteUpdateStatusOut,
+    UpdateSettingsOut,
 )
 from mediamop.version import __version__
 
@@ -125,4 +127,47 @@ def build_suite_update_status(
     return _build_release_status(
         current_version=current_version,
         install_type=install_type,
+    )
+
+
+_UPDATE_SETTINGS_FILE = "update-settings.json"
+_DEFAULT_UPDATE_SETTINGS = UpdateSettingsOut(
+    mode="Auto",
+    check_on_startup=True,
+    check_interval_minutes=60,
+)
+
+
+def get_update_settings(settings: MediaMopSettings) -> UpdateSettingsOut:
+    path = Path(settings.mediamop_home) / _UPDATE_SETTINGS_FILE
+    if not path.exists():
+        return _DEFAULT_UPDATE_SETTINGS
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        return UpdateSettingsOut(
+            mode=raw.get("mode", "Auto"),
+            check_on_startup=bool(raw.get("checkOnStartup", True)),
+            check_interval_minutes=int(raw.get("checkIntervalMinutes", 60)),
+        )
+    except Exception:
+        return _DEFAULT_UPDATE_SETTINGS
+
+
+def put_update_settings(
+    settings: MediaMopSettings,
+    mode: str,
+    check_on_startup: bool,
+    check_interval_minutes: int,
+) -> UpdateSettingsOut:
+    path = Path(settings.mediamop_home) / _UPDATE_SETTINGS_FILE
+    payload = {
+        "mode": mode,
+        "checkOnStartup": check_on_startup,
+        "checkIntervalMinutes": check_interval_minutes,
+    }
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return UpdateSettingsOut(
+        mode=mode,
+        check_on_startup=check_on_startup,
+        check_interval_minutes=check_interval_minutes,
     )

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6237,6 +6237,68 @@
         "title": "SystemStatusOut",
         "type": "object"
       },
+      "UpdateSettingsOut": {
+        "additionalProperties": false,
+        "description": "Tray update behaviour persisted in update-settings.json.",
+        "properties": {
+          "check_interval_minutes": {
+            "maximum": 10080.0,
+            "minimum": 1.0,
+            "title": "Check Interval Minutes",
+            "type": "integer"
+          },
+          "check_on_startup": {
+            "default": true,
+            "title": "Check On Startup",
+            "type": "boolean"
+          },
+          "mode": {
+            "description": "Auto, DownloadOnly, or NotifyOnly",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "mode",
+          "check_interval_minutes"
+        ],
+        "title": "UpdateSettingsOut",
+        "type": "object"
+      },
+      "UpdateSettingsPutIn": {
+        "additionalProperties": false,
+        "description": "Body for PUT /suite/update-settings.",
+        "properties": {
+          "check_interval_minutes": {
+            "default": 60,
+            "maximum": 10080.0,
+            "minimum": 1.0,
+            "title": "Check Interval Minutes",
+            "type": "integer"
+          },
+          "check_on_startup": {
+            "default": true,
+            "title": "Check On Startup",
+            "type": "boolean"
+          },
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          },
+          "mode": {
+            "pattern": "^(Auto|DownloadOnly|NotifyOnly)$",
+            "title": "Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csrf_token",
+          "mode"
+        ],
+        "title": "UpdateSettingsPutIn",
+        "type": "object"
+      },
       "UserPublic": {
         "properties": {
           "id": {
@@ -10211,6 +10273,68 @@
           }
         },
         "summary": "Get Suite Update Status",
+        "tags": [
+          "suite"
+        ]
+      }
+    },
+    "/api/v1/suite/update-settings": {
+      "get": {
+        "description": "Read the tray update-mode preferences from update-settings.json.",
+        "operationId": "get_suite_update_settings_api_v1_suite_update_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateSettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Suite Update Settings",
+        "tags": [
+          "suite"
+        ]
+      },
+      "put": {
+        "description": "Persist tray update-mode preferences to update-settings.json.",
+        "operationId": "put_suite_update_settings_api_v1_suite_update_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateSettingsPutIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateSettingsOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Suite Update Settings",
         "tags": [
           "suite"
         ]

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -1378,6 +1378,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/suite/update-settings": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Suite Update Settings
+     * @description Read the tray update-mode preferences from update-settings.json.
+     */
+    get: operations["get_suite_update_settings_api_v1_suite_update_settings_get"];
+    /**
+     * Put Suite Update Settings
+     * @description Persist tray update-mode preferences to update-settings.json.
+     */
+    put: operations["put_suite_update_settings_api_v1_suite_update_settings_put"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/suite/update-status": {
     parameters: {
       query?: never;
@@ -4129,6 +4153,44 @@ export interface components {
       /** Worker Health */
       worker_health?: components["schemas"]["WorkerLaneHealthOut"][];
     };
+    /**
+     * UpdateSettingsOut
+     * @description Tray update behaviour persisted in update-settings.json.
+     */
+    UpdateSettingsOut: {
+      /** Check Interval Minutes */
+      check_interval_minutes: number;
+      /**
+       * Check On Startup
+       * @default true
+       */
+      check_on_startup: boolean;
+      /**
+       * Mode
+       * @description Auto, DownloadOnly, or NotifyOnly
+       */
+      mode: string;
+    };
+    /**
+     * UpdateSettingsPutIn
+     * @description Body for PUT /suite/update-settings.
+     */
+    UpdateSettingsPutIn: {
+      /**
+       * Check Interval Minutes
+       * @default 60
+       */
+      check_interval_minutes: number;
+      /**
+       * Check On Startup
+       * @default true
+       */
+      check_on_startup: boolean;
+      /** Csrf Token */
+      csrf_token: string;
+      /** Mode */
+      mode: string;
+    };
     /** UserPublic */
     UserPublic: {
       /** Id */
@@ -6786,6 +6848,59 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SuiteUpdateStatusOut"];
+        };
+      };
+    };
+  };
+  get_suite_update_settings_api_v1_suite_update_settings_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UpdateSettingsOut"];
+        };
+      };
+    };
+  };
+  put_suite_update_settings_api_v1_suite_update_settings_put: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateSettingsPutIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UpdateSettingsOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };

--- a/apps/web/src/lib/suite/queries.ts
+++ b/apps/web/src/lib/suite/queries.ts
@@ -10,12 +10,18 @@ import {
   fetchSuiteSecurityOverview,
   fetchSuiteSettings,
   fetchSuiteUpdateStatus,
+  fetchUpdateSettings,
   putSuiteSettings,
+  putUpdateSettings,
   resetSuiteOperationalHistory,
   testNotificationChannel,
   updateNotificationChannel,
 } from "./suite-settings-api";
-import type { NotificationChannelIn, SuiteSettingsPutBody } from "./types";
+import type {
+  NotificationChannelIn,
+  SuiteSettingsPutBody,
+  UpdateSettingsPutBody,
+} from "./types";
 
 export const suiteSettingsQueryKey = ["suite", "settings"] as const;
 export const suiteSecurityOverviewQueryKey = [
@@ -27,6 +33,10 @@ export const suiteConfigurationBackupsQueryKey = [
   "configuration-backups",
 ] as const;
 export const suiteUpdateStatusQueryKey = ["suite", "update-status"] as const;
+export const suiteUpdateSettingsQueryKey = [
+  "suite",
+  "update-settings",
+] as const;
 export const suiteLogsQueryKey = ["suite", "logs"] as const;
 export const suiteMetricsQueryKey = ["suite", "metrics"] as const;
 
@@ -66,6 +76,26 @@ export function useSuiteUpdateStatusQuery(
     staleTime: enabled && refetchInterval ? 0 : 60_000,
     refetchInterval,
     retry: false,
+  });
+}
+
+export function useUpdateSettingsQuery(enabled = true) {
+  return useQuery({
+    queryKey: suiteUpdateSettingsQueryKey,
+    queryFn: () => fetchUpdateSettings(),
+    enabled,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+export function useUpdateSettingsMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateSettingsPutBody) => putUpdateSettings(body),
+    onSuccess: (data) => {
+      qc.setQueryData(suiteUpdateSettingsQueryKey, data);
+    },
   });
 }
 

--- a/apps/web/src/lib/suite/suite-settings-api.ts
+++ b/apps/web/src/lib/suite/suite-settings-api.ts
@@ -19,6 +19,8 @@ import type {
   SuiteSettingsOut,
   SuiteSettingsPutBody,
   SuiteUpdateStatusOut,
+  UpdateSettingsOut,
+  UpdateSettingsPutBody,
 } from "./types";
 
 export const suiteSettingsPath = () => "/api/v1/suite/settings";
@@ -33,6 +35,7 @@ export const suiteLogsPath = () => "/api/v1/suite/logs";
 export const suiteMetricsPath = () => "/api/v1/suite/metrics";
 export const suiteOperationalHistoryResetPath = () =>
   "/api/v1/suite/operational-history/reset";
+export const suiteUpdateSettingsPath = () => "/api/v1/suite/update-settings";
 
 /**
  * GET/PUT configuration bundle: same handler on the backend, several URL aliases for older builds
@@ -128,6 +131,27 @@ export async function fetchSuiteMetrics(): Promise<SuiteMetricsOut> {
   const r = await apiFetch(path);
   await requireOk(path, r, "Could not load runtime health");
   return readJson<SuiteMetricsOut>(r);
+}
+
+export async function fetchUpdateSettings(): Promise<UpdateSettingsOut> {
+  const path = suiteUpdateSettingsPath();
+  const r = await apiFetch(path);
+  await requireOk(path, r, "Could not load update settings");
+  return readJson<UpdateSettingsOut>(r);
+}
+
+export async function putUpdateSettings(
+  body: UpdateSettingsPutBody,
+): Promise<UpdateSettingsOut> {
+  const csrf_token = await fetchCsrfToken();
+  const path = suiteUpdateSettingsPath();
+  const r = await apiFetch(path, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...body, csrf_token }),
+  });
+  await requireOk(path, r, "Could not save update settings");
+  return readJson<UpdateSettingsOut>(r);
 }
 
 export async function resetSuiteOperationalHistory(

--- a/apps/web/src/lib/suite/types.ts
+++ b/apps/web/src/lib/suite/types.ts
@@ -64,6 +64,20 @@ type OpenApiSchema<T extends OpenApiSchemaName> = components["schemas"][T];
 
 export type SuiteUpdateStatusOut = OpenApiSchema<"SuiteUpdateStatusOut">;
 
+export type UpdateMode = "Auto" | "DownloadOnly" | "NotifyOnly";
+
+export type UpdateSettingsOut = {
+  mode: UpdateMode;
+  check_on_startup: boolean;
+  check_interval_minutes: number;
+};
+
+export type UpdateSettingsPutBody = {
+  mode: UpdateMode;
+  check_on_startup: boolean;
+  check_interval_minutes: number;
+};
+
 export type SuiteOperationalHistoryResetOut = {
   status: "reset" | string;
   activity_events_deleted: number;

--- a/apps/web/src/pages/settings/settings-upgrade-tab.tsx
+++ b/apps/web/src/pages/settings/settings-upgrade-tab.tsx
@@ -1,4 +1,10 @@
+import { useState, useEffect } from "react";
 import type { useSuiteUpdateStatusQuery } from "../../lib/suite/queries";
+import {
+  useUpdateSettingsQuery,
+  useUpdateSettingsMutation,
+} from "../../lib/suite/queries";
+import type { UpdateMode } from "../../lib/suite/types";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
 import {
   mmModuleTabBlurbBandClass,
@@ -14,7 +20,64 @@ type SettingsUpgradeTabProps = {
   updateStatusQ: ReturnType<typeof useSuiteUpdateStatusQuery>;
 };
 
+const UPDATE_MODES: {
+  value: UpdateMode;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "Auto",
+    label: "Auto",
+    description:
+      "Download and install updates automatically. You will be prompted to restart.",
+  },
+  {
+    value: "DownloadOnly",
+    label: "Download only",
+    description:
+      "Download updates silently in the background, then notify you when ready to install.",
+  },
+  {
+    value: "NotifyOnly",
+    label: "Notify only",
+    description:
+      "Alert you when an update is available without downloading anything.",
+  },
+];
+
 export function SettingsUpgradeTab({ updateStatusQ }: SettingsUpgradeTabProps) {
+  const updateSettingsQ = useUpdateSettingsQuery(
+    updateStatusQ.data?.install_type === "windows",
+  );
+  const saveMode = useUpdateSettingsMutation();
+  const [modeDraft, setModeDraft] = useState<UpdateMode | null>(null);
+  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (updateSettingsQ.data) {
+      setModeDraft(updateSettingsQ.data.mode);
+    }
+  }, [updateSettingsQ.data]);
+
+  const serverMode = updateSettingsQ.data?.mode ?? null;
+  const modeDirty = modeDraft !== null && modeDraft !== serverMode;
+
+  async function handleSaveMode() {
+    if (!modeDraft || !updateSettingsQ.data) return;
+    setSaveMsg(null);
+    saveMode.reset();
+    try {
+      await saveMode.mutateAsync({
+        mode: modeDraft,
+        check_on_startup: updateSettingsQ.data.check_on_startup,
+        check_interval_minutes: updateSettingsQ.data.check_interval_minutes,
+      });
+      setSaveMsg("Update mode saved.");
+    } catch {
+      /* surfaced via saveMode.isError */
+    }
+  }
+
   return (
     <div data-testid="suite-settings-upgrade-tab" className="mm-bubble-stack">
       <div className={mmModuleTabBlurbBandClass}>
@@ -114,20 +177,113 @@ export function SettingsUpgradeTab({ updateStatusQ }: SettingsUpgradeTabProps) {
               </div>
             </div>
 
-            <div className={SUITE_SETTINGS_PREMIUM_PANEL_CLASS}>
-              <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
-                What happens next
-              </h4>
-              {updateStatusQ.data.install_type === "windows" ? (
-                <p className="text-sm leading-6 text-[var(--mm-text2)]">
-                  {updateStatusQ.data.in_app_upgrade_summary ||
-                    (updateStatusQ.data.status === "update_available"
-                      ? "A newer version is available. The MediaMop tray app will download and apply updates automatically based on your update preferences."
-                      : "This Windows install does not need an update right now.")}
+            {updateStatusQ.data.install_type === "windows" ? (
+              <div className={SUITE_SETTINGS_PREMIUM_PANEL_CLASS}>
+                <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
+                  Update mode
+                </h4>
+                <p className="text-sm text-[var(--mm-text2)]">
+                  Choose how the MediaMop tray app handles available updates.
                 </p>
-              ) : null}
-              {updateStatusQ.data.install_type === "docker" &&
+                {updateSettingsQ.isPending ? (
+                  <p className="text-sm text-[var(--mm-text3)]">
+                    Loading update preferences...
+                  </p>
+                ) : updateSettingsQ.isError ? (
+                  <p className="text-sm text-[var(--mm-text3)]">
+                    Could not load update preferences.
+                  </p>
+                ) : (
+                  <fieldset className="mt-1 space-y-3">
+                    <legend className="sr-only">Update mode</legend>
+                    {UPDATE_MODES.map((opt) => (
+                      <label
+                        key={opt.value}
+                        className="flex cursor-pointer items-start gap-3"
+                      >
+                        <input
+                          type="radio"
+                          name="update-mode"
+                          value={opt.value}
+                          checked={modeDraft === opt.value}
+                          onChange={() => {
+                            setModeDraft(opt.value);
+                            setSaveMsg(null);
+                            saveMode.reset();
+                          }}
+                          className="mt-0.5 accent-[var(--mm-accent)]"
+                        />
+                        <span>
+                          <span className="block text-sm font-medium text-[var(--mm-text1)]">
+                            {opt.label}
+                          </span>
+                          <span className="block text-sm text-[var(--mm-text2)]">
+                            {opt.description}
+                          </span>
+                        </span>
+                      </label>
+                    ))}
+                  </fieldset>
+                )}
+
+                {saveMode.isError && (
+                  <p
+                    className="rounded-md border border-red-500/40 bg-red-950/25 px-3 py-2 text-sm text-red-200"
+                    role="alert"
+                  >
+                    {saveMode.error instanceof Error
+                      ? saveMode.error.message
+                      : "Could not save update mode."}
+                  </p>
+                )}
+                {saveMsg && !saveMode.isError && (
+                  <p className="text-sm text-emerald-400">{saveMsg}</p>
+                )}
+
+                <div className="flex gap-2 pt-1">
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({
+                      variant: "primary",
+                      disabled:
+                        !modeDirty ||
+                        saveMode.isPending ||
+                        updateSettingsQ.isPending,
+                    })}
+                    disabled={
+                      !modeDirty ||
+                      saveMode.isPending ||
+                      updateSettingsQ.isPending
+                    }
+                    onClick={() => void handleSaveMode()}
+                  >
+                    {saveMode.isPending ? "Saving..." : "Save"}
+                  </button>
+                  {modeDirty && (
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({
+                        variant: "secondary",
+                        disabled: saveMode.isPending,
+                      })}
+                      disabled={saveMode.isPending}
+                      onClick={() => {
+                        setModeDraft(serverMode);
+                        setSaveMsg(null);
+                        saveMode.reset();
+                      }}
+                    >
+                      Discard
+                    </button>
+                  )}
+                </div>
+              </div>
+            ) : updateStatusQ.data.install_type === "docker" &&
               updateStatusQ.data.docker_update_command ? (
+              <div className={SUITE_SETTINGS_PREMIUM_PANEL_CLASS}>
+                <h4 className="text-sm font-semibold text-[var(--mm-text1)]">
+                  What happens next
+                </h4>
                 <div className="space-y-2">
                   <p className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] px-3 py-2 font-mono text-xs text-[var(--mm-text3)]">
                     {updateStatusQ.data.docker_update_command}
@@ -138,8 +294,8 @@ export function SettingsUpgradeTab({ updateStatusQ }: SettingsUpgradeTabProps) {
                     sessions and setup state continue cleanly.
                   </p>
                 </div>
-              ) : null}
-            </div>
+              </div>
+            ) : null}
 
             <div className="mt-auto flex flex-wrap gap-2 border-t border-[var(--mm-border)] pt-4">
               <button

--- a/apps/web/src/pages/settings/settings-upgrade-tab.tsx
+++ b/apps/web/src/pages/settings/settings-upgrade-tab.tsx
@@ -194,12 +194,17 @@ export function SettingsUpgradeTab({ updateStatusQ }: SettingsUpgradeTabProps) {
                     Could not load update preferences.
                   </p>
                 ) : (
-                  <fieldset className="mt-1 space-y-3">
+                  <fieldset className="mt-1 space-y-2">
                     <legend className="sr-only">Update mode</legend>
                     {UPDATE_MODES.map((opt) => (
                       <label
                         key={opt.value}
-                        className="flex cursor-pointer items-start gap-3"
+                        className={[
+                          "flex min-w-0 cursor-pointer items-start gap-2.5 rounded-md border px-3 py-2.5 text-sm transition-colors",
+                          modeDraft === opt.value
+                            ? "border-[var(--mm-accent)] bg-[var(--mm-accent)]/12 text-[var(--mm-text)]"
+                            : "border-[var(--mm-border)] bg-transparent text-[var(--mm-text2)] hover:bg-[var(--mm-card-bg)]",
+                        ].join(" ")}
                       >
                         <input
                           type="radio"
@@ -211,13 +216,11 @@ export function SettingsUpgradeTab({ updateStatusQ }: SettingsUpgradeTabProps) {
                             setSaveMsg(null);
                             saveMode.reset();
                           }}
-                          className="mt-0.5 accent-[var(--mm-accent)]"
+                          className="mt-0.5 h-4 w-4 shrink-0 accent-[var(--mm-accent)]"
                         />
-                        <span>
-                          <span className="block text-sm font-medium text-[var(--mm-text1)]">
-                            {opt.label}
-                          </span>
-                          <span className="block text-sm text-[var(--mm-text2)]">
+                        <span className="min-w-0">
+                          <span className="block font-medium">{opt.label}</span>
+                          <span className="block text-xs text-[var(--mm-text3)]">
                             {opt.description}
                           </span>
                         </span>


### PR DESCRIPTION
## Summary

- Adds `GET /suite/update-settings` and `PUT /suite/update-settings` endpoints that read/write the tray's `update-settings.json` in `MEDIAMOP_HOME`
- The Settings > Upgrade tab now shows an **Update mode** radio group (Auto / Download only / Notify only) for Windows installs
- Saving writes the preference to disk; the tray picks it up on its next update check cycle
- OpenAPI spec and generated types synced to include the two new schemas

## Test plan

- [ ] Open Settings > Upgrade on a Windows install — confirm the Update mode section appears with three radio options and the current mode pre-selected
- [ ] Change the mode and click Save — confirm the preference persists (check `MEDIAMOP_HOME/update-settings.json`)
- [ ] Reload the page — confirm the saved mode is shown
- [ ] Confirm Docker and source installs show no Update mode section (still shows docker command)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)