### PR TITLE
Fix Subber Arr connection testing

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.5"
+version = "2.3.6"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_settings_api.py
@@ -128,6 +128,11 @@ class SubberCsrfIn(BaseModel):
     csrf_token: str = Field(..., min_length=1)
 
 
+class SubberArrConnectionTestIn(SubberCsrfIn):
+    base_url: str | None = None
+    api_key: str | None = None
+
+
 @router.get("/settings", response_model=SubberSettingsOut)
 def get_subber_settings(
     _user: RequireOperatorDep,
@@ -369,6 +374,20 @@ def _arr_api_key(settings: MediaMopSettings, ciphertext: str | None) -> str:
     return str(sec.get("api_key") or "").strip()
 
 
+def _arr_test_credentials(
+    settings: MediaMopSettings,
+    *,
+    saved_base_url: str,
+    saved_ciphertext: str | None,
+    body: SubberArrConnectionTestIn,
+) -> tuple[str, str]:
+    base_url = body.base_url.strip() if body.base_url is not None else saved_base_url.strip()
+    api_key = body.api_key.strip() if body.api_key is not None and body.api_key.strip() else ""
+    if not api_key:
+        api_key = _arr_api_key(settings, saved_ciphertext)
+    return base_url, api_key
+
+
 def _arr_root_folders(base_url: str, api_key: str) -> tuple[bool, str, list[SubberArrRootFolderOut]]:
     try:
         root = normalize_local_service_base_url(base_url)
@@ -415,22 +434,21 @@ def post_test_sonarr(
     db: DbSessionDep,
     request: Request,
     settings: SettingsDep,
-    body: SubberCsrfIn,
+    body: SubberArrConnectionTestIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
-    key_raw = decrypt_subber_credentials_json(settings, row.sonarr_credentials_ciphertext or "") or "{}"
-    try:
-        kd = json.loads(key_raw)
-    except json.JSONDecodeError:
-        kd = {}
-    sec = kd.get("secrets") if isinstance(kd.get("secrets"), dict) else {}
-    api_key = str(sec.get("api_key") or "").strip()
-    if not row.sonarr_base_url.strip() or not api_key:
+    base_url, api_key = _arr_test_credentials(
+        settings,
+        saved_base_url=row.sonarr_base_url or "",
+        saved_ciphertext=row.sonarr_credentials_ciphertext,
+        body=body,
+    )
+    if not base_url or not api_key:
         return SubberTestConnectionOut(ok=False, message="Sonarr URL or API key not set.")
-    ok, msg = _arr_status_probe(row.sonarr_base_url, api_key)
+    ok, msg = _arr_status_probe(base_url, api_key)
     return SubberTestConnectionOut(ok=ok, message=msg)
 
 
@@ -459,22 +477,21 @@ def post_test_radarr(
     db: DbSessionDep,
     request: Request,
     settings: SettingsDep,
-    body: SubberCsrfIn,
+    body: SubberArrConnectionTestIn,
 ) -> SubberTestConnectionOut:
     secret = settings.session_secret or ""
     if not verify_csrf_token(secret, body.csrf_token, raw_session_token=current_raw_session_token(request, settings)):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid CSRF token.")
     row = ensure_subber_settings_row(db)
-    key_raw = decrypt_subber_credentials_json(settings, row.radarr_credentials_ciphertext or "") or "{}"
-    try:
-        kd = json.loads(key_raw)
-    except json.JSONDecodeError:
-        kd = {}
-    sec = kd.get("secrets") if isinstance(kd.get("secrets"), dict) else {}
-    api_key = str(sec.get("api_key") or "").strip()
-    if not row.radarr_base_url.strip() or not api_key:
+    base_url, api_key = _arr_test_credentials(
+        settings,
+        saved_base_url=row.radarr_base_url or "",
+        saved_ciphertext=row.radarr_credentials_ciphertext,
+        body=body,
+    )
+    if not base_url or not api_key:
         return SubberTestConnectionOut(ok=False, message="Radarr URL or API key not set.")
-    ok, msg = _arr_status_probe(row.radarr_base_url, api_key)
+    ok, msg = _arr_status_probe(base_url, api_key)
     return SubberTestConnectionOut(ok=ok, message=msg)
 
 

--- a/apps/backend/tests/test_subber_settings_api.py
+++ b/apps/backend/tests/test_subber_settings_api.py
@@ -209,6 +209,39 @@ def test_put_settings_sonarr_api_key_sets_flag(client_admin: TestClient) -> None
     assert body.get("sonarr_api_key_set") is True
 
 
+def test_test_sonarr_accepts_unsaved_draft_connection(client_admin: TestClient) -> None:
+    _login_admin(client_admin)
+    tok = csrf(client_admin)
+    with patch("urllib.request.urlopen", return_value=_JsonResponse('{"version":"4.0.0"}')) as mocked:
+        r = client_admin.post(
+            "/api/v1/subber/settings/test-sonarr",
+            json={"base_url": "http://draft-sonarr.local/", "api_key": "draft-key", "csrf_token": tok},
+            headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "message": "OK"}
+    req = mocked.call_args.args[0]
+    assert req.full_url == "http://draft-sonarr.local/api/v3/system/status"
+    assert dict(req.header_items())["X-api-key"] == "draft-key"
+
+
+def test_test_radarr_can_use_draft_url_with_saved_api_key(client_admin: TestClient) -> None:
+    _login_admin(client_admin)
+    _put_settings(client_admin, {"radarr_api_key": "saved-rad-key"})
+    tok = csrf(client_admin)
+    with patch("urllib.request.urlopen", return_value=_JsonResponse('{"version":"4.0.0"}')) as mocked:
+        r = client_admin.post(
+            "/api/v1/subber/settings/test-radarr",
+            json={"base_url": "http://draft-radarr.local", "csrf_token": tok},
+            headers={**trusted_browser_origin_headers(), "Content-Type": "application/json"},
+        )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "message": "OK"}
+    req = mocked.call_args.args[0]
+    assert req.full_url == "http://draft-radarr.local/api/v3/system/status"
+    assert dict(req.header_items())["X-api-key"] == "saved-rad-key"
+
+
 def test_put_settings_opensubtitles_credentials_set_flag(client_admin: TestClient) -> None:
     _login_admin(client_admin)
     _put_settings(

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -4042,6 +4042,42 @@
         "title": "RefinerWatchedFolderRemuxScanDispatchManualEnqueueOut",
         "type": "object"
       },
+      "SubberArrConnectionTestIn": {
+        "properties": {
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csrf_token"
+        ],
+        "title": "SubberArrConnectionTestIn",
+        "type": "object"
+      },
       "SubberArrRootFolderOut": {
         "properties": {
           "free_space": {
@@ -6454,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.5"
+    "version": "2.3.6"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -9459,7 +9495,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubberCsrfIn"
+                "$ref": "#/components/schemas/SubberArrConnectionTestIn"
               }
             }
           },
@@ -9501,7 +9537,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubberCsrfIn"
+                "$ref": "#/components/schemas/SubberArrConnectionTestIn"
               }
             }
           },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.5",
