### PR TITLE
docs: ADR-0014 and exec plan for the Refiner library model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,11 @@ This is the top-level map for agents and contributors. Deeper decisions live in 
 
 MediaMop is a self-hosted media operations app:
 
-- **Refiner** remuxes watched media into cleaner outputs.
+- **Refiner** remuxes watched media into cleaner outputs. It is configured today as two
+  fixed scopes, one movie and one TV, each a singleton settings row.
+  [ADR-0014](docs/adr/ADR-0014-refiner-libraries-replace-fixed-scopes.md) — *proposed,
+  not yet implemented* — replaces those scopes with any number of libraries, each with
+  its own paths, admission rules, remux rules, schedule and media manager.
 - **Pruner** previews and removes media from connected media servers.
 - **Media managers** are the products MediaMop accepts work from and reports back to.
   A connection carries a *kind* (Radarr, Sonarr, Deluno, or anything posting MediaMop's

--- a/docs/adr/ADR-0014-refiner-libraries-replace-fixed-scopes.md
+++ b/docs/adr/ADR-0014-refiner-libraries-replace-fixed-scopes.md
@@ -1,0 +1,174 @@
+# ADR-0014: A Refiner library is a row, not one of two fixed scopes
+
+## Status
+
+Proposed — applies to every Refiner path, rule, guardrail, schedule and job payload
+that currently partitions on `media_scope`.
+
+## Context
+
+Refiner is configured by exactly **two scopes**, `movie` and `tv`, and they are not
+data. They are the shape of the schema:
+
+- `refiner_path_settings` is one singleton row (`id = 1`) holding
+  `refiner_watched_folder`, `refiner_work_folder`, `refiner_output_folder` and then
+  the same three again as `refiner_tv_*`, plus two poll intervals.
+- `refiner_remux_rules_settings` is one singleton row holding ten fields, then the
+  same ten again `tv_`-prefixed.
+- `refiner_operator_settings` holds the guardrails — files at once, minimum file age,
+  minimum input size, minimum free disk — **globally**, shared by both scopes, plus a
+  schedule window per scope.
+
+This is the same shape ADR-0013 found in `arr_library_operator_settings` and removed:
+every setting written twice, once per hardcoded product. The cost is the same too. It
+is not the typing. It is that **a third path cannot exist without a migration**, so
+none ever has.
+
+Concretely, an operator who wants a 4K library processed with different audio rules, or
+a kids library with a different schedule, or a staging folder that is checked but never
+mutated, cannot have any of it. They get one movie folder and one TV folder.
+
+Three further consequences that only became visible while designing the surrounding
+work:
+
+**Admission rules are frozen in source.** `_MEDIA_EXTENSIONS` is five extensions in
+`refiner_remux_rules.py`; `_TRANSIENT_DOWNLOAD_DIR_MARKERS` is a fixed set of
+downloader-staging markers in the scan ops module. Neither is reachable by an operator,
+and neither can differ between libraries that genuinely need different answers.
+
+**The media manager is inferred from the scope.** `credentials.py` maps
+`{"movie": "radarr", "tv": "sonarr"}` and falls back to a general kind. ADR-0013 already
+made a connection a row with a `kind`; this inference is the last place that treats the
+mapping as fixed. It breaks the moment a manager serves both scopes — Deluno does — or
+two connections could serve the same one.
+
+**The manager already knows the answer.** Deluno publishes
+`GET /api/integrations/external/manifest` whose documented purpose is to say which
+libraries exist and which roots are configured. MediaMop asks the operator to retype it,
+and can only accept two of them.
+
+## Decision
+
+### 1. A library is a row
+
+`refiner_libraries` holds one row per library. `media_scope` becomes a **property of a
+library** — it still selects the movie or TV cleanup behaviour — rather than the key the
+whole module partitions on.
+
+Each row carries what is today spread across three singletons:
+
+| Group | Fields |
+|---|---|
+| Identity | name, enabled, media scope, display order |
+| Paths | watched, work, output |
+| Admission | extensions, include patterns, exclude patterns, min/max size, min age, created and modified windows |
+| Timing | scan interval, hold minutes, file-detection interval, schedule |
+| Capacity | max concurrent files, priority |
+| Manager | connection reference(s) |
+
+### 2. Admission rules are data on the row, not constants in a module
+
+`_MEDIA_EXTENSIONS` and `_TRANSIENT_DOWNLOAD_DIR_MARKERS` become that library's saved
+values, seeded from today's constants so nothing changes on upgrade. The hash-stem
+staging heuristic stays built in — it is a shape, not a preference — but the marker list
+is editable.
+
+### 3. Rules are a named object a library points at
+
+Not inline. Two libraries that want identical audio and subtitle handling should share
+one rule set, and changing it once should change both. Inline is simpler for exactly one
+library, which is the situation this ADR exists to end.
+
+A library references a rule set; a rule set is not owned by any library. Deleting a rule
+set still referenced is refused.
+
+### 4. A library names its manager connection explicitly
+
+The `{"movie": "radarr", "tv": "sonarr"}` inference is retired. A library states which
+media manager connection(s) cover it.
+
+**Multiple connections are permitted and are the edge case.** A library may name more
+than one — two Radarr instances, or Radarr alongside Deluno during a migration — in
+which case Refiner asks all of them and treats an in-progress import reported by *any*
+as blocking. The UI defaults to one and must not make the common case harder to
+configure.
+
+This is also what makes library discovery coherent: a library imported from a manager
+arrives already knowing which manager it came from.
+
+### 5. Job payloads gain a library reference as an additive field
+
+`refiner.file.remux_pass.v1` and the scan dispatch family keep their job kind. A
+`library_id` is added alongside the existing `media_scope`, and a payload without one
+resolves to the seeded library for its scope.
+
+A new job-kind version is rejected: a version bump would strand every row already queued
+at upgrade time, and the queue is exactly where a half-finished remux lives. The
+additive field costs one fallback branch and strands nothing.
+
+### 6. Upgrade is a behavioural no-op
+
+The migration seeds two libraries, "Movies" and "TV", from the existing singleton rows,
+carrying every current value including the hardcoded extension and marker lists as saved
+defaults. It links each to whichever manager connection the current inference would have
+chosen.
+
+**No operator reconfiguration on upgrade.** This is the hard constraint the design is
+answerable to, not a nice-to-have.
+
+## Consequences
+
+- Adding a library is a POST. No migration.
+- Every guardrail currently global becomes per-library. `refiner_operator_settings`
+  keeps only what is genuinely suite-wide.
+- The singleton path and rules tables are dropped once nothing reads them, in a later
+  migration than the one that seeds from them, so a rollback has somewhere to land.
+- Deleting a library must be guarded: it may not orphan queued or leased jobs.
+- Discovery ([#351]) and the media manager port ([#350]) both depend on this shape, and
+  neither is in scope here.
+
+## Relationship to existing ADRs
+
+**ADR-0012 (Refiner preflight parity boundary) is untouched.** That ADR bounds parity
+work to probe depth and observability, and requires a follow-up ADR for anything beyond.
+Nothing here is preflight depth — this is configuration ownership and storage — so its
+boundary neither constrains this decision nor is loosened by it. `probe_size_mb` and
+`analyze_duration_seconds` stay on `MediaMopSettings` per ADR-0008.
+
+**ADR-0013 (a media manager is a kind) is completed, not changed.** That ADR made a
+connection a row with a kind and stated the principle that callers want *the manager that
+knows about movies*, not Radarr. Refiner never adopted it. Decision 4 above is that
+adoption. What a connection *is* does not change; who consults it, and how it is chosen,
+does.
+
+**ADR-0009 (suite-wide timing isolation) is respected, and a library schedule is not a
+second timing authority.** ADR-0009 governs *when a job family ticks*. A library schedule
+governs *whether a file in that library is eligible right now*. A family still owns its
+own interval and its own persisted timing state; the library schedule is an eligibility
+predicate the family consults, in the same way it already consults `movie_schedule_*`
+today. Where a family ticks for several libraries, it keeps one timing state per family
+per scope as ADR-0009 requires, and evaluates eligibility per library inside the tick.
+
+**ADR-0007 (module-owned worker lanes) is unchanged.** Libraries do not add a lane, a
+prefix, or a queue. Everything stays on `refiner_jobs` under `refiner.*`.
+
+## Out of scope
+
+- The media manager port itself ([#350]) — the dialects, the fan-out, and the
+  no-queue-signal outcome. This ADR only settles that a library names its connections.
+- Library discovery from a manager ([#351]).
+- Whether Pruner adopts the same library shape. It has its own instance model and its
+  own constraints in `docs/pruner-forward-design-constraints.md`; folding the two is a
+  separate decision that should not be smuggled in here.
+
+## Related
+
+- [ADR-0007](ADR-0007-module-owned-worker-lanes.md) — module-owned worker lanes
+- [ADR-0008](ADR-0008-mediamop-settings-aggregate-runtime-config.md) — settings aggregate
+- [ADR-0009](ADR-0009-suite-wide-timing-isolation.md) — suite-wide timing isolation
+- [ADR-0012](ADR-0012-refiner-preflight-parity-boundary.md) — preflight parity boundary
+- [ADR-0013](ADR-0013-media-managers-are-kinds-not-products.md) — a media manager is a kind
+- Execution plan: [`docs/exec-plans/active/refiner-library-model.md`](../exec-plans/active/refiner-library-model.md)
+
+[#350]: https://github.com/jampat000/MediaMop/issues/350
+[#351]: https://github.com/jampat000/MediaMop/issues/351

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,4 @@ and timing-based pruning must follow [ADR-0009](ADR-0009-suite-wide-timing-isola
 | [ADR-0009](ADR-0009-suite-wide-timing-isolation.md) | Suite-wide timing isolation (durable work) |
 | [ADR-0012](ADR-0012-refiner-preflight-parity-boundary.md) | Refiner preflight parity boundary (FileFlows-aligned) |
 | [ADR-0013](ADR-0013-media-managers-are-kinds-not-products.md) | A media manager is a kind, not a product name |
+| [ADR-0014](ADR-0014-refiner-libraries-replace-fixed-scopes.md) | A Refiner library is a row, not one of two fixed scopes |

--- a/docs/exec-plans/active/refiner-library-model.md
+++ b/docs/exec-plans/active/refiner-library-model.md
@@ -1,0 +1,128 @@
+# Plan: Refiner library model
+
+## Goal
+
+An operator can configure any number of Refiner libraries — each with its own paths,
+admission rules, remux rules, schedule, guardrails and media manager — instead of one
+movie folder and one TV folder. Upgrading an existing install changes nothing an
+operator can observe until they choose to add a library.
+
+Decision record: [ADR-0014](../../adr/ADR-0014-refiner-libraries-replace-fixed-scopes.md).
+Tracking epic: [#347](https://github.com/jampat000/MediaMop/issues/347).
+
+## Current State
+
+- `refiner_path_settings` — singleton row, movie paths plus `refiner_tv_*` duplicates.
+- `refiner_remux_rules_settings` — singleton row, ten fields plus `tv_` duplicates.
+- `refiner_operator_settings` — global guardrails, per-scope schedule windows.
+- `_MEDIA_EXTENSIONS` and `_TRANSIENT_DOWNLOAD_DIR_MARKERS` are module constants.
+- `credentials.py` infers the manager from `{"movie": "radarr", "tv": "sonarr"}`.
+- `media_scope` is the partition key for the scan dispatch, remux pass, cleanup and
+  sweep families.
+
+Baseline at the time of writing: 763 backend tests, 166 web tests, coverage 77.62%
+against a 70% CI floor, `alembic check` clean.
+
+## Scope
+
+- `apps/backend/src/mediamop/modules/refiner/` — path, rules and operator settings
+  models, services, schemas and APIs; the four job families that resolve configuration.
+- `apps/backend/alembic/versions/` — new tables, seed, and a later drop.
+- `apps/backend/src/mediamop/platform/media_managers/credentials.py` — retire the
+  scope-to-kind inference.
+- `apps/web/src/pages/refiner/` and `apps/web/src/lib/refiner/` — Libraries screen.
+- `docs/adr/`, `ARCHITECTURE.md`, `docs/settings-truthfulness-audit.md`.
+
+## Non-Goals
+
+- The media manager port and its dialects ([#350]) — a prerequisite, tracked separately.
+- Library discovery from a manager ([#351]).
+- Any change to Pruner's instance model.
+- Any change to preflight probe depth — ADR-0012's boundary is untouched.
+- File states, hold timers, watcher, schedules-gate-processing, runner units, retry, and
+  per-file logs. All of them sit on top of this and are separately tracked.
+
+## Acceptance Criteria
+
+- An operator can create, edit, reorder, disable and delete a Refiner library.
+- A third library processes independently of the seeded two, with its own paths, rules,
+  schedule and guardrails.
+- After upgrade and before any operator action, Refiner behaves **identically**: same
+  folders, same rules, same guardrails, same schedule, same manager.
+- Deleting a library with queued or leased jobs is refused with a clear reason.
+- Extensions and exclusion markers are editable per library and seeded from today's
+  constants.
+- A library names its manager connection(s); no code path infers a manager from scope.
+- Full CRUD over `/api/v1/refiner/libraries` with OpenAPI regenerated and no drift.
+- `pytest -q --cov=mediamop --cov-fail-under=70`, `ruff check src tests`, `mypy src/mediamop`,
+  `alembic upgrade head && alembic check`, `npm run lint`, `npm run format`,
+  `npm run build`, `npm run test`, `npm run api:types:check` all pass.
+- E2E smoke passes.
+
+## Steps
+
+Each step is a PR that leaves `main` releasable.
+
+1. **Prerequisite: media manager port ([#350]).** Refiner stops naming Radarr and Sonarr
+   and gains a fan-out port. Lands first because step 5 needs somewhere for a library's
+   manager reference to point, and because it is independent of this schema.
+
+2. **Schema and seed.** Add `refiner_libraries` and `refiner_rule_sets`. Migration seeds
+   "Movies" and "TV" from the singleton rows, carrying every current value and the two
+   module constants as saved defaults. **Nothing reads the new tables yet.** A rollback at
+   this point is a table drop.
+
+3. **Read path.** Every family resolves configuration by library instead of by scope,
+   still reading only the two seeded rows. No UI, no CRUD. This is the step that proves
+   the no-op: the full suite must pass unchanged.
+
+4. **Job payloads.** Add `library_id` alongside `media_scope`, with a payload lacking one
+   resolving to the seeded library for its scope. Test a pre-upgrade payload explicitly.
+
+5. **Manager binding.** A library names its connection(s). Retire the scope-to-kind
+   inference in `credentials.py`. Migration links the seeded libraries to whatever the
+   inference would have chosen.
+
+6. **CRUD and API.** `/api/v1/refiner/libraries` and `/api/v1/refiner/rule-sets`, with
+   deletion guards. OpenAPI regenerated.
+
+7. **Libraries screen.** Replaces the current Libraries tab. Add, edit, reorder, enable,
+   disable, delete.
+
+8. **Drop the singletons.** A separate migration, only once nothing reads them, so steps
+   2 through 7 each have somewhere to roll back to.
+
+9. **Docs.** `ARCHITECTURE.md`, `docs/settings-truthfulness-audit.md`, and move this plan
+   to `completed/`.
+
+## Risks
+
+- **Silent path repointing.** A library's watched folder is the input to source-folder
+  deletion. Any migration or edit that changes a path without the operator intending it is
+  destructive. Migrations copy values verbatim; edits require explicit save.
+- **Coverage floor.** 7.6 points of headroom above the 70% CI floor. Steps 2, 6 and 7 add
+  significant code; each PR carries its own tests rather than deferring them.
+- **The no-op claim is the whole risk.** Step 3 is where it is proven or lost. If the full
+  suite does not pass unchanged there, stop rather than adjusting tests to fit.
+
+## Validation Log
+
+- 2026-08-28 — baseline recorded: 763 backend tests, 166 web tests, coverage 77.62%,
+  `alembic check` reports no new upgrade operations, working tree clean at `07c5fab`.
+
+## Decisions
+
+- 2026-08-28 — **Rule sets are a named object, not inline on the library.** Inline is
+  simpler for one library, which is the situation this plan exists to end. ADR-0014 §3.
+- 2026-08-28 — **`library_id` is an additive payload field, not a new job-kind version.**
+  A version bump would strand rows already queued at upgrade, and the queue is where a
+  half-finished remux lives. ADR-0014 §5.
+- 2026-08-28 — **A library names its manager explicitly; the scope-to-kind inference is
+  retired.** It cannot express a manager serving both scopes, which Deluno does.
+  ADR-0014 §4.
+- 2026-08-28 — **[#350] lands before step 2.** Writing the ADR's manager-binding decision
+  against a real port is more reliable than against a planned one, and #350 changes no
+  schema so it is a clean first PR.
+
+[#350]: https://github.com/jampat000/MediaMop/issues/350
+[#351]: https://github.com/jampat000/MediaMop/issues/351


### PR DESCRIPTION
Closes #332.

Documentation only — no code, no schema, no behaviour change.

## What this decides

Refiner's two hardcoded scopes become rows. `ADR-0014` settles the eight questions #332 listed; the exec plan sequences the work as nine PRs that each leave `main` releasable.

Four decisions worth reviewing specifically, because each had a defensible alternative:

**Rule sets are a named object, not inline on the library.** Inline is simpler for exactly one library — which is the situation this ADR exists to end. Two libraries wanting identical handling should share one rule set and change it once.

**`library_id` is an additive payload field, not a new job-kind version.** A version bump strands every row already queued at upgrade, and the queue is precisely where a half-finished remux lives. The additive field costs one fallback branch and strands nothing.

**A library names its manager connection explicitly.** The `{"movie": "radarr", "tv": "sonarr"}` inference in `credentials.py` cannot express a manager that serves both scopes — Deluno does — or two connections serving one scope. This is the ADR-0013 adoption Refiner never made; #350 builds the port it points at.

**Upgrade is a behavioural no-op**, and the plan proves it at step 3 before any UI exists. If the full suite does not pass unchanged there, stop rather than adjust tests to fit.

## Relationship to existing ADRs

- **ADR-0012 is untouched.** Its boundary limits parity work to probe depth and observability. Configuration ownership is not probe depth, so this neither breaches nor loosens it.
- **ADR-0013 is completed, not changed.** What a connection *is* stays the same; who consults it, and how it is chosen, changes.
- **ADR-0009 is respected.** A library schedule is an eligibility predicate a family consults inside its tick, not a second timing authority. Families keep their own interval and persisted timing state.
- **ADR-0007 is unchanged.** No new lane, prefix or queue.

## On ARCHITECTURE.md

The first draft described libraries in the present tense, which would have been the exact settings-truthfulness problem #329 exists to fix. It now says plainly that ADR-0014 is proposed and not yet implemented.

## Validation

- `node scripts/check-agent-docs.mjs` — valid
- `npm run format` — clean
- Baseline unchanged: 763 backend tests, 166 web tests, coverage 77.62%, `alembic check` reports no new upgrade operations

## Next

Per the plan, **#350** lands before step 2 — it changes no schema, and writing the manager-binding decision against a real port beats writing it against a planned one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
