### PR TITLE
chore: bump version to 2.3.4

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.3"
+version = "2.3.4"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6454,7 +6454,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.3"
+    "version": "2.3.4"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.3",
+  "version": "2.3.4",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.4.md
+++ b/docs/release-notes/v2.3.4.md
@@ -1,0 +1,31 @@
+# MediaMop v2.3.4
+
+Date: 2026-05-14
+
+Adds a visible update-ready state to Settings > Upgrade so users can see when an update has been downloaded and trigger a restart without touching the tray icon.
+
+## What Changed
+
+- **Settings > Upgrade** now shows a green "Update ready to install" banner when the tray has downloaded an update. The banner includes the pending version number and a **Restart to apply** button.
+- Clicking **Restart to apply** signals the tray app to apply the update and restart — no need to right-click the tray icon.
+- The banner polls every 10 seconds so it appears automatically after a background download completes.
+- New backend endpoints: `GET /suite/update-state` (reads tray download state) and `POST /suite/apply-update` (writes the restart signal file).
+
+## Fixes And Stability
+
+- Fixed pre-push hook to auto-commit OpenAPI schema drift instead of silently passing, preventing CI failures caused by stale generated files.
+
+## Upgrade Notes
+
+- **Windows**: The Velopack tray will apply this update automatically in the background. No action required.
+- **Docker**: No changes to the container image schema. Pull the new tag and restart.
+- No database or configuration migration is required.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.4`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.3...v2.3.4


### PR DESCRIPTION
Version bump for the update-ready UI feature shipped in #261.

Release notes included in `docs/release-notes/v2.3.4.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)