### PR TITLE
Fix Subber TV show pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist/
 
 *.egg-info/
 .pytest_cache/
+pytest-cache-files-*/
 .mypy_cache/
 .ruff_cache/
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 license = "AGPL-3.0-or-later"
 dependencies = [
-  "fastapi>=0.115",
+  "fastapi>=0.115,!=0.136.3",
   "python-dotenv>=1.0",
   "uvicorn>=0.32",
   "sqlalchemy>=2.0.40",

--- a/apps/backend/src/mediamop/modules/subber/subber_library_service.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_service.py
@@ -39,33 +39,6 @@ def _lang_states(rows: Sequence[SubberSubtitleState], lang_filter: str | None) -
     return [r for r in rows if r.language_code.lower() == lf]
 
 
-def _flatten_tv_shows(show_out: list[SubberTvShowOut]) -> list[tuple[str, int | None, SubberTvEpisodeOut]]:
-    flat: list[tuple[str, int | None, SubberTvEpisodeOut]] = []
-    for show in show_out:
-        for season in show.seasons:
-            for ep in season.episodes:
-                flat.append((show.show_title, season.season_number, ep))
-    return flat
-
-
-def _rebuild_tv_shows_from_flat(flat: list[tuple[str, int | None, SubberTvEpisodeOut]]) -> list[SubberTvShowOut]:
-    shows: dict[str, dict[int | None, list[SubberTvEpisodeOut]]] = defaultdict(lambda: defaultdict(list))
-    for show_title, sn, ep in flat:
-        shows[show_title][sn].append(ep)
-    show_out: list[SubberTvShowOut] = []
-    for show_title in sorted(shows.keys(), key=lambda s: s.lower()):
-        seasons_map = shows[show_title]
-        seasons: list[SubberTvSeasonOut] = []
-        for sn in sorted(seasons_map.keys(), key=lambda x: (x is None, x or -1)):
-            eps = sorted(
-                seasons_map[sn],
-                key=lambda e: (e.episode_number is None, e.episode_number or -1, e.file_path),
-            )
-            seasons.append(SubberTvSeasonOut(season_number=sn, episodes=eps))
-        show_out.append(SubberTvShowOut(show_title=show_title, seasons=seasons))
-    return show_out
-
-
 def _episode_status_filter(rows: Sequence[SubberSubtitleState], status: str | None, prefs: list[str]) -> bool:
     if not status or status == "all":
         return True
@@ -140,11 +113,9 @@ def build_tv_library(
             )
             seasons.append(SubberTvSeasonOut(season_number=sn, episodes=eps))
         show_out.append(SubberTvShowOut(show_title=show_title, seasons=seasons))
-    flat = _flatten_tv_shows(show_out)
-    total = len(flat)
+    total = len(show_out)
     if limit is not None:
-        flat = flat[offset : offset + limit]
-        show_out = _rebuild_tv_shows_from_flat(flat)
+        show_out = show_out[offset : offset + limit]
     return SubberTvLibraryOut(shows=show_out, total=total)
 
 

--- a/apps/backend/tests/test_subber_library_api.py
+++ b/apps/backend/tests/test_subber_library_api.py
@@ -245,6 +245,50 @@ def test_get_library_movies_pagination(client_admin: TestClient) -> None:
     assert r1.json()["movies"][0]["file_path"] != j0["movies"][0]["file_path"]
 
 
+def test_get_library_tv_pagination_keeps_whole_shows(client_admin: TestClient) -> None:
+    fac = create_session_factory(create_db_engine(client_admin.app.state.settings))
+    with fac() as db:
+        for ep in range(1, 4):
+            db.add(
+                SubberSubtitleState(
+                    media_scope="tv",
+                    file_path=f"/t/pag/alpha-s01e{ep}.mkv",
+                    language_code="en",
+                    status="missing",
+                    show_title="Pag Alpha",
+                    season_number=1,
+                    episode_number=ep,
+                    episode_title=f"Alpha {ep}",
+                ),
+            )
+        for title in ("Pag Beta", "Pag Gamma"):
+            db.add(
+                SubberSubtitleState(
+                    media_scope="tv",
+                    file_path=f"/t/pag/{title.lower().replace(' ', '-')}.mkv",
+                    language_code="en",
+                    status="missing",
+                    show_title=title,
+                    season_number=1,
+                    episode_number=1,
+                    episode_title="Pilot",
+                ),
+            )
+        db.commit()
+    _login_admin(client_admin)
+
+    r0 = client_admin.get("/api/v1/subber/library/tv", params={"limit": 1, "offset": 0, "search": "Pag"})
+    assert r0.status_code == 200
+    j0 = r0.json()
+    assert j0["total"] == 3
+    assert [s["show_title"] for s in j0["shows"]] == ["Pag Alpha"]
+    assert len(j0["shows"][0]["seasons"][0]["episodes"]) == 3
+
+    r1 = client_admin.get("/api/v1/subber/library/tv", params={"limit": 1, "offset": 1, "search": "Pag"})
+    assert r1.status_code == 200
+    assert [s["show_title"] for s in r1.json()["shows"]] == ["Pag Beta"]
+
+
 def test_get_library_movies_requires_auth(client_admin: TestClient) -> None:
     r = client_admin.get("/api/v1/subber/library/movies")
     assert r.status_code == 401

--- a/apps/web/src/pages/subber/subber-library-pager.tsx
+++ b/apps/web/src/pages/subber/subber-library-pager.tsx
@@ -28,7 +28,7 @@ export function writeSubberLibraryPageSize(n: SubberLibraryPageSize): void {
 }
 
 type SubberLibraryPagerProps = {
-  /** Total rows matching filters (movies or TV episodes). */
+  /** Total rows matching filters (movies or TV shows). */
   total: number;
   page: number;
   pageSize: SubberLibraryPageSize;

--- a/apps/web/src/pages/subber/subber-tv-tab.tsx
+++ b/apps/web/src/pages/subber/subber-tv-tab.tsx
@@ -364,7 +364,7 @@ export function SubberTvTab({ canOperate }: { canOperate: boolean }) {
           pageSize={pageSize}
           onPageChange={setPage}
           onPageSizeChange={setPageSize}
-          itemLabel="episodes"
+          itemLabel="shows"
         />
       ) : null}
       <div className="space-y-2">


### PR DESCRIPTION
## Summary
- paginate Subber TV library results by show instead of episode slices
- update the TV pager label to show counts
- add a regression test proving a multi-episode show stays whole across pages

## Validation
- apps/backend: python -m pytest -q tests/test_subber_library_api.py
- apps/web: vitest run src/pages/subber/subber-tv-tab.test.tsx
- apps/web: tsc -p tsconfig.json --noEmit
- apps/web: prettier --check changed Subber files
- apps/web: eslint changed Subber files
- apps/web: vite build
- node scripts/check-agent-docs.mjs