### PR TITLE
Prepare v2.3.10 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.9"
+version = "2.3.10"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6490,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.9"
+    "version": "2.3.10"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.3.9",
+  "version": "2.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.3.9",
+      "version": "2.3.10",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.9",
+  "version": "2.3.10",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.10.md
+++ b/docs/release-notes/v2.3.10.md
@@ -1,0 +1,15 @@
+# MediaMop v2.3.10
+
+## Fixes
+
+- Fixed Subber TV pagination after the show/season/episode drilldown update.
+- TV pages now paginate whole shows instead of slicing episodes first, so the same show no longer repeats across pages with different episode subsets.
+- The TV pager now labels pages as shows while coverage counts still summarize the episodes inside the visible shows.
+
+## Security
+
+- Excluded FastAPI `0.136.3` after OSV flagged that exact package release as `MAL-2026-4750`; dependency resolution falls back to a clean FastAPI release.
+
+## Validation
+
+- Subber backend regression tests, Subber TV unit tests, frontend type check, lint, formatting, production build, full CI, Docker smoke, CodeQL, and Windows package smoke passed before release.


### PR DESCRIPTION
## Summary
- bump backend, web, package-lock, and OpenAPI metadata to 2.3.10
- add release notes for the Subber TV show-pagination fix
- include the FastAPI 0.136.3 advisory exclusion in the release metadata

## Validation
- apps/backend: python -m pytest -q tests/test_subber_library_api.py -p no:cacheprovider
- apps/web: vitest run src/pages/subber/subber-tv-tab.test.tsx
- apps/web: tsc -p tsconfig.json --noEmit
- apps/web: vite build
- git diff --check
- node scripts/check-agent-docs.mjs