### PR TITLE
chore(release): bump version to 2.3.5 and ship auth+packaging fixes

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.4"
+version = "2.3.5"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/auth/password.py
+++ b/apps/backend/src/mediamop/platform/auth/password.py
@@ -9,7 +9,7 @@ from argon2.exceptions import InvalidHashError, VerifyMismatchError
 
 logger = logging.getLogger(__name__)
 
-MIN_PASSWORD_LENGTH = 12
+MIN_PASSWORD_LENGTH = 8
 _WEAK_PASSWORDS = {
     "admin",
     "changeme",

--- a/apps/backend/tests/test_auth_api.py
+++ b/apps/backend/tests/test_auth_api.py
@@ -557,7 +557,7 @@ def test_bootstrap_rejects_short_password() -> None:
         assert r.status_code == 422, r.text
         detail = r.json().get("detail") or []
         assert any(
-            item.get("loc") == ["body", "password"] and "at least 12 characters" in item.get("msg", "")
+            item.get("loc") == ["body", "password"] and "at least 8 characters" in item.get("msg", "")
             for item in detail
             if isinstance(item, dict)
         )

--- a/apps/backend/tests/test_windows_packaging_paths.py
+++ b/apps/backend/tests/test_windows_packaging_paths.py
@@ -62,8 +62,9 @@ def test_velopack_build_script_includes_ffmpeg_and_version_validation() -> None:
     assert 'FFMPEG_VENDOR = ROOT / "packaging" / "windows" / "vendor" / "ffmpeg"' in spec_text
     assert '(str(FFMPEG_VENDOR), "bin/ffmpeg")' in spec_text
     assert "Ensure-WindowsFfmpegRuntime" in build_text
-    assert "autobuild-2026-04-29-13-28" in build_text
-    assert "ffmpeg-N-124254-g397c7c7524-win64-lgpl.zip" in build_text
+    assert "ffmpeg-master-latest-win64-lgpl.zip" in build_text
+    assert "checksums.sha256" in build_text
+    assert "FFmpeg checksum entry" in build_text
     assert "Get-FileHash" in build_text
     assert "MEDIAMOP_BUILD_VERSION" in build_text
     assert '$buildVersion.StartsWith("v")' in build_text

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -588,7 +588,7 @@
           },
           "password": {
             "maxLength": 512,
-            "minLength": 12,
+            "minLength": 8,
             "title": "Password",
             "type": "string"
           },
