### PR TITLE
Write the media managers screen for the person reading it

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.4.0"
+version = "2.4.1"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/backend/src/mediamop/platform/media_managers/connections_api.py
+++ b/apps/backend/src/mediamop/platform/media_managers/connections_api.py
@@ -278,8 +278,12 @@ _HEALTH_PATHS: dict[str, str] = {
 }
 
 
-def _probe(kind: str, base_url: str, api_key: str | None) -> tuple[bool, str]:
-    """Ask a manager whether it is there, in whichever way that manager answers."""
+def _probe(name: str, kind: str, base_url: str, api_key: str | None) -> tuple[bool, str]:
+    """Ask a manager whether it is there, and say what happened in plain words.
+
+    These strings go straight onto a settings card, so they name the thing the
+    operator recognises and, when something is wrong, what to go and check.
+    """
 
     path = _HEALTH_PATHS.get(kind, "/api/integrations/external/health")
     try:
@@ -288,13 +292,17 @@ def _probe(kind: str, base_url: str, api_key: str | None) -> tuple[bool, str]:
     except MediaManagerHttpError as exc:
         detail = str(exc)
         if "HTTP 401" in detail or "HTTP 403" in detail:
-            return False, f"{base_url} is reachable but rejected the API key."
-        return False, f"MediaMop could not get a healthy answer from {base_url}: {detail}"
-    except OSError as exc:
+            return False, f"MediaMop reached {name}, but the API key was refused. Check the key and save it again."
         return False, (
-            f"MediaMop could not reach {base_url}. Check the address and that the service is running ({exc})."
+            f"MediaMop reached {name} but did not get the answer it expected. "
+            "Check the address points at the app itself, not a page inside it."
         )
