### PR TITLE
Stop re-downloading FFmpeg on every Windows package build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,19 @@ jobs:
           npm run api:types:check
           npm run build
 
+      # FFmpeg is ~46% of this job (203.8s of 444.9s measured on v2.4.1) and the
+      # vendor folder is gitignored, so every run started from nothing. The key
+      # rolls per run and restores the newest previous cache; the build script
+      # still checks the vendored copy against the current upstream checksum, so
+      # a stale restore is refreshed rather than shipped.
+      - name: Cache vendored FFmpeg
+        uses: actions/cache@v4
+        with:
+          path: packaging/windows/vendor/ffmpeg
+          key: ffmpeg-vendor-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            ffmpeg-vendor-${{ runner.os }}-
+
       - name: Build MediaMop Windows package (Velopack)
         run: powershell -ExecutionPolicy Bypass -File packaging/windows/build-velopack.ps1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,19 @@ jobs:
           npm run api:types:check
           npm run build
 
+      # FFmpeg is ~46% of this job (203.8s of 444.9s measured on v2.4.1) and the
+      # vendor folder is gitignored, so every run started from nothing. The key
+      # rolls per run and restores the newest previous cache; the build script
+      # still checks the vendored copy against the current upstream checksum, so
+      # a stale restore is refreshed rather than shipped.
+      - name: Cache vendored FFmpeg
+        uses: actions/cache@v4
+        with:
+          path: packaging/windows/vendor/ffmpeg
+          key: ffmpeg-vendor-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            ffmpeg-vendor-${{ runner.os }}-
+
       - name: Build MediaMop Windows package (Velopack)
         env:
           MEDIAMOP_BUILD_VERSION: ${{ steps.version.outputs.plain }}

--- a/packaging/windows/build-velopack.ps1
+++ b/packaging/windows/build-velopack.ps1
@@ -141,11 +141,46 @@ function Invoke-Native {
   }
 }
 
