### PR TITLE
Answer HEAD the way HTTP says to

### DIFF
--- a/apps/backend/src/mediamop/api/factory.py
+++ b/apps/backend/src/mediamop/api/factory.py
@@ -18,6 +18,7 @@ from mediamop.api.router import build_v1_router
 from mediamop.core.config import MediaMopSettings
 from mediamop.core.lifespan import lifespan
 from mediamop.platform.health import health_router
+from mediamop.platform.http.head_mirrors_get import HeadMirrorsGetMiddleware
 from mediamop.platform.http.request_context import RequestContextMiddleware
 from mediamop.platform.http.security_headers import SecurityHeadersMiddleware
 from mediamop.platform.http.xrw_csrf_middleware import XRequestedWithCsrfMiddleware
@@ -125,6 +126,7 @@ def create_app() -> FastAPI:
     application.add_middleware(SecurityHeadersMiddleware)
     application.add_middleware(RequestContextMiddleware)
     application.add_middleware(XRequestedWithCsrfMiddleware)
+    application.add_middleware(HeadMirrorsGetMiddleware)
 
     @application.exception_handler(StarletteHTTPException)
     async def _friendly_upgrade_landing_handler(request: Request, exc: StarletteHTTPException):

--- a/apps/backend/src/mediamop/platform/http/head_mirrors_get.py
+++ b/apps/backend/src/mediamop/platform/http/head_mirrors_get.py
@@ -1,0 +1,52 @@
+"""Answer HEAD the way HTTP says to: same as GET, without the body.
+
+FastAPI registers only the method a route declares, so `@router.get(...)` does not
+answer HEAD and the request falls through to a 404. That is wrong on its own terms —
+`HEAD /health` returning 404 while `GET /health` returns 200 tells a health checker
+the endpoint does not exist — and it misleads anything that probes with HEAD before
+committing to a real request.
+
+This runs the request as a GET and discards the body, so every GET route answers HEAD
+with the same status and headers. A path with no GET handler — a POST-only webhook,
+say — then gets the spec-correct 405 instead of a 404, which matters because callers
+probe webhooks with HEAD and a 404 tells them the endpoint is missing when it is not.
+"""
+
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class HeadMirrorsGetMiddleware:
+    """Serve HEAD from the GET handler, returning headers without a body."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("method") != "HEAD":
+            await self.app(scope, receive, send)
+            return
+
+        # Route as a GET so the matching handler runs...
+        scope = dict(scope)
+        scope["method"] = "GET"
+
+        body_closed = False
+
+        async def send_without_body(message: Message) -> None:
+            # ...then drop the body, keeping the status line and headers. Content-Length
+            # is deliberately left as GET reported it: RFC 9110 says a HEAD response
+            # carries the header fields the GET would have, including the length the
+            # body would have had.
+            nonlocal body_closed
+            if message["type"] == "http.response.body":
+                # A streaming handler sends many body chunks. Close the response on the
+                # first one and swallow the rest, or we would send after completion.
+                if not body_closed:
+                    body_closed = True
+                    await send({"type": "http.response.body", "body": b"", "more_body": False})
+                return
+            await send(message)
+
+        await self.app(scope, receive, send_without_body)

--- a/apps/backend/tests/test_head_mirrors_get.py
+++ b/apps/backend/tests/test_head_mirrors_get.py
@@ -1,0 +1,57 @@
+"""HEAD should answer like GET, without a body.
+
+FastAPI registers only the declared method, so `@router.get(...)` used to leave HEAD
+falling through to a 404 — `HEAD /health` said the endpoint did not exist while
+`GET /health` returned 200. Anything probing with HEAD before committing to a real
+request was told the wrong thing.
+"""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+
+def test_head_on_a_get_route_answers_like_get(client_with_admin: TestClient) -> None:
+    get = client_with_admin.get("/health")
+    head = client_with_admin.head("/health")
+
+    assert get.status_code == 200
+    assert head.status_code == 200
+    assert head.content == b""
+
+
+def test_head_carries_the_same_content_type_as_get(client_with_admin: TestClient) -> None:
+    get = client_with_admin.get("/health")
+    head = client_with_admin.head("/health")
+
+    assert head.headers.get("content-type") == get.headers.get("content-type")
+
+
+def test_head_on_the_readiness_probe_answers(client_with_admin: TestClient) -> None:
+    head = client_with_admin.head("/ready")
+    assert head.status_code in (200, 503)
+    assert head.content == b""
+
+
+def test_head_on_a_post_only_route_says_method_not_allowed(client_with_admin: TestClient) -> None:
+    """A POST-only webhook has nothing for HEAD to describe.
+
+    Routing it as a GET gets the spec-correct answer for a path that exists but has no
+    GET handler: 405, not the 404 FastAPI produced before. That matters because callers
+    probe webhooks with HEAD, and 404 tells them the endpoint is missing when it is not.
+    """
+
+    head = client_with_admin.head("/api/v1/intake/webhook/deluno")
+    assert head.status_code == 405
+
+
+def test_head_on_a_path_that_does_not_exist_is_not_found(client_with_admin: TestClient) -> None:
+    assert client_with_admin.head("/api/v1/nothing-here").status_code == 404
+
+
+def test_get_still_returns_a_body(client_with_admin: TestClient) -> None:
+    """The middleware must not strip bodies from ordinary requests."""
+
+    r = client_with_admin.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"


### PR DESCRIPTION
## The bug

```
GET  /health  → 200
HEAD /health  → 404
```

FastAPI registers only the method a route declares, so `@router.get(...)` never answered HEAD and the request fell through to a not-found. Anything probing with HEAD — health checkers, load balancers, and integrations checking a webhook before trusting it — was told the endpoint does not exist.

## How it surfaced

Found live, wiring Deluno to MediaMop 2.4.0 on a test VM. Deluno probes a configured processor with a HEAD request before reporting it healthy. MediaMop answered 404, so Deluno reported the processor **unreachable** — while the very same endpoint was accepting authenticated hand-offs in the same minute.

Deluno has been fixed separately to stop drawing conclusions from one status code, but the 404 was wrong regardless of who was asking.

## The fix

HEAD requests route as GET with the body discarded, so every GET route answers HEAD with the same status and headers. Per RFC 9110 the headers are left as GET produced them, `Content-Length` included.

**One improvement I did not predict:** a path with *no* GET handler now answers **405** rather than 404. That is the spec-correct answer for a path that exists but has no GET, and it is what a caller probing a POST-only webhook should see — a 404 tells them the endpoint is missing when it is not. My first test asserted 404 and was wrong; the code was right.

The response body is closed on the first chunk and later chunks are swallowed, so a streaming handler cannot send after the response has completed.

## Gates

- **866 passed, 2 skipped**
- `ruff check` clean, `mypy` clean across 303 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)