### PR TITLE
Prepare v2.3.9 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.8"
+version = "2.3.9"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6490,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.8"
+    "version": "2.3.9"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.3.8",
+  "version": "2.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.3.8",
+      "version": "2.3.9",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.8",
+  "version": "2.3.9",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.9.md
+++ b/docs/release-notes/v2.3.9.md
@@ -1,0 +1,11 @@
+# MediaMop v2.3.9
+
+## Improvements
+
+- Compressed the Subber TV library into a drilldown view.
+- TV shows now appear as collapsed coverage rows first, with seasons and episodes revealed only when expanded.
+- Episode subtitle status, missing language chips, and per-episode search actions remain available inside the expanded season view.
+
+## Validation
+
+- Subber TV unit tests, frontend type check, lint, formatting, production build, Playwright visual smoke, full CI, Docker smoke, and Windows package smoke passed before release.


### PR DESCRIPTION
## Summary
- bump backend, web, package-lock, and OpenAPI release metadata to `2.3.9`
- add `docs/release-notes/v2.3.9.md` for the Subber TV drilldown release

## Validation
- `git diff --check`
- bundled Node: `node scripts/check-agent-docs.mjs`

After this merges, I will tag `v2.3.9` to trigger the release workflow for Docker and Windows.