### PR TITLE
fix(ci): lint and format the Alembic migrations

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -10,7 +10,7 @@ else
     PRETTIER="$REPO/apps/web/node_modules/prettier/bin/prettier.cjs"
     if [ -f "$RUFF" ]; then
         echo "[pre-push] ruff..."
-        (cd "$REPO/apps/backend" && "$RUFF" check src tests && "$RUFF" format --check src tests)
+        (cd "$REPO/apps/backend" && "$RUFF" check src tests alembic && "$RUFF" format --check src tests alembic)
     fi
     if [ -f "$PRETTIER" ]; then
         echo "[pre-push] prettier..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: MediaMop backend lint
         working-directory: apps/backend
-        run: ruff check src tests
+        run: |
+          ruff check src tests alembic
+          ruff format --check src tests alembic
 
       - name: Backend security scan (bandit)
         working-directory: apps/backend

--- a/apps/backend/alembic/versions/0003_pruner_auto_apply_snapshot_limits.py
+++ b/apps/backend/alembic/versions/0003_pruner_auto_apply_snapshot_limits.py
@@ -6,9 +6,9 @@ Revises: 0002_mediamop_schema_tip
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 revision: str = "0003_pruner_auto_apply_snapshot_limits"
 down_revision: str | None = "0002_mediamop_schema_tip"

--- a/apps/backend/alembic/versions/0004_pruner_uniqueness_constraints.py
+++ b/apps/backend/alembic/versions/0004_pruner_uniqueness_constraints.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 
 from urllib.parse import urlparse, urlunparse
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 revision: str = "0004_pruner_uniqueness_constraints"
 down_revision: str | None = "0003_pruner_auto_apply_snapshot_limits"
@@ -24,7 +24,11 @@ def _normalize(raw: str) -> str:
     path = parsed.path if parsed.netloc else ("/" + parsed.path.split("/", 1)[1] if "/" in parsed.path else "")
     host = (parsed.hostname or netloc.split(":", 1)[0]).lower()
     port = parsed.port
-    canon_netloc = host if port is None or (scheme == "http" and port == 80) or (scheme == "https" and port == 443) else f"{host}:{port}"
+    canon_netloc = (
+        host
+        if port is None or (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+        else f"{host}:{port}"
+    )
     return urlunparse((scheme, canon_netloc, path.rstrip("/"), "", "", "")).rstrip("/")
 
 
@@ -36,7 +40,9 @@ def upgrade() -> None:
             "pruner_server_instances",
             sa.Column("normalized_base_url", sa.String(length=512), nullable=False, server_default=""),
         )
-    rows = list(bind.execute(sa.text("select id, provider, base_url from pruner_server_instances order by id asc")).mappings())
+    rows = list(
+        bind.execute(sa.text("select id, provider, base_url from pruner_server_instances order by id asc")).mappings()
+    )
     seen: dict[tuple[str, str], int] = {}
     for row in rows:
         norm = _normalize(str(row["base_url"]))
@@ -46,8 +52,12 @@ def upgrade() -> None:
         )
         key = (str(row["provider"]), norm)
         if key in seen:
-            bind.execute(sa.text("delete from pruner_scope_settings where server_instance_id = :id"), {"id": int(row["id"])})
-            bind.execute(sa.text("delete from pruner_preview_runs where server_instance_id = :id"), {"id": int(row["id"])})
+            bind.execute(
+                sa.text("delete from pruner_scope_settings where server_instance_id = :id"), {"id": int(row["id"])}
+            )
+            bind.execute(
+                sa.text("delete from pruner_preview_runs where server_instance_id = :id"), {"id": int(row["id"])}
+            )
             bind.execute(sa.text("delete from pruner_server_instances where id = :id"), {"id": int(row["id"])})
         else:
             seen[key] = int(row["id"])
@@ -55,7 +65,10 @@ def upgrade() -> None:
     inspector = sa.inspect(bind)
     idx = {i["name"] for i in inspector.get_indexes("pruner_server_instances")}
     unique = {u["name"] for u in inspector.get_unique_constraints("pruner_server_instances")}
