### PR TITLE
chore: bump version to 2.3.2

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.1"
+version = "2.3.2"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6414,7 +6414,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.1"
+    "version": "2.3.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.1",
+  "version": "2.3.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.2.md
+++ b/docs/release-notes/v2.3.2.md
@@ -1,0 +1,27 @@
+# MediaMop v2.3.2
+
+Date: 2026-05-14
+
+Adds an update mode selector to the Settings > Upgrade tab so you can control how the tray handles available updates.
+
+## What Changed
+
+- **Update mode selector**: Settings > Upgrade now shows a radio group (Auto / Download only / Notify only) on Windows installs. The chosen mode is written to `update-settings.json` in MEDIAMOP_HOME and picked up by the tray on its next update check.
+  - **Auto** — download and install automatically, then prompt to restart (default)
+  - **Download only** — download silently in the background, notify when ready
+  - **Notify only** — alert you when an update is available without downloading
+
+## Upgrade Notes
+
+- **Windows**: The Velopack tray will apply this update automatically in the background. No action required.
+- **Docker**: No changes to the container image. Pull the new tag and restart.
+- No database or configuration migration is required.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.2`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.1...v2.3.2


### PR DESCRIPTION
Version bump for v2.3.2 release — update mode selector (Settings > Upgrade tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)