@@ -659,7 +659,7 @@
           },
           "new_password": {
             "maxLength": 512,
-            "minLength": 12,
+            "minLength": 8,
             "title": "New Password",
             "type": "string"
           }

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6454,7 +6454,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.4"
+    "version": "2.3.5"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.4",
+  "version": "2.3.5",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.5.md
+++ b/docs/release-notes/v2.3.5.md
@@ -1,0 +1,32 @@
+# MediaMop v2.3.5
+
+Date: 2026-05-15
+
+This release focuses on aligning password setup behavior and improving Windows packaging reliability.
+
+## What Changed
+
+- Password minimum length is now consistently 8 characters during first-run setup and API validation.
+- Password policy messaging is now consistent with runtime behavior and security documentation.
+- Windows packaging now validates FFmpeg downloads using the upstream release checksum file.
+
+## Fixes And Stability
+
+- Fixed a mismatch where some password flows showed 8 characters while backend validation required 12.
+- Updated packaging tests to match current FFmpeg verification behavior.
+- Removed fragile hardcoded FFmpeg release pinning that could break packaging when upstream assets rotate.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No manual migration is required for this release.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.5`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.4...v2.3.5

--- a/docs/security-hardening.md
+++ b/docs/security-hardening.md
@@ -5,7 +5,7 @@ This checklist defines the current practical hardening baseline for MediaMop.
 ## Authentication and setup
 
 - First-run bootstrap is only available when no admin user exists.
-- Passwords shorter than 12 characters must be blocked by both frontend and backend validation.
+- Passwords shorter than 8 characters must be blocked by both frontend and backend validation.
 - Login and bootstrap routes are rate-limited.
 - Authenticated state-changing browser requests require CSRF protection.
 - Session cookies are HTTP-only.

--- a/packaging/windows/build-velopack.ps1
+++ b/packaging/windows/build-velopack.ps1
@@ -15,9 +15,9 @@ $velopackOut = Join-Path $distRoot "releases"
 $ffmpegVendorDir = Join-Path $PSScriptRoot "vendor\\ffmpeg"
 $venvScriptsDir = Join-Path $backendDir ".venv\\Scripts"
 $py = Join-Path $venvScriptsDir "python.exe"
-$ffmpegArchiveName = "ffmpeg-N-124254-g397c7c7524-win64-lgpl.zip"
-$ffmpegArchiveUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-29-13-28/$ffmpegArchiveName"
-$ffmpegArchiveSha256 = "42f9457901fcc1928834ded69f0fc4903bd16c9a41c185234a40490060bda9fb"
+$ffmpegArchiveName = "ffmpeg-master-latest-win64-lgpl.zip"
+$ffmpegArchiveUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/$ffmpegArchiveName"
+$ffmpegChecksumsUrl = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/checksums.sha256"
 
 function Resolve-VenvExecutable {
   param(
@@ -105,15 +105,25 @@ function Ensure-WindowsFfmpegRuntime {
 
   $downloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-ffmpeg-" + [System.Guid]::NewGuid().ToString("N"))
   $archivePath = Join-Path $downloadRoot $ffmpegArchiveName
+  $checksumsPath = Join-Path $downloadRoot "checksums.sha256"
   $extractRoot = Join-Path $downloadRoot "extract"
   try {
     New-Item -ItemType Directory -Path $downloadRoot | Out-Null
     New-Item -ItemType Directory -Path $extractRoot | Out-Null
+    Write-Host "Resolving Windows FFmpeg checksum..."
+    Invoke-WebRequest -Uri $ffmpegChecksumsUrl -OutFile $checksumsPath -UseBasicParsing
+    $checksumsText = Get-Content -LiteralPath $checksumsPath -Raw
+    $checksumPattern = "(?im)^([a-f0-9]{64})\s+\*?$([regex]::Escape($ffmpegArchiveName))\s*$"
+    $checksumMatch = [regex]::Match($checksumsText, $checksumPattern)
+    if (-not $checksumMatch.Success) {
+      throw "FFmpeg checksum entry for '$ffmpegArchiveName' was not found in checksums.sha256."
+    }
+    $expectedSha256 = $checksumMatch.Groups[1].Value.ToLowerInvariant()
     Write-Host "Downloading Windows FFmpeg runtime..."
     Invoke-WebRequest -Uri $ffmpegArchiveUrl -OutFile $archivePath -UseBasicParsing
     $actualSha256 = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($actualSha256 -ne $ffmpegArchiveSha256) {
-      throw "Downloaded FFmpeg archive hash mismatch. Expected $ffmpegArchiveSha256 but got $actualSha256."
+    if ($actualSha256 -ne $expectedSha256) {
+      throw "Downloaded FFmpeg archive hash mismatch. Expected $expectedSha256 but got $actualSha256."
     }
     Expand-Archive -LiteralPath $archivePath -DestinationPath $extractRoot -Force
     $binDir = Get-ChildItem -Path $extractRoot -Recurse -Directory |


### PR DESCRIPTION
## Summary
- standardize auth minimum password length to 8 across backend validation, schema contract, and docs
- harden Windows packaging FFmpeg retrieval by validating against upstream checksums file
- update packaging path tests for new FFmpeg verification flow
- bump version to 2.3.5 and add release notes

## Validation
- backend: ruff, mypy, alembic upgrade/check, pytest --cov --cov-fail-under=70
- frontend: api:types:check, lint, format, build, vitest
- docs map: node scripts/check-agent-docs.mjs
- windows packaging: build-velopack.ps1 + smoke-windows-package.ps1 passed locally