+  "version": "2.3.6",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -3368,6 +3368,15 @@ export interface components {
        */
       ok: boolean;
     };
+    /** SubberArrConnectionTestIn */
+    SubberArrConnectionTestIn: {
+      /** Api Key */
+      api_key?: string | null;
+      /** Base Url */
+      base_url?: string | null;
+      /** Csrf Token */
+      csrf_token: string;
+    };
     /** SubberArrRootFolderOut */
     SubberArrRootFolderOut: {
       /** Free Space */
@@ -6281,7 +6290,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["SubberCsrfIn"];
+        "application/json": components["schemas"]["SubberArrConnectionTestIn"];
       };
     };
     responses: {
@@ -6314,7 +6323,7 @@ export interface operations {
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["SubberCsrfIn"];
+        "application/json": components["schemas"]["SubberArrConnectionTestIn"];
       };
     };
     responses: {

--- a/apps/web/src/lib/subber/subber-api.ts
+++ b/apps/web/src/lib/subber/subber-api.ts
@@ -140,6 +140,11 @@ export type SubberSettingsPutIn = {
 
 export type SubberTestConnectionOut = { ok: boolean; message: string };
 
+export type SubberArrConnectionTestIn = {
+  base_url?: string;
+  api_key?: string;
+};
+
 export type SubberArrRootFolderOut = {
   path: string;
   free_space: number | null;
@@ -237,25 +242,29 @@ export async function postSubberTestOpensubtitles(): Promise<SubberTestConnectio
   return readJson<SubberTestConnectionOut>(r);
 }
 
-export async function postSubberTestSonarr(): Promise<SubberTestConnectionOut> {
+export async function postSubberTestSonarr(
+  body: SubberArrConnectionTestIn = {},
+): Promise<SubberTestConnectionOut> {
   const csrf = await fetchCsrfToken();
   const path = "/api/v1/subber/settings/test-sonarr";
   const r = await apiFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ csrf_token: csrf }),
+    body: JSON.stringify({ ...body, csrf_token: csrf }),
   });
   await requireOk(path, r, "Could not test Sonarr");
   return readJson<SubberTestConnectionOut>(r);
 }
 
