### PR TITLE
Run release validation alongside the Windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: apps/backend/pyproject.toml
 
       - name: Install MediaMop backend (editable) + Playwright browser
         run: |
@@ -67,6 +69,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
 
       - name: MediaMop agent documentation map
         run: node scripts/check-agent-docs.mjs
@@ -132,10 +136,14 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: apps/backend/pyproject.toml
 
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
 
       - uses: actions/setup-dotnet@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,9 @@
 # Tag-driven release: push tag v* -> full validation, Windows installer, Docker image, GitHub Release.
+#
+# windows-smoke and validate run in parallel: validation does not need the Windows
+# package, and waiting for it wasted about seven minutes of every release. publish
+# needs both, so nothing reaches ghcr or the Releases page unless the installer
+# built and the tests passed.
 name: Release
 
 on:
@@ -35,6 +40,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: apps/backend/pyproject.toml
 
       - name: Validate release version alignment
         shell: bash
@@ -76,6 +83,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
 
       - uses: actions/setup-dotnet@v6
         with:
@@ -166,14 +175,14 @@ jobs:
           if-no-files-found: error
           path: dist/windows/releases/*
 
-  tagged-release:
+  validate:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref_name, '-') }}
     timeout-minutes: 90
-    needs: windows-smoke
+    # Deliberately no `needs`: none of this touches the Windows package, so it runs
+    # while that builds instead of after it.
     permissions:
-      contents: write
-      packages: write
+      contents: read
     env:
       MEDIAMOP_SESSION_SECRET: ${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-release-session-secret-32chars-min
     steps:
@@ -182,6 +191,8 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: apps/backend/pyproject.toml
 
       - name: Install MediaMop backend (editable) and Playwright browser
         run: |
@@ -208,6 +219,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
 
       - name: MediaMop web - install and unit tests
         working-directory: apps/web
@@ -233,6 +246,34 @@ jobs:
           MEDIAMOP_HOME: ${{ runner.temp }}/mediamop-e2e
           PYTHONPATH: ${{ github.workspace }}/apps/backend/src
         run: python -m pytest tests/e2e/mediamop -q --tb=short
+
+      - name: Upload web dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: mediamop-web-dist
+          if-no-files-found: error
+          path: mediamop-web-dist.zip
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.ref_name, '-') }}
+    timeout-minutes: 60
+    # Both gates. Publishing on a green validation but a failed installer would put a
+    # Docker image on ghcr for a release that has no Windows build.
+    needs: [windows-smoke, validate]
+    permissions:
+      contents: write
+      packages: write
+    env:
+      MEDIAMOP_SESSION_SECRET: ${{ github.run_id }}-${{ github.job }}-${{ github.run_attempt }}-release-session-secret-32chars-min
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download web dist
+        uses: actions/download-artifact@v8
+        with:
+          name: mediamop-web-dist
+          path: ${{ github.workspace }}
 
       - name: Docker image name
         id: image

--- a/packaging/windows/build-velopack.ps1
+++ b/packaging/windows/build-velopack.ps1
@@ -5,6 +5,51 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# ── Phase timing ──
+# The Windows package build is the critical path of every release and nobody knew
+# where its minutes went, so it reports them. Each phase prints its own duration and
+# a summary lands at the end; on Actions the summary is also a ::notice:: so it shows
+# without opening the log.
+$script:PhaseTimings = [ordered]@{}
+$script:PhaseStopwatch = $null
+$script:PhaseName = $null
+
+function Start-BuildPhase {
+  param([Parameter(Mandatory)][string]$Name)
+  Stop-BuildPhase
+  $script:PhaseName = $Name
+  $script:PhaseStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+  Write-Host "--- $Name ---"
+}
+
+function Stop-BuildPhase {
+  if ($null -eq $script:PhaseStopwatch) { return }
+  $script:PhaseStopwatch.Stop()
+  $seconds = [math]::Round($script:PhaseStopwatch.Elapsed.TotalSeconds, 1)
+  $script:PhaseTimings[$script:PhaseName] = $seconds
+  Write-Host ("--- {0}: {1}s ---" -f $script:PhaseName, $seconds)
+  $script:PhaseStopwatch = $null
+  $script:PhaseName = $null
+}
+
+function Write-BuildPhaseSummary {
+  Stop-BuildPhase
+  if ($script:PhaseTimings.Count -eq 0) { return }
+  $total = ($script:PhaseTimings.Values | Measure-Object -Sum).Sum
+  Write-Host ""
+  Write-Host "=== Windows package build timings ==="
+  foreach ($entry in $script:PhaseTimings.GetEnumerator()) {
+    $share = if ($total -gt 0) { [math]::Round(100 * $entry.Value / $total) } else { 0 }
+    Write-Host ("  {0,-38} {1,7}s  {2,3}%" -f $entry.Key, $entry.Value, $share)
+  }
+  Write-Host ("  {0,-38} {1,7}s" -f "TOTAL", [math]::Round($total, 1))
+  if ($env:GITHUB_ACTIONS -eq "true") {
+    $parts = $script:PhaseTimings.GetEnumerator() | ForEach-Object { "$($_.Key) $($_.Value)s" }
+    Write-Host ("::notice title=Windows package build::" + ($parts -join ", "))
+  }
+}
+
+
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\\..")).Path
 $backendDir = Join-Path $repoRoot "apps\\backend"
 $webDir = Join-Path $repoRoot "apps\\web"
@@ -168,6 +213,7 @@ if ($buildVersion -ne $backendProjectVersion) {
 }
 
 # ── Python venv ──
+Start-BuildPhase "Python venv"
 if (-not (Test-Path $py)) {
   $systemPython = Resolve-SystemPython
   Push-Location $backendDir
@@ -179,6 +225,7 @@ if (-not (Test-Path $py)) {
 }
 
 # ── Web build ──
+Start-BuildPhase "Web build"
 if (-not $SkipWebBuild) {
   $webBuildRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-web-build-" + [System.Guid]::NewGuid().ToString("N"))
   $webBuildWebDir = Join-Path $webBuildRoot "apps\\web"
@@ -225,6 +272,7 @@ if (-not $SkipWebBuild) {
 }
 
 # ── Backend install + PyInstaller (server-only) ──
+Start-BuildPhase "Backend pip install"
 Push-Location $backendDir
 try {
   Invoke-Native -FilePath $py -ArgumentList @("-m", "ensurepip", "--upgrade")
@@ -251,6 +299,7 @@ if (Test-Path $distRoot) {
 New-Item -ItemType Directory -Path $distRoot | Out-Null
 
 # ── FFmpeg ──
+Start-BuildPhase "FFmpeg download + vendor"
 if (Test-Path -LiteralPath $ffmpegVendorDir) {
   Write-Host "Cleaning stale FFmpeg vendor folder..."
   Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
@@ -258,6 +307,7 @@ if (Test-Path -LiteralPath $ffmpegVendorDir) {
 Ensure-WindowsFfmpegRuntime
 
 # ── PyInstaller: server-only ──
+Start-BuildPhase "PyInstaller bundle"
 Push-Location $repoRoot
 try {
   Invoke-Native -FilePath $py -ArgumentList @("-m", "PyInstaller", "--noconfirm", "--clean", "--distpath", $distRoot, "--workpath", (Join-Path $distRoot "build"), $serverSpecPath)
@@ -276,6 +326,7 @@ if ($serverVersion -ne $buildVersion) {
 }
 
 # ── .NET tray app publish ──
+Start-BuildPhase ".NET tray publish"
 $trayPublishDir = Join-Path $distRoot "tray-publish"
 if (-not $SkipDotnetPublish) {
   Write-Host "Publishing .NET tray app..."
@@ -290,6 +341,7 @@ if (-not $SkipDotnetPublish) {
 }
 
 # ── Assemble Velopack pack directory ──
+Start-BuildPhase "Assemble pack dir"
 $packDir = Join-Path $distRoot "pack"
 if (Test-Path $packDir) {
   Remove-Item -LiteralPath $packDir -Recurse -Force
@@ -304,6 +356,7 @@ New-Item -ItemType Directory -Path $serverDestDir | Out-Null
 Copy-Item -Path (Join-Path $serverOutputDir "*") -Destination $serverDestDir -Recurse -Force
 
 # ── vpk pack ──
+Start-BuildPhase "vpk pack"
 Write-Host "Running vpk pack..."
 $vpk = Get-Command vpk -ErrorAction SilentlyContinue
 if (-not $vpk) {
@@ -335,3 +388,5 @@ Invoke-Native -FilePath $vpkExe -ArgumentList @(
 Write-Host ""
 Write-Host "Velopack packaging output:"
 Get-ChildItem -Path $velopackOut | Select-Object Name, Length
+
+Write-BuildPhaseSummary


### PR DESCRIPTION
Closes #319. Closes #320.

## #319 — the jobs were sequential but independent

Measured on the v2.4.1 release: **18m49s**, made of `windows-smoke` (10.7 min) then `tagged-release` (8.0 min), back to back because of `needs: windows-smoke`.

But `tagged-release` had 22 steps and did not touch anything the Windows job produced until **step 14**. Everything before it — backend tests, pip-audit, web unit tests, the production build, the Playwright E2E, and the entire Docker build/publish/verify/smoke sequence — is platform-independent. About seven minutes of Linux work sat waiting for a Windows package it did not need.

### The trap I nearly walked into

Simply removing `needs:` would have been worse than the delay it fixed. `tagged-release` publishes the Docker image *and* the GitHub Release. Run it in parallel and a green validation could push an image to ghcr for a release whose installer had just failed — a half-published release, which is worse than a slow one.

So the split is three jobs, not two:

| Job | `needs` | What it does |
|---|---|---|
| `windows-smoke` | — | Builds the Velopack package |
| `validate` | — | Every test, plus the web build |
| `publish` | `[windows-smoke, validate]` | Docker image + GitHub Release |

The Docker publish **moved into `publish`** rather than staying with the tests. Nothing reaches ghcr or the Releases page unless both gates are green — the same guarantee the sequential version gave, without the queue.

Expected wall clock: bounded by `windows-smoke`, so roughly **11 minutes** instead of the sum.

I did *not* skip the tests that `ci.yml` already ran on the same SHA. It looks like duplication, but once the jobs run in parallel it costs no wall clock at all, and re-verifying the exact tree being shipped is cheap insurance.

## #320 — no dependency caching

`ci.yml` and `release.yml` had none, so every job resolved and downloaded its full Python and npm dependency sets from scratch, and the release did it twice. Added `cache: pip` and `cache: npm` with explicit `cache-dependency-path` values.

Correcting my own issue: I wrote "no `actions/cache` step anywhere". **`docs.yml` already had `cache: npm`** — it was the other two that were missing it.

## #321 — instrumentation, not a fix

Left open deliberately. The Velopack build is 8.2 min and becomes the entire critical path once #319 lands, but I could not say where those minutes go, and my guess in the issue was **wrong**: I suggested ReadyToRun, and there is no `PublishReadyToRun` in that publish at all — it is `--self-contained -r win-x64` only.

What is actually in there: a from-scratch Python venv, a full `pip install --force-reinstall`, a PyInstaller bundle with `--clean`, an FFmpeg archive downloaded and verified **on every build** because the vendor folder is deleted first, a self-contained .NET publish, and `vpk pack` compressing ~176 MB.

Rather than guess again, the build now reports each phase's duration with a summary and an Actions notice. The next release produces the breakdown #321 asked for, and the decision can be made on numbers.

## Gates

Workflow YAML parsed and job graph verified; `build-velopack.ps1` parses cleanly. CI exercises all of it — `windows-package-smoke` runs the very script that was instrumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)