### PR TITLE
feat(refiner): discover libraries from a connected media manager

### DIFF
--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -25,11 +25,21 @@ from mediamop.modules.refiner.refiner_library_crud import (
     update_library,
     update_rule_set,
 )
+from mediamop.modules.refiner.refiner_library_discovery import (
+    RefinerDiscoveryError,
+    discoverable_libraries,
+    import_libraries,
+    resync_drift,
+    unlink_library,
+)
 from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow, RefinerRuleSetRow
 from mediamop.modules.refiner.refiner_library_service import list_libraries, manager_connection_ids_for
 from mediamop.modules.refiner.schemas_refiner_libraries import (
+    DiscoverableLibraryOut,
+    LibraryDriftOut,
     RefinerLibraryCreateIn,
     RefinerLibraryDeleteIn,
+    RefinerLibraryImportIn,
     RefinerLibraryOut,
     RefinerLibraryReorderIn,
     RefinerLibraryUpdateIn,
@@ -44,6 +54,7 @@ from mediamop.platform.auth.csrf import (
     verify_csrf_token,
 )
 from mediamop.platform.auth.deps_auth import UserPublicDep
+from mediamop.platform.media_managers.connection_model import MediaManagerConnectionRow
 
 router = APIRouter(tags=["refiner"])
 
@@ -284,3 +295,96 @@ def delete_refiner_rule_set(
     except RefinerLibraryError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     db.commit()
+
+
+def _require_connection(db: DbSessionDep, connection_id: int) -> MediaManagerConnectionRow:
+    row = db.get(MediaManagerConnectionRow, connection_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="That media manager connection does not exist."
+        )
+    return row
+
+
+@router.get(
+    "/refiner/libraries/discover/{connection_id}",
+    response_model=list[DiscoverableLibraryOut],
+)
+def get_refiner_discoverable_libraries(
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    connection_id: int = Path(ge=1),
+) -> list[DiscoverableLibraryOut]:
+    """What this manager says it looks after, and whether MediaMop already has it."""
+
+    connection = _require_connection(db, connection_id)
+    try:
+        found = discoverable_libraries(db, settings, connection)
+    except RefinerDiscoveryError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    return [DiscoverableLibraryOut(**vars(item)) for item in found]
+
+
+@router.post(
+    "/refiner/libraries/discover/{connection_id}/import",
+    response_model=list[RefinerLibraryOut],
+    status_code=status.HTTP_201_CREATED,
+)
+def post_refiner_import_libraries(
+    body: RefinerLibraryImportIn,
+    request: Request,
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    connection_id: int = Path(ge=1),
+) -> list[RefinerLibraryOut]:
+    """Create a Refiner library per selected manager library."""
+
+    _verify_csrf(request, settings, body.csrf_token)
+    connection = _require_connection(db, connection_id)
+    try:
+        created = import_libraries(db, settings, connection, keys=list(body.keys))
+    except RefinerDiscoveryError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    return [_library_out(db, row) for row in created]
+
+
+@router.get(
+    "/refiner/libraries/discover/{connection_id}/drift",
+    response_model=list[LibraryDriftOut],
+)
+def get_refiner_library_drift(
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    connection_id: int = Path(ge=1),
+) -> list[LibraryDriftOut]:
+    """Differences between the manager and MediaMop. Reported only — nothing is applied."""
+
+    connection = _require_connection(db, connection_id)
+    try:
+        drift = resync_drift(db, settings, connection)
+    except RefinerDiscoveryError as exc:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+    return [LibraryDriftOut(**vars(item)) for item in drift]
+
+
+@router.post("/refiner/libraries/{library_id}/unlink", response_model=RefinerLibraryOut)
+def post_refiner_library_unlink(
+    body: RefinerLibraryDeleteIn,
+    request: Request,
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    library_id: int = Path(ge=1),
+) -> RefinerLibraryOut:
+    """Forget where a library came from. The library itself is untouched."""
+
+    _verify_csrf(request, settings, body.csrf_token)
+    row = _require_library(db, library_id)
+    unlink_library(db, row)
+    db.commit()
+    db.refresh(row)
+    return _library_out(db, row)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_discovery.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_discovery.py
@@ -1,0 +1,317 @@
+"""Create Refiner libraries from what a connected media manager already knows.
+
+The operator typing a watched folder into MediaMop is re-entering information the
+manager holds and keeps current — and until libraries existed they could only enter two
+of them. Deluno publishes a manifest built for exactly this, and the arr products expose
+a cruder version of the same thing through their root folders.
+
+Two rules shape everything here, and both come from what Refiner does after a successful
+pass — it deletes source folders:
+
+**Re-sync reports, it never applies.** A watched folder that silently repoints is a
+destructive surprise. Drift is surfaced with the manager's value and MediaMop's own value
+side by side, and the operator decides.
+
+**A path on the manager's host is not automatically a path MediaMop can see.** The check
+is purely textual, the same approach ``handoff_paths`` already uses, so it behaves
+identically on the API host and the worker and fails with a sentence rather than a stat
+error on an unmounted share.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_library_service import list_libraries
+from mediamop.platform.media_managers.connection_model import MediaManagerConnectionRow
+from mediamop.platform.media_managers.manager_binding import connections_by_id
+from mediamop.platform.media_managers.manager_dialects import port_for_kind
+from mediamop.platform.media_managers.manager_port import ManagerLibraryDescriptor
+
+DriftKind = Literal["root_moved", "library_removed", "library_added", "path_not_local"]
+
+
+class RefinerDiscoveryError(ValueError):
+    """Discovery could not run, with an operator-readable reason."""
+
+
+@dataclass(frozen=True, slots=True)
+class DiscoverableLibrary:
+    """One library a manager reports, and whether MediaMop already has it."""
+
+    key: str
+    name: str
+    media_scope: str | None
+    root_path: str | None
+    already_imported: bool
+    local_path_problem: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryDrift:
+    """A difference between what the manager says and what MediaMop has saved."""
+
+    kind: DriftKind
+    library_id: int | None
+    library_name: str
+    manager_value: str | None
+    mediamop_value: str | None
+    detail: str
+
+
+def _comparable(path: str) -> str:
+    """Case- and separator-insensitive, matching ``handoff_paths``."""
+
+    return path.replace("\\", "/").strip().rstrip("/").lower()
+
+
+def _looks_absolute(raw: str) -> bool:
+    """Absolute on *any* host, judged textually.
+
+    ``Path.is_absolute()`` answers for the host running this code, so a perfectly good
+    POSIX root reported by a Linux manager reads as relative on Windows. The manager's
+    path is not this host's path — that is the whole point — so the shape is what is
+    checked here, and whether MediaMop can actually see it is the next question.
+    """
+
+    text = raw.replace("\\", "/")
+    if text.startswith("/"):
+        return True
+    # Drive letter (C:/...) or UNC (//server/share).
+    return bool(re.match(r"^[A-Za-z]:/", text)) or text.startswith("//")
+
+
+def local_path_problem(root_path: str | None) -> str | None:
+    """Why a manager-reported root cannot be used locally, or ``None`` if it can.
+
+    Deliberately not a filesystem check first: a share that is simply not mounted yet
+    should read as "not visible here", not as a crash. The existence check comes last
+    and only sharpens the message.
+    """
+
+    raw = (root_path or "").strip()
+    if not raw:
+        return (
+            "The manager did not say where this library lives, so MediaMop has no folder to watch. "
+            "Set the watched folder yourself after importing."
+        )
+    if not _looks_absolute(raw):
+        return f"The manager reported {raw!r}, which is not an absolute path MediaMop can resolve."
+    if not Path(raw).expanduser().is_dir():
+        return (
+            f"The manager sees this library at {raw!r}. That path does not exist on the machine running "
+            "MediaMop — both hosts have to see the same folder at the same path. Mount it there, or set "
+            "MediaMop's own watched folder after importing."
+        )
+    return None
+
+
+def _descriptors_for(
+    session: Session,
+    settings: MediaMopSettings,
+    connection_row: MediaManagerConnectionRow,
+) -> tuple[ManagerLibraryDescriptor, ...]:
+    resolved = connections_by_id(session, settings, [connection_row.id])
+    if not resolved:
+        raise RefinerDiscoveryError(
+            f"{connection_row.name} has no saved address and API key, so MediaMop cannot ask it anything."
+        )
+    port = port_for_kind(connection_row.kind)
+    if port is None:
+        raise RefinerDiscoveryError(f"MediaMop does not know how to talk to a {connection_row.kind} connection.")
+    described = port.describe(resolved[0])
+    if described.status != "reported":
+        raise RefinerDiscoveryError(
+            described.detail or f"{resolved[0].label} did not answer when asked what it manages."
+        )
+    return described.libraries
+
+
+def discoverable_libraries(
+    session: Session,
+    settings: MediaMopSettings,
+    connection_row: MediaManagerConnectionRow,
+) -> list[DiscoverableLibrary]:
+    """What this manager reports, marked up with what MediaMop already has."""
+
+    imported = {
+        (row.discovered_from_connection_id, row.discovered_library_key)
+        for row in list_libraries(session)
+        if row.discovered_library_key
+    }
+    out: list[DiscoverableLibrary] = []
+    for descriptor in _descriptors_for(session, settings, connection_row):
+        out.append(
+            DiscoverableLibrary(
+                key=descriptor.key,
+                name=descriptor.name,
+                media_scope=descriptor.media_scope,
+                root_path=descriptor.root_path,
+                already_imported=(connection_row.id, descriptor.key) in imported,
+                local_path_problem=local_path_problem(descriptor.root_path),
+            )
+        )
+    return out
+
+
+def _unique_name(session: Session, wanted: str) -> str:
+    existing = {row.name for row in list_libraries(session)}
+    if wanted not in existing:
+        return wanted
+    for suffix in range(2, 100):
+        candidate = f"{wanted} ({suffix})"
+        if candidate not in existing:
+            return candidate
+    raise RefinerDiscoveryError(f"Too many libraries already named like {wanted!r}.")
+
+
+def import_libraries(
+    session: Session,
+    settings: MediaMopSettings,
+    connection_row: MediaManagerConnectionRow,
+    *,
+    keys: list[str],
+) -> list[RefinerLibraryRow]:
+    """Create a Refiner library per selected manager library.
+
+    The manager's id is stored as a durable integration reference, which is what Deluno's
+    own guidance asks external tools to keep. Everything else is an ordinary library:
+    editable afterwards, and indistinguishable from a hand-made one everywhere else.
+    """
+
+    wanted = [k for k in keys if k]
+    if not wanted:
+        raise RefinerDiscoveryError("Choose at least one library to import.")
+
+    by_key = {d.key: d for d in _descriptors_for(session, settings, connection_row)}
+    missing = [k for k in wanted if k not in by_key]
+    if missing:
+        raise RefinerDiscoveryError(
+            f"{connection_row.name} no longer reports a library with id {missing[0]}. Refresh the list and try again."
+        )
+
+    highest = session.scalars(
+        select(RefinerLibraryRow.display_order).order_by(RefinerLibraryRow.display_order.desc())
+    ).first()
+    order = int(highest or 0)
+
+    created: list[RefinerLibraryRow] = []
+    for key in wanted:
+        descriptor = by_key[key]
+        order += 1
+        # An unusable root is imported as an empty watched folder rather than a path
+        # MediaMop cannot see: a library pointed at a folder that is not there would
+        # fail every scan, and the operator is told why on the way in.
+        usable_root = descriptor.root_path if local_path_problem(descriptor.root_path) is None else ""
+        row = RefinerLibraryRow(
+            name=_unique_name(session, descriptor.name or f"{connection_row.name} library {key}"),
+            media_scope=descriptor.media_scope or "movie",
+            display_order=order,
+            watched_folder=usable_root or "",
+            discovered_from_connection_id=connection_row.id,
+            discovered_library_key=key,
+        )
+        session.add(row)
+        session.flush()
+        created.append(row)
+    return created
+
+
+def resync_drift(
+    session: Session,
+    settings: MediaMopSettings,
+    connection_row: MediaManagerConnectionRow,
+) -> list[LibraryDrift]:
+    """Differences between the manager and MediaMop. Reported only, never applied."""
+
+    descriptors = {d.key: d for d in _descriptors_for(session, settings, connection_row)}
+    linked = [
+        row
+        for row in list_libraries(session)
+        if row.discovered_from_connection_id == connection_row.id and row.discovered_library_key
+    ]
+
+    drift: list[LibraryDrift] = []
+    for row in linked:
+        descriptor = descriptors.get(row.discovered_library_key or "")
+        if descriptor is None:
+            drift.append(
+                LibraryDrift(
+                    kind="library_removed",
+                    library_id=row.id,
+                    library_name=row.name,
+                    manager_value=None,
+                    mediamop_value=row.watched_folder or None,
+                    detail=(
+                        f"{connection_row.name} no longer reports this library. MediaMop has left it exactly as "
+                        "it is — remove it here if it is genuinely gone, or unlink it to keep it as a manual one."
+                    ),
+                )
+            )
+            continue
+        manager_root = (descriptor.root_path or "").strip()
+        saved = (row.watched_folder or "").strip()
+        if manager_root and saved and _comparable(manager_root) != _comparable(saved):
+            drift.append(
+                LibraryDrift(
+                    kind="root_moved",
+                    library_id=row.id,
+                    library_name=row.name,
+                    manager_value=manager_root,
+                    mediamop_value=saved,
+                    detail=(
+                        f"{connection_row.name} now says this library lives at {manager_root!r}, but MediaMop is "
+                        f"watching {saved!r}. Nothing has been changed — Refiner deletes source folders after a "
+                        "successful pass, so a watched folder only moves when you move it."
+                    ),
+                )
+            )
+        problem = local_path_problem(descriptor.root_path)
+        if problem and not saved:
+            drift.append(
+                LibraryDrift(
+                    kind="path_not_local",
+                    library_id=row.id,
+                    library_name=row.name,
+                    manager_value=manager_root or None,
+                    mediamop_value=None,
+                    detail=problem,
+                )
+            )
+
+    known = {row.discovered_library_key for row in linked}
+    for key, descriptor in descriptors.items():
+        if key in known:
+            continue
+        drift.append(
+            LibraryDrift(
+                kind="library_added",
+                library_id=None,
+                library_name=descriptor.name,
+                manager_value=descriptor.root_path,
+                mediamop_value=None,
+                detail=(
+                    f"{connection_row.name} reports a library MediaMop has not imported. Import it if you want "
+                    "Refiner to process it."
+                ),
+            )
+        )
+    return drift
+
+
+def unlink_library(session: Session, row: RefinerLibraryRow) -> RefinerLibraryRow:
+    """Forget where a library came from, keeping the library itself untouched."""
+
+    row.discovered_from_connection_id = None
+    row.discovered_library_key = None
+    session.add(row)
+    session.flush()
+    return row

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -145,3 +145,37 @@ class RefinerLibraryReorderIn(BaseModel):
 
     csrf_token: str = Field(..., min_length=1)
     library_ids_in_order: list[int] = Field(..., min_length=1)
+
+
+class DiscoverableLibraryOut(BaseModel):
+    """One library a connected manager reports."""
+
+    key: str = Field(description="The manager's own id, kept only as an integration reference.")
+    name: str
+    media_scope: MediaScope | None = None
+    root_path: str | None = Field(
+        default=None, description="Where the manager sees this library, on the manager's host."
+    )
+    already_imported: bool
+    local_path_problem: str | None = Field(
+        default=None,
+        description="Why that path cannot be used on this machine, shown beside the manager's value.",
+    )
+
+
+class RefinerLibraryImportIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)
+    keys: list[str] = Field(..., min_length=1, description="Manager library ids to import.")
+
+
+class LibraryDriftOut(BaseModel):
+    """A difference between the manager and MediaMop. Reported, never applied."""
+
+    kind: Literal["root_moved", "library_removed", "library_added", "path_not_local"]
+    library_id: int | None = None
+    library_name: str
+    manager_value: str | None = None
+    mediamop_value: str | None = None
+    detail: str

--- a/apps/backend/src/mediamop/platform/media_managers/manager_dialects.py
+++ b/apps/backend/src/mediamop/platform/media_managers/manager_dialects.py
@@ -26,6 +26,7 @@ from mediamop.platform.media_managers.manager_port import (
     ManagerCapabilities,
     ManagerConnection,
     ManagerDescription,
+    ManagerLibraryDescriptor,
     ManagerLibraryTruth,
     ManagerQueueRow,
     ManagerQueueSignal,
@@ -160,8 +161,27 @@ class ArrV3ManagerPort:
                 capabilities=caps,
                 detail=_unreachable(connection, exc, what="which folders it manages"),
             )
-        roots = _paths_under(str(row.get("path", "")) for row in _dicts(payload))
-        return ManagerDescription(connection=connection, status="reported", capabilities=caps, library_roots=roots)
+        rows = _dicts(payload)
+        roots = _paths_under(str(row.get("path", "")) for row in rows)
+        libraries = tuple(
+            ManagerLibraryDescriptor(
+                key=str(_first_number(row, "id") or path),
+                # An arr root folder has no name of its own; the path is what an
+                # operator recognises it by.
+                name=path,
+                media_scope=self._scope,
+                root_path=path,
+            )
+            for row, path in ((row, _text(row.get("path"))) for row in rows)
+            if path
+        )
+        return ManagerDescription(
+            connection=connection,
+            status="reported",
+            capabilities=caps,
+            library_roots=roots,
+            libraries=libraries,
+        )
 
     def queue_rows(self, connection: ManagerConnection) -> ManagerQueueSignal:
         try:
@@ -304,6 +324,7 @@ class ExternalIntegrationManagerPort:
             status="reported",
             capabilities=caps,
             library_roots=roots,
+            libraries=tuple(_manifest_library_descriptor(lib) for lib in libraries if _manifest_library_key(lib)),
         )
 
     def queue_rows(self, connection: ManagerConnection) -> ManagerQueueSignal:
@@ -331,6 +352,34 @@ class ExternalIntegrationManagerPort:
                 "individual files it still keeps, so it cannot clear a folder for deletion."
             ),
         )
+
+
+def _manifest_library_key(library: Mapping[str, Any]) -> str | None:
+    """The manager's own id for a library, kept only as an integration reference."""
+
+    number = _first_number(library, "id", "libraryId", "library_id")
+    if number is not None:
+        return str(number)
+    return _first_text(library, "id", "libraryId", "library_id", "key", "uuid", "guid")
+
+
+def _manifest_library_descriptor(library: Mapping[str, Any]) -> ManagerLibraryDescriptor:
+    """One manifest entry, read tolerantly.
+
+    The documented manifest sample shows ``"libraries": []`` from an unconfigured
+    instance, so the populated entry shape is unconfirmed (Deluno#331). Every plausible
+    spelling of name, media type and root is accepted rather than guessing one and
+    failing on the others; a missing root surfaces as a mismatch the operator can fix,
+    which is the same outcome as a root MediaMop cannot see.
+    """
+
+    key = _manifest_library_key(library) or ""
+    name = _first_text(library, "name", "title", "label", "displayName", "display_name") or key
+    scope = _scope_from_media_type(
+        library.get("mediaType") or library.get("media_type") or library.get("scope") or library.get("type")
+    )
+    root = _first_text(library, "path", "rootFolder", "root_folder", "root", "rootPath", "root_path")
+    return ManagerLibraryDescriptor(key=key, name=name, media_scope=scope, root_path=root)
 
 
 def _manifest_libraries(payload: Any) -> list[dict[str, Any]]:

--- a/apps/backend/src/mediamop/platform/media_managers/manager_port.py
+++ b/apps/backend/src/mediamop/platform/media_managers/manager_port.py
@@ -141,6 +141,22 @@ class ManagerCapabilities:
 
 
 @dataclass(frozen=True, slots=True)
+class ManagerLibraryDescriptor:
+    """One library a manager says it looks after.
+
+    ``key`` is the manager's own identifier, kept as a durable integration reference —
+    Deluno's documentation asks external tools to store its ids for exactly this and
+    nothing else. ``root_path`` is a path **on the manager's host**, which is not
+    necessarily a path MediaMop can see.
+    """
+
+    key: str
+    name: str
+    media_scope: MediaScope | None
+    root_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class ManagerDescription:
     """A live answer to "what do you manage", degrading to the static capabilities."""
 
@@ -148,6 +164,7 @@ class ManagerDescription:
     status: SignalStatus
     capabilities: ManagerCapabilities
     library_roots: tuple[str, ...] = field(default=())
+    libraries: tuple[ManagerLibraryDescriptor, ...] = field(default=())
     detail: str | None = None
 
 

--- a/apps/backend/tests/test_refiner_library_discovery.py
+++ b/apps/backend/tests/test_refiner_library_discovery.py
@@ -1,0 +1,306 @@
+"""Libraries discovered from a manager, and the drift report that never applies itself.
+
+Refiner deletes source folders after a successful pass, so a watched folder that
+silently repoints is a destructive surprise. Every test here that touches a path asserts
+MediaMop reported rather than moved it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.platform.media_managers.connection_model  # noqa: F401
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import Base
+from mediamop.modules.refiner import refiner_library_discovery as discovery
+from mediamop.modules.refiner.refiner_library_discovery import (
+    RefinerDiscoveryError,
+    discoverable_libraries,
+    import_libraries,
+    local_path_problem,
+    resync_drift,
+    unlink_library,
+)
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.platform.media_managers.connection_model import MediaManagerConnectionRow
+from mediamop.platform.media_managers.manager_port import ManagerLibraryDescriptor
+
+
+@pytest.fixture
+def session(tmp_path: Path) -> Session:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'discovery.sqlite'}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)()
+
+
+@pytest.fixture
+def connection(session: Session) -> MediaManagerConnectionRow:
+    row = MediaManagerConnectionRow(
+        kind="deluno", name="Deluno", enabled=True, base_url="http://h", api_key_ciphertext="c"
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _reports(monkeypatch: pytest.MonkeyPatch, *descriptors: ManagerLibraryDescriptor) -> None:
+    monkeypatch.setattr(discovery, "_descriptors_for", lambda _s, _c, _row: tuple(descriptors))
+
+
+def _settings() -> MediaMopSettings:
+    return MediaMopSettings.load()
+
+
+def test_a_local_path_that_exists_has_no_problem(tmp_path: Path) -> None:
+    assert local_path_problem(str(tmp_path)) is None
+
+
+def test_a_path_the_manager_sees_but_mediamop_cannot_is_reported_with_both_values(tmp_path: Path) -> None:
+    problem = local_path_problem("/srv/on-another-host/movies")
+    assert problem is not None
+    assert "/srv/on-another-host/movies" in problem
+    assert "machine running" in problem
+
+
+def test_a_missing_root_is_reported_rather_than_guessed() -> None:
+    problem = local_path_problem(None)
+    assert problem is not None
+    assert "did not say where" in problem
+
+
+def test_listing_marks_what_is_already_imported(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path)),
+        ManagerLibraryDescriptor(key="8", name="Shows", media_scope="tv", root_path=str(tmp_path)),
+    )
+    session.add(
+        RefinerLibraryRow(
+            name="Films", media_scope="movie", discovered_from_connection_id=connection.id, discovered_library_key="7"
+        )
+    )
+    session.commit()
+
+    found = {item.key: item for item in discoverable_libraries(session, _settings(), connection)}
+
+    assert found["7"].already_imported is True
+    assert found["8"].already_imported is False
+    assert found["8"].media_scope == "tv"
+
+
+def test_importing_a_subset_creates_only_what_was_chosen(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path)),
+        ManagerLibraryDescriptor(key="8", name="Shows", media_scope="tv", root_path=str(tmp_path)),
+        ManagerLibraryDescriptor(key="9", name="Kids", media_scope="movie", root_path=str(tmp_path)),
+    )
+
+    created = import_libraries(session, _settings(), connection, keys=["7", "9"])
+    session.commit()
+
+    assert sorted(r.name for r in created) == ["Films", "Kids"]
+    assert {r.discovered_library_key for r in created} == {"7", "9"}
+    assert all(r.discovered_from_connection_id == connection.id for r in created)
+    # The manager's root is adopted as the watched folder when MediaMop can see it.
+    assert all(r.watched_folder == str(tmp_path) for r in created)
+
+
+def test_an_imported_library_is_editable_afterwards(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reports(monkeypatch, ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path)))
+    created = import_libraries(session, _settings(), connection, keys=["7"])[0]
+    session.commit()
+
+    created.name = "Films renamed"
+    created.min_file_size_mb = 700
+    session.commit()
+
+    reloaded = session.get(RefinerLibraryRow, created.id)
+    assert reloaded is not None
+    assert reloaded.name == "Films renamed"
+    assert reloaded.min_file_size_mb == 700
+    # Still linked, so a later re-sync can still report on it.
+    assert reloaded.discovered_library_key == "7"
+
+
+def test_a_root_mediamop_cannot_see_imports_without_a_watched_folder(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Better an empty folder the operator fills in than one that fails every scan."""
+
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path="/srv/elsewhere"),
+    )
+
+    created = import_libraries(session, _settings(), connection, keys=["7"])[0]
+
+    assert created.watched_folder == ""
+    assert created.discovered_library_key == "7"
+
+
+def test_a_duplicate_name_is_disambiguated_rather_than_refused(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    session.add(RefinerLibraryRow(name="Films", media_scope="movie"))
+    session.commit()
+    _reports(monkeypatch, ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path)))
+
+    created = import_libraries(session, _settings(), connection, keys=["7"])[0]
+
+    assert created.name == "Films (2)"
+
+
+def test_importing_nothing_is_refused(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reports(monkeypatch)
+    with pytest.raises(RefinerDiscoveryError):
+        import_libraries(session, _settings(), connection, keys=[])
+
+
+def test_resync_reports_a_moved_root_and_changes_nothing(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The rule this feature turns on: a watched folder only moves when the operator moves it."""
+
+    row = RefinerLibraryRow(
+        name="Films",
+        media_scope="movie",
+        watched_folder=str(tmp_path / "old"),
+        discovered_from_connection_id=connection.id,
+        discovered_library_key="7",
+    )
+    session.add(row)
+    session.commit()
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path / "new")),
+    )
+
+    drift = resync_drift(session, _settings(), connection)
+
+    moved = [d for d in drift if d.kind == "root_moved"]
+    assert len(moved) == 1
+    assert moved[0].manager_value == str(tmp_path / "new")
+    assert moved[0].mediamop_value == str(tmp_path / "old")
+    # Nothing applied.
+    session.refresh(row)
+    assert row.watched_folder == str(tmp_path / "old")
+
+
+def test_resync_reports_a_library_the_manager_no_longer_has(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    row = RefinerLibraryRow(
+        name="Gone",
+        media_scope="movie",
+        watched_folder=str(tmp_path),
+        discovered_from_connection_id=connection.id,
+        discovered_library_key="7",
+    )
+    session.add(row)
+    session.commit()
+    _reports(monkeypatch)
+
+    drift = resync_drift(session, _settings(), connection)
+
+    assert [d.kind for d in drift] == ["library_removed"]
+    assert drift[0].library_id == row.id
+    # Left exactly as it was.
+    session.refresh(row)
+    assert row.watched_folder == str(tmp_path)
+
+
+def test_resync_reports_a_library_that_appeared(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="9", name="New", media_scope="movie", root_path=str(tmp_path)),
+    )
+
+    drift = resync_drift(session, _settings(), connection)
+
+    assert [d.kind for d in drift] == ["library_added"]
+    assert drift[0].library_name == "New"
+    # Reported only — nothing was created.
+    assert session.query(RefinerLibraryRow).count() == 0
+
+
+def test_resync_is_quiet_when_nothing_has_changed(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    session.add(
+        RefinerLibraryRow(
+            name="Films",
+            media_scope="movie",
+            watched_folder=str(tmp_path),
+            discovered_from_connection_id=connection.id,
+            discovered_library_key="7",
+        )
+    )
+    session.commit()
+    _reports(monkeypatch, ManagerLibraryDescriptor(key="7", name="Films", media_scope="movie", root_path=str(tmp_path)))
+
+    assert resync_drift(session, _settings(), connection) == []
+
+
+def test_a_manual_library_is_never_reported_as_drift(
+    session: Session, connection: MediaManagerConnectionRow, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Discovery is a convenience. A hand-made library is nobody's business but the operator's."""
+
+    session.add(RefinerLibraryRow(name="Hand made", media_scope="movie", watched_folder=str(tmp_path / "mine")))
+    session.commit()
+    _reports(monkeypatch)
+
+    assert resync_drift(session, _settings(), connection) == []
+
+
+def test_unlinking_keeps_the_library(session: Session, connection: MediaManagerConnectionRow, tmp_path: Path) -> None:
+    row = RefinerLibraryRow(
+        name="Films",
+        media_scope="movie",
+        watched_folder=str(tmp_path),
+        discovered_from_connection_id=connection.id,
+        discovered_library_key="7",
+    )
+    session.add(row)
+    session.commit()
+
+    unlink_library(session, row)
+    session.commit()
+
+    reloaded = session.get(RefinerLibraryRow, row.id)
+    assert reloaded is not None
+    assert reloaded.name == "Films"
+    assert reloaded.watched_folder == str(tmp_path)
+    assert reloaded.discovered_from_connection_id is None
+    assert reloaded.discovered_library_key is None
+
+
+def test_a_connection_with_no_saved_key_cannot_be_asked(session: Session, tmp_path: Path) -> None:
+    row = MediaManagerConnectionRow(kind="deluno", name="Half", enabled=True, base_url="http://h")
+    session.add(row)
+    session.commit()
+
+    with pytest.raises(RefinerDiscoveryError) as exc:
+        discoverable_libraries(session, MediaMopSettings.load(), row)
+    assert "address and API key" in str(exc.value)

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -398,6 +398,70 @@
         "title": "DirectoryBrowseOut",
         "type": "object"
       },
+      "DiscoverableLibraryOut": {
+        "description": "One library a connected manager reports.",
+        "properties": {
+          "already_imported": {
+            "title": "Already Imported",
+            "type": "boolean"
+          },
+          "key": {
+            "description": "The manager's own id, kept only as an integration reference.",
+            "title": "Key",
+            "type": "string"
+          },
+          "local_path_problem": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why that path cannot be used on this machine, shown beside the manager's value.",
+            "title": "Local Path Problem"
+          },
+          "media_scope": {
+            "anyOf": [
+              {
+                "enum": [
+                  "movie",
+                  "tv"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Media Scope"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "root_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Where the manager sees this library, on the manager's host.",
+            "title": "Root Path"
+          }
+        },
+        "required": [
+          "key",
+          "name",
+          "already_imported"
+        ],
+        "title": "DiscoverableLibraryOut",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -432,6 +496,69 @@
           "status"
         ],
         "title": "HealthResponse",
+        "type": "object"
+      },
+      "LibraryDriftOut": {
+        "description": "A difference between the manager and MediaMop. Reported, never applied.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "kind": {
+            "enum": [
+              "root_moved",
+              "library_removed",
+              "library_added",
+              "path_not_local"
+            ],
+            "title": "Kind",
+            "type": "string"
+          },
+          "library_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Library Id"
+          },
+          "library_name": {
+            "title": "Library Name",
+            "type": "string"
+          },
+          "manager_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Manager Value"
+          },
+          "mediamop_value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mediamop Value"
+          }
+        },
+        "required": [
+          "kind",
+          "library_name",
+          "detail"
+        ],
+        "title": "LibraryDriftOut",
         "type": "object"
       },
       "LoginIn": {
@@ -3192,6 +3319,31 @@
           "csrf_token"
         ],
         "title": "RefinerLibraryDeleteIn",
