### PR TITLE
docs: add v2.3.3 release notes

### DIFF
--- a/docs/release-notes/v2.3.3.md
+++ b/docs/release-notes/v2.3.3.md
@@ -1,0 +1,32 @@
+# MediaMop v2.3.3
+
+Date: 2026-05-14
+
+Completes the update system introduced in v2.3.2 — tray modes now behave correctly, the Settings page exposes startup and interval controls, and double-clicking the tray icon opens MediaMop.
+
+## What Changed
+
+- **Auto update mode** now applies the downloaded update automatically on the next tray restart — no click required. A notification confirms the update is scheduled.
+- **Download only mode** retains the click-to-install balloon so you choose when to restart.
+- **Settings > Upgrade** now shows a "Check for updates on startup" toggle and a "Check interval" dropdown (15 min to 24 h) alongside the existing mode selector.
+- **Tray icon double-click** opens MediaMop in the browser.
+- **Docker update command** now shows the exact version tag to pull (e.g. `docker pull ghcr.io/jampat000/mediamop:v2.3.3`).
+
+## Fixes And Stability
+
+- Resolved two security advisories (GHSA-5c6j-r48x-rmvq high, GHSA-qj8w-gfj5-8c6v moderate) in the docs site by pinning `serialize-javascript` to 7.0.5.
+
+## Upgrade Notes
+
+- **Windows**: The Velopack tray will apply this update automatically in the background. No action required.
+- **Docker**: No changes to the container image schema. Pull the new tag and restart.
+- No database or configuration migration is required.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.3`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.2...v2.3.3


### PR DESCRIPTION
Release notes required by the release workflow before re-tagging v2.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)