+function Get-ExpectedFfmpegSha256 {
+  # A few KB, against ~90 MB for the archive. Worth fetching every time so the
+  # rolling "latest" build is still tracked, rather than pinning whatever was
+  # vendored first.
+  $checksumsPath = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-ffmpeg-checksums-" + [System.Guid]::NewGuid().ToString("N") + ".sha256")
+  try {
+    Invoke-WebRequest -Uri $ffmpegChecksumsUrl -OutFile $checksumsPath -UseBasicParsing
+    $checksumsText = Get-Content -LiteralPath $checksumsPath -Raw
+    $checksumPattern = "(?im)^([a-f0-9]{64})\s+\*?$([regex]::Escape($ffmpegArchiveName))\s*$"
+    $checksumMatch = [regex]::Match($checksumsText, $checksumPattern)
+    if (-not $checksumMatch.Success) {
+      throw "FFmpeg checksum entry for '$ffmpegArchiveName' was not found in checksums.sha256."
+    }
+    return $checksumMatch.Groups[1].Value.ToLowerInvariant()
+  } finally {
+    if (Test-Path -LiteralPath $checksumsPath) {
+      Remove-Item -LiteralPath $checksumsPath -Force -ErrorAction SilentlyContinue
+    }
+  }
+}
+
 function Ensure-WindowsFfmpegRuntime {
   $ffmpegExe = Join-Path $ffmpegVendorDir "ffmpeg.exe"
   $ffprobeExe = Join-Path $ffmpegVendorDir "ffprobe.exe"
-  if ((Test-Path -LiteralPath $ffmpegExe) -and (Test-Path -LiteralPath $ffprobeExe)) {
-    return
+  $stampPath = Join-Path $ffmpegVendorDir ".ffmpeg-archive.sha256"
+
+  Write-Host "Resolving Windows FFmpeg checksum..."
+  $expectedSha256 = Get-ExpectedFfmpegSha256
+
+  # Reuse what is already vendored, but only when it came from exactly this
+  # archive. The stamp is what makes that safe to assert.
+  if ((Test-Path -LiteralPath $ffmpegExe) -and
+      (Test-Path -LiteralPath $ffprobeExe) -and
+      (Test-Path -LiteralPath $stampPath)) {
+    $vendoredSha256 = (Get-Content -LiteralPath $stampPath -Raw).Trim().ToLowerInvariant()
+    if ($vendoredSha256 -eq $expectedSha256) {
+      Write-Host "Vendored FFmpeg already matches upstream ($expectedSha256); skipping download."
+      return
+    }
+    Write-Host "Vendored FFmpeg is stale (have $vendoredSha256, want $expectedSha256); refreshing."
   }
 
   $downloadRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("mediamop-ffmpeg-" + [System.Guid]::NewGuid().ToString("N"))
@@ -155,15 +190,6 @@ function Ensure-WindowsFfmpegRuntime {
   try {
     New-Item -ItemType Directory -Path $downloadRoot | Out-Null
     New-Item -ItemType Directory -Path $extractRoot | Out-Null
-    Write-Host "Resolving Windows FFmpeg checksum..."
-    Invoke-WebRequest -Uri $ffmpegChecksumsUrl -OutFile $checksumsPath -UseBasicParsing
-    $checksumsText = Get-Content -LiteralPath $checksumsPath -Raw
-    $checksumPattern = "(?im)^([a-f0-9]{64})\s+\*?$([regex]::Escape($ffmpegArchiveName))\s*$"
-    $checksumMatch = [regex]::Match($checksumsText, $checksumPattern)
-    if (-not $checksumMatch.Success) {
-      throw "FFmpeg checksum entry for '$ffmpegArchiveName' was not found in checksums.sha256."
-    }
-    $expectedSha256 = $checksumMatch.Groups[1].Value.ToLowerInvariant()
     Write-Host "Downloading Windows FFmpeg runtime..."
     Invoke-WebRequest -Uri $ffmpegArchiveUrl -OutFile $archivePath -UseBasicParsing
     $actualSha256 = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -191,6 +217,9 @@ function Ensure-WindowsFfmpegRuntime {
       }
       Copy-Item -LiteralPath $src -Destination (Join-Path $ffmpegVendorDir $name) -Force
     }
+    # Written last, so a build interrupted mid-copy leaves no stamp and the next
+    # run re-downloads rather than trusting a half-populated folder.
+    Set-Content -LiteralPath (Join-Path $ffmpegVendorDir ".ffmpeg-archive.sha256") -Value $expectedSha256 -Encoding ascii
   } finally {
     if (Test-Path $downloadRoot) {
       Remove-Item -LiteralPath $downloadRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -300,10 +329,10 @@ New-Item -ItemType Directory -Path $distRoot | Out-Null
 
 # ── FFmpeg ──
 Start-BuildPhase "FFmpeg download + vendor"
-if (Test-Path -LiteralPath $ffmpegVendorDir) {
-  Write-Host "Cleaning stale FFmpeg vendor folder..."
-  Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
-}
+# Deliberately not deleted first. Doing so made the skip inside
+# Ensure-WindowsFfmpegRuntime unreachable and cost 203.8s of a 444.9s build. The
+# function decides for itself, by comparing the vendored copy against the current
+# upstream checksum, so a stale copy is still refreshed.
 Ensure-WindowsFfmpegRuntime
 
 # ── PyInstaller: server-only ──


### PR DESCRIPTION
Closes #321.

## The number

The instrumentation added in #324 answered this issue on its first CI run:

```
FFmpeg download + vendor   203.8s   46%
Web build                  132.3s   30%
PyInstaller bundle          41.5s    9%
vpk pack                    21.2s    5%
Backend pip install         20.4s    5%
.NET tray publish           18.8s    4%
Python venv                  6.2s    1%
Assemble pack dir            0.7s    0%
TOTAL                      444.9s
```

**FFmpeg is nearly half the build**, and my original guess in this issue — ReadyToRun — was wrong; there is no `PublishReadyToRun` in that publish at all. Worth stating plainly, because acting on the guess would have wasted someone's afternoon.

## Why it was happening

`Ensure-WindowsFfmpegRuntime` already skipped the download when a vendored copy existed:

```powershell
if ((Test-Path $ffmpegExe) -and (Test-Path $ffprobeExe)) { return }
```

But the step immediately before it deleted the folder:

```powershell
if (Test-Path $ffmpegVendorDir) {
  Write-Host "Cleaning stale FFmpeg vendor folder..."
  Remove-Item -LiteralPath $ffmpegVendorDir -Recurse -Force
}
Ensure-WindowsFfmpegRuntime
```

So the skip could never fire. ~90 MB fetched, checksum-verified and extracted on every build.

**The delete was not pointless.** The archive is `ffmpeg-master-latest-win64-lgpl.zip`, a rolling build. Simply removing the delete would pin whatever FFmpeg was vendored first and never pick up a new one — trading 200 seconds for a silently ageing dependency, which is a bad trade at any price.

## The fix keeps both

Resolve the upstream checksum **first** — a few KB against ~90 MB — then reuse the vendored copy only when a stamp written beside the binaries matches it:

- identical to upstream → skip the download entirely
- different → refresh, exactly as before
- no stamp → download, so a build interrupted mid-copy is never trusted

The stamp is written *after* the binaries are in place, which is what makes that last case safe.

## CI needed the other half

`packaging/windows/vendor/` is gitignored, so CI starts from an empty checkout and the script fix alone would change nothing there. Both workflows now cache the vendor folder with a key that rolls per run and `restore-keys` that pick up the newest previous cache.

A rolling key rather than a content-hash key because the content hash is not knowable before the restore. The script validates whatever comes back, so a stale cache is corrected rather than shipped — the cache is an optimisation, not the source of truth.

## Expected effect

The Windows package build should drop from ~445s to roughly ~245s on a cache hit, which makes it about 4 minutes rather than 7.4. Combined with #324's parallelisation, a release should land near 7 minutes against the 18m49s it took for v2.4.1.

Numbers to be confirmed from the next release's timing summary rather than assumed — the whole point of this issue was that guessing had already been wrong once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)