### PR TITLE
fix(refiner): the media allowlist silently ignores container formats

### DIFF
--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
@@ -64,7 +64,39 @@ def normalize_audio_preference_mode(raw: str | None) -> AudioSelectionPolicy:
     return "preferred_langs_quality"
 
 
-_MEDIA_EXTENSIONS = frozenset({".mkv", ".mp4", ".m4v", ".webm", ".avi"})
+# Containers Refiner can genuinely process: ffprobe reads them and a stream-copy remux
+# to MKV succeeds. Each was verified against ffmpeg rather than assumed (#348).
+#
+# Deliberately absent: ``.h264``, ``.h265`` and ``.mpv``. They remux to MKV perfectly
+# well — but they are raw elementary streams with no audio track, so ``plan_remux``
+# returns None ("no retainable audio"), the pass records a terminal failure, and Pass 4
+# failure cleanup then deletes the source folder once the grace period elapses. Admitting
+# them would turn "silently ignored" into "your folder is gone", which is a worse bug
+# than the one this list is fixing. They belong to whatever handles video-only files.
+REFINER_MEDIA_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".mkv",
+        ".mp4",
+        ".m4v",
+        ".webm",
+        ".avi",
+        ".mpe",
+        ".mpeg",
+        ".mpg",
+        ".mov",
+        ".flv",
+        ".wmv",
+        ".avchd",
+    }
+)
+
+_MEDIA_EXTENSIONS = REFINER_MEDIA_EXTENSIONS
+
+
+def refiner_media_extensions_sorted() -> tuple[str, ...]:
+    """The effective allowlist, for operator-facing reporting."""
+
+    return tuple(sorted(REFINER_MEDIA_EXTENSIONS))
 
 
 def is_refiner_media_candidate(path: Path) -> bool:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_runtime_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_runtime_visibility.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_remux_rules import refiner_media_extensions_sorted
 from mediamop.modules.refiner.schemas_refiner_runtime_visibility import RefinerRuntimeSettingsOut
 
 _VISIBILITY_NOTE = (
@@ -109,6 +110,7 @@ def refiner_runtime_settings_from_settings(settings: MediaMopSettings) -> Refine
         sqlite_throughput_note=_SQLITE_THROUGHPUT_NOTE,
         configuration_note=_CONFIGURATION_NOTE,
         visibility_note=_VISIBILITY_NOTE,
+        refiner_media_extensions=list(refiner_media_extensions_sorted()),
         refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs=(
             settings.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs
         ),

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -16,12 +16,13 @@ from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMU
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
+from mediamop.modules.refiner.refiner_remux_rules import refiner_media_extensions_sorted
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_evaluate import (
     evaluate_watched_media_file_for_dispatch,
     fetch_manager_queue_signals_for_scan,
 )
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops import (
-    iter_watched_folder_media_candidate_files,
+    iter_watched_folder_media_candidates,
     refiner_active_remux_pass_exists_for_relative_path,
     refiner_completed_remux_output_exists_for_relative_path,
     relative_posix_path_under_watched,
@@ -77,10 +78,11 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             )
 
         watched_path = Path(watched_root)
-        files = iter_watched_folder_media_candidate_files(
+        candidates = iter_watched_folder_media_candidates(
             watched_path,
             min_file_age_seconds=op_settings.min_file_age_seconds,
         )
+        files = candidates.files
 
         sample_paths: list[str] = []
         upstream_block_reasons: list[str] = []
@@ -100,6 +102,9 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             "manager_queue_signal_notes": list(signal_report.silent_details),
             "upstream_block_reasons": upstream_block_reasons,
             "media_candidates_seen": len(files),
+            "ignored_unsupported_type": candidates.ignored_unsupported_type,
+            "ignored_unsupported_extensions": list(candidates.ignored_unsupported_extensions),
+            "media_extensions_applied": list(refiner_media_extensions_sorted()),
             "verdict_proceed": 0,
             "verdict_wait_upstream": 0,
             "verdict_not_held": 0,
@@ -253,6 +258,16 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             else:
                 summary["scan_result_label"] = "no_media_found"
                 summary["user_message"] = "MediaMop did not find any media files in this watched folder."
+
+            # Extension mismatch was the one admission decision that said nothing at all.
+            ignored = int(summary["ignored_unsupported_type"])
+            if ignored:
+                kinds = ", ".join(summary["ignored_unsupported_extensions"])
+                summary["user_message"] = (
+                    f"{summary['user_message']} {ignored} file{'' if ignored == 1 else 's'} "
+                    f"{'was' if ignored == 1 else 'were'} ignored because MediaMop does not process "
+                    f"that kind of file ({kinds})."
+                ).strip()
 
             # A manager that could not be reached must never read as "nothing is importing".
             # The scan still runs — the file-settling gates are the fallback — but the

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_ops.py
@@ -6,6 +6,7 @@ import json
 import re
 import shutil
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from sqlalchemy import func, select
@@ -15,6 +16,61 @@ from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMU
 from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_remux_rules import is_refiner_media_candidate
 from mediamop.platform.activity.models import ActivityEvent
+
+# Files that legitimately sit beside media and are not a failed attempt at it. Counting
+# these as "unsupported type" would bury the signal in subtitles and artwork.
+_NON_MEDIA_COMPANION_SUFFIXES: frozenset[str] = frozenset(
+    {
+        ".srt",
+        ".sub",
+        ".idx",
+        ".ass",
+        ".ssa",
+        ".vtt",
+        ".sup",
+        ".nfo",
+        ".txt",
+        ".md",
+        ".log",
+        ".xml",
+        ".json",
+        ".yml",
+        ".yaml",
+        ".jpg",
+        ".jpeg",
+        ".png",
+        ".gif",
+        ".webp",
+        ".tbn",
+        ".bmp",
+        ".par2",
+        ".sfv",
+        ".nzb",
+        ".torrent",
+        ".url",
+        ".db",
+        ".ini",
+        ".bak",
+        ".mp3",
+        ".flac",
+        ".m4a",
+        ".aac",
+        ".ac3",
+        ".dts",
+        ".ogg",
+        ".wav",
+        # In-progress downloads. The same file is admitted under its real name once the
+        # client renames it, so reporting it as an unsupported type would put a message
+        # on screen for every active download.
+        ".part",
+        ".partial",
+        ".crdownload",
+        ".downloading",
+        ".tmp",
+        ".!ut",
+        ".!qb",
+    }
+)
 
 _HASH_ARTIFACT_STEM_RE = re.compile(r"^[a-fA-F0-9]{32,64}$")
 _TRANSIENT_DOWNLOAD_DIR_MARKERS = {
@@ -58,19 +114,47 @@ def _existing_completed_output_path_is_safe(path: Path) -> bool:
         return False
 
 
-def iter_watched_folder_media_candidate_files(watched_root: Path, *, min_file_age_seconds: int = 0) -> list[Path]:
-    """Sorted candidate files under ``watched_root`` honoring optional minimum file-age guardrail."""
+@dataclass(frozen=True, slots=True)
+class WatchedFolderScanCandidates:
+    """What a watched-folder walk found, and what it decided not to look at.
+
+    ``ignored_unsupported_type`` is the point of this type. Extension mismatch used to be
+    the one admission decision that produced no counter, no reason and no activity row —
+    a ``.mov`` in a watched folder simply never appeared, and nothing said why (#348).
+    Every other guardrail alongside it reports itself.
+    """
+
+    files: list[Path]
+    ignored_unsupported_type: int = 0
+    ignored_unsupported_extensions: tuple[str, ...] = ()
+
+
+def iter_watched_folder_media_candidates(
+    watched_root: Path,
+    *,
+    min_file_age_seconds: int = 0,
+) -> WatchedFolderScanCandidates:
+    """Candidate files under ``watched_root``, plus a count of what the allowlist rejected."""
 
     root = watched_root.resolve()
     now = time.time()
     min_age = max(0, int(min_file_age_seconds))
     found: list[Path] = []
+    rejected = 0
+    rejected_suffixes: set[str] = set()
     for p in sorted(root.rglob("*")):
         if not p.is_file():
             continue
-        if not is_refiner_media_candidate(p):
-            continue
         if is_transient_download_artifact_media_path(p):
+            # A part-file is not an unsupported type; it is the same file mid-copy.
+            continue
+        if not is_refiner_media_candidate(p):
+            suffix = p.suffix.lower()
+            # Only count things that look like an attempt at media. Counting every
+            # .nfo and .srt beside a film would bury the signal this exists to give.
+            if suffix and suffix not in _NON_MEDIA_COMPANION_SUFFIXES:
+                rejected += 1
+                rejected_suffixes.add(suffix)
             continue
         try:
             p.resolve().relative_to(root)
@@ -84,7 +168,17 @@ def iter_watched_folder_media_candidate_files(watched_root: Path, *, min_file_ag
             if age_s < min_age:
                 continue
         found.append(p)
-    return found
+    return WatchedFolderScanCandidates(
+        files=found,
+        ignored_unsupported_type=rejected,
+        ignored_unsupported_extensions=tuple(sorted(rejected_suffixes)),
+    )
+
+
+def iter_watched_folder_media_candidate_files(watched_root: Path, *, min_file_age_seconds: int = 0) -> list[Path]:
+    """Files only. Kept for callers that do not report on what was skipped."""
+
+    return iter_watched_folder_media_candidates(watched_root, min_file_age_seconds=min_file_age_seconds).files
 
 
 def relative_posix_path_under_watched(*, watched_root: Path, file_path: Path) -> str:

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_runtime_visibility.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_runtime_visibility.py
@@ -31,6 +31,9 @@ class RefinerRuntimeSettingsOut(BaseModel):
     visibility_note: str = Field(
         description="Caveat: from settings loaded at startup — not a live probe of worker threads.",
     )
+    refiner_media_extensions: list[str] = Field(
+        description="File types Refiner will pick up in a watched folder. Anything else is ignored and counted.",
+    )
     refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: bool = Field(
         description="When true, periodic scans may enqueue ``refiner.file.remux_pass.v1``.",
     )

--- a/apps/backend/tests/test_refiner_media_allowlist.py
+++ b/apps/backend/tests/test_refiner_media_allowlist.py
@@ -1,0 +1,98 @@
+"""What Refiner will pick up in a watched folder, and what it says about the rest.
+
+Extension mismatch used to be the only admission decision that produced no counter, no
+reason and no activity row: a ``.mov`` beside a film simply never appeared, and nothing
+explained why (#348).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from mediamop.modules.refiner.refiner_remux_rules import (
+    is_refiner_media_candidate,
+    refiner_media_extensions_sorted,
+)
+from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops import (
+    iter_watched_folder_media_candidates,
+)
+
+# Verified against ffmpeg before being added: ffprobe reads each, and a stream-copy
+# remux to MKV succeeds.
+_NEWLY_ADMITTED = (".mpe", ".mpeg", ".mpg", ".mov", ".flv", ".wmv", ".avchd")
+_ALREADY_ADMITTED = (".mkv", ".mp4", ".m4v", ".webm", ".avi")
+
+
+@pytest.mark.parametrize("suffix", _NEWLY_ADMITTED + _ALREADY_ADMITTED)
+def test_supported_container_is_admitted(tmp_path: Path, suffix: str) -> None:
+    f = tmp_path / f"Some Film 2024{suffix}"
+    f.write_bytes(b"x")
+    assert is_refiner_media_candidate(f) is True
+    assert suffix in refiner_media_extensions_sorted()
+
+
+@pytest.mark.parametrize("suffix", [".h264", ".h265", ".mpv"])
+def test_raw_elementary_streams_stay_out(tmp_path: Path, suffix: str) -> None:
+    """These remux fine and must still be refused.
+
+    A raw elementary stream carries no audio track, so ``plan_remux`` returns None, the
+    pass records a terminal failure, and Pass 4 failure cleanup deletes the source folder
+    once the grace period elapses. Admitting them would turn "silently ignored" into
+    "your folder is gone".
+    """
+
+    f = tmp_path / f"Some Film 2024{suffix}"
+    f.write_bytes(b"x")
+    assert is_refiner_media_candidate(f) is False
+    assert suffix not in refiner_media_extensions_sorted()
+
+
+@pytest.mark.parametrize("suffix", [".iso", ".exe", ".rar", ".zip"])
+def test_genuinely_unsupported_types_stay_out(tmp_path: Path, suffix: str) -> None:
+    f = tmp_path / f"Some Film 2024{suffix}"
+    f.write_bytes(b"x")
+    assert is_refiner_media_candidate(f) is False
+
+
+def test_a_rejected_file_is_counted_rather_than_dropped_in_silence(tmp_path: Path) -> None:
+    for name in ("keep.mkv", "keep.mov", "drop.iso", "drop.h264"):
+        (tmp_path / name).write_bytes(b"x")
+
+    result = iter_watched_folder_media_candidates(tmp_path)
+
+    assert sorted(p.name for p in result.files) == ["keep.mkv", "keep.mov"]
+    assert result.ignored_unsupported_type == 2
+    assert result.ignored_unsupported_extensions == (".h264", ".iso")
+
+
+def test_subtitles_and_artwork_are_not_counted_as_unsupported_media(tmp_path: Path) -> None:
+    """Counting every sidecar would bury the signal this counter exists to give."""
+
+    for name in ("film.mkv", "film.srt", "poster.jpg", "film.nfo", "film.par2", "theme.mp3"):
+        (tmp_path / name).write_bytes(b"x")
+
+    result = iter_watched_folder_media_candidates(tmp_path)
+
+    assert [p.name for p in result.files] == ["film.mkv"]
+    assert result.ignored_unsupported_type == 0
+
+
+def test_a_part_file_is_not_reported_as_an_unsupported_type(tmp_path: Path) -> None:
+    """A part-file is the same file mid-copy, not a failed attempt at a media file."""
+
+    (tmp_path / "film.mkv.part").write_bytes(b"x")
+    (tmp_path / "film.mkv").write_bytes(b"x")
+
+    result = iter_watched_folder_media_candidates(tmp_path)
+
+    assert [p.name for p in result.files] == ["film.mkv"]
+    assert result.ignored_unsupported_type == 0
+
+
+def test_the_effective_allowlist_is_reportable(tmp_path: Path) -> None:
+    applied = refiner_media_extensions_sorted()
+    assert applied == tuple(sorted(applied))
+    assert all(e.startswith(".") and e == e.lower() for e in applied)
+    assert len(applied) == 12

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -3817,6 +3817,14 @@
             "title": "Refiner Analyze Duration Seconds",
             "type": "integer"
           },
+          "refiner_media_extensions": {
+            "description": "File types Refiner will pick up in a watched folder. Anything else is ignored and counted.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Refiner Media Extensions",
+            "type": "array"
+          },
           "refiner_movie_failure_cleanup_grace_period_seconds": {
             "description": "Failed remux age gate for Movies failure cleanup (uses refiner_jobs.updated_at).",
             "maximum": 604800.0,
@@ -3950,6 +3958,7 @@
           "sqlite_throughput_note",
           "configuration_note",
           "visibility_note",
+          "refiner_media_extensions",
           "refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs",
           "refiner_probe_size_mb",
           "refiner_analyze_duration_seconds",

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -2941,6 +2941,11 @@ export interface components {
        */
       refiner_analyze_duration_seconds: number;
       /**
+       * Refiner Media Extensions
+       * @description File types Refiner will pick up in a watched folder. Anything else is ignored and counted.
+       */
+      refiner_media_extensions: string[];
+      /**
        * Refiner Movie Failure Cleanup Grace Period Seconds
        * @description Failed remux age gate for Movies failure cleanup (uses refiner_jobs.updated_at).
        */

--- a/apps/web/src/lib/refiner/types.ts
+++ b/apps/web/src/lib/refiner/types.ts
@@ -45,6 +45,7 @@ export type RefinerRuntimeSettingsOut = {
   sqlite_throughput_note: string;
   configuration_note: string;
   visibility_note: string;
+  refiner_media_extensions: string[];
   refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs: boolean;
   refiner_watched_folder_min_file_age_seconds: number;
   refiner_movie_output_cleanup_min_age_seconds: number;


### PR DESCRIPTION
Closes #348. Part of #347. Milestone v2.5.0.

## Verified, not assumed

The issue asked me to confirm each extension against a real stream-copy remux rather than trust the FileFlows list. I did — built a file in each container with ffmpeg and ran the `-c copy` remux to MKV that Refiner actually performs.

**Admitted** (all confirmed to probe and remux): `.mpe` `.mpeg` `.mpg` `.mov` `.flv` `.wmv` `.avchd`, alongside the existing `.mkv` `.mp4` `.m4v` `.webm` `.avi`.

## The finding: three of the ten must stay out

`.h264`, `.h265` and `.mpv` remux to MKV **perfectly well**. They are still refused, because remuxing is not the whole story:

1. They are raw elementary streams — one video track, no audio.
2. `plan_remux` returns `None` when no audio would remain (`refiner_remux_rules.py`, documented on the function).
3. The caller turns that into `_fail_before("remux plan could not be built (no retainable audio)")` — a terminal failed job.
4. Pass 4 failure cleanup treats terminal failures as eligible and, after the grace period, `_safe_rmtree(src_folder)`.

So admitting them would convert *"silently ignored"* into *"your source folder is gone"* — worse than the bug this issue is fixing. That chain is traced end-to-end in the code, not inferred.

`.avchd` is admitted despite being a folder-structure name rather than a real-world extension: it probes as `mpegts`, carries audio, and remuxes cleanly, so there is no reason to refuse it.

## Making the decision visible

Extension mismatch was the only admission gate with no counter, no reason and no activity row — every guardrail beside it reports itself.

- `iter_watched_folder_media_candidates` now returns the files **plus** how many it turned away and which suffixes those were.
- Scan summary gains `ignored_unsupported_type`, `ignored_unsupported_extensions`, and `media_extensions_applied` (the effective list).
- The operator message says it: *"2 files were ignored because MediaMop does not process that kind of file (.h264, .iso)."*
- The effective allowlist is exposed on `GET /api/v1/refiner/runtime-settings` and reaches the generated OpenAPI schema.

**Two things deliberately not counted**, or the signal would drown: sidecars (subtitles, artwork, `.nfo`, `.par2`, loose audio) and in-progress downloads (`.part`, `.crdownload`, `.!ut`…). A part-file is the same file mid-copy — it gets admitted under its real name moments later, so flagging it would put a message on screen during every active download.

## Note for #333

`REFINER_MEDIA_EXTENSIONS` is now a named, exported constant with a reporting accessor, so #333 can seed it as a per-library editable value without unpicking anything.

## Validation

`ruff check`/`format --check` (incl. alembic), `mypy`, `pytest -q` — **873 passed**, 2 skipped, coverage **78.98%** against the 75 floor. Web `lint`/`format`/`build`/`test` (166), OpenAPI + types regenerated, dead-code guard, `check-agent-docs`, full `pre-push-check.ps1`.

Tests cover every newly-admitted extension, each deliberate exclusion with the reason, genuinely unsupported types, the counter, and both no-count cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