+        "type": "object"
+      },
+      "RefinerLibraryImportIn": {
+        "additionalProperties": false,
+        "properties": {
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          },
+          "keys": {
+            "description": "Manager library ids to import.",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "title": "Keys",
+            "type": "array"
+          }
+        },
+        "required": [
+          "csrf_token",
+          "keys"
+        ],
+        "title": "RefinerLibraryImportIn",
         "type": "object"
       },
       "RefinerLibraryOut": {
@@ -8092,6 +8244,163 @@
         ]
       }
     },
+    "/api/v1/refiner/libraries/discover/{connection_id}": {
+      "get": {
+        "description": "What this manager says it looks after, and whether MediaMop already has it.",
+        "operationId": "get_refiner_discoverable_libraries_api_v1_refiner_libraries_discover__connection_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Connection Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DiscoverableLibraryOut"
+                  },
+                  "title": "Response Get Refiner Discoverable Libraries Api V1 Refiner Libraries Discover  Connection Id  Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Refiner Discoverable Libraries",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/libraries/discover/{connection_id}/drift": {
+      "get": {
+        "description": "Differences between the manager and MediaMop. Reported only \u2014 nothing is applied.",
+        "operationId": "get_refiner_library_drift_api_v1_refiner_libraries_discover__connection_id__drift_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Connection Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LibraryDriftOut"
+                  },
+                  "title": "Response Get Refiner Library Drift Api V1 Refiner Libraries Discover  Connection Id  Drift Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Refiner Library Drift",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/libraries/discover/{connection_id}/import": {
+      "post": {
+        "description": "Create a Refiner library per selected manager library.",
+        "operationId": "post_refiner_import_libraries_api_v1_refiner_libraries_discover__connection_id__import_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Connection Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefinerLibraryImportIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RefinerLibraryOut"
+                  },
+                  "title": "Response Post Refiner Import Libraries Api V1 Refiner Libraries Discover  Connection Id  Import Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Refiner Import Libraries",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
     "/api/v1/refiner/libraries/reorder": {
       "post": {
         "description": "Set display order. Order decides which library a scope-only payload resolves to.",
@@ -8276,6 +8585,61 @@
           }
         },
         "summary": "Put Refiner Library",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/libraries/{library_id}/unlink": {
+      "post": {
+        "description": "Forget where a library came from. The library itself is untouched.",
+        "operationId": "post_refiner_library_unlink_api_v1_refiner_libraries__library_id__unlink_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "library_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "Library Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefinerLibraryDeleteIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefinerLibraryOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Refiner Library Unlink",
         "tags": [
           "refiner",
           "refiner"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -760,6 +760,66 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/refiner/libraries/discover/{connection_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Refiner Discoverable Libraries
+     * @description What this manager says it looks after, and whether MediaMop already has it.
+     */
+    get: operations["get_refiner_discoverable_libraries_api_v1_refiner_libraries_discover__connection_id__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/libraries/discover/{connection_id}/drift": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Refiner Library Drift
+     * @description Differences between the manager and MediaMop. Reported only — nothing is applied.
+     */
+    get: operations["get_refiner_library_drift_api_v1_refiner_libraries_discover__connection_id__drift_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/libraries/discover/{connection_id}/import": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Post Refiner Import Libraries
+     * @description Create a Refiner library per selected manager library.
+     */
+    post: operations["post_refiner_import_libraries_api_v1_refiner_libraries_discover__connection_id__import_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/refiner/libraries/reorder": {
     parameters: {
       query?: never;
@@ -800,6 +860,26 @@ export interface paths {
      * @description Remove a library. Refused while it still has queued or running work.
      */
     delete: operations["delete_refiner_library_api_v1_refiner_libraries__library_id__delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/libraries/{library_id}/unlink": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Post Refiner Library Unlink
+     * @description Forget where a library came from. The library itself is untouched.
+     */
+    post: operations["post_refiner_library_unlink_api_v1_refiner_libraries__library_id__unlink_post"];
+    delete?: never;
     options?: never;
     head?: never;
     patch?: never;
@@ -1603,6 +1683,33 @@ export interface components {
       /** Parent Path */
       parent_path: string | null;
     };
+    /**
+     * DiscoverableLibraryOut
+     * @description One library a connected manager reports.
+     */
+    DiscoverableLibraryOut: {
+      /** Already Imported */
+      already_imported: boolean;
+      /**
+       * Key
+       * @description The manager's own id, kept only as an integration reference.
+       */
+      key: string;
+      /**
+       * Local Path Problem
+       * @description Why that path cannot be used on this machine, shown beside the manager's value.
+       */
+      local_path_problem?: string | null;
+      /** Media Scope */
+      media_scope?: ("movie" | "tv") | null;
+      /** Name */
+      name: string;
+      /**
+       * Root Path
+       * @description Where the manager sees this library, on the manager's host.
+       */
+      root_path?: string | null;
+    };
     /** HTTPValidationError */
     HTTPValidationError: {
       /** Detail */
@@ -1625,6 +1732,31 @@ export interface components {
        * @description Application liveness indicator.
        */
       status: string;
+    };
+    /**
+     * LibraryDriftOut
+     * @description A difference between the manager and MediaMop. Reported, never applied.
+     */
+    LibraryDriftOut: {
+      /** Detail */
+      detail: string;
+      /**
+       * Kind
+       * @enum {string}
+       */
+      kind:
+        | "root_moved"
+        | "library_removed"
+        | "library_added"
+        | "path_not_local";
+      /** Library Id */
+      library_id?: number | null;
+      /** Library Name */
+      library_name: string;
+      /** Manager Value */
+      manager_value?: string | null;
+      /** Mediamop Value */
+      mediamop_value?: string | null;
     };
     /** LoginIn */
     LoginIn: {
@@ -2834,6 +2966,16 @@ export interface components {
     RefinerLibraryDeleteIn: {
       /** Csrf Token */
       csrf_token: string;
+    };
+    /** RefinerLibraryImportIn */
+    RefinerLibraryImportIn: {
+      /** Csrf Token */
+      csrf_token: string;
+      /**
+       * Keys
+       * @description Manager library ids to import.
+       */
+      keys: string[];
     };
     /** RefinerLibraryOut */
     RefinerLibraryOut: {
@@ -5531,6 +5673,103 @@ export interface operations {
       };
     };
   };
+  get_refiner_discoverable_libraries_api_v1_refiner_libraries_discover__connection_id__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        connection_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["DiscoverableLibraryOut"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_refiner_library_drift_api_v1_refiner_libraries_discover__connection_id__drift_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        connection_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["LibraryDriftOut"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  post_refiner_import_libraries_api_v1_refiner_libraries_discover__connection_id__import_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        connection_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RefinerLibraryImportIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["RefinerLibraryOut"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   post_refiner_libraries_reorder_api_v1_refiner_libraries_reorder_post: {
     parameters: {
       query?: never;
@@ -5651,6 +5890,41 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  post_refiner_library_unlink_api_v1_refiner_libraries__library_id__unlink_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        library_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RefinerLibraryDeleteIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["RefinerLibraryOut"];
+        };
       };
       /** @description Validation Error */
       422: {


### PR DESCRIPTION
Closes #351. Part of #347. Milestone v2.5.0. Stacked on #361.

The manager already knows where the libraries are, keeps it current, and publishes it. The operator was retyping it — and until libraries existed, could only type two.

## What it does

**Discover** — `describe()` now reports per-library detail (the manager's own id, a name, a media type, a root) rather than just a list of paths. The arr ports derive it from `/api/v3/rootfolder`; the external-integration ports read the manifest.

**Import** — creates a Refiner library per selection, carrying the manager's id as a durable integration reference *and nothing else*, which is exactly what Deluno's documentation asks external tools to store. Afterwards it is an ordinary library: editable, and identical to a hand-made one everywhere else.

**Re-sync reports, never applies.** Four kinds of drift — a moved root, a library that vanished, a library that appeared, a root this host cannot see — each with the manager's value and MediaMop's value side by side. Refiner deletes source folders after a successful pass, so a watched folder only ever moves when the operator moves it.

**Unlink** forgets where a library came from and leaves the library completely untouched.

## The unconfirmed manifest shape

The issue flags that the documented sample shows `"libraries": []` from an unconfigured instance, so the populated entry shape is unknown (Deluno#331). Rather than stopping, the parser accepts every plausible spelling of name, media type and root. Guessing one and failing on the others would be the fragile choice; a missing root already has a defined outcome — it surfaces as a mismatch to fix, which is the same path as a root MediaMop cannot see.

## A bug the tests caught

The local-path check originally used `Path.is_absolute()`. On Windows that rejects `/srv/media/movies` — a perfectly good root reported by a Linux manager — and would have told the operator their path was *malformed* when the real answer is *this host cannot see it*. The check is now textual (leading `/`, drive letter, or UNC), matching the reason `handoff_paths` is textual: it must behave the same on the API host and the worker, and fail with a sentence rather than a stat error on a share that is not mounted yet.

A root MediaMop cannot see is imported with an **empty** watched folder rather than a path that would fail every scan, and the reason is reported on the way in.

## API

`GET /refiner/libraries/discover/{connection_id}`, `POST .../import`, `GET .../drift`, `POST /refiner/libraries/{id}/unlink`. OpenAPI regenerated, no drift.

## Validation

`ruff check`/`format --check`, `mypy`, `pytest -q` — **920 passed**, 2 skipped, coverage **79.00%** against the 75 floor. Web lint/format/test, dead-code guard, types regenerated.

16 new tests: import a subset, re-sync with a moved root (asserting the saved path is *unchanged*), a removed library, a library that appeared (asserting nothing was created), a path that does not resolve locally, unlink keeping the library, a manual library never reported as drift, and duplicate-name disambiguation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
