### PR TITLE
Improve Subber TV coverage layout

### DIFF
--- a/apps/web/src/pages/subber/subber-tv-tab.test.tsx
+++ b/apps/web/src/pages/subber/subber-tv-tab.test.tsx
@@ -98,6 +98,20 @@ describe("SubberTvTab", () => {
     expect(mutate).toHaveBeenCalledWith(8);
   });
 
+  it("summarizes show, season, and episode subtitle coverage", async () => {
+    const client = new QueryClient();
+    render(wrap(<SubberTvTab canOperate />, client));
+
+    await waitFor(() => expect(screen.getByText(/Demo/)).toBeInTheDocument());
+
+    expect(
+      screen.getByText("1 episode still needs subtitles"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 missing, 0 complete")).toBeInTheDocument();
+    expect(screen.getByText("Needs subtitles")).toBeInTheDocument();
+    expect(screen.getByText("Missing FR")).toBeInTheDocument();
+  });
+
   it("shows empty state when no shows", async () => {
     vi.spyOn(subberQueries, "useSubberLibraryTvQuery").mockReturnValue({
       data: { shows: [], total: 0 },

--- a/apps/web/src/pages/subber/subber-tv-tab.tsx
+++ b/apps/web/src/pages/subber/subber-tv-tab.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
-import type { SubberTvEpisode } from "../../lib/subber/subber-api";
+import type {
+  SubberSubtitleLangState,
+  SubberTvEpisode,
+  SubberTvSeason,
+  SubberTvShow,
+} from "../../lib/subber/subber-api";
 import {
   useSubberLibraryTvQuery,
   useSubberSearchAllMissingTvMutation,
@@ -19,17 +24,28 @@ import {
   type SubberLibraryPageSize,
 } from "./subber-library-pager";
 
-function langBadge(status: string, code: string) {
-  const ok = status === "found";
+type CoverageCounts = {
+  complete: number;
+  missing: number;
+  total: number;
+};
+
+function langBadge(lang: SubberSubtitleLangState) {
+  const ok = lang.status === "found";
   return (
     <span
-      key={code}
-      className={`inline-flex min-w-[2.25rem] items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium ${
-        ok ? "bg-emerald-600/25 text-emerald-200" : "bg-red-600/25 text-red-200"
+      key={lang.state_id}
+      title={`${lang.language_code.toUpperCase()} ${
+        ok ? "subtitle found" : "subtitle missing"
+      }`}
+      className={`inline-flex min-w-[3rem] items-center justify-center rounded-full border px-2 py-0.5 text-[0.7rem] font-semibold ${
+        ok
+          ? "border-emerald-400/30 bg-emerald-600/20 text-emerald-100"
+          : "border-red-400/35 bg-red-600/20 text-red-100"
       }`}
     >
-      {code.toUpperCase()}
-      {ok ? " ✓" : " ✗"}
+      {lang.language_code.toUpperCase()}
+      <span className="ml-1 text-[0.6rem] uppercase">{ok ? "ok" : "miss"}</span>
     </span>
   );
 }
@@ -48,21 +64,138 @@ function pickSearchStateId(
   return any?.state_id ?? null;
 }
 
-function coverageState(ep: SubberTvEpisode, prefs: string[]): string {
-  const preferredRows = prefs
+function preferredLanguageRows(
+  ep: SubberTvEpisode,
+  prefs: string[],
+): SubberSubtitleLangState[] {
+  return prefs
     .map((code) =>
       ep.languages.find(
         (row) => row.language_code.toLowerCase() === code.toLowerCase(),
       ),
     )
-    .filter((row): row is NonNullable<typeof row> => Boolean(row));
-  if (
+    .filter((row): row is SubberSubtitleLangState => Boolean(row));
+}
+
+function hasPreferredCoverage(ep: SubberTvEpisode, prefs: string[]): boolean {
+  const preferredRows = preferredLanguageRows(ep, prefs);
+  return (
     preferredRows.length > 0 &&
     preferredRows.every((row) => row.status === "found")
-  ) {
-    return "Preferred subtitle found";
-  }
-  return "Still missing";
+  );
+}
+
+function countCoverage(
+  episodes: SubberTvEpisode[],
+  prefs: string[],
+): CoverageCounts {
+  const complete = episodes.filter((ep) =>
+    hasPreferredCoverage(ep, prefs),
+  ).length;
+  return {
+    complete,
+    missing: episodes.length - complete,
+    total: episodes.length,
+  };
+}
+
+function showEpisodes(show: SubberTvShow): SubberTvEpisode[] {
+  return show.seasons.flatMap((season) => season.episodes);
+}
+
+function formatEpisodeCode(
+  season: SubberTvSeason,
+  ep: SubberTvEpisode,
+): string {
+  return `S${String(season.season_number ?? 0).padStart(2, "0")}E${String(
+    ep.episode_number ?? 0,
+  ).padStart(2, "0")}`;
+}
+
+function CoverageMeter({ counts }: { counts: CoverageCounts }) {
+  const completePercent =
+    counts.total > 0 ? Math.round((counts.complete / counts.total) * 100) : 0;
+  return (
+    <div className="min-w-[9rem]">
+      <div className="flex items-center justify-between gap-3 text-xs text-[var(--mm-text2)]">
+        <span>{completePercent}% covered</span>
+        <span>
+          {counts.complete}/{counts.total}
+        </span>
+      </div>
+      <div className="mt-1.5 h-2 overflow-hidden rounded-full bg-red-950/45">
+        <div
+          className="h-full rounded-full bg-emerald-400/80"
+          style={{ width: `${completePercent}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CoverageSummaryPill({
+  tone,
+  label,
+  value,
+}: {
+  tone: "good" | "warn" | "neutral";
+  label: string;
+  value: number;
+}) {
+  const toneClass =
+    tone === "good"
+      ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-100"
+      : tone === "warn"
+        ? "border-red-400/30 bg-red-500/10 text-red-100"
+        : "border-[var(--mm-border)] bg-black/15 text-[var(--mm-text)]";
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium ${toneClass}`}
+    >
+      <span className="text-sm font-semibold">{value}</span>
+      {label}
+    </span>
+  );
+}
+
+function EpisodeStatusPill({ complete }: { complete: boolean }) {
+  return (
+    <span
+      className={`inline-flex w-fit items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${
+        complete
+          ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-100"
+          : "border-red-400/35 bg-red-500/10 text-red-100"
+      }`}
+    >
+      {complete ? "Complete" : "Needs subtitles"}
+    </span>
+  );
+}
+
+function EpisodeSubtitleSummary({
+  ep,
+  prefs,
+}: {
+  ep: SubberTvEpisode;
+  prefs: string[];
+}) {
+  const preferredRows = preferredLanguageRows(ep, prefs);
+  const visibleRows = preferredRows.length > 0 ? preferredRows : ep.languages;
+  const missingPreferred = visibleRows.filter((row) => row.status !== "found");
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs text-[var(--mm-text2)]">
+        {missingPreferred.length > 0
+          ? `Missing ${missingPreferred
+              .map((row) => row.language_code.toUpperCase())
+              .join(", ")}`
+          : "Preferred subtitles found"}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {visibleRows.map((lang) => langBadge(lang))}
+      </div>
+    </div>
+  );
 }
 
 export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
@@ -91,6 +224,11 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
   const searchAll = useSubberSearchAllMissingTvMutation();
 
   const total = libQ.data?.total ?? 0;
+  const visibleEpisodes = useMemo(
+    () => (libQ.data?.shows ?? []).flatMap(showEpisodes),
+    [libQ.data?.shows],
+  );
+  const visibleCounts = countCoverage(visibleEpisodes, prefs);
   const hasActiveFilters =
     status !== "all" || Boolean(search.trim()) || Boolean(language.trim());
 
@@ -114,55 +252,80 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
   return (
     <div className="space-y-4" data-testid="subber-tv-tab">
       <div className="rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/30 p-4">
-        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">
-          Filters
-        </p>
-        <div className="flex flex-wrap items-end gap-3">
-          <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
-            Search
-            <input
-              className="mm-input min-w-[12rem]"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Show, episode, or path"
-            />
-          </label>
-          <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
-            Subtitles
-            <select
-              className="mm-input min-w-[11rem]"
-              value={status}
-              onChange={(e) => setStatus(e.target.value)}
-            >
-              <option value="all">All episodes</option>
-              <option value="missing">Missing subtitles</option>
-              <option value="complete">All preferred languages found</option>
-            </select>
-          </label>
-          <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
-            Language code
-            <input
-              className="mm-input w-28"
-              value={language}
-              onChange={(e) => setLanguage(e.target.value)}
-              placeholder="e.g. en"
-            />
-          </label>
-          {canOperate ? (
-            <button
-              type="button"
-              className={mmActionButtonClass({ variant: "primary" })}
-              disabled={searchAll.isPending}
-              onClick={() => searchAll.mutate()}
-              data-testid="subber-tv-search-all-missing"
-            >
-              Search all missing TV
-            </button>
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div>
+            <p className="mb-3 text-xs font-medium uppercase tracking-wide text-[var(--mm-text2)]">
+              Filters
+            </p>
+            <div className="flex flex-wrap items-end gap-3">
+              <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
+                Search
+                <input
+                  className="mm-input min-w-[12rem]"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Show, episode, or path"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
+                Subtitles
+                <select
+                  className="mm-input min-w-[11rem]"
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value)}
+                >
+                  <option value="all">All episodes</option>
+                  <option value="missing">Missing subtitles</option>
+                  <option value="complete">
+                    All preferred languages found
+                  </option>
+                </select>
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-[var(--mm-text2)]">
+                Language code
+                <input
+                  className="mm-input w-28"
+                  value={language}
+                  onChange={(e) => setLanguage(e.target.value)}
+                  placeholder="e.g. en"
+                />
+              </label>
+              {canOperate ? (
+                <button
+                  type="button"
+                  className={mmActionButtonClass({ variant: "primary" })}
+                  disabled={searchAll.isPending}
+                  onClick={() => searchAll.mutate()}
+                  data-testid="subber-tv-search-all-missing"
+                >
+                  Search all missing TV
+                </button>
+              ) : null}
+            </div>
+          </div>
+          {total > 0 ? (
+            <div className="flex flex-wrap gap-2 xl:justify-end">
+              <CoverageSummaryPill
+                tone="neutral"
+                label="shown"
+                value={visibleCounts.total}
+              />
+              <CoverageSummaryPill
+                tone="good"
+                label="complete"
+                value={visibleCounts.complete}
+              />
+              <CoverageSummaryPill
+                tone="warn"
+                label="need subtitles"
+                value={visibleCounts.missing}
+              />
+            </div>
           ) : null}
         </div>
       </div>
       {libQ.isLoading ? (
-        <p className="text-sm text-[var(--mm-text2)]">Loading TV library…</p>
+        <p className="text-sm text-[var(--mm-text2)]">Loading TV library...</p>
       ) : null}
       {libQ.isError ? (
         <p className="text-sm text-red-600">{(libQ.error as Error).message}</p>
@@ -187,92 +350,134 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
           itemLabel="episodes"
         />
       ) : null}
-      {libQ.data?.shows.map((show) => (
-        <section
-          key={show.show_title}
-          className="rounded-lg border border-[var(--mm-border)] bg-black/10 p-3"
-        >
-          <h3 className="text-base font-semibold text-[var(--mm-text)]">
-            {show.show_title}
-          </h3>
-          <div className="mt-2 space-y-3">
-            {show.seasons.map((season) => (
-              <div key={String(season.season_number)}>
-                <p className="text-sm font-medium text-[var(--mm-text2)]">
-                  Season {season.season_number ?? "?"}
-                </p>
-                <ul className="mt-1 space-y-2">
-                  {season.episodes.map((ep) => {
-                    const sid = pickSearchStateId(ep, prefs);
-                    const hasMissing = ep.languages.some(
-                      (l) => l.status !== "found",
-                    );
-                    return (
-                      <li
-                        key={ep.file_path}
-                        className="rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/35 p-3 text-sm shadow-sm"
-                      >
-                        <div className="flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
-                          <div className="min-w-0 flex-1 space-y-2">
-                            <h4 className="text-sm font-semibold leading-snug text-[var(--mm-text)]">
-                              S
-                              {String(season.season_number ?? 0).padStart(
-                                2,
-                                "0",
-                              )}
-                              E{String(ep.episode_number ?? 0).padStart(2, "0")}
-                              <span className="font-normal text-[var(--mm-text2)]">
-                                {" "}
-                                ·{" "}
-                              </span>
-                              {ep.episode_title ?? "Episode"}
-                            </h4>
-                            <p className="text-sm text-[var(--mm-text2)]">
-                              {coverageState(ep, prefs)}
-                            </p>
-                            <div className="flex flex-wrap gap-1">
-                              {ep.languages.map((l) =>
-                                langBadge(l.status, l.language_code),
-                              )}
-                            </div>
-                          </div>
-                          {canOperate && hasMissing && sid != null ? (
-                            <div className="flex shrink-0">
-                              <button
-                                type="button"
-                                className={mmActionButtonClass({
-                                  variant: "secondary",
-                                })}
-                                disabled={searchNow.isPending}
-                                data-testid="subber-tv-search-now"
-                                onClick={() => searchNow.mutate(sid)}
-                              >
-                                Search now
-                              </button>
-                            </div>
-                          ) : null}
+      <div className="space-y-3">
+        {libQ.data?.shows.map((show) => {
+          const showCounts = countCoverage(showEpisodes(show), prefs);
+          return (
+            <section
+              key={show.show_title}
+              className="overflow-hidden rounded-xl border border-[var(--mm-border)] bg-[var(--mm-card-bg)]/35 shadow-sm"
+            >
+              <header className="flex flex-col gap-3 border-b border-[var(--mm-border)] bg-black/15 px-4 py-3 lg:flex-row lg:items-center lg:justify-between">
+                <div className="min-w-0">
+                  <h3 className="truncate text-lg font-semibold leading-tight text-[var(--mm-text)]">
+                    {show.show_title}
+                  </h3>
+                  <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                    {showCounts.missing > 0
+                      ? `${showCounts.missing} episode${
+                          showCounts.missing === 1 ? "" : "s"
+                        } still ${
+                          showCounts.missing === 1 ? "needs" : "need"
+                        } subtitles`
+                      : "All shown episodes have preferred subtitles"}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <div className="flex flex-wrap gap-2">
+                    <CoverageSummaryPill
+                      tone="neutral"
+                      label="episodes"
+                      value={showCounts.total}
+                    />
+                    <CoverageSummaryPill
+                      tone="warn"
+                      label="missing"
+                      value={showCounts.missing}
+                    />
+                  </div>
+                  <CoverageMeter counts={showCounts} />
+                </div>
+              </header>
+              <div className="divide-y divide-[var(--mm-border)]">
+                {show.seasons.map((season) => {
+                  const seasonCounts = countCoverage(season.episodes, prefs);
+                  return (
+                    <section key={String(season.season_number)} className="p-4">
+                      <div className="mb-2.5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                          <h4 className="text-sm font-semibold text-[var(--mm-text)]">
+                            Season {season.season_number ?? "?"}
+                          </h4>
+                          <p className="text-xs text-[var(--mm-text2)]">
+                            {seasonCounts.missing > 0
+                              ? `${seasonCounts.missing} missing, ${seasonCounts.complete} complete`
+                              : "Season complete"}
+                          </p>
                         </div>
-                        <details className="group mt-2.5 rounded-lg border border-[var(--mm-border)] open:border-[var(--mm-accent)]/25 open:bg-black/10">
-                          <summary className="flex cursor-pointer list-none items-center gap-2 px-2.5 py-2 text-sm font-medium text-[var(--mm-text)] outline-none marker:hidden hover:bg-black/[0.08] [&::-webkit-details-marker]:hidden">
-                            <SubberDetailsChevron />
-                            Path & subtitle details
-                          </summary>
-                          <div className="space-y-4 border-t border-[var(--mm-border)] px-2.5 pb-3.5 pt-3.5">
-                            <SubberMediaFilePathBlock path={ep.file_path} />
-                            <SubberLanguageTracksDetails
-                              languages={ep.languages}
-                            />
-                          </div>
-                        </details>
-                      </li>
-                    );
-                  })}
-                </ul>
+                        <CoverageMeter counts={seasonCounts} />
+                      </div>
+                      <ul className="rounded-lg border border-[var(--mm-border)]">
+                        {season.episodes.map((ep) => {
+                          const sid = pickSearchStateId(ep, prefs);
+                          const complete = hasPreferredCoverage(ep, prefs);
+                          const hasMissing = ep.languages.some(
+                            (l) => l.status !== "found",
+                          );
+                          return (
+                            <li
+                              key={ep.file_path}
+                              className={`border-b border-[var(--mm-border)] bg-black/10 last:border-b-0 ${
+                                complete
+                                  ? "border-l-4 border-l-emerald-400/70"
+                                  : "border-l-4 border-l-red-400/70"
+                              }`}
+                            >
+                              <div className="grid gap-3 px-3 py-3 md:grid-cols-[minmax(15rem,1fr)_minmax(12rem,18rem)_auto] md:items-center">
+                                <div className="min-w-0">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <span className="rounded-md bg-black/25 px-2 py-1 font-mono text-xs font-semibold text-[var(--mm-text)]">
+                                      {formatEpisodeCode(season, ep)}
+                                    </span>
+                                    <EpisodeStatusPill complete={complete} />
+                                  </div>
+                                  <p className="mt-2 truncate text-sm font-semibold text-[var(--mm-text)]">
+                                    {ep.episode_title ?? "Episode"}
+                                  </p>
+                                </div>
+                                <EpisodeSubtitleSummary ep={ep} prefs={prefs} />
+                                <div className="flex items-center md:justify-end">
+                                  {canOperate && hasMissing && sid != null ? (
+                                    <button
+                                      type="button"
+                                      className={mmActionButtonClass({
+                                        variant: "secondary",
+                                      })}
+                                      disabled={searchNow.isPending}
+                                      data-testid="subber-tv-search-now"
+                                      onClick={() => searchNow.mutate(sid)}
+                                    >
+                                      Search now
+                                    </button>
+                                  ) : null}
+                                </div>
+                                <details className="group md:col-span-3">
+                                  <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 rounded-md border border-[var(--mm-border)] px-2.5 py-2 text-xs font-medium text-[var(--mm-text)] outline-none marker:hidden hover:bg-black/[0.12] [&::-webkit-details-marker]:hidden">
+                                    <SubberDetailsChevron />
+                                    Path, provider, and search details
+                                  </summary>
+                                  <div className="mt-3 space-y-4 rounded-lg border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-3">
+                                    <SubberMediaFilePathBlock
+                                      path={ep.file_path}
+                                    />
+                                    <SubberLanguageTracksDetails
+                                      languages={ep.languages}
+                                    />
+                                  </div>
+                                </details>
+                              </div>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </section>
+                  );
+                })}
               </div>
-            ))}
-          </div>
-        </section>
-      ))}
+            </section>
+          );
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the Subber TV library view around show, season, and episode subtitle coverage
- add coverage counts, progress bars, clear complete/missing status pills, and visible missing language chips
- keep file/provider/search metadata behind a full-width details expander
- add a regression test for the new coverage summary copy

## Validation
- `vitest run src/pages/subber/subber-tv-tab.test.tsx`
- `tsc -p tsconfig.json --noEmit`
- `vite build`
- `eslint src/pages/subber/subber-tv-tab.tsx src/pages/subber/subber-tv-tab.test.tsx --max-warnings 0`
- Playwright screenshot check against mocked Subber TV data at desktop width; no horizontal overflow