### PR TITLE
Release v2.3.7

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.6"
+version = "2.3.7"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6490,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.6"
+    "version": "2.3.7"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.2.7",
+  "version": "2.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.2.7",
+      "version": "2.3.7",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.6",
+  "version": "2.3.7",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.7.md
+++ b/docs/release-notes/v2.3.7.md
@@ -1,0 +1,9 @@
+# MediaMop v2.3.7
+
+## Fixes
+
+- Fixed Subber TV library sync for Sonarr episode payloads that expose the media file through top-level `episodeFileId`. This restores TV tab population when Sonarr connects successfully but sync reports series with zero file-backed episodes.
+
+## Validation
+
+- Backend, CodeQL, Docker smoke, and Windows package smoke passed on the Subber sync fix PR.


### PR DESCRIPTION
## Summary
- bump backend, web, lockfile, and OpenAPI metadata to `2.3.7`
- add v2.3.7 release notes for the Subber Sonarr TV sync fix

## Why
The app-server logs show the deployed v2.3.6 build can connect to Sonarr and process 14 series, but records 0 file-backed episodes. The fix for top-level Sonarr `episodeFileId` handling is already merged to main and needs a tagged release for Docker and Windows.

## Validation
- `node scripts/check-agent-docs.mjs`
- JSON parse/version assertion for package/OpenAPI metadata
- `git diff --check`