-    return True, f"{base_url} answered."
+    except OSError:
+        return False, (
+            f"MediaMop could not reach {name} at {base_url}. "
+            "Check the address is right, and that the app is running and reachable from this machine."
+        )
+    return True, f"Connected. MediaMop can reach {name}."
 
 
 @router.post(
@@ -316,10 +324,10 @@ def post_media_manager_connection_test(
     checked_at = datetime.now(UTC)
 
     if not (row.base_url or "").strip():
-        ok, detail = False, "No address is saved for this manager yet."
+        ok, detail = False, "Add the address where this app can be reached, then test again."
     else:
         api_key = decrypt_arr_api_key(settings, row.api_key_ciphertext) if row.api_key_ciphertext else None
-        ok, detail = _probe(row.kind, row.base_url, api_key)
+        ok, detail = _probe(row.name, row.kind, row.base_url, api_key)
 
     row.last_connection_test_ok = ok
     row.last_connection_test_at = checked_at

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6462,7 +6462,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.4.0"
+    "version": "2.4.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/pages/settings/settings-media-managers-tab.test.tsx
+++ b/apps/web/src/pages/settings/settings-media-managers-tab.test.tsx
@@ -44,7 +44,7 @@ describe("SettingsMediaManagersTab", () => {
     render(<SettingsMediaManagersTab />, { wrapper });
 
     expect(
-      await screen.findByText(/No media managers yet/i),
+      await screen.findByText(/No apps are connected yet/i),
     ).toBeInTheDocument();
   });
 
@@ -62,12 +62,19 @@ describe("SettingsMediaManagersTab", () => {
 
     expect(await screen.findByText("Deluno")).toBeInTheDocument();
     expect(screen.getByText("Radarr")).toBeInTheDocument();
-    expect(
-      screen.getByText("/api/v1/intake/webhook/deluno"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("/api/v1/intake/webhook/radarr"),
-    ).toBeInTheDocument();
+
+    // The card shows a full URL, not the bare path the API returns, because the
+    // operator has to paste it into another app on another machine.
+    const urls = screen
+      .getAllByTestId("media-manager-webhook-url")
+      .map((el) => el.textContent);
+    expect(urls.some((u) => u?.endsWith("/api/v1/intake/webhook/deluno"))).toBe(
+      true,
+    );
+    expect(urls.some((u) => u?.endsWith("/api/v1/intake/webhook/radarr"))).toBe(
+      true,
+    );
+    expect(urls.every((u) => u?.startsWith("http"))).toBe(true);
   });
 
   it("warns when a manager has no secret, since anyone could post as it", async () => {
@@ -76,7 +83,7 @@ describe("SettingsMediaManagersTab", () => {
     ]);
     render(<SettingsMediaManagersTab />, { wrapper });
 
-    expect(await screen.findByText(/No secret set/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no secret yet/i)).toBeInTheDocument();
   });
 
   it("shows a generated secret once, and says that is the only time", async () => {
@@ -98,7 +105,7 @@ describe("SettingsMediaManagersTab", () => {
         "s3cr3t-value",
       ),
     );
-    expect(screen.getByText(/only time it is shown/i)).toBeInTheDocument();
+    expect(screen.getByText(/will not show it again/i)).toBeInTheDocument();
   });
 
   it("reports a failed connection test in the words the API used", async () => {
@@ -106,14 +113,12 @@ describe("SettingsMediaManagersTab", () => {
       connection({
         last_test_ok: false,
         last_test_detail:
-          "http://10.1.1.142:5099 is reachable but rejected the API key.",
+          "MediaMop reached Deluno, but the API key was refused. Check the key and save it again.",
       }),
     ]);
     render(<SettingsMediaManagersTab />, { wrapper });
 
-    expect(
-      await screen.findByText(/rejected the API key/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/API key was refused/i)).toBeInTheDocument();
   });
 
   it("adds a manager of a kind that never had columns of its own", async () => {

--- a/apps/web/src/pages/settings/settings-media-managers-tab.tsx
+++ b/apps/web/src/pages/settings/settings-media-managers-tab.tsx
@@ -27,11 +27,14 @@ const KINDS: MediaManagerKind[] = ["radarr", "sonarr", "deluno", "native"];
 
 /** What each kind is for, in one line, so the picker is not just four names. */
 const KIND_BLURBS: Record<MediaManagerKind, string> = {
-  radarr: "Sends its Download event when a film has been imported.",
-  sonarr: "Sends its Download event when an episode has been imported.",
+  radarr:
+    "Tells MediaMop when it has added a film, so subtitles can be found for it.",
+  sonarr:
+    "Tells MediaMop when it has added an episode, so subtitles can be found for it.",
   deluno:
-    "Hands a finished download to Refiner before importing, and waits to be told the cleaned file is ready.",
-  native: "Anything else that can post JSON. Use MediaMop's own payload shape.",
+    "Passes a finished download to MediaMop to clean up first, and waits to be told the tidied file is ready.",
+  native:
+    "Anything else that can send MediaMop a message. Use this if your app is not listed.",
 };
 
 type FormState = {
@@ -47,6 +50,13 @@ const EMPTY_FORM: FormState = {
   base_url: "",
   api_key: "",
 };
+
+function webhookUrl(connection: MediaManagerConnection): string {
+  // The API returns a path, but the operator has to paste this into another app on
+  // another machine, so it needs the host MediaMop is actually reachable on.
+  if (typeof window === "undefined") return connection.webhook_url_path;
+  return `${window.location.origin}${connection.webhook_url_path}`;
+}
 
 function testTone(connection: MediaManagerConnection): string {
   if (connection.last_test_ok === true) return "text-emerald-400";
@@ -67,7 +77,7 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
     <form onSubmit={submit} className={SUITE_SETTINGS_DASH_CARD_CLASS}>
       <div className="grid gap-3">
         <label className="grid gap-1 text-sm">
-          <span className="text-[var(--mm-text2)]">What is it?</span>
+          <span className="text-[var(--mm-text2)]">Which app is it?</span>
           <select
             data-testid="media-manager-kind"
             className={mmEditableTextFieldClass}
@@ -99,7 +109,7 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
         </label>
 
         <label className="grid gap-1 text-sm">
-          <span className="text-[var(--mm-text2)]">Address</span>
+          <span className="text-[var(--mm-text2)]">Where to find it</span>
           <input
             data-testid="media-manager-base-url"
             className={mmEditableTextFieldClass}
@@ -108,8 +118,8 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
             onChange={(e) => setForm({ ...form, base_url: e.target.value })}
           />
           <span className="text-xs text-[var(--mm-text2)]">
-            Where MediaMop reaches it, and where it reports finished work back
-            to.
+            The address you use to open this app in a browser. MediaMop uses it
+            to check the app is there, and to tell it when work is finished.
           </span>
         </label>
 
@@ -123,7 +133,7 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
             onChange={(e) => setForm({ ...form, api_key: e.target.value })}
           />
           <span className="text-xs text-[var(--mm-text2)]">
-            Stored encrypted. MediaMop never shows it again.
+            MediaMop stores this safely and never shows it again.
           </span>
         </label>
       </div>
@@ -178,7 +188,7 @@ function ConnectionCard({
           </h3>
           <p className="text-xs text-[var(--mm-text2)]">
             {MEDIA_MANAGER_KIND_LABELS[connection.kind]} ·{" "}
-            {connection.base_url || "no address saved"}
+            {connection.base_url || "no address yet"}
           </p>
         </div>
         <span className="text-xs text-[var(--mm-text2)]">
@@ -194,31 +204,43 @@ function ConnectionCard({
 
       <div className="mt-3 rounded-md border border-[var(--mm-border)] p-3">
         <p className="text-sm text-[var(--mm-text)]">
-          Point it at this address:
+          Tell {connection.name} to send its files here
         </p>
-        <code className="mt-1 block break-all text-xs text-[var(--mm-text2)]">
-          {connection.webhook_url_path}
+        <code
+          className="mt-1 block break-all text-xs text-[var(--mm-text2)]"
+          data-testid="media-manager-webhook-url"
+        >
+          {webhookUrl(connection)}
         </code>
+        <p className="mt-1 text-xs text-[var(--mm-text2)]">
+          Copy this into {connection.name}, so it knows where to send a file
+          when it wants MediaMop to work on one.
+        </p>
         {connection.webhook_secret_is_set ? (
           <p className="mt-2 text-xs text-[var(--mm-text2)]">
-            A secret is set. It must send it as <code>X-Webhook-Secret</code>.
+            {connection.name} also has to send its secret with every file.
+            Anything that turns up without it is ignored.
           </p>
         ) : (
           <p className="mt-2 text-xs text-[var(--mm-text2)]">
-            No secret set — anything that can reach MediaMop can post as this
-            manager.
+            There is no secret yet, so anything on your network could send files
+            here pretending to be {connection.name}. Generate one below and
+            paste it into {connection.name} as well.
           </p>
         )}
         {revealed ? (
-          <p
-            className="mt-2 break-all rounded bg-[var(--mm-card-bg)] p-2 text-xs text-[var(--mm-text)]"
+          <div
+            className="mt-2 rounded bg-[var(--mm-card-bg)] p-2 text-xs"
             data-testid="media-manager-secret"
           >
-            {revealed}
+            <code className="block break-all text-[var(--mm-text)]">
+              {revealed}
+            </code>
             <span className="mt-1 block text-[var(--mm-text2)]">
-              Copy it now — this is the only time it is shown.
+              Copy this into {connection.name} now — MediaMop will not show it
+              again.
             </span>
-          </p>
+          </div>
         ) : null}
       </div>
 
@@ -244,8 +266,8 @@ function ConnectionCard({
           }
         >
           {connection.webhook_secret_is_set
-            ? "Replace secret"
-            : "Generate secret"}
+            ? "Replace the secret"
+            : "Create a secret"}
         </button>
         <button
           type="button"
@@ -283,10 +305,10 @@ export function SettingsMediaManagersTab() {
     <div className="grid gap-4">
       <div className={mmModuleTabBlurbBandClass}>
         <p className={mmModuleTabBlurbTextClass}>
-          A media manager tells MediaMop about files. Radarr and Sonarr say a
-          file has been imported, so Subber goes looking for subtitles. Deluno
-          hands a file over before importing it, so Refiner cleans it and
-          reports back when it is ready.
+          These are the apps that send files to MediaMop. Radarr and Sonarr tell
+          MediaMop when they have added something, so it can go and find
+          subtitles for it. Deluno passes a file over before adding it, so
+          MediaMop can tidy it up first and say when it is ready.
         </p>
       </div>
 
@@ -296,8 +318,8 @@ export function SettingsMediaManagersTab() {
 
       {connections.data?.length === 0 && !adding ? (
         <p className="text-sm text-[var(--mm-text2)]">
-          No media managers yet. Nothing will be sent to MediaMop until one is
-          added.
+          No apps are connected yet, so nothing is being sent to MediaMop. Add
+          one below to get started.
         </p>
       ) : null}
 

--- a/docs/release-notes/v2.4.1.md
+++ b/docs/release-notes/v2.4.1.md
@@ -1,0 +1,33 @@
+# MediaMop v2.4.1
+
+Date: 2026-08-26
+
+This release makes the media managers screen readable, and fixes MediaMop telling other apps it does not exist.
+
+## What Changed
+
+- **Settings → Media managers** now shows the **full web address** to give your other app, instead of just the path. You can copy it straight across; before, there was nothing useful to copy.
+- The same screen is written in plain language throughout. It tells you what to do — "Tell Deluno to send its files here" — rather than describing how it works internally.
+- When a connection test fails, the message now says what to go and check, and names the app it was talking to.
+- The app picker explains what each app does, instead of naming the message types it sends.
+
+## Fixes And Stability
+
+- MediaMop answered "not found" to a **HEAD request**, which is the quick "are you there?" check other software uses before trusting a connection. Health checkers were told MediaMop did not exist, and at least one media manager reported a perfectly working MediaMop as unreachable. It now answers those checks properly.
+- A web address that exists but only accepts submissions now says so, instead of claiming there is nothing there at all.
+- Connection results are clearer about the difference between "MediaMop could not reach it at all" and "MediaMop reached it, but something was wrong" — the second is usually a wrong key or a wrong address, and is fixable from the screen you are already on.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings → Upgrade**.
+- Nothing to reconfigure. Existing media manager connections, secrets and settings carry across untouched.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.4.1`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.4.0...v2.4.1


### PR DESCRIPTION
## What was wrong

The card was accurate and unusable. From the live VM:

> Deluno · http://10.1.1.142:5099
> **http://10.1.1.142:5099 answered.**
> **Point it at this address:** `/api/v1/intake/webhook/deluno`
> A secret is set. It must send it as `X-Webhook-Secret`.

Every statement is true and every one assumes you already know how the feature works.

The path was the real defect. The API returns `/api/v1/intake/webhook/deluno` and the card printed exactly that — **you cannot paste a path into another app on another machine.** It now shows the full URL, built from the address MediaMop is actually being reached on.

## After

> **Tell Deluno to send its files here**
> `http://10.1.1.142:8788/api/v1/intake/webhook/deluno`
> Copy this into Deluno, so it knows where to send a file when it wants MediaMop to work on one.
> Deluno also has to send its secret with every file. Anything that turns up without it is ignored.

Same information, said plainly:

| Before | After |
|---|---|
| `http://10.1.1.142:5099 answered.` | `Connected. MediaMop can reach Deluno.` |
| `… is reachable but rejected the API key.` | `MediaMop reached Deluno, but the API key was refused. Check the key and save it again.` |
| `No address is saved for this manager yet.` | `Add the address where this app can be reached, then test again.` |
| `No secret set — anything that can reach MediaMop can post as this manager.` | `There is no secret yet, so anything on your network could send files here pretending to be Deluno.` |

Also:

- The kind picker says what each app **does** rather than naming its event types — "Tells MediaMop when it has added a film, so subtitles can be found for it" instead of "Sends its Download event when a film has been imported".
- The intro no longer mentions **Refiner** or **Subber**. Those are internal module names a new operator has no reason to know, and the sentence works better without them.
- Cards use the connection's own name throughout, so it reads as being about *Deluno*, not about "this manager".
- Failure messages now say **what to go and check**, which is the only thing that makes an error message worth printing.

## Gates

- Backend **866 passed, 2 skipped**; `ruff` and `mypy` clean across 303 files
- Web lint, format, build, **180 tests / 40 files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)