### PR TITLE
Prepare v2.3.8 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.7"
+version = "2.3.8"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6490,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.7"
+    "version": "2.3.8"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.3.7",
+  "version": "2.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.3.7",
+      "version": "2.3.8",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.7",
+  "version": "2.3.8",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.8.md
+++ b/docs/release-notes/v2.3.8.md
@@ -1,0 +1,11 @@
+# MediaMop v2.3.8
+
+## Improvements
+
+- Redesigned the Subber TV library view so shows, seasons, and episodes are easier to scan.
+- Added visible subtitle coverage counts, progress bars, complete/missing status labels, and language chips.
+- Moved file path, provider, and search metadata behind a clearer episode details expander.
+
+## Validation
+
+- Frontend Subber TV coverage tests, TypeScript, build, lint, E2E smoke, Docker smoke, CodeQL, and Windows package smoke passed before release.


### PR DESCRIPTION
## Summary
- bump backend, web, package-lock, and OpenAPI release metadata to `2.3.8`
- add `docs/release-notes/v2.3.8.md` for the Subber TV coverage UI release

## Validation
- `git diff --check`
- bundled Node: `node scripts/check-agent-docs.mjs`

After this merges, I will tag `v2.3.8` to trigger the release workflow for Docker and Windows.