### PR TITLE
Fix open dependency PR blockers and security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           node-version: "20"
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -39,7 +39,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/build
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           node-version: "20"
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "9.0.x"
 

--- a/apps/backend/src/mediamop/modules/subber/subber_library_scan_job_handler.py
+++ b/apps/backend/src/mediamop/modules/subber/subber_library_scan_job_handler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, timedelta
 
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -41,7 +41,7 @@ def make_subber_library_scan_handler(
         payload = json.loads(ctx.payload_json or "{}")
         if str(payload.get("media_scope") or "") != media_scope:
             return
-        when = datetime.now(UTC)
+        when = ctx.now
         default_cutoff = when - timedelta(hours=6)
         enqueued = 0
         with session_factory() as session, session.begin():

--- a/apps/backend/src/mediamop/modules/subber/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/subber/worker_loop.py
@@ -46,6 +46,7 @@ class SubberJobWorkContext:
     job_kind: str
     payload_json: str | None
     lease_owner: str
+    now: datetime
 
 
 class SubberNoHandlerForJobKind(LookupError):
@@ -85,6 +86,7 @@ def process_one_subber_job(
             job_kind=job.job_kind,
             payload_json=job.payload_json,
             lease_owner=lease_owner,
+            now=when,
         )
 
     if job_kind_forbidden_on_subber_lane(ctx.job_kind):

--- a/apps/backend/tests/test_local_browse_api.py
+++ b/apps/backend/tests/test_local_browse_api.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import tempfile
+import uuid
+from pathlib import Path
+
 from starlette.testclient import TestClient
 
 from tests.integration_helpers import auth_post
@@ -48,8 +52,9 @@ def test_system_directories_lists_roots(client_with_admin: TestClient) -> None:
 
 def test_system_directories_returns_not_found(client_with_admin: TestClient) -> None:
     _login_admin(client_with_admin)
+    missing_path = Path(tempfile.gettempdir()) / f"mediamop-missing-{uuid.uuid4()}"
 
-    r = client_with_admin.get("/api/v1/system/directories", params={"path": "/definitely-not-real-mediamop-xyz-abc123"})
+    r = client_with_admin.get("/api/v1/system/directories", params={"path": str(missing_path)})
 
     assert r.status_code == 404
     assert r.json()["detail"] == "The requested directory does not exist."

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,7 +13,7 @@
         "@tanstack/react-query": "^5.62.8",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
-        "react-router-dom": "^6.28.0"
+        "react-router-dom": "^6.30.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -909,9 +909,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -5764,12 +5764,12 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2"
+        "@remix-run/router": "1.23.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5779,13 +5779,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "6.30.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "@remix-run/router": "1.23.3",
+        "react-router": "6.30.4"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "@tanstack/react-query": "^5.62.8",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "react-router-dom": "^6.28.0"
+    "react-router-dom": "^6.30.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -15,14 +15,14 @@
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.10.1",
         "@docusaurus/tsconfig": "3.10.1",
         "@docusaurus/types": "3.10.1",
-        "@types/react": "^19.0.0",
+        "@types/react": "^19.2.17",
         "typescript": "~6.0.2"
       },
       "engines": {
@@ -6597,9 +6597,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -17463,24 +17463,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-fast-compare": {
@@ -18607,9 +18607,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -22,14 +22,14 @@
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.1",
     "@docusaurus/tsconfig": "3.10.1",
     "@docusaurus/types": "3.10.1",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.2.17",
     "typescript": "~6.0.2"
   },
   "browserslist": {
@@ -50,6 +50,7 @@
   "overrides": {
     "qs": "^6.15.2",
     "serialize-javascript": "^7.0.5",
-    "uuid": "^14.0.0"
+    "uuid": "^14.0.0",
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
## What changed
- fixed the Subber library-scan worker to use the claimed job timestamp instead of wall-clock time
- updated the local-browse not-found test to build a valid nonexistent absolute path on every OS
- refreshed the stale GitHub Actions versions from the open Dependabot workflow PR
- updated `apps/web` to `react-router-dom@^6.30.4` so `react-router@6.30.4` is resolved
- updated `docs-site` React packages and pinned transitive `shell-quote@^1.8.4` via `overrides`

## Why
- PRs `#279`, `#280`, and `#281` were failing for an unrelated backend regression in `test_subber_library_scan_job_handler`
- the default branch still has two open Dependabot alerts:
  - `react-router` open redirect advisory
  - `shell-quote` command injection advisory
- the docs/workflow action versions were already queued in open Dependabot PRs and are folded into this branch so one PR can supersede the backlog cleanly

## Impact
- Subber scan scheduling is now deterministic under worker-controlled time, which matches the worker contract and removes the CI drift
- the active Dependabot alerts on `apps/web` and `docs-site` should clear once this lands on `main`
- the workflow versions align with the currently open Dependabot actions PR

## Validation
- `apps/backend`: `.\.venv\Scripts\python.exe -m pytest -q`
- `apps/web`: `npm run api:types:check`, `npm run build`, `npm run test`
- `docs-site`: `npm run build`
- repo root: `node scripts/check-agent-docs.mjs`

## Supersedes
- `#264`
- `#265`
- `#279`
- `#280`
- `#281`