-    if "uq_pruner_server_provider_normalized_url" not in idx and "uq_pruner_server_provider_normalized_url" not in unique:
+    if (
+        "uq_pruner_server_provider_normalized_url" not in idx
+        and "uq_pruner_server_provider_normalized_url" not in unique
+    ):
         op.create_index(
             "uq_pruner_server_provider_normalized_url",
             "pruner_server_instances",

--- a/apps/backend/alembic/versions/0005_refiner_guardrail_settings.py
+++ b/apps/backend/alembic/versions/0005_refiner_guardrail_settings.py
@@ -6,9 +6,9 @@ Revises: 0004_pruner_uniqueness_constraints
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
 
+from alembic import op
 
 revision: str = "0005_refiner_guardrail_settings"
 down_revision: str | None = "0004_pruner_uniqueness_constraints"

--- a/apps/backend/alembic/versions/0006_trusted_device_sessions.py
+++ b/apps/backend/alembic/versions/0006_trusted_device_sessions.py
@@ -7,10 +7,10 @@ Create Date: 2026-05-01 09:58:00
 
 from __future__ import annotations
 
-from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import inspect
 
+from alembic import op
 
 revision = "0006_trusted_device_sessions"
 down_revision = "0005_refiner_guardrail_settings"

--- a/apps/backend/alembic/versions/0008_notification_channels.py
+++ b/apps/backend/alembic/versions/0008_notification_channels.py
@@ -8,8 +8,9 @@ Create Date: 2026-05-12 00:00:00
 from __future__ import annotations
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy import inspect
+
+from alembic import op
 
 revision = "0008_notification_channels"
 down_revision = "0007_indexes_and_retry_backoff"

--- a/apps/backend/alembic/versions/0009_media_manager_connections.py
+++ b/apps/backend/alembic/versions/0009_media_manager_connections.py
@@ -18,8 +18,9 @@ Create Date: 2026-08-26 00:00:00
 from __future__ import annotations
 
 import sqlalchemy as sa
-from alembic import op
 from sqlalchemy import inspect
+
+from alembic import op
 
 revision = "0009_media_manager_connections"
 down_revision = "0008_notification_channels"

--- a/scripts/pre-push-check.ps1
+++ b/scripts/pre-push-check.ps1
@@ -32,12 +32,12 @@ if (-not (Test-Path $ruff)) {
 } else {
     Step "ruff"
     Push-Location "$REPO\apps\backend"
-    & $ruff check src tests
+    & $ruff check src tests alembic
     if ($LASTEXITCODE -ne 0) { Pop-Location; Fail "ruff check failed" }
-    & $ruff format --check src tests
+    & $ruff format --check src tests alembic
     if ($LASTEXITCODE -ne 0) {
         Pop-Location
-        Write-Host "  Fix: ruff format src tests" -ForegroundColor Yellow
+        Write-Host "  Fix: ruff format src tests alembic" -ForegroundColor Yellow
         Fail "ruff format --check failed"
     }
     Pop-Location


### PR DESCRIPTION
Closes #330. Part of #347. Milestone v2.4.3.

CI ran `ruff check src tests`; the pre-push hook added `ruff format --check src tests`. `apps/backend/alembic/` was in neither — the highest-consequence Python in the repo was the only Python nothing linted. Confirmed the drift on `main` before touching anything: **6 `I001` errors** across `0003`, `0004`, `0005`, `0006`, `0008`, `0009`, and **1 file** that `ruff format --check` would reformat.

## What changed

**The drift, fixed** — imports and line wrapping only. No logic edits to any migration. The whole diff is `from alembic import op` moving below the third-party block, plus four expressions in `0004` re-wrapped across lines with identical operands and order.

**The gap, closed** — `alembic` is now covered in `.github/workflows/ci.yml`, `scripts/pre-push-check.ps1`, and the `.githooks/pre-push` Linux fallback.

CI also gains `ruff format --check`, which it never ran at all — the format check existed only in the local hook, so a push from a machine without the hook installed could land unformatted code. `src` and `tests` already pass it, so widening it costs nothing today.

## Validation beyond the linters

A formatter reflowing a migration is low-risk but not zero-risk, so:

- `alembic upgrade head` + `alembic check` on a **fresh** database — succeeds, no new upgrade operations
- `pytest -q` — 763 passed, 2 skipped, unchanged from `main`
- `0004`'s `_normalize` is the one reflowed expression a fresh database never exercises (it only runs against pre-existing rows). Diffed against its pre-format self across 13 URL shapes — default ports, uppercase hosts, embedded credentials, missing scheme, trailing slashes — **zero mismatches**.

## Note on scope

The issue is milestone v2.4.3 and this PR is independent of #350 (v2.5.0), so it can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
