### PR TITLE
The media managers card should answer "is it connected"

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.4.1"
+version = "2.4.2"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -6462,7 +6462,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.4.1"
+    "version": "2.4.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/apps/web/src/lib/media-managers/media-managers-api.ts
+++ b/apps/web/src/lib/media-managers/media-managers-api.ts
@@ -10,7 +10,7 @@ export const MEDIA_MANAGER_KIND_LABELS: Record<MediaManagerKind, string> = {
   radarr: "Radarr",
   sonarr: "Sonarr",
   deluno: "Deluno",
-  native: "Other (MediaMop payload)",
+  native: "Something else",
 };
 
 export interface MediaManagerSearchLane {

--- a/apps/web/src/pages/settings/settings-media-managers-tab.test.tsx
+++ b/apps/web/src/pages/settings/settings-media-managers-tab.test.tsx
@@ -44,7 +44,7 @@ describe("SettingsMediaManagersTab", () => {
     render(<SettingsMediaManagersTab />, { wrapper });
 
     expect(
-      await screen.findByText(/No apps are connected yet/i),
+      await screen.findByText(/Nothing is connected yet/i),
     ).toBeInTheDocument();
   });
 
@@ -108,17 +108,73 @@ describe("SettingsMediaManagersTab", () => {
     expect(screen.getByText(/will not show it again/i)).toBeInTheDocument();
   });
 
-  it("reports a failed connection test in the words the API used", async () => {
+  it("says Connected, not what the endpoint replied", async () => {
+    vi.spyOn(api, "fetchMediaManagerConnections").mockResolvedValue([
+      connection({
+        last_test_ok: true,
+        last_test_at: "2026-08-26T10:00:00Z",
+        last_test_detail: "Connected. MediaMop can reach Deluno.",
+      }),
+    ]);
+    render(<SettingsMediaManagersTab />, { wrapper });
+
+    const status = await screen.findByTestId("media-manager-status");
+    expect(status).toHaveTextContent("Connected");
+    // The headline already says it. Repeating the backend's sentence underneath
+    // would be the same fact twice.
+    expect(status).not.toHaveTextContent("MediaMop can reach");
+  });
+
+  it("shows why a failed test failed, because that is the actionable part", async () => {
     vi.spyOn(api, "fetchMediaManagerConnections").mockResolvedValue([
       connection({
         last_test_ok: false,
+        last_test_at: "2026-08-26T10:00:00Z",
         last_test_detail:
           "MediaMop reached Deluno, but the API key was refused. Check the key and save it again.",
       }),
     ]);
     render(<SettingsMediaManagersTab />, { wrapper });
 
-    expect(await screen.findByText(/API key was refused/i)).toBeInTheDocument();
+    const status = await screen.findByTestId("media-manager-status");
+    expect(status).toHaveTextContent("Connection failed");
+    expect(status).toHaveTextContent(/API key was refused/i);
+  });
+
+  it("says it has not been checked rather than implying a result", async () => {
+    vi.spyOn(api, "fetchMediaManagerConnections").mockResolvedValue([
+      connection({ last_test_ok: null, last_test_at: null }),
+    ]);
+    render(<SettingsMediaManagersTab />, { wrapper });
+
+    const status = await screen.findByTestId("media-manager-status");
+    expect(status).toHaveTextContent("Not checked yet");
+    expect(status).toHaveTextContent("never");
+  });
+
+  it("keeps the address and secret folded away behind a disclosure", async () => {
+    vi.spyOn(api, "fetchMediaManagerConnections").mockResolvedValue([
+      connection(),
+    ]);
+    render(<SettingsMediaManagersTab />, { wrapper });
+
+    // The card answers "is it connected" first; wiring details are one click away.
+    const details = await screen.findByTestId("media-manager-setup-details");
+    expect(details.tagName.toLowerCase()).toBe("details");
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("does not name internal modules in the intro", async () => {
+    vi.spyOn(api, "fetchMediaManagerConnections").mockResolvedValue([]);
+    const { container } = render(<SettingsMediaManagersTab />, { wrapper });
+    await screen.findByText(/Nothing is connected yet/i);
+
+    // The intro used to explain Radarr, Sonarr, Deluno, Subber and Refiner in one
+    // breath. None of that helps someone deciding what this screen is for.
+    const text = container.textContent ?? "";
+    for (const word of ["Subber", "Refiner", "Pruner"]) {
+      expect(text).not.toContain(word);
+    }
   });
 
   it("adds a manager of a kind that never had columns of its own", async () => {

--- a/apps/web/src/pages/settings/settings-media-managers-tab.tsx
+++ b/apps/web/src/pages/settings/settings-media-managers-tab.tsx
@@ -16,7 +16,9 @@ import {
 import {
   mmActionButtonClass,
   mmEditableTextFieldClass,
+  mmTechnicalMonoSmallClass,
 } from "../../lib/ui/mm-control-roles";
+import { useAppDateFormatter } from "../../lib/ui/mm-format-date";
 import {
   mmModuleTabBlurbBandClass,
   mmModuleTabBlurbTextClass,
@@ -25,16 +27,13 @@ import { SUITE_SETTINGS_DASH_CARD_CLASS } from "./settings-shared";
 
 const KINDS: MediaManagerKind[] = ["radarr", "sonarr", "deluno", "native"];
 
-/** What each kind is for, in one line, so the picker is not just four names. */
+/** What choosing each one means, without naming what MediaMop does internally. */
 const KIND_BLURBS: Record<MediaManagerKind, string> = {
-  radarr:
-    "Tells MediaMop when it has added a film, so subtitles can be found for it.",
-  sonarr:
-    "Tells MediaMop when it has added an episode, so subtitles can be found for it.",
+  radarr: "Tells MediaMop when it has added a film.",
+  sonarr: "Tells MediaMop when it has added an episode.",
   deluno:
-    "Passes a finished download to MediaMop to clean up first, and waits to be told the tidied file is ready.",
-  native:
-    "Anything else that can send MediaMop a message. Use this if your app is not listed.",
+    "Hands a file to MediaMop to work on, and waits to be told it is ready.",
+  native: "Anything else that can send MediaMop a message.",
 };
 
 type FormState = {
@@ -52,16 +51,62 @@ const EMPTY_FORM: FormState = {
 };
 
 function webhookUrl(connection: MediaManagerConnection): string {
-  // The API returns a path, but the operator has to paste this into another app on
-  // another machine, so it needs the host MediaMop is actually reachable on.
+  // The API returns a path, but this gets pasted into another app on another
+  // machine, so it needs the host MediaMop is actually reachable on.
   if (typeof window === "undefined") return connection.webhook_url_path;
   return `${window.location.origin}${connection.webhook_url_path}`;
 }
 
-function testTone(connection: MediaManagerConnection): string {
-  if (connection.last_test_ok === true) return "text-emerald-400";
-  if (connection.last_test_ok === false) return "text-red-400";
-  return "text-[var(--mm-text2)]";
+/**
+ * The same shape Subber uses for its connections: a plain headline, when it was
+ * last checked, and the detail underneath. What an operator wants to know here is
+ * "is it connected", not what the endpoint said.
+ */
+function ConnectionStatusPanel({
+  connection,
+  fmt,
+}: {
+  connection: MediaManagerConnection;
+  fmt: (iso: string | null) => string;
+}) {
+  const headline =
+    connection.last_test_ok === null
+      ? "Not checked yet"
+      : connection.last_test_ok
+        ? "Connected"
+        : "Connection failed";
+
+  const tone =
+    connection.last_test_ok === null
+      ? "text-[var(--mm-text)]"
+      : connection.last_test_ok
+        ? "text-emerald-400"
+        : "text-red-400";
+
+  return (
+    <div
+      className="mt-4 rounded-md border border-[var(--mm-border)] bg-[var(--mm-card-bg)] p-3.5 text-sm text-[var(--mm-text2)]"
+      data-testid="media-manager-status"
+    >
+      <p className={`text-sm font-medium ${tone}`}>{headline}</p>
+      <p className="mt-1 text-xs text-[var(--mm-text2)]">
+        Last checked:{" "}
+        <span className="font-medium text-[var(--mm-text)]">
+          {connection.last_test_at ? fmt(connection.last_test_at) : "never"}
+        </span>
+      </p>
+      {connection.last_test_ok === false && connection.last_test_detail ? (
+        <p className="mt-1 text-xs text-red-400">
+          {connection.last_test_detail}
+        </p>
+      ) : null}
+      {connection.last_test_ok === null ? (
+        <p className="mt-2 text-xs text-[var(--mm-text2)]">
+          Run a test to check MediaMop can reach it.
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
@@ -118,8 +163,7 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
             onChange={(e) => setForm({ ...form, base_url: e.target.value })}
           />
           <span className="text-xs text-[var(--mm-text2)]">
-            The address you use to open this app in a browser. MediaMop uses it
-            to check the app is there, and to tell it when work is finished.
+            The address you use to open it in a browser.
           </span>
         </label>
 
@@ -167,8 +211,10 @@ function AddConnectionForm({ onCancel }: { onCancel: () => void }) {
 
 function ConnectionCard({
   connection,
+  fmt,
 }: {
   connection: MediaManagerConnection;
+  fmt: (iso: string | null) => string;
 }) {
   const update = useUpdateMediaManagerConnection();
   const remove = useDeleteMediaManagerConnection();
@@ -182,92 +228,25 @@ function ConnectionCard({
       data-testid="media-manager-card"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-2">
-        <div>
-          <h3 className="text-base font-medium text-[var(--mm-text)]">
-            {connection.name}
-          </h3>
-          <p className="text-xs text-[var(--mm-text2)]">
-            {MEDIA_MANAGER_KIND_LABELS[connection.kind]} ·{" "}
-            {connection.base_url || "no address yet"}
-          </p>
-        </div>
+        <h3 className="text-base font-medium text-[var(--mm-text)]">
+          {connection.name}
+        </h3>
         <span className="text-xs text-[var(--mm-text2)]">
           {connection.enabled ? "Enabled" : "Disabled"}
         </span>
       </div>
 
-      {connection.last_test_detail ? (
-        <p className={`mt-2 text-sm ${testTone(connection)}`}>
-          {connection.last_test_detail}
-        </p>
-      ) : null}
-
-      <div className="mt-3 rounded-md border border-[var(--mm-border)] p-3">
-        <p className="text-sm text-[var(--mm-text)]">
-          Tell {connection.name} to send its files here
-        </p>
-        <code
-          className="mt-1 block break-all text-xs text-[var(--mm-text2)]"
-          data-testid="media-manager-webhook-url"
-        >
-          {webhookUrl(connection)}
-        </code>
-        <p className="mt-1 text-xs text-[var(--mm-text2)]">
-          Copy this into {connection.name}, so it knows where to send a file
-          when it wants MediaMop to work on one.
-        </p>
-        {connection.webhook_secret_is_set ? (
-          <p className="mt-2 text-xs text-[var(--mm-text2)]">
-            {connection.name} also has to send its secret with every file.
-            Anything that turns up without it is ignored.
-          </p>
-        ) : (
-          <p className="mt-2 text-xs text-[var(--mm-text2)]">
-            There is no secret yet, so anything on your network could send files
-            here pretending to be {connection.name}. Generate one below and
-            paste it into {connection.name} as well.
-          </p>
-        )}
-        {revealed ? (
-          <div
-            className="mt-2 rounded bg-[var(--mm-card-bg)] p-2 text-xs"
-            data-testid="media-manager-secret"
-          >
-            <code className="block break-all text-[var(--mm-text)]">
-              {revealed}
-            </code>
-            <span className="mt-1 block text-[var(--mm-text2)]">
-              Copy this into {connection.name} now — MediaMop will not show it
-              again.
-            </span>
-          </div>
-        ) : null}
-      </div>
+      <ConnectionStatusPanel connection={connection} fmt={fmt} />
 
       <div className="mt-3 flex flex-wrap gap-2">
         <button
           type="button"
           data-testid="media-manager-test"
-          className={mmActionButtonClass({ variant: "secondary" })}
+          className={mmActionButtonClass({ variant: "primary" })}
           disabled={test.isPending}
           onClick={() => test.mutate(connection.id)}
         >
-          {test.isPending ? "Testing…" : "Test"}
-        </button>
-        <button
-          type="button"
-          data-testid="media-manager-generate-secret"
-          className={mmActionButtonClass({ variant: "secondary" })}
-          disabled={secret.isPending}
-          onClick={() =>
-            secret.mutate(connection.id, {
-              onSuccess: (data) => setRevealed(data.webhook_secret),
-            })
-          }
-        >
-          {connection.webhook_secret_is_set
-            ? "Replace the secret"
-            : "Create a secret"}
+          {test.isPending ? "Testing…" : "Test connection"}
         </button>
         <button
           type="button"
@@ -292,23 +271,82 @@ function ConnectionCard({
           Remove
         </button>
       </div>
+
+      {/* The address and secret are needed once, when wiring the other app up.
+          Folded away so the card answers "is it connected" at a glance. */}
+      <details
+        className="group mt-4 rounded-md border border-[var(--mm-border)] bg-black/10 px-4 py-3 text-xs text-[var(--mm-text3)]"
+        data-testid="media-manager-setup-details"
+      >
+        <summary className="cursor-pointer list-none font-medium text-[var(--mm-text2)] marker:hidden [&::-webkit-details-marker]:hidden">
+          <span className="underline-offset-2 group-open:underline">
+            How to point {connection.name} at MediaMop
+          </span>
+        </summary>
+
+        <div className="mt-3 border-t border-[var(--mm-border)] pt-3">
+          <p className="text-[var(--mm-text2)]">
+            In {connection.name}, send files to this address:
+          </p>
+          <code
+            className={`mt-1 block ${mmTechnicalMonoSmallClass}`}
+            data-testid="media-manager-webhook-url"
+          >
+            {webhookUrl(connection)}
+          </code>
+
+          <p className="mt-3 text-[var(--mm-text2)]">
+            {connection.webhook_secret_is_set
+              ? `${connection.name} must send its secret with every file. Anything without it is ignored.`
+              : `There is no secret yet, so anything on your network could send files here pretending to be ${connection.name}.`}
+          </p>
+
+          {revealed ? (
+            <div
+              className="mt-2 rounded bg-[var(--mm-card-bg)] p-2"
+              data-testid="media-manager-secret"
+            >
+              <code className={mmTechnicalMonoSmallClass}>{revealed}</code>
+              <span className="mt-1 block text-[var(--mm-text3)]">
+                Copy this into {connection.name} now — MediaMop will not show it
+                again.
+              </span>
+            </div>
+          ) : null}
+
+          <button
+            type="button"
+            data-testid="media-manager-generate-secret"
+            className={`mt-3 ${mmActionButtonClass({ variant: "secondary" })}`}
+            disabled={secret.isPending}
+            onClick={() =>
+              secret.mutate(connection.id, {
+                onSuccess: (data) => setRevealed(data.webhook_secret),
+              })
+            }
+          >
+            {connection.webhook_secret_is_set
+              ? "Replace the secret"
+              : "Create a secret"}
+          </button>
+        </div>
+      </details>
     </div>
   );
 }
 
-/** Settings: the media managers MediaMop accepts work from and reports back to. */
+/** Settings: the apps that send files to MediaMop. */
 export function SettingsMediaManagersTab() {
   const connections = useMediaManagerConnectionsQuery();
+  const fmt = useAppDateFormatter();
   const [adding, setAdding] = useState(false);
 
   return (
     <div className="grid gap-4">
       <div className={mmModuleTabBlurbBandClass}>
         <p className={mmModuleTabBlurbTextClass}>
-          These are the apps that send files to MediaMop. Radarr and Sonarr tell
-          MediaMop when they have added something, so it can go and find
-          subtitles for it. Deluno passes a file over before adding it, so
-          MediaMop can tidy it up first and say when it is ready.
+          The apps that send files to MediaMop. Connect one so MediaMop knows
+          when there is something to work on.
         </p>
       </div>
 
@@ -318,13 +356,13 @@ export function SettingsMediaManagersTab() {
 
       {connections.data?.length === 0 && !adding ? (
         <p className="text-sm text-[var(--mm-text2)]">
-          No apps are connected yet, so nothing is being sent to MediaMop. Add
-          one below to get started.
+          Nothing is connected yet, so no files are reaching MediaMop. Add an
+          app below to get started.
         </p>
       ) : null}
 
       {connections.data?.map((connection) => (
-        <ConnectionCard key={connection.id} connection={connection} />
+        <ConnectionCard key={connection.id} connection={connection} fmt={fmt} />
       ))}
 
       {adding ? (
@@ -337,7 +375,7 @@ export function SettingsMediaManagersTab() {
             className={mmActionButtonClass({ variant: "primary" })}
             onClick={() => setAdding(true)}
           >
-            Add a media manager
+            Add an app
           </button>
         </div>
       )}

--- a/docs/release-notes/v2.4.2.md
+++ b/docs/release-notes/v2.4.2.md
@@ -1,0 +1,32 @@
+# MediaMop v2.4.2
+
+Date: 2026-08-26
+
+This release makes **Settings → Media managers** answer the question you actually have: is it connected or not.
+
+## What Changed
+
+- Each connected app now shows a plain status — **Connected**, **Connection failed**, or **Not checked yet** — with when it was last checked. The same panel Subber already uses for its connections, so the two screens read the same way.
+- When a check fails, the reason is shown. When it succeeds, it just says Connected, instead of repeating the same fact in a second sentence.
+- The web address and secret an app needs are now folded away under **"How to point &lt;app&gt; at MediaMop"**. You need them once while wiring things up, not every time you glance at the screen.
+- The introduction no longer explains Radarr, Sonarr and Deluno in one breath, or name MediaMop's internal parts. It says what the screen is for.
+- **Test connection** is now the primary button on the card, since checking is the thing you came to do.
+
+## Fixes And Stability
+
+- No functional changes. This release is the screen only.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings → Upgrade**.
+- Nothing to reconfigure. Connections, secrets and settings carry across untouched.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.4.2`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.4.1...v2.4.2


### PR DESCRIPTION
## What was wrong

The screen explained itself instead of reporting.

**The intro** walked through five proper nouns in one breath:

> A media manager tells MediaMop about files. Radarr and Sonarr say a file has been imported, so Subber goes looking for subtitles. Deluno hands a file over before importing it, so Refiner cleans it and reports back when it is ready.

Two of those — **Subber** and **Refiner** — are MediaMop's own internals. Nobody outside the codebase has any reason to know them, and naming them does not help someone decide what this screen is for.

**The card** led with plumbing:

> Deluno · http://10.1.1.142:5099
> http://10.1.1.142:5099 answered.
> **Point it at this address:** `/api/v1/intake/webhook/deluno`
> A secret is set. It must send it as `X-Webhook-Secret`.

Nothing there is the question you opened the screen with, which is *is it connected, and did the last test pass.*

## After

The card uses **the same status panel Subber already uses** for its connections — a plain headline, when it was last checked, the reason underneath when it failed:

> **Deluno**                                          Enabled
> ┌─────────────────────────────────────────┐
> │ **Connected**                            │
> │ Last checked: 26 Aug 2026, 8:47 pm       │
> └─────────────────────────────────────────┘
> [ Test connection ] [ Disable ] [ Remove ]
> ▸ How to point Deluno at MediaMop

Two screens doing the same job now read the same way, which is the point of having a house pattern.

## The specific decisions

- **On success it says Connected and stops.** It used to also print *"Connected. MediaMop can reach Deluno."* underneath — the same fact twice. On failure the detail stays, because that is the part you can act on.
- **The address and secret moved behind a disclosure.** They are needed once, while wiring the other app up. They were taking the most valuable space on the card to tell you something you had already done.
- **Test connection is now the primary button.** Checking is what you came to do.
- **The intro is one sentence** and names nothing internal: *"The apps that send files to MediaMop. Connect one so MediaMop knows when there is something to work on."*

## Tests

Four new cases pin the behaviour rather than the wording: that success does not repeat itself, that failure shows its reason, that an unchecked connection says so rather than implying a result, and that the intro contains no internal module names.

Web CI green: lint, format, build, **184 tests / 40 files**.

Releases **2.4.2** — version bumped in both files with the OpenAPI snapshot resynced in the same commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)