-export async function postSubberTestRadarr(): Promise<SubberTestConnectionOut> {
+export async function postSubberTestRadarr(
+  body: SubberArrConnectionTestIn = {},
+): Promise<SubberTestConnectionOut> {
   const csrf = await fetchCsrfToken();
   const path = "/api/v1/subber/settings/test-radarr";
   const r = await apiFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ csrf_token: csrf }),
+    body: JSON.stringify({ ...body, csrf_token: csrf }),
   });
   await requireOk(path, r, "Could not test Radarr");
   return readJson<SubberTestConnectionOut>(r);

--- a/apps/web/src/lib/subber/subber-queries.ts
+++ b/apps/web/src/lib/subber/subber-queries.ts
@@ -19,6 +19,7 @@ import {
   postSubberTestSonarr,
   putSubberProvider,
   putSubberSettings,
+  type SubberArrConnectionTestIn,
   type SubberProviderPutIn,
   type SubberSettingsPutIn,
 } from "./subber-api";
@@ -175,11 +176,17 @@ export function useSubberTestOpensubtitlesMutation() {
 }
 
 export function useSubberTestSonarrMutation() {
-  return useMutation({ mutationFn: postSubberTestSonarr });
+  return useMutation({
+    mutationFn: (body?: SubberArrConnectionTestIn) =>
+      postSubberTestSonarr(body),
+  });
 }
 
 export function useSubberTestRadarrMutation() {
-  return useMutation({ mutationFn: postSubberTestRadarr });
+  return useMutation({
+    mutationFn: (body?: SubberArrConnectionTestIn) =>
+      postSubberTestRadarr(body),
+  });
 }
 
 export function useSubberSonarrRootFoldersMutation() {

--- a/apps/web/src/pages/subber/subber-connections-tab.tsx
+++ b/apps/web/src/pages/subber/subber-connections-tab.tsx
@@ -41,26 +41,37 @@ const initialCheck: ConnectionCheckState = {
 
 function ConnectionStatusPanel({
   check,
+  configured,
+  dirty,
   idleHelper,
   fmt,
 }: {
   check: ConnectionCheckState;
+  configured: boolean;
+  dirty: boolean;
   idleHelper?: string;
   fmt: (iso: string | null) => string;
 }) {
   const main =
     check.outcome === null
-      ? "Not connected yet"
+      ? configured
+        ? dirty
+          ? "Unsaved changes"
+          : "Connection saved"
+        : "Not connected yet"
       : check.outcome === "ok"
         ? "Connected"
         : "Connection failed";
+  const lastCompleted = check.at
+    ? fmt(check.at)
+    : "Not checked in this session";
   return (
     <div className="mt-4 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-3.5 text-sm text-[var(--mm-text2)]">
       <p className="text-sm font-medium text-[var(--mm-text)]">{main}</p>
       <p className="mt-1 text-xs text-[var(--mm-text2)]">
         Last completed check:{" "}
         <span className="font-medium text-[var(--mm-text)]">
-          {fmt(check.at)}
+          {lastCompleted}
         </span>
       </p>
       {check.outcome === "ok" && check.quotaNote ? (
@@ -72,7 +83,13 @@ function ConnectionStatusPanel({
       {check.outcome === "fail" && check.detail ? (
         <p className="mt-1 text-xs text-red-400">{check.detail}</p>
       ) : null}
-      {check.outcome === null && idleHelper ? (
+      {check.outcome === null && configured ? (
+        <p className="mt-2 text-xs text-[var(--mm-text2)]">
+          Credentials are saved. Run a test to verify the service is reachable
+          now.
+        </p>
+      ) : null}
+      {check.outcome === null && !configured && idleHelper ? (
         <p className="mt-2 text-xs text-[var(--mm-text2)]">{idleHelper}</p>
       ) : null}
     </div>
@@ -391,7 +408,10 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
   async function runTestSon() {
     const at = new Date().toISOString();
     try {
-      const r = await testSon.mutateAsync();
+      const r = await testSon.mutateAsync({
+        base_url: sonUrl.trim(),
+        ...(sonKey.trim() ? { api_key: sonKey.trim() } : {}),
+      });
       if (r.ok) {
         setSonCheck({ outcome: "ok", at, detail: r.message || "OK" });
       } else {
@@ -409,7 +429,10 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
   async function runTestRad() {
     const at = new Date().toISOString();
     try {
-      const r = await testRad.mutateAsync();
+      const r = await testRad.mutateAsync({
+        base_url: radUrl.trim(),
+        ...(radKey.trim() ? { api_key: radKey.trim() } : {}),
+      });
       if (r.ok) {
         setRadCheck({ outcome: "ok", at, detail: r.message || "OK" });
       } else {
@@ -463,6 +486,12 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
 
   const sonHint = (q.data?.arr_library_sonarr_base_url_hint || "").trim();
   const radHint = (q.data?.arr_library_radarr_base_url_hint || "").trim();
+  const sonConfigured = Boolean(
+    (q.data?.sonarr_base_url || "").trim() && q.data?.sonarr_api_key_set,
+  );
+  const radConfigured = Boolean(
+    (q.data?.radarr_base_url || "").trim() && q.data?.radarr_api_key_set,
+  );
 
   return (
     <div className="mm-bubble-stack" data-testid="subber-connections-tab">
@@ -558,6 +587,8 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
                 <SaveFeedback ok={saveSon.ok} err={saveSon.err} />
                 <ConnectionStatusPanel
                   check={sonCheck}
+                  configured={sonConfigured}
+                  dirty={sonDirty}
                   idleHelper="Save your URL and API key, then run a test to confirm Sonarr is reachable."
                   fmt={fmt}
                 />
@@ -816,6 +847,8 @@ export function SubberConnectionsTab({ canOperate }: { canOperate: boolean }) {
                 <SaveFeedback ok={saveRad.ok} err={saveRad.err} />
                 <ConnectionStatusPanel
                   check={radCheck}
+                  configured={radConfigured}
+                  dirty={radDirty}
                   idleHelper="Save your URL and API key, then run a test to confirm Radarr is reachable."
                   fmt={fmt}
                 />

--- a/docs/release-notes/v2.3.6.md
+++ b/docs/release-notes/v2.3.6.md
@@ -1,0 +1,31 @@
+# MediaMop v2.3.6
+
+Date: 2026-05-26
+
+This release focuses on Subber connection reliability for Sonarr and Radarr.
+
+## What Changed
+
+- Subber can now test Sonarr and Radarr draft connection details before saving.
+- Testing a changed Sonarr or Radarr URL can reuse the saved API key when the key field is left blank.
+- The Subber connection panel now shows saved credentials as a saved connection after page reloads.
+
+## Fixes And Stability
+
+- Fixed a mismatch where Subber connection tests only used persisted credentials, making first-time tests fail until after saving.
+- Added backend regression coverage for draft Sonarr and Radarr connection tests.
+- Updated OpenAPI and generated web API types for the new Subber connection test request shape.
+
+## Upgrade Notes
+
+- No manual migration is required for this release.
+- Re-test Sonarr and Radarr from **Subber -> Connections** after upgrading if the panel previously looked disconnected.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.6`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.5...v2.3.6


### PR DESCRIPTION
## Summary

- Fix Subber Sonarr/Radarr connection tests so draft URL/API key values can be tested before saving.
- Keep saved-key fallback when only the URL is changed, and show saved connection state after reload.
- Bump release metadata to v2.3.6 and add release notes for the Docker/Windows release workflow.

## Validation

- `python -m compileall -q apps/backend/src/mediamop/modules/subber apps/backend/tests/test_subber_settings_api.py`
- Parsed `apps/web/openapi/mediamop-openapi.json` as JSON

Local full validation was blocked because this environment does not have repo-local `pytest`, `npm`, or `apps/web/node_modules` installed. The GitHub PR workflow should run the full backend, frontend, E2E, Docker smoke, and Windows package smoke checks.