### PR TITLE
Prepare v2.3.11 release

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.3.10"
+version = "2.3.11"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6490,7 +6490,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.3.10"
+    "version": "2.3.11"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.3.10",
+  "version": "2.3.11",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.3.11.md
+++ b/docs/release-notes/v2.3.11.md
@@ -1,0 +1,32 @@
+# MediaMop v2.3.11
+
+Date: 2026-06-12
+
+This release focuses on security updates and steadier background processing.
+
+## What Changed
+
+- Updated the bundled web application dependencies to include the latest React Router security fix.
+- Rolled the current security-alert cleanup into the shipped application release so Windows and Docker installs pick it up.
+- Kept the existing installer and container upgrade path unchanged.
+
+## Fixes And Stability
+
+- Fixed Subber library scan fan-out timing so follow-up work uses a consistent job timestamp.
+- Reduced the chance of duplicate or drifted background scan windows during longer scan runs.
+- No configuration or data migration is required for this release.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No manual database changes are required.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.3.11`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.3.10...v2.3.11


### PR DESCRIPTION
## Summary
- bump backend and web versions from `2.3.10` to `2.3.11`
- add `docs/release-notes/v2.3.11.md`
- prepare the repo for a tag-driven release that includes the recently merged security and stability fixes

## Why
The repo's latest merged fixes are on `main`, but release artifacts are only published from `v*` tags. This PR advances the versioned files and release notes so the next tag can build and publish updated Windows and Docker artifacts.

## Validation
- `npm run build` in `apps/web` (run from mapped drive path due Windows UNC shell limits)
- PR CI will run the required `mediamop`, `docker-smoke`, and `windows-package-smoke` checks