### PR TITLE
fix(refiner): three settings that do not describe what the code does

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -103,12 +103,10 @@ MEDIAMOP_PRUNER_WORKER_COUNT=1
 # MEDIAMOP_REFINER_TV_OUTPUT_CLEANUP_MIN_AGE_SECONDS=172800
 
 # Refiner — watched-folder remux scan dispatch (``refiner.watched_folder.remux_scan_dispatch.v1``) periodic enqueue.
-# Refiner-only asyncio tick (same pattern as supplied payload evaluation schedule). Not a filesystem watcher.
-# Does not share interval/enable state with other Refiner families. Restart API after changes.
-# MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED=0
-# MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_INTERVAL_SECONDS=3600
-# Optional remux enqueue for periodic ticks only (manual UI unchanged):
-# MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS=0
+# Whether each scope is scanned, and how often, lives on the Refiner Libraries tab (per scope, in the
+# database, no restart needed) — there is no environment variable for it. Not a filesystem watcher.
+# Whether those periodic ticks may also queue file work is set here. Default is 1 (they do). Restart API after changes:
+# MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS=1
 
 # Refiner — work/temp stale sweep (``refiner.work_temp_stale_sweep.v1``) periodic enqueue — **per scope** (Movies vs TV).
 # Each scope has its own enable + interval dedupe row. Legacy vars apply to **both** scopes when per-scope vars are unset:

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -159,10 +159,9 @@ class MediaMopSettings:
     # Refiner supplied payload evaluation (``refiner.supplied_payload_evaluation.v1``) — Refiner-only schedule.
     refiner_supplied_payload_evaluation_schedule_enabled: bool
     refiner_supplied_payload_evaluation_schedule_interval_seconds: int
-    # Refiner watched-folder remux scan dispatch (``refiner.watched_folder.remux_scan_dispatch.v1``) — Refiner-only
-    # periodic enqueue (optional). Separate enable/interval from supplied payload evaluation (ADR-0009).
-    refiner_watched_folder_remux_scan_dispatch_schedule_enabled: bool
-    refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds: int
+    # Refiner watched-folder remux scan dispatch (``refiner.watched_folder.remux_scan_dispatch.v1``).
+    # Whether each scope is scheduled, and how often, is stored per scope in the database
+    # (Refiner Libraries tab), not here — see ADR-0009 and docs/settings-truthfulness-audit.md.
     refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: bool
     # Refiner ffprobe preflight depth (FileFlows-style Video File parity).
     refiner_probe_size_mb: int
@@ -242,8 +241,6 @@ class MediaMopSettings:
             worker_count=self.refiner_worker_count,
             supplied_payload_evaluation_schedule_enabled=self.refiner_supplied_payload_evaluation_schedule_enabled,
             supplied_payload_evaluation_schedule_interval_seconds=self.refiner_supplied_payload_evaluation_schedule_interval_seconds,
-            watched_folder_remux_scan_dispatch_schedule_enabled=self.refiner_watched_folder_remux_scan_dispatch_schedule_enabled,
-            watched_folder_remux_scan_dispatch_schedule_interval_seconds=self.refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds,
             watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=self.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs,
             probe_size_mb=self.refiner_probe_size_mb,
             analyze_duration_seconds=self.refiner_analyze_duration_seconds,
@@ -386,13 +383,6 @@ class MediaMopSettings:
 
         refiner_payload_eval_on = _refiner_supplied_payload_eval_schedule_enabled()
         refiner_payload_eval_iv = _refiner_supplied_payload_eval_schedule_interval_seconds()
