### PR TITLE
Fix Subber Sonarr TV library sync

### DIFF
--- a/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py
@@ -88,6 +88,9 @@ def _episode_file_path(ep: dict, episode_file_id_to_path: dict[int, str]) -> str
         efid = ef.get("id")
         if efid is not None and str(efid).strip().isdigit():
             return episode_file_id_to_path.get(int(efid), "")
+    efid = ep.get("episodeFileId")
+    if efid is not None and str(efid).strip().isdigit():
+        return episode_file_id_to_path.get(int(efid), "")
     return ""
 
 

--- a/apps/backend/tests/test_subber_library_sync_job_handler.py
+++ b/apps/backend/tests/test_subber_library_sync_job_handler.py
@@ -309,6 +309,55 @@ def test_library_sync_tv_resolves_path_via_episode_file_table(session_factory, t
         assert r.file_path == str(mkv)
 
 
+def test_library_sync_tv_resolves_path_via_top_level_episode_file_id(session_factory, tmp_path: Path) -> None:
+    """Sonarr commonly returns episodeFileId at the episode root instead of nested episodeFile.id."""
+    settings = MediaMopSettings.load()
+    mkv = tmp_path / "top-level-episode-file-id.mkv"
+    mkv.write_bytes(b"x")
+
+    with session_factory() as s:
+        s.add(_sonarr_row(settings))
+        s.commit()
+        subber_enqueue_or_get_job(
+            s,
+            dedupe_key="lsync:tv:top-level-ef",
+            job_kind=SUBBER_JOB_KIND_LIBRARY_SYNC_TV,
+            payload_json="{}",
+        )
+        s.commit()
+
+    series = [{"id": 1, "title": "Top Level Show"}]
+    episodes = [
+        {
+            "id": 201,
+            "title": "B",
+            "seasonNumber": 2,
+            "episodeNumber": 3,
+            "hasFile": True,
+            "episodeFileId": 556,
+        },
+    ]
+    ep_files = [{"id": 556, "path": str(mkv), "seriesId": 1}]
+
+    handlers = build_subber_job_handlers(settings, session_factory)
+    t0 = datetime(2026, 6, 1, 12, 0, 0, tzinfo=UTC)
+    with (
+        patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_series", return_value=series),
+        patch("mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episodes", return_value=episodes),
+        patch(
+            "mediamop.modules.subber.subber_library_sync_job_handler.get_sonarr_episode_files", return_value=ep_files
+        ),
+    ):
+        process_one_subber_job(session_factory, lease_owner="ls6", job_handlers=handlers, now=t0, lease_seconds=600)
+
+    with session_factory() as s:
+        r = s.scalars(select(SubberSubtitleState).where(SubberSubtitleState.sonarr_episode_id == 201)).one()
+        assert r.file_path == str(mkv)
+        assert r.show_title == "Top Level Show"
+        assert r.season_number == 2
+        assert r.episode_number == 3
+
+
 def test_upsert_service_merge_found_over_missing(session_factory) -> None:
     with session_factory() as s:
         s.add(SubberSettingsRow(id=1, enabled=True))


### PR DESCRIPTION
## Summary
- resolve Sonarr episode media paths from top-level `episodeFileId` when `episodeFile.path` is not embedded
- add a regression test for Sonarr payloads that use top-level `episodeFileId`

## Why
A connected Sonarr instance can still leave the Subber TV tab empty if `/api/v3/episode` returns episodes with `hasFile: true` and `episodeFileId`, but no nested `episodeFile.path`. The sync handler previously skipped those episodes because it could not resolve a media path.

## Validation
- `python -m compileall -q apps/backend/src/mediamop/modules/subber/subber_library_sync_job_handler.py apps/backend/tests/test_subber_library_sync_job_handler.py`
- `git diff --check`

Note: local `pytest` is not installed in this workspace runtime, so CI should run the focused and full suites.