### PR TITLE
docs: release the Subber removal as v2.4.3

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.4.2"
+version = "2.4.3"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -5002,7 +5002,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.4.2"
+    "version": "2.4.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.4.2",
+  "version": "2.4.3",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.4.3.md
+++ b/docs/release-notes/v2.4.3.md
@@ -1,0 +1,37 @@
+# MediaMop v2.4.3
+
+Date: 2026-08-28
+
+This release removes Subber from MediaMop — subtitles are Deluno's job now — and clears out settings and code that no longer described what MediaMop actually does.
+
+## What Changed
+
+- **Subtitles have moved to Deluno.** MediaMop no longer looks for or downloads subtitles, and the Subber screen is gone. Deluno sees its own library and does this better; MediaMop stays on cleaning up media files.
+- **Apps that tell MediaMop about a finished import are no longer refused.** Radarr, Sonarr or Deluno announcing "I have added this file" used to get an error back, because that message was Subber's cue. MediaMop now accepts it and says it was ignored, so nothing starts filling your manager's log with failures.
+- **Refiner's scan schedule is set in one place.** Whether Movies and TV are scanned automatically, and how often, is on **Settings → Refiner → Libraries**, per library, saved straight away. Two environment variables that looked like they controlled this never did, and have been removed.
+
+## Fixes And Stability
+
+- **A settings page no longer contradicts itself.** The Refiner runtime settings view reported an automatic-scan switch as off while scheduled scans were running. That switch was never read by the scheduler; it has been removed rather than left to mislead.
+- **MediaMop no longer warns about its own default setup.** Every start-up logged a warning about the Refiner worker count being a "guarded capability" — for the value MediaMop ships with. It is now an ordinary detail in the debug log.
+- **An example setting file no longer states the wrong default.** `MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS` was documented as off; it ships on. That is the difference between a scheduled scan only looking and a scheduled scan queueing work on your media.
+- **The steps that refuse to delete are now covered by tests.** Refiner's output-folder and season-folder cleanup will not remove anything while a download manager still lists the file, the folder is too new, or another job is working on it. Those refusals now have tests behind them, so a future change cannot quietly turn one off.
+- **Housekeeping.** Removed code and screens left behind by earlier changes, and added a check that fails the build if unused code accumulates again. The database migrations are now linted like the rest of the codebase — they were the only part of MediaMop nothing checked.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings → Upgrade**.
+- **Four Subber database tables are removed on upgrade** (`subber_jobs`, `subber_subtitle_state`, `subber_providers`, `subber_settings`). Subtitle history and provider settings held only by MediaMop are not kept, and this step cannot be undone. Take a backup first if you want that history.
+- **Configuration backups taken before this release cannot be restored into it.** The backup format moved to version 3 to drop the Subber section. Existing backups are not deleted and stay readable as files — but restoring one needs a MediaMop from before this release. Take a fresh backup after upgrading.
+- **If you set `MEDIAMOP_SUBBER_WEBHOOK_SECRET`, rename it to `MEDIAMOP_MEDIA_MANAGER_WEBHOOK_SECRET`.** The old name is still read, so nothing breaks today, but it will not be read forever.
+- Connections, credentials and Refiner settings carry across untouched. Nothing else to reconfigure.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.4.3`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.4.2...v2.4.3


### PR DESCRIPTION
Closes #331. Part of #347. Milestone v2.4.3.

**Merge this last.** The release notes describe #328, #329 and #330 as shipping in v2.4.3, which is only true once those are in.

## Version

`2.4.2` → `2.4.3` in `apps/backend/pyproject.toml` and `apps/web/package.json`.

Also synced `apps/web/package-lock.json`, which had drifted to **2.3.11** — it was never bumped through v2.4.0, v2.4.1 or v2.4.2. Diff is the two version fields only, no dependency resolution changes. The OpenAPI spec's `info.version` is regenerated to match.

## Release notes

`docs/release-notes/v2.4.3.md`, written from `TEMPLATE.md`. Every fact the AC lists was checked against the code rather than taken from the issue text:

| Claim | Verified |
| --- | --- |
| Four tables dropped | `subber_jobs`, `subber_subtitle_state`, `subber_providers`, `subber_settings` in `0010`, named individually in the notes |
| Bundle `format_version` 3 | `BUNDLE_FORMAT_VERSION = 3`, and the loader rejects anything else — so the notes say restoring an older backup needs an older MediaMop |
| Webhook secret rename | `MEDIAMOP_MEDIA_MANAGER_WEBHOOK_SECRET` read first, `MEDIAMOP_SUBBER_WEBHOOK_SECRET` still read as fallback |
| `imported` now ignored, not 404 | `intake_api.py` returns `{"status": "ignored"}` |

The two destructive-on-upgrade items — the table drop and the backup format change — are stated plainly under **Upgrade Notes** with what is lost and what to do first, rather than being softened.

## One item left for you

**The stale `area: subber` label is not deleted.** Three closed issues (#162, #200, #229) still carry it, so deleting it would strip their historical categorisation. Renaming or deleting repo metadata is your call, not a side effect of a docs PR — tell me which and I'll do it.

## Validation

`pytest -q` (763 passed, 2 skipped), web `build`/`test` (166 passed), `check-agent-docs`, full `pre-push-check.ps1`.

## Tagging

Not tagged. Once all four PRs are on `main`, `docs/release.md` step 4 is:

```bash
git fetch origin && git checkout main && git pull origin main && git tag -a v2.4.3 -m "MediaMop v2.4.3" && git push origin v2.4.3
```

That push triggers `release.yml`, which publishes a GitHub Release, the Windows Velopack installer and `ghcr.io/jampat000/mediamop:v2.4.3` + `:latest`. Say the word and I'll run it — I have not, because it publishes artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