-        refiner_wf_scan_dispatch_on = _env_bool(
-            "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED",
-            False,
-        )
-        refiner_wf_scan_dispatch_iv = clamp_refiner_schedule_interval_seconds(
-            _env_int("MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_INTERVAL_SECONDS", 3600),
-        )
         refiner_wf_scan_periodic_remux_enq = _env_bool(
             "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS",
             True,
@@ -531,8 +521,6 @@ class MediaMopSettings:
             pruner_plex_live_abs_max_items=pruner_plex_live_abs_max,
             refiner_supplied_payload_evaluation_schedule_enabled=refiner_payload_eval_on,
             refiner_supplied_payload_evaluation_schedule_interval_seconds=refiner_payload_eval_iv,
-            refiner_watched_folder_remux_scan_dispatch_schedule_enabled=refiner_wf_scan_dispatch_on,
-            refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds=refiner_wf_scan_dispatch_iv,
             refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=refiner_wf_scan_periodic_remux_enq,
             refiner_probe_size_mb=refiner_probe_size_mb,
             refiner_analyze_duration_seconds=refiner_analyze_duration_seconds,

--- a/apps/backend/src/mediamop/core/config_domains.py
+++ b/apps/backend/src/mediamop/core/config_domains.py
@@ -38,8 +38,6 @@ class RefinerSettings:
     worker_count: int
     supplied_payload_evaluation_schedule_enabled: bool
     supplied_payload_evaluation_schedule_interval_seconds: int
-    watched_folder_remux_scan_dispatch_schedule_enabled: bool
-    watched_folder_remux_scan_dispatch_schedule_interval_seconds: int
     watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: bool
     probe_size_mb: int
     analyze_duration_seconds: int

--- a/apps/backend/src/mediamop/modules/refiner/refiner_runtime_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_runtime_visibility.py
@@ -61,15 +61,15 @@ _FAILURE_CLEANUP_NOTE = (
 )
 
 _WATCHED_FOLDER_SCAN_PERIODIC_NOTE = (
-    "Optional periodic enqueue for refiner.watched_folder.remux_scan_dispatch.v1 uses "
-    "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED and "
-    "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_INTERVAL_SECONDS in apps/backend/.env "
-    "(Refiner-only schedule). Each tick evaluates Movies and TV "
-    "independently: when a scope has no pending/leased scan for that scope and its watched folder is saved, "
-    "one periodic scan job is enqueued for that scope (still not a filesystem watcher). "
-    "File-pass options for periodic ticks: "
-    "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS. "
-    "Restart the API after changing any of these — values are read at process start only."
+    "Periodic scanning for refiner.watched_folder.remux_scan_dispatch.v1 is controlled **per scope on the "
+    "Refiner Libraries tab**, not by an environment variable: each of Movies and TV has its own on/off switch "
+    "and its own check interval, saved in the database and applied without a restart. Each tick evaluates the "
+    "two scopes independently: when a scope is switched on, is inside its schedule window, has no pending or "
+    "leased scan already, and has a saved watched folder, one periodic scan job is enqueued for that scope "
+    "(still not a filesystem watcher). "
+    "Whether those periodic ticks may also queue file work is the one part still set in apps/backend/.env: "
+    "MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS (default on). "
+    "Restart the API after changing that one — it is read at process start only."
 )
 _REFINER_PROBE_NOTE = (
     "Refiner ffprobe preflight depth: MEDIAMOP_REFINER_PROBE_SIZE_MB and "
@@ -106,12 +106,6 @@ def refiner_runtime_settings_from_settings(settings: MediaMopSettings) -> Refine
         sqlite_throughput_note=_SQLITE_THROUGHPUT_NOTE,
         configuration_note=_CONFIGURATION_NOTE,
         visibility_note=_VISIBILITY_NOTE,
-        refiner_watched_folder_remux_scan_dispatch_schedule_enabled=(
-            settings.refiner_watched_folder_remux_scan_dispatch_schedule_enabled
-        ),
-        refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds=(
-            settings.refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds
-        ),
         refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=(
             settings.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs
         ),

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_enqueue.py
@@ -113,12 +113,16 @@ def try_enqueue_periodic_watched_folder_remux_scan_dispatch(
 ) -> tuple[bool, str | None]:
     """Periodic tick enqueue helper.
 
-    When ``media_scope`` is provided, evaluates one scope only (Movies or TV). When omitted, preserves the original
-    behavior and evaluates both scopes.
+    When ``media_scope`` is provided, evaluates one scope only (Movies or TV) — this is the
+    production call shape. When omitted, evaluates both scopes.
+
+    Whether a scope is scheduled at all is decided by the caller from the per-scope
+    ``movie_schedule_enabled`` / ``tv_schedule_enabled`` rows. There is deliberately no
+    process-wide kill switch here: one existed, was only ever consulted on the
+    ``media_scope is None`` path the scheduler never takes, and reported itself as live
+    configuration while scheduled scans ran regardless (#329).
     """
     if media_scope is None:
-        if not settings.refiner_watched_folder_remux_scan_dispatch_schedule_enabled:
-            return False, "schedule_disabled"
         inserted_any = False
         last_skip: str | None = None
         for scope_name in ("movie", "tv"):

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -45,6 +45,18 @@ def _next_scheduler_sleep_seconds(
     return max(0.25, min(float(poll_seconds), until_due))
 
 
+def refiner_scope_periodic_scan_enabled(operator_row: object, *, media_scope: str) -> bool:
+    """Whether periodic scanning is switched on for one scope.
+
+    This is the *only* enable check the scheduler makes. It was inline in the tick
+    closure, which meant the shipped behaviour could not be asserted directly and the
+    coverage that existed tested an environment flag the scheduler never read (#329).
+    """
+
+    attr = "tv_schedule_enabled" if media_scope == "tv" else "movie_schedule_enabled"
+    return bool(getattr(operator_row, attr))
+
+
 def _watched_folder_scan_interval_seconds(path_row: object, *, media_scope: str) -> float:
     """Actual watched-folder scan cadence configured on the Refiner Libraries tab."""
 
@@ -89,8 +101,7 @@ async def _run_periodic_watched_folder_scan_dispatch_enqueue(
                 row = ensure_refiner_operator_settings_row(session)
                 path_row = ensure_refiner_path_settings_row(session)
                 interval = _watched_folder_scan_interval_seconds(path_row, media_scope=media_scope)
-                enabled_attr = "tv_schedule_enabled" if media_scope == "tv" else "movie_schedule_enabled"
-                if not bool(getattr(row, enabled_attr)):
+                if not refiner_scope_periodic_scan_enabled(row, media_scope=media_scope):
                     return next_run_loop, interval
                 if now_loop < next_run_loop:
                     return next_run_loop, interval

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_runtime_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_runtime_visibility.py
@@ -31,13 +31,6 @@ class RefinerRuntimeSettingsOut(BaseModel):
     visibility_note: str = Field(
         description="Caveat: from settings loaded at startup — not a live probe of worker threads.",
     )
-    refiner_watched_folder_remux_scan_dispatch_schedule_enabled: bool = Field(
-        description="``MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED`` at process start.",
-    )
-    refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds: int = Field(
-        ge=60,
-        description="Seconds between periodic enqueue attempts (clamped 60..7d); restart required to change.",
-    )
     refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: bool = Field(
         description="When true, periodic scans may enqueue ``refiner.file.remux_pass.v1``.",
     )

--- a/apps/backend/src/mediamop/modules/refiner/worker_limits.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_limits.py
@@ -1,16 +1,22 @@
 """Refiner worker bounds — shared by :mod:`mediamop.core.config` without import cycles.
 
-Worker count rollout semantics:
+``refiner_worker_count`` is an **internal startup slot cap**, not the number of files
+Refiner will work on. The effective limit is the operator-facing "Files at once" value on
+the Processing settings page, applied at runtime by ``max_concurrent_files_getter``, and
+changing it needs no restart.
 
 - **0** — In-process Refiner asyncio workers disabled (tests, controlled runtime).
-- **1** — Supported default for SQLite-first deployments (single writer; predictable).
-- **2..8** — Guarded capability only: claim SQL is atomic, but SQLite remains one writer;
-  multi-worker is **not** the normal production posture until ops validate under load.
+- **1..8** — Available worker slots. The shipped default is **8**
+  (``MEDIAMOP_REFINER_WORKER_COUNT``), because the saved "Files at once" value is what
+  actually gates concurrency; a lower cap here would silently ceiling that setting.
+
+SQLite still serializes writes, so raising "Files at once" does not scale throughput
+linearly — that caveat belongs to the operator-facing setting, not to this cap.
 """
 
 
 def clamp_refiner_worker_count(raw: int) -> int:
-    """Enforce 0..8 workers (0 = disabled; default from env is typically 0 until operators enable Refiner)."""
+    """Enforce 0..8 slots (0 = disabled). The env default is 8; negative values mean 1."""
 
     if raw < 0:
         return 1

--- a/apps/backend/src/mediamop/modules/refiner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_loop.py
@@ -341,12 +341,13 @@ def start_refiner_worker_background_tasks(
       from the user-facing "Files at once" setting while SQLite still serializes writes.
     """
 
-    if settings.refiner_worker_count > 1:
-        logger.warning(
-            "Refiner refiner_worker_count=%s: multi-worker is a guarded capability under SQLite "
-            "(single-writer database). The user-facing files-at-once setting gates active slots.",
-            settings.refiner_worker_count,
-        )
+    # The shipped default is 8 slots, so warning above 1 warned about the intended
+    # configuration on every startup of every install (#329). The slot cap is not the
+    # concurrency limit — the saved "Files at once" value is — so this is a debug detail.
+    logger.debug(
+        "Refiner worker slot cap is %s; the saved files-at-once setting gates how many are active.",
+        settings.refiner_worker_count,
+    )
 
     handlers: Mapping[str, Callable[[RefinerJobWorkContext], None]]
     if job_handlers is not None:

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -66,8 +66,6 @@ def _csrf_settings(**overrides: object) -> MediaMopSettings:
         arr_sonarr_api_key=None,
         refiner_supplied_payload_evaluation_schedule_enabled=False,
         refiner_supplied_payload_evaluation_schedule_interval_seconds=3600,
-        refiner_watched_folder_remux_scan_dispatch_schedule_enabled=False,
-        refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds=3600,
         refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=False,
         refiner_probe_size_mb=10,
         refiner_analyze_duration_seconds=10,

--- a/apps/backend/tests/test_refiner_runtime_settings_api.py
+++ b/apps/backend/tests/test_refiner_runtime_settings_api.py
@@ -35,9 +35,11 @@ def test_refiner_runtime_settings_operator_shape(client_with_admin: TestClient) 
     assert "sqlite_throughput_note" in body
     assert "configuration_note" in body
     assert "visibility_note" in body
-    assert "refiner_watched_folder_remux_scan_dispatch_schedule_enabled" in body
-    assert "refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds" in body
     assert "refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs" in body
+    # Removed in #329: both reported themselves as live startup configuration while the
+    # scheduler read the per-scope database toggles instead.
+    assert "refiner_watched_folder_remux_scan_dispatch_schedule_enabled" not in body
+    assert "refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds" not in body
     assert "refiner_probe_size_mb" in body
     assert "refiner_analyze_duration_seconds" in body
     assert "refiner_watched_folder_min_file_age_seconds" in body

--- a/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
+++ b/apps/backend/tests/test_refiner_watched_folder_remux_scan_dispatch_periodic_enqueue.py
@@ -30,6 +30,7 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodi
     _missed_due_run_count,
     _next_scheduler_sleep_seconds,
     _watched_folder_scan_interval_seconds,
+    refiner_scope_periodic_scan_enabled,
 )
 
 
@@ -43,8 +44,6 @@ def _settings_on() -> MediaMopSettings:
     base = MediaMopSettings.load()
     return replace(
         base,
-        refiner_watched_folder_remux_scan_dispatch_schedule_enabled=True,
-        refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds=3600,
         refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=True,
     )
 
@@ -297,15 +296,53 @@ def test_queue_has_active_scan_detects_pending_and_leased_per_scope() -> None:
         assert refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan(db, media_scope="tv") is False
 
 
-def test_try_enqueue_periodic_skips_when_schedule_disabled() -> None:
+def test_scheduler_enable_gate_reads_the_per_scope_database_toggle() -> None:
+    """The gate the scheduler actually consults, asserted directly.
+
+    The removed env flag was only ever read on the ``media_scope is None`` path, which the
+    production scheduler never takes — so the coverage that set it proved nothing about
+    shipped behaviour (#329).
+    """
+
+    row = SimpleNamespace(movie_schedule_enabled=True, tv_schedule_enabled=False)
+    assert refiner_scope_periodic_scan_enabled(row, media_scope="movie") is True
+    assert refiner_scope_periodic_scan_enabled(row, media_scope="tv") is False
+
+    both_off = SimpleNamespace(movie_schedule_enabled=False, tv_schedule_enabled=False)
+    assert refiner_scope_periodic_scan_enabled(both_off, media_scope="movie") is False
+    assert refiner_scope_periodic_scan_enabled(both_off, media_scope="tv") is False
+
+
+def test_production_call_shape_enqueues_one_scope_at_a_time(tmp_path) -> None:
+    """``media_scope`` is always explicit in production; no process-wide switch gates it."""
+
     fac = _fac()
-    base = MediaMopSettings.load()
-    off = replace(base, refiner_watched_folder_remux_scan_dispatch_schedule_enabled=False)
+    settings = _settings_on()
+    watched = tmp_path / "watch"
+    out = tmp_path / "out"
+    watched.mkdir()
+    out.mkdir()
     with fac() as db:
-        ins, skip = try_enqueue_periodic_watched_folder_remux_scan_dispatch(db, off)
-        db.rollback()
-    assert ins is False
-    assert skip == "schedule_disabled"
+        db.execute(delete(RefinerJob))
+        db.execute(
+            update(RefinerPathSettingsRow)
+            .where(RefinerPathSettingsRow.id == 1)
+            .values(refiner_watched_folder=str(watched), refiner_output_folder=str(out)),
+        )
+        db.commit()
+    try:
+        with fac() as db:
+            inserted, skip = try_enqueue_periodic_watched_folder_remux_scan_dispatch(db, settings, media_scope="movie")
+            db.commit()
+        assert inserted is True, skip
+        with fac() as db:
+            assert refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan(db, media_scope="movie") is True
+            # Asking about Movies must not queue TV work.
+            assert refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan(db, media_scope="tv") is False
+    finally:
+        with fac() as db:
+            db.execute(delete(RefinerJob))
+            db.commit()
 
 
 def test_try_enqueue_periodic_skips_when_active_scan_exists() -> None:

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -3802,17 +3802,6 @@
             "title": "Refiner Watched Folder Remux Scan Dispatch Periodic Enqueue Remux Jobs",
             "type": "boolean"
           },
-          "refiner_watched_folder_remux_scan_dispatch_schedule_enabled": {
-            "description": "``MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED`` at process start.",
-            "title": "Refiner Watched Folder Remux Scan Dispatch Schedule Enabled",
-            "type": "boolean"
-          },
-          "refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds": {
-            "description": "Seconds between periodic enqueue attempts (clamped 60..7d); restart required to change.",
-            "minimum": 60.0,
-            "title": "Refiner Watched Folder Remux Scan Dispatch Schedule Interval Seconds",
-            "type": "integer"
-          },
           "refiner_work_temp_stale_sweep_min_stale_age_seconds": {
             "description": "Minimum file age before Refiner removes its own stale temp work files (60s..30d). Shared for both scopes (narrow exception: same temp filename semantics).",
             "minimum": 60.0,
@@ -3880,8 +3869,6 @@
           "sqlite_throughput_note",
           "configuration_note",
           "visibility_note",
-          "refiner_watched_folder_remux_scan_dispatch_schedule_enabled",
-          "refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds",
           "refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs",
           "refiner_probe_size_mb",
           "refiner_analyze_duration_seconds",

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -2913,16 +2913,6 @@ export interface components {
        */
       refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: boolean;
       /**
-       * Refiner Watched Folder Remux Scan Dispatch Schedule Enabled
-       * @description ``MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED`` at process start.
-       */
-      refiner_watched_folder_remux_scan_dispatch_schedule_enabled: boolean;
-      /**
-       * Refiner Watched Folder Remux Scan Dispatch Schedule Interval Seconds
-       * @description Seconds between periodic enqueue attempts (clamped 60..7d); restart required to change.
-       */
-      refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds: number;
-      /**
        * Refiner Work Temp Stale Sweep Min Stale Age Seconds
        * @description Minimum file age before Refiner removes its own stale temp work files (60s..30d). Shared for both scopes (narrow exception: same temp filename semantics).
        */

--- a/apps/web/src/lib/refiner/types.ts
+++ b/apps/web/src/lib/refiner/types.ts
@@ -45,8 +45,6 @@ export type RefinerRuntimeSettingsOut = {
   sqlite_throughput_note: string;
   configuration_note: string;
   visibility_note: string;
-  refiner_watched_folder_remux_scan_dispatch_schedule_enabled: boolean;
-  refiner_watched_folder_remux_scan_dispatch_schedule_interval_seconds: number;
   refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: boolean;
   refiner_watched_folder_min_file_age_seconds: number;
   refiner_movie_output_cleanup_min_age_seconds: number;

--- a/docs/settings-truthfulness-audit.md
+++ b/docs/settings-truthfulness-audit.md
@@ -18,6 +18,8 @@ MediaMop settings must describe runtime behaviour as shipped, not intended behav
 - Processing settings: files-at-once and age/size guardrails are database-backed operator settings used by active Refiner worker gating and new watched-folder scans.
 - Audio/subtitle defaults: saved rules are used by new Refiner file passes after save.
 - Runtime settings endpoint: read-only startup configuration. Any value requiring environment changes and restart must remain labelled as restart-required.
+- Watched-folder scan schedule: whether each scope is scanned, and how often, is **per scope on the Libraries tab**, saved in the database and applied without a restart. There is no environment variable for it. `MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_SCHEDULE_ENABLED` and `..._SCHEDULE_INTERVAL_SECONDS` were removed in #329: the scheduler never read either, while the runtime-settings endpoint reported the flag as live configuration — so an operator could read `false` while scheduled scans ran.
+- Worker count: `MEDIAMOP_REFINER_WORKER_COUNT` is an internal startup slot cap (default 8), not the number of files processed at once. The operator-facing "Files at once" value is the effective limit and needs no restart.
 
 ## Pruner settings
 


### PR DESCRIPTION
Closes #329. Part of #347. Milestone v2.4.3.

## 1. A schedule flag the scheduler never read

`refiner_watched_folder_remux_scan_dispatch_schedule_enabled` was only consulted inside the `media_scope is None` branch. The production scheduler always calls with an explicit scope, so the flag had no effect — while `GET /api/v1/refiner/runtime-settings` reported it as live startup configuration. An operator could read `false` while scheduled scans were running.

Removed, per the issue's preferred option (a). The per-scope `movie_schedule_enabled` / `tv_schedule_enabled` database toggles are the only control, and they need no restart.

**One thing the issue did not list.** `..._SCHEDULE_INTERVAL_SECONDS` has the *identical* defect: the scheduler takes its cadence from the per-scope `*_watched_folder_check_interval_seconds` rows and never reads the environment value. Removing only the flag would have left the same endpoint still lying about the same feature, so both are gone — from `config.py`, `RefinerSettings`, the runtime-settings response and schema, `.env.example`, and the hand-written web type that still declared them.

## 2. A documented default that was wrong

`.env.example` said `..._PERIODIC_ENQUEUE_REMUX_JOBS=0`; the code default is `True`. That is the difference between "scheduled scans only look" and "scheduled scans queue work on media". Now `=1`, and the surrounding comment says where scan scheduling actually lives.

## 3. A docstring contradicting the shipped default — and a warning on every boot

`worker_limits.py` called 1 the supported default and 2..8 a guarded capability "not the normal production posture". The shipped default is **8**. So `start_refiner_worker_background_tasks` logged a warning *on every startup of every install*, about the intended configuration — squarely against the operator messaging standard's "normal work must not be logged or displayed as a warning".

Docstrings now describe the real model: `refiner_worker_count` is an internal startup slot cap, and the operator-facing "Files at once" value is the effective limit. The warning is now a debug line.

## Testing the gate that actually ships

The AC asked for a test of the periodic path's enable/disable behaviour, noting the old coverage passed `media_scope=None` — not the production call shape. That check lived inside a closure in the scheduler tick, so it could not be asserted directly at all. Extracted as `refiner_scope_periodic_scan_enabled` and tested, plus a test driving the explicit-scope enqueue and asserting a Movies tick queues no TV work.

The old `test_try_enqueue_periodic_skips_when_schedule_disabled` is replaced rather than adapted: it asserted a kill switch that shipped code never consulted, so it was passing for the wrong reason.

`test_refiner_runtime_settings_api` now asserts both fields are **absent**, so a re-add has to be deliberate.

## Validation

`ruff check`/`format --check`, `mypy`, `pytest -q` — 764 passed, 2 skipped; coverage 77.59% against the 75 floor. Web `lint`/`format`/`build`/`test` (166 passed), OpenAPI spec and types regenerated, `check-agent-docs`, full `pre-push-check.ps1`.

`docs/settings-truthfulness-audit.md` gains lines for both the scan schedule and the worker-count cap, as the AC requires.

## Merge notes

Independent of #355 (#330). Touches `refiner_runtime_visibility.py`, which #354 (#350, v2.5.0) also edits — small conflict, #350 rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
