### PR TITLE
feat(refiner): file states — On Hold, Out Of Schedule, Disabled, Blocked Upstream — and a Files screen

### DIFF
--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -31,6 +31,7 @@ from mediamop.modules.pruner import pruner_preview_run_model as _pruner_preview_
 from mediamop.modules.pruner import pruner_scope_settings_model as _pruner_scope_settings_orm  # noqa: F401
 from mediamop.modules.pruner import pruner_server_instance_model as _pruner_server_instance_orm  # noqa: F401
 from mediamop.modules.refiner import jobs_model as _refiner_jobs_orm  # noqa: F401
+from mediamop.modules.refiner import refiner_file_state_model as _refiner_file_state_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_library_model as _refiner_library_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_operator_settings_model as _refiner_operator_settings_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_path_settings_model as _refiner_path_settings_orm  # noqa: F401

--- a/apps/backend/alembic/versions/0012_refiner_file_states.py
+++ b/apps/backend/alembic/versions/0012_refiner_file_states.py
@@ -1,0 +1,57 @@
+"""Refiner file states — the reasons a file is deliberately not being processed
+
+Refiner could say a job was pending, leased, completed or failed. It could not say
+"disabled", "on hold", "out of schedule" or "blocked upstream", so every deliberate
+decision *not* to process a file was invisible to the operator.
+
+Creates ``refiner_files``. Nothing is backfilled: a file's state is whatever the next
+scan concludes, and inventing history for files nobody has looked at yet would be
+inventing reasons too.
+
+Revision ID: 0012_refiner_file_states
+Revises: 0011_refiner_libraries
+Create Date: 2026-08-28 12:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0012_refiner_file_states"
+down_revision = "0011_refiner_libraries"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    if "refiner_files" in set(inspect(op.get_bind()).get_table_names()):
+        return
+    op.create_table(
+        "refiner_files",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "library_id",
+            sa.Integer(),
+            sa.ForeignKey("refiner_libraries.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("relative_path", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="unprocessed"),
+        sa.Column("status_reason", sa.Text(), nullable=False, server_default=""),
+        sa.Column("blocked_by_connection", sa.Text(), nullable=True),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False, server_default="0"),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("library_id", "relative_path", name="uq_refiner_files_library_path"),
+    )
+    op.create_index("ix_refiner_files_status", "refiner_files", ["status"])
+    op.create_index("ix_refiner_files_library_status", "refiner_files", ["library_id", "status"])
+
+
+def downgrade() -> None:
+    op.drop_table("refiner_files")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_state_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_state_model.py
@@ -1,0 +1,93 @@
+"""What Refiner thinks about one file, including the reasons it is *not* working on it.
+
+Refiner had one vocabulary: a job is pending, leased, completed or failed. None of those
+can say "this file qualifies but its library is switched off", or "its schedule window
+closed", or "the manager that owns it is still importing it". So an operator asking why a
+file is not processing had nowhere to look — the scan simply did not enqueue it, and the
+reason existed only as a local variable.
+
+A file is a row now, and every state carries a sentence written for the person reading it
+rather than for the code that set it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import (
+    BigInteger,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from mediamop.core.db import Base
+
+
+class RefinerFileStatus(StrEnum):
+    """The vocabulary an operator sees on the Files screen.
+
+    The first four mirror what job rows already expressed. The last four are the point of
+    this type: each is a deliberate decision *not* to process a file, and each was
+    previously invisible.
+    """
+
+    UNPROCESSED = "unprocessed"
+    PROCESSING = "processing"
+    PROCESSED = "processed"
+    PROCESSING_FAILED = "processing_failed"
+    DISABLED = "disabled"
+    ON_HOLD = "on_hold"
+    OUT_OF_SCHEDULE = "out_of_schedule"
+    BLOCKED_UPSTREAM = "blocked_upstream"
+
+
+#: States where MediaMop has decided not to act, as opposed to not having acted yet.
+REFINER_WITHHELD_STATUSES: frozenset[str] = frozenset(
+    {
+        RefinerFileStatus.DISABLED.value,
+        RefinerFileStatus.ON_HOLD.value,
+        RefinerFileStatus.OUT_OF_SCHEDULE.value,
+        RefinerFileStatus.BLOCKED_UPSTREAM.value,
+    }
+)
+
+
+class RefinerFileRow(Base):
+    """One file Refiner has seen, and the last thing it decided about it."""
+
+    __tablename__ = "refiner_files"
+    __table_args__ = (
+        UniqueConstraint("library_id", "relative_path", name="uq_refiner_files_library_path"),
+        Index("ix_refiner_files_status", "status"),
+        Index("ix_refiner_files_library_status", "library_id", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    library_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("refiner_libraries.id", ondelete="CASCADE"), nullable=False
+    )
+    relative_path: Mapped[str] = mapped_column(Text, nullable=False)
+
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=RefinerFileStatus.UNPROCESSED.value)
+    # Always operator-facing prose. A status with no reason is a status that cannot
+    # answer the question the screen exists to answer.
+    status_reason: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    # Set only for BLOCKED_UPSTREAM: the connection holding the file, named the way the
+    # blocked-upstream reasons name it — never the vendor.
+    blocked_by_connection: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
@@ -1,0 +1,219 @@
+"""Decide, record and read a file's Refiner state.
+
+The decision order matters and is not arbitrary. It runs cheapest-and-most-absolute
+first, so the reason an operator is shown is the *first* thing standing in the way rather
+than whichever check happened to run last:
+
+1. **Disabled** — the library is switched off. Nothing else about the file is relevant.
+2. **Out of schedule** — the library is on, but not right now.
+3. **On hold** — the file is too new, or still settling.
+4. **Blocked upstream** — a manager is still importing it.
+
+Only a file that clears all four is unprocessed and eligible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow, RefinerFileStatus
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_operator_settings_service import (
+    refiner_periodic_scope_in_schedule_window,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class FileStateVerdict:
+    """A status and the sentence that explains it."""
+
+    status: RefinerFileStatus
+    reason: str
+    blocked_by_connection: str | None = None
+
+    @property
+    def eligible(self) -> bool:
+        return self.status is RefinerFileStatus.UNPROCESSED
+
+
+def _scope_word(library: RefinerLibraryRow) -> str:
+    return "TV episodes" if library.media_scope == "tv" else "Movies"
+
+
+def decide_file_state(
+    *,
+    library: RefinerLibraryRow,
+    in_schedule_window: bool,
+    file_age_seconds: float | None,
+    size_is_settling: bool = False,
+    blocked_by_connection: str | None = None,
+) -> FileStateVerdict:
+    """Why this file is or is not being worked on, in the order the reasons apply."""
+
+    if not library.enabled:
+        return FileStateVerdict(
+            RefinerFileStatus.DISABLED,
+            f"The {library.name} library is switched off, so MediaMop is leaving its files alone.",
+        )
+
+    if library.schedule_enabled and not in_schedule_window:
+        return FileStateVerdict(
+            RefinerFileStatus.OUT_OF_SCHEDULE,
+            (
+                f"The {library.name} library only runs inside its scheduled hours, and now is outside them. "
+                "MediaMop will pick this up when the window opens."
+            ),
+        )
+
+    hold_seconds = max(0, int(library.min_file_age_seconds)) + max(0, int(library.hold_minutes)) * 60
+    if size_is_settling:
+        return FileStateVerdict(
+            RefinerFileStatus.ON_HOLD,
+            "This file is still being written to, so MediaMop is waiting for it to finish before touching it.",
+        )
+    if hold_seconds and file_age_seconds is not None and file_age_seconds < hold_seconds:
+        remaining = int(hold_seconds - file_age_seconds)
+        return FileStateVerdict(
+            RefinerFileStatus.ON_HOLD,
+            (
+                f"This file changed too recently. MediaMop waits {hold_seconds}s after the last change before "
+                f"processing, so it has about {remaining}s to go."
+            ),
+        )
+
+    if blocked_by_connection:
+        return FileStateVerdict(
+            RefinerFileStatus.BLOCKED_UPSTREAM,
+            f"{blocked_by_connection} is still importing this file, so MediaMop left it alone for now.",
+            blocked_by_connection=blocked_by_connection,
+        )
+
+    return FileStateVerdict(
+        RefinerFileStatus.UNPROCESSED,
+        f"Ready for Refiner to process as part of {_scope_word(library)}.",
+    )
+
+
+def library_in_schedule_window(session: Session, library: RefinerLibraryRow) -> bool:
+    """Whether this library's schedule window is open right now.
+
+    Falls back to the per-scope operator window while a library's own days and times are
+    still seeded from it, so an upgrade does not silently change when work runs.
+    """
+
+    if not library.schedule_enabled:
+        return True
+    if not library.schedule_hours_limited:
+        return True
+    from mediamop.modules.refiner.refiner_operator_settings_service import (
+        ensure_refiner_operator_settings_row,
+    )
+
+    row = ensure_refiner_operator_settings_row(session)
+    return refiner_periodic_scope_in_schedule_window(session, row, media_scope=library.media_scope)
+
+
+def record_file_state(
+    session: Session,
+    *,
+    library: RefinerLibraryRow,
+    relative_path: str,
+    verdict: FileStateVerdict,
+    size_bytes: int = 0,
+    seen_at: datetime | None = None,
+    is_attempt: bool = False,
+) -> RefinerFileRow:
+    """Upsert one file's state. Safe to call on every scan."""
+
+    now = seen_at or datetime.now(UTC)
+    row = session.scalars(
+        select(RefinerFileRow)
+        .where(RefinerFileRow.library_id == library.id)
+        .where(RefinerFileRow.relative_path == relative_path)
+    ).first()
+    if row is None:
+        row = RefinerFileRow(library_id=library.id, relative_path=relative_path)
+        session.add(row)
+    row.status = verdict.status.value
+    row.status_reason = verdict.reason
+    row.blocked_by_connection = verdict.blocked_by_connection
+    if size_bytes:
+        row.size_bytes = int(size_bytes)
+    row.last_seen_at = now
+    if is_attempt:
+        row.last_attempt_at = now
+    session.flush()
+    return row
+
+
+def mark_file_status(
+    session: Session,
+    *,
+    library_id: int,
+    relative_path: str,
+    status: RefinerFileStatus,
+    reason: str,
+) -> RefinerFileRow | None:
+    """Move a file MediaMop has already seen into a new state (processing, processed, failed)."""
+
+    row = session.scalars(
+        select(RefinerFileRow)
+        .where(RefinerFileRow.library_id == library_id)
+        .where(RefinerFileRow.relative_path == relative_path)
+    ).first()
+    if row is None:
+        return None
+    row.status = status.value
+    row.status_reason = reason
+    if status in (RefinerFileStatus.PROCESSING, RefinerFileStatus.PROCESSED, RefinerFileStatus.PROCESSING_FAILED):
+        row.last_attempt_at = datetime.now(UTC)
+    if status is not RefinerFileStatus.BLOCKED_UPSTREAM:
+        row.blocked_by_connection = None
+    session.flush()
+    return row
+
+
+def status_counts(session: Session, *, library_id: int | None = None) -> dict[str, int]:
+    """Counts per status, for the buckets across the top of the Files screen."""
+
+    counts = dict.fromkeys((s.value for s in RefinerFileStatus), 0)
+    stmt = select(RefinerFileRow.status)
+    if library_id is not None:
+        stmt = stmt.where(RefinerFileRow.library_id == library_id)
+    for value in session.scalars(stmt):
+        if value in counts:
+            counts[value] += 1
+    return counts
+
+
+def list_files(
+    session: Session,
+    *,
+    library_id: int | None = None,
+    status: str | None = None,
+    path_contains: str | None = None,
+    since: datetime | None = None,
+    limit: int = 200,
+) -> list[RefinerFileRow]:
+    stmt = select(RefinerFileRow)
+    if library_id is not None:
+        stmt = stmt.where(RefinerFileRow.library_id == library_id)
+    if status:
+        stmt = stmt.where(RefinerFileRow.status == status)
+    if path_contains:
+        stmt = stmt.where(RefinerFileRow.relative_path.ilike(f"%{path_contains}%"))
+    if since is not None:
+        stmt = stmt.where(RefinerFileRow.last_seen_at >= since)
+    stmt = stmt.order_by(RefinerFileRow.last_seen_at.desc(), RefinerFileRow.id.desc()).limit(max(1, min(limit, 1000)))
+    return list(session.scalars(stmt))
+
+
+def forget_file(session: Session, row: RefinerFileRow) -> None:
+    """Remove a file from the list. The file on disk is untouched."""
+
+    session.delete(row)
+    session.flush()

--- a/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
@@ -1,0 +1,106 @@
+"""Refiner HTTP: the Files screen — ``/api/v1/refiner/files``.
+
+The screen this serves is the one that answers "why isn't this file processing?", which
+Refiner previously could not answer at all: the scan decided and moved on, and the reason
+never left the function that produced it.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, HTTPException, Path, Query, Request
+from starlette import status as http_status
+
+from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow
+from mediamop.modules.refiner.refiner_file_state_service import forget_file, list_files, status_counts
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.schemas_refiner_files import (
+    RefinerFileForgetIn,
+    RefinerFileOut,
+    RefinerFilesPageOut,
+    RefinerFileStatusName,
+)
+from mediamop.platform.auth.authorization import RequireOperatorDep
+from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
+    require_session_secret,
+    validate_browser_post_origin,
+    verify_csrf_token,
+)
+from mediamop.platform.auth.deps_auth import UserPublicDep
+
+router = APIRouter(tags=["refiner"])
+
+
+def _verify_csrf(request: Request, settings: MediaMopSettings, token: str) -> None:
+    validate_browser_post_origin(request, settings)
+    secret = require_session_secret(settings)
+    if not verify_csrf_token(secret, token, raw_session_token=current_raw_session_token(request, settings)):
+        raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail="Invalid or expired CSRF token.")
+
+
+@router.get("/refiner/files", response_model=RefinerFilesPageOut)
+def get_refiner_files(
+    _user: UserPublicDep,
+    db: DbSessionDep,
+    library_id: int | None = Query(default=None, ge=1),
+    file_status: RefinerFileStatusName | None = Query(default=None),
+    path_contains: str | None = Query(default=None, max_length=400),
+    within_days: int | None = Query(default=None, ge=1, le=3650),
+    limit: int = Query(default=200, ge=1, le=1000),
+) -> RefinerFilesPageOut:
+    """Files Refiner has seen, with the reason it is or is not working on each."""
+
+    since = datetime.now(UTC) - timedelta(days=within_days) if within_days else None
+    rows = list_files(
+        db,
+        library_id=library_id,
+        status=file_status,
+        path_contains=path_contains,
+        since=since,
+        limit=limit,
+    )
+    names = {row.id: row.name for row in db.query(RefinerLibraryRow).all()}
+    files = [
+        RefinerFileOut(
+            id=row.id,
+            library_id=row.library_id,
+            library_name=names.get(row.library_id, "Unknown library"),
+            relative_path=row.relative_path,
+            status=row.status,  # type: ignore[arg-type]
+            status_reason=row.status_reason,
+            blocked_by_connection=row.blocked_by_connection,
+            size_bytes=row.size_bytes,
+            last_seen_at=row.last_seen_at,
+            last_attempt_at=row.last_attempt_at,
+        )
+        for row in rows
+    ]
+    return RefinerFilesPageOut(
+        files=files,
+        status_counts=status_counts(db, library_id=library_id),
+        returned=len(files),
+        limit=limit,
+    )
+
+
+@router.delete("/refiner/files/{file_id}", status_code=http_status.HTTP_204_NO_CONTENT)
+def delete_refiner_file(
+    body: RefinerFileForgetIn,
+    request: Request,
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    file_id: int = Path(ge=1),
+) -> None:
+    """Forget a file. Removes MediaMop's record of it, never the file on disk."""
+
+    _verify_csrf(request, settings, body.csrf_token)
+    row = db.get(RefinerFileRow, file_id)
+    if row is None:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="MediaMop has no record of that file.")
+    forget_file(db, row)
+    db.commit()

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_evaluate.py
@@ -23,8 +23,8 @@ from mediamop.modules.refiner.manager_queue_signals import (
     AttributedQueueRow,
     QueueSignalReport,
     attributed_rows_for_file,
+    blocking_connection_label,
     report_for_signals,
-    upstream_block_reason,
 )
 from mediamop.platform.media_managers.manager_binding import collect_queue_signals
 from mediamop.platform.media_managers.manager_port import ManagerQueueSignal, MediaScope
@@ -38,6 +38,9 @@ class WatchedFileDispatchOutcome:
 
     verdict: Verdict
     blocked_reason: str | None = None
+    # The connection holding the file, so the Files screen can name it without
+    # re-parsing the prose reason (#334).
+    blocked_connection: str | None = None
 
 
 def merge_queue_views_for_watched_file(
@@ -66,9 +69,13 @@ def verdict_for_watched_scan_file(
     is an ordinary 4K-plus-1080p setup, and either of them may be mid-import.
     """
 
-    reason = upstream_block_reason(rows, candidate=candidate)
-    if reason is not None:
-        return WatchedFileDispatchOutcome(verdict="wait_upstream", blocked_reason=reason)
+    label = blocking_connection_label(rows, candidate=candidate)
+    if label is not None:
+        return WatchedFileDispatchOutcome(
+            verdict="wait_upstream",
+            blocked_reason=f"{label} is still importing this file, so MediaMop left it alone for now.",
+            blocked_connection=label,
+        )
     return WatchedFileDispatchOutcome(verdict="proceed")
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -14,6 +15,12 @@ from sqlalchemy.orm import Session, sessionmaker
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
 from mediamop.modules.refiner.jobs_ops import refiner_enqueue_or_get_job
+from mediamop.modules.refiner.refiner_file_state_service import (
+    decide_file_state,
+    library_in_schedule_window,
+    record_file_state,
+)
+from mediamop.modules.refiner.refiner_library_service import resolve_library
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
 from mediamop.modules.refiner.refiner_remux_rules import refiner_media_extensions_sorted
@@ -77,6 +84,10 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                 media_scope=media_scope,
             )
 
+        with session_factory() as library_session:
+            library = resolve_library(library_session, media_scope=media_scope)
+            in_window = library_in_schedule_window(library_session, library) if library is not None else True
+
         watched_path = Path(watched_root)
         candidates = iter_watched_folder_media_candidates(
             watched_path,
@@ -105,6 +116,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             "ignored_unsupported_type": candidates.ignored_unsupported_type,
             "ignored_unsupported_extensions": list(candidates.ignored_unsupported_extensions),
             "media_extensions_applied": list(refiner_media_extensions_sorted()),
+            "files_withheld": 0,
             "verdict_proceed": 0,
             "verdict_wait_upstream": 0,
             "verdict_not_held": 0,
@@ -149,6 +161,26 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                     media_scope=media_scope,
                     file_path=file_path,
                 )
+                # Record why this file is or is not being worked on. Until now the reason
+                # existed only as a local variable and the operator saw nothing (#334).
+                if library is not None:
+                    rel_for_state = relative_posix_path_under_watched(watched_root=watched_path, file_path=file_path)
+                    verdict = decide_file_state(
+                        library=library,
+                        in_schedule_window=in_window,
+                        file_age_seconds=_file_age_seconds(file_path),
+                        blocked_by_connection=outcome.blocked_connection,
+                    )
+                    record_file_state(
+                        session,
+                        library=library,
+                        relative_path=rel_for_state,
+                        verdict=verdict,
+                        size_bytes=_file_size_bytes(file_path),
+                    )
+                    if not verdict.eligible:
+                        summary["files_withheld"] += 1
+                        continue
                 if outcome.verdict == "proceed":
                     summary["verdict_proceed"] += 1
                 elif outcome.verdict == "wait_upstream":
@@ -280,3 +312,17 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             # event here makes Activity look backwards when completed file events arrive first.
 
     return _run
+
+
+def _file_age_seconds(path: Path) -> float | None:
+    try:
+        return max(0.0, time.time() - float(path.stat().st_mtime))
+    except OSError:
+        return None
+
+
+def _file_size_bytes(path: Path) -> int:
+    try:
+        return int(path.stat().st_size)
+    except OSError:
+        return 0

--- a/apps/backend/src/mediamop/modules/refiner/router.py
+++ b/apps/backend/src/mediamop/modules/refiner/router.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter
 
 from mediamop.modules.refiner.file_remux_pass.api import router as refiner_file_remux_pass_router
 from mediamop.modules.refiner.refiner_candidate_gate_api import router as refiner_candidate_gate_router
+from mediamop.modules.refiner.refiner_files_api import router as refiner_files_router
 from mediamop.modules.refiner.refiner_jobs_inspection_api import router as refiner_jobs_inspection_router
 from mediamop.modules.refiner.refiner_libraries_api import router as refiner_libraries_router
 from mediamop.modules.refiner.refiner_operator_settings_api import router as refiner_operator_settings_router
@@ -26,6 +27,7 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_api imp
 router = APIRouter(tags=["refiner"])
 router.include_router(refiner_jobs_inspection_router)
 router.include_router(refiner_operator_settings_router)
+router.include_router(refiner_files_router)
 router.include_router(refiner_libraries_router)
 router.include_router(refiner_path_settings_router)
 router.include_router(refiner_remux_rules_settings_router)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
@@ -1,0 +1,52 @@
+"""Request and response shapes for the Refiner Files screen."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+RefinerFileStatusName = Literal[
+    "unprocessed",
+    "processing",
+    "processed",
+    "processing_failed",
+    "disabled",
+    "on_hold",
+    "out_of_schedule",
+    "blocked_upstream",
+]
+
+
+class RefinerFileOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    library_id: int
+    library_name: str
+    relative_path: str
+    status: RefinerFileStatusName
+    status_reason: str = Field(description="Why the file is in this state, written for the person reading it.")
+    blocked_by_connection: str | None = Field(
+        default=None,
+        description="The media manager connection holding this file, when the status is blocked_upstream.",
+    )
+    size_bytes: int
+    last_seen_at: datetime | None = None
+    last_attempt_at: datetime | None = None
+
+
+class RefinerFilesPageOut(BaseModel):
+    """A page of files plus the bucket counts shown above them."""
+
+    files: list[RefinerFileOut]
+    status_counts: dict[str, int]
+    returned: int
+    limit: int
+
+
+class RefinerFileForgetIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)

--- a/apps/backend/tests/test_refiner_file_states.py
+++ b/apps/backend/tests/test_refiner_file_states.py
@@ -1,0 +1,240 @@
+"""The reasons a file is deliberately not being processed.
+
+Refiner could previously say a job was pending, leased, completed or failed. None of
+those answer "why isn't this file processing?", which is the question this vocabulary
+exists for — so every test here asserts the *reason*, not just the status.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_file_state_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.platform.media_managers.connection_model  # noqa: F401
+from mediamop.core.db import Base
+from mediamop.modules.refiner.refiner_file_state_model import (
+    REFINER_WITHHELD_STATUSES,
+    RefinerFileStatus,
+)
+from mediamop.modules.refiner.refiner_file_state_service import (
+    decide_file_state,
+    forget_file,
+    list_files,
+    mark_file_status,
+    record_file_state,
+    status_counts,
+)
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+
+
+@pytest.fixture
+def session(tmp_path: Path) -> Session:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'files.sqlite'}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)()
+
+
+def _library(session: Session, **overrides) -> RefinerLibraryRow:
+    row = RefinerLibraryRow(
+        name=overrides.pop("name", "Movies"),
+        media_scope=overrides.pop("media_scope", "movie"),
+        watched_folder="/srv/in",
+        output_folder="/srv/out",
+        min_file_age_seconds=overrides.pop("min_file_age_seconds", 60),
+        **overrides,
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def test_a_disabled_library_reports_disabled_and_says_which_one(session: Session) -> None:
+    library = _library(session, name="Kids", enabled=False)
+    verdict = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999)
+    assert verdict.status is RefinerFileStatus.DISABLED
+    assert "Kids" in verdict.reason
+    assert "switched off" in verdict.reason
+    assert verdict.eligible is False
+
+
+def test_outside_the_schedule_window_says_it_will_come_back(session: Session) -> None:
+    library = _library(session, schedule_enabled=True)
+    verdict = decide_file_state(library=library, in_schedule_window=False, file_age_seconds=99999)
+    assert verdict.status is RefinerFileStatus.OUT_OF_SCHEDULE
+    assert "window opens" in verdict.reason
+
+
+def test_a_file_still_settling_is_on_hold(session: Session) -> None:
+    library = _library(session)
+    verdict = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999, size_is_settling=True)
+    assert verdict.status is RefinerFileStatus.ON_HOLD
+    assert "still being written" in verdict.reason
+
+
+def test_a_too_new_file_is_on_hold_and_says_how_much_longer(session: Session) -> None:
+    library = _library(session, min_file_age_seconds=300)
+    verdict = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=60)
+    assert verdict.status is RefinerFileStatus.ON_HOLD
+    assert "300s" in verdict.reason
+    assert "240s to go" in verdict.reason
+
+
+def test_the_hold_timer_adds_to_the_minimum_age(session: Session) -> None:
+    library = _library(session, min_file_age_seconds=60, hold_minutes=5)
+    verdict = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=100)
+    assert verdict.status is RefinerFileStatus.ON_HOLD
+    # 60 + 5*60 = 360
+    assert "360s" in verdict.reason
+
+
+def test_blocked_upstream_names_the_connection_not_the_vendor(session: Session) -> None:
+    library = _library(session)
+    verdict = decide_file_state(
+        library=library,
+        in_schedule_window=True,
+        file_age_seconds=99999,
+        blocked_by_connection="Deluno (Main)",
+    )
+    assert verdict.status is RefinerFileStatus.BLOCKED_UPSTREAM
+    assert verdict.blocked_by_connection == "Deluno (Main)"
+    assert "Deluno (Main) is still importing this file" in verdict.reason
+
+
+def test_a_file_clearing_every_gate_is_eligible(session: Session) -> None:
+    library = _library(session)
+    verdict = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999)
+    assert verdict.status is RefinerFileStatus.UNPROCESSED
+    assert verdict.eligible is True
+
+
+def test_the_first_reason_wins_so_the_operator_sees_what_to_fix(session: Session) -> None:
+    """A disabled library is the answer even when the file is also too new and blocked."""
+
+    library = _library(session, enabled=False, min_file_age_seconds=999)
+    verdict = decide_file_state(
+        library=library,
+        in_schedule_window=False,
+        file_age_seconds=1,
+        blocked_by_connection="Deluno (Main)",
+    )
+    assert verdict.status is RefinerFileStatus.DISABLED
+
+
+def test_every_withheld_status_is_a_deliberate_decision_not_to_act() -> None:
+    assert {
+        "disabled",
+        "on_hold",
+        "out_of_schedule",
+        "blocked_upstream",
+    } == REFINER_WITHHELD_STATUSES
+
+
+def test_recording_a_state_is_idempotent_across_scans(session: Session) -> None:
+    library = _library(session)
+    first = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=1)
+    record_file_state(session, library=library, relative_path="a.mkv", verdict=first, size_bytes=2048)
+    session.commit()
+
+    second = decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999)
+    row = record_file_state(session, library=library, relative_path="a.mkv", verdict=second)
+    session.commit()
+
+    assert len(list_files(session)) == 1
+    assert row.status == RefinerFileStatus.UNPROCESSED.value
+    assert row.size_bytes == 2048
+
+
+def test_moving_out_of_blocked_upstream_clears_the_connection(session: Session) -> None:
+    library = _library(session)
+    blocked = decide_file_state(
+        library=library, in_schedule_window=True, file_age_seconds=99999, blocked_by_connection="Radarr (4K)"
+    )
+    record_file_state(session, library=library, relative_path="a.mkv", verdict=blocked)
+    session.commit()
+
+    row = mark_file_status(
+        session,
+        library_id=library.id,
+        relative_path="a.mkv",
+        status=RefinerFileStatus.PROCESSING,
+        reason="Refiner is working on this file now.",
+    )
+    session.commit()
+
+    assert row is not None
+    assert row.blocked_by_connection is None
+    assert row.last_attempt_at is not None
+
+
+def test_marking_a_file_mediamop_has_never_seen_does_nothing(session: Session) -> None:
+    library = _library(session)
+    assert (
+        mark_file_status(
+            session,
+            library_id=library.id,
+            relative_path="never-seen.mkv",
+            status=RefinerFileStatus.PROCESSED,
+            reason="done",
+        )
+        is None
+    )
+
+
+def test_status_counts_cover_every_bucket_even_when_empty(session: Session) -> None:
+    library = _library(session)
+    record_file_state(
+        session,
+        library=library,
+        relative_path="a.mkv",
+        verdict=decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999),
+    )
+    session.commit()
+
+    counts = status_counts(session)
+
+    assert counts["unprocessed"] == 1
+    # Every bucket is present so the screen can render a zero rather than a gap.
+    assert set(counts) == {s.value for s in RefinerFileStatus}
+    assert counts["blocked_upstream"] == 0
+
+
+def test_filters_narrow_by_library_status_and_path(session: Session) -> None:
+    movies = _library(session, name="Movies")
+    kids = _library(session, name="Kids")
+    ready = decide_file_state(library=movies, in_schedule_window=True, file_age_seconds=99999)
+    held = decide_file_state(library=kids, in_schedule_window=True, file_age_seconds=1)
+    record_file_state(session, library=movies, relative_path="Film/movie.mkv", verdict=ready)
+    record_file_state(session, library=kids, relative_path="Cartoon/toon.mkv", verdict=held)
+    session.commit()
+
+    assert len(list_files(session, library_id=movies.id)) == 1
+    assert len(list_files(session, status="on_hold")) == 1
+    assert len(list_files(session, path_contains="toon")) == 1
+    assert len(list_files(session, since=datetime.now(UTC) + timedelta(days=1))) == 0
+
+
+def test_forgetting_a_file_removes_only_the_record(session: Session) -> None:
+    library = _library(session)
+    row = record_file_state(
+        session,
+        library=library,
+        relative_path="a.mkv",
+        verdict=decide_file_state(library=library, in_schedule_window=True, file_age_seconds=99999),
+    )
+    session.commit()
+
+    forget_file(session, row)
+    session.commit()
+
+    assert list_files(session) == []

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -2770,6 +2770,111 @@
         "title": "RefinerCandidateGateManualEnqueueOut",
         "type": "object"
       },
+      "RefinerFileForgetIn": {
+        "additionalProperties": false,
+        "properties": {
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csrf_token"
+        ],
+        "title": "RefinerFileForgetIn",
+        "type": "object"
+      },
+      "RefinerFileOut": {
+        "properties": {
+          "blocked_by_connection": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The media manager connection holding this file, when the status is blocked_upstream.",
+            "title": "Blocked By Connection"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_attempt_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Attempt At"
+          },
+          "last_seen_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen At"
+          },
+          "library_id": {
+            "title": "Library Id",
+            "type": "integer"
+          },
+          "library_name": {
+            "title": "Library Name",
+            "type": "string"
+          },
+          "relative_path": {
+            "title": "Relative Path",
+            "type": "string"
+          },
+          "size_bytes": {
+            "title": "Size Bytes",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "unprocessed",
+              "processing",
+              "processed",
+              "processing_failed",
+              "disabled",
+              "on_hold",
+              "out_of_schedule",
+              "blocked_upstream"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "status_reason": {
+            "description": "Why the file is in this state, written for the person reading it.",
+            "title": "Status Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "library_id",
+          "library_name",
+          "relative_path",
+          "status",
+          "status_reason",
+          "size_bytes"
+        ],
+        "title": "RefinerFileOut",
+        "type": "object"
+      },
       "RefinerFileRemuxPassManualEnqueueIn": {
         "additionalProperties": false,
         "description": "Manual ``refiner.file.remux_pass.v1`` enqueue \u2014 requires a saved Refiner watched folder before this POST succeeds.",
@@ -2830,6 +2935,41 @@
           "job_kind"
         ],
         "title": "RefinerFileRemuxPassManualEnqueueOut",
+        "type": "object"
+      },
+      "RefinerFilesPageOut": {
+        "description": "A page of files plus the bucket counts shown above them.",
+        "properties": {
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/RefinerFileOut"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "returned": {
+            "title": "Returned",
+            "type": "integer"
+          },
+          "status_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Status Counts",
+            "type": "object"
+          }
+        },
+        "required": [
+          "files",
+          "status_counts",
+          "returned",
+          "limit"
+        ],
+        "title": "RefinerFilesPageOut",
         "type": "object"
       },
       "RefinerJobCancelPendingIn": {
@@ -7725,6 +7865,179 @@
         "tags": [
           "pruner",
           "pruner"
+        ]
+      }
+    },
+    "/api/v1/refiner/files": {
+      "get": {
+        "description": "Files Refiner has seen, with the reason it is or is not working on each.",
+        "operationId": "get_refiner_files_api_v1_refiner_files_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "library_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Library Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "file_status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "unprocessed",
+                    "processing",
+                    "processed",
+                    "processing_failed",
+                    "disabled",
+                    "on_hold",
+                    "out_of_schedule",
+                    "blocked_upstream"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "File Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "path_contains",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 400,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Path Contains"
+            }
+          },
+          {
+            "in": "query",
+            "name": "within_days",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 3650,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Within Days"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefinerFilesPageOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Refiner Files",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/files/{file_id}": {
+      "delete": {
+        "description": "Forget a file. Removes MediaMop's record of it, never the file on disk.",
+        "operationId": "delete_refiner_file_api_v1_refiner_files__file_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "File Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefinerFileForgetIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Refiner File",
+        "tags": [
+          "refiner",
+          "refiner"
         ]
       }
     },

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -616,6 +616,46 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/refiner/files": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Refiner Files
+     * @description Files Refiner has seen, with the reason it is or is not working on each.
+     */
+    get: operations["get_refiner_files_api_v1_refiner_files_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/files/{file_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Delete Refiner File
+     * @description Forget a file. Removes MediaMop's record of it, never the file on disk.
+     */
+    delete: operations["delete_refiner_file_api_v1_refiner_files__file_id__delete"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/refiner/jobs/candidate-gate/enqueue": {
     parameters: {
       query?: never;
@@ -2598,6 +2638,51 @@ export interface components {
        */
       ok: boolean;
     };
+    /** RefinerFileForgetIn */
+    RefinerFileForgetIn: {
+      /** Csrf Token */
+      csrf_token: string;
+    };
+    /** RefinerFileOut */
+    RefinerFileOut: {
+      /**
+       * Blocked By Connection
+       * @description The media manager connection holding this file, when the status is blocked_upstream.
+       */
+      blocked_by_connection?: string | null;
+      /** Id */
+      id: number;
+      /** Last Attempt At */
+      last_attempt_at?: string | null;
+      /** Last Seen At */
+      last_seen_at?: string | null;
+      /** Library Id */
+      library_id: number;
+      /** Library Name */
+      library_name: string;
+      /** Relative Path */
+      relative_path: string;
+      /** Size Bytes */
+      size_bytes: number;
+      /**
+       * Status
+       * @enum {string}
+       */
+      status:
+        | "unprocessed"
+        | "processing"
+        | "processed"
+        | "processing_failed"
+        | "disabled"
+        | "on_hold"
+        | "out_of_schedule"
+        | "blocked_upstream";
+      /**
+       * Status Reason
+       * @description Why the file is in this state, written for the person reading it.
+       */
+      status_reason: string;
+    };
     /**
      * RefinerFileRemuxPassManualEnqueueIn
      * @description Manual ``refiner.file.remux_pass.v1`` enqueue — requires a saved Refiner watched folder before this POST succeeds.
@@ -2631,6 +2716,22 @@ export interface components {
        * @default true
        */
       ok: boolean;
+    };
+    /**
+     * RefinerFilesPageOut
+     * @description A page of files plus the bucket counts shown above them.
+     */
+    RefinerFilesPageOut: {
+      /** Files */
+      files: components["schemas"]["RefinerFileOut"][];
+      /** Limit */
+      limit: number;
+      /** Returned */
+      returned: number;
+      /** Status Counts */
+      status_counts: {
+        [key: string]: number;
+      };
     };
     /** RefinerJobCancelPendingIn */
     RefinerJobCancelPendingIn: {
@@ -5273,6 +5374,85 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["PrunerOverviewStatsOut"];
+        };
+      };
+    };
+  };
+  get_refiner_files_api_v1_refiner_files_get: {
+    parameters: {
+      query?: {
+        library_id?: number | null;
+        file_status?:
+          | (
+              | "unprocessed"
+              | "processing"
+              | "processed"
+              | "processing_failed"
+              | "disabled"
+              | "on_hold"
+              | "out_of_schedule"
+              | "blocked_upstream"
+            )
+          | null;
+        path_contains?: string | null;
+        within_days?: number | null;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["RefinerFilesPageOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  delete_refiner_file_api_v1_refiner_files__file_id__delete: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        file_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RefinerFileForgetIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };

--- a/apps/web/src/lib/refiner/files-api.ts
+++ b/apps/web/src/lib/refiner/files-api.ts
@@ -1,0 +1,81 @@
+import { fetchCsrfToken } from "../api/auth-api";
+import { apiFetch, readJson, requireOk } from "../api/client";
+
+export type RefinerFileStatus =
+  | "unprocessed"
+  | "processing"
+  | "processed"
+  | "processing_failed"
+  | "disabled"
+  | "on_hold"
+  | "out_of_schedule"
+  | "blocked_upstream";
+
+/** Plain words for each state. The reason string carries the detail. */
+export const REFINER_FILE_STATUS_LABELS: Record<RefinerFileStatus, string> = {
+  unprocessed: "Waiting",
+  processing: "Processing",
+  processed: "Done",
+  processing_failed: "Failed",
+  disabled: "Library off",
+  on_hold: "On hold",
+  out_of_schedule: "Out of schedule",
+  blocked_upstream: "Blocked upstream",
+};
+
+export interface RefinerFile {
+  id: number;
+  library_id: number;
+  library_name: string;
+  relative_path: string;
+  status: RefinerFileStatus;
+  status_reason: string;
+  blocked_by_connection: string | null;
+  size_bytes: number;
+  last_seen_at: string | null;
+  last_attempt_at: string | null;
+}
+
+export interface RefinerFilesPage {
+  files: RefinerFile[];
+  status_counts: Record<string, number>;
+  returned: number;
+  limit: number;
+}
+
+export interface RefinerFilesQuery {
+  library_id?: number;
+  file_status?: RefinerFileStatus;
+  path_contains?: string;
+  within_days?: number;
+  limit?: number;
+}
+
+export const refinerFilesPath = () => "/api/v1/refiner/files";
+
+export async function fetchRefinerFiles(
+  query: RefinerFilesQuery = {},
+): Promise<RefinerFilesPage> {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null && value !== "") {
+      params.set(key, String(value));
+    }
+  }
+  const suffix = params.toString();
+  const path = suffix ? `${refinerFilesPath()}?${suffix}` : refinerFilesPath();
+  const r = await apiFetch(path);
+  await requireOk(path, r, "Could not load Refiner files");
+  return readJson<RefinerFilesPage>(r);
+}
+
+export async function forgetRefinerFile(id: number): Promise<void> {
+  const csrf_token = await fetchCsrfToken();
+  const path = `${refinerFilesPath()}/${id}`;
+  const r = await apiFetch(path, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ csrf_token }),
+  });
+  await requireOk(path, r, "Could not remove that file from the list");
+}

--- a/apps/web/src/lib/refiner/files-queries.ts
+++ b/apps/web/src/lib/refiner/files-queries.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchRefinerFiles,
+  forgetRefinerFile,
+  type RefinerFilesPage,
+  type RefinerFilesQuery,
+} from "./files-api";
+
+export const refinerFilesKey = (query: RefinerFilesQuery) => [
+  "refiner",
+  "files",
+  query,
+];
+
+export function useRefinerFilesQuery(query: RefinerFilesQuery = {}) {
+  return useQuery<RefinerFilesPage>({
+    queryKey: refinerFilesKey(query),
+    queryFn: () => fetchRefinerFiles(query),
+  });
+}
+
+export function useForgetRefinerFile() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => forgetRefinerFile(id),
+    onSuccess: () =>
+      void qc.invalidateQueries({ queryKey: ["refiner", "files"] }),
+  });
+}

--- a/apps/web/src/pages/refiner/refiner-files-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.test.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import * as api from "../../lib/refiner/files-api";
+import type {
+  RefinerFile,
+  RefinerFilesPage,
+} from "../../lib/refiner/files-api";
+import * as librariesApi from "../../lib/refiner/libraries-api";
+import * as authQueries from "../../lib/auth/queries";
+import { RefinerFilesSection } from "./refiner-files-section";
+
+function file(over: Partial<RefinerFile> = {}): RefinerFile {
+  return {
+    id: 1,
+    library_id: 1,
+    library_name: "Movies",
+    relative_path: "Some Film/film.mkv",
+    status: "unprocessed",
+    status_reason: "Ready for Refiner to process as part of Movies.",
+    blocked_by_connection: null,
+    size_bytes: 2048,
+    last_seen_at: null,
+    last_attempt_at: null,
+    ...over,
+  };
+}
+
+function page(over: Partial<RefinerFilesPage> = {}): RefinerFilesPage {
+  return {
+    files: [file()],
+    status_counts: { unprocessed: 1, on_hold: 0, blocked_upstream: 0 },
+    returned: 1,
+    limit: 200,
+    ...over,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function asOperator() {
+  vi.spyOn(authQueries, "useMeQuery").mockReturnValue({
+    data: { role: "operator" },
+  } as ReturnType<typeof authQueries.useMeQuery>);
+  vi.spyOn(librariesApi, "fetchRefinerLibraries").mockResolvedValue([]);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("shows the reason a file is not being processed", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({
+      files: [
+        file({
+          status: "blocked_upstream",
+          status_reason:
+            "Deluno (Main) is still importing this file, so MediaMop left it alone for now.",
+          blocked_by_connection: "Deluno (Main)",
+        }),
+      ],
+      status_counts: { blocked_upstream: 1 },
+    }),
+  );
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  expect(
+    await screen.findByText(/Deluno \(Main\) is still importing this file/),
+  ).toBeInTheDocument();
+});
+
+it("shows a bucket for every state, including empty ones", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(page());
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  expect(
+    await screen.findByTestId("refiner-files-bucket-on_hold"),
+  ).toHaveTextContent("On hold (0)");
+  expect(
+    screen.getByTestId("refiner-files-bucket-out_of_schedule"),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByTestId("refiner-files-bucket-disabled"),
+  ).toBeInTheDocument();
+});
+
+it("filters by bucket", async () => {
+  asOperator();
+  const fetchFiles = vi
+    .spyOn(api, "fetchRefinerFiles")
+    .mockResolvedValue(page());
+
+  render(<RefinerFilesSection />, { wrapper });
+  fireEvent.click(await screen.findByTestId("refiner-files-bucket-on_hold"));
+
+  await waitFor(() => {
+    expect(fetchFiles).toHaveBeenCalledWith(
+      expect.objectContaining({ file_status: "on_hold" }),
+    );
+  });
+});
+
+it("says removing a file only removes the record", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(page());
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  const button = await screen.findByTestId("refiner-file-forget-1");
+  expect(button).toHaveAttribute(
+    "title",
+    expect.stringContaining("file on disk is untouched"),
+  );
+});
+
+it("does not offer removal to a viewer", async () => {
+  vi.spyOn(authQueries, "useMeQuery").mockReturnValue({
+    data: { role: "viewer" },
+  } as ReturnType<typeof authQueries.useMeQuery>);
+  vi.spyOn(librariesApi, "fetchRefinerLibraries").mockResolvedValue([]);
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(page());
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  expect(await screen.findByText("Some Film/film.mkv")).toBeInTheDocument();
+  expect(screen.queryByTestId("refiner-file-forget-1")).not.toBeInTheDocument();
+});
+
+it("explains an empty list rather than showing nothing", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({ files: [], status_counts: {}, returned: 0 }),
+  );
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  expect(await screen.findByText(/No files match/)).toBeInTheDocument();
+});

--- a/apps/web/src/pages/refiner/refiner-files-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.tsx
@@ -1,0 +1,227 @@
+import { useState } from "react";
+
+import { PageLoading } from "../../components/shared/page-loading";
+import { useMeQuery } from "../../lib/auth/queries";
+import {
+  REFINER_FILE_STATUS_LABELS,
+  type RefinerFile,
+  type RefinerFileStatus,
+} from "../../lib/refiner/files-api";
+import {
+  useForgetRefinerFile,
+  useRefinerFilesQuery,
+} from "../../lib/refiner/files-queries";
+import { useRefinerLibrariesQuery } from "../../lib/refiner/libraries-queries";
+import {
+  mmActionButtonClass,
+  mmEditableTextFieldClass,
+  mmSelectFieldClass,
+} from "../../lib/ui/mm-control-roles";
+
+function canEdit(role: string | undefined): boolean {
+  return role === "operator" || role === "admin";
+}
+
+/** Buckets in the order an operator reads them: working, waiting, withheld, finished. */
+const BUCKETS: RefinerFileStatus[] = [
+  "processing",
+  "unprocessed",
+  "on_hold",
+  "out_of_schedule",
+  "blocked_upstream",
+  "disabled",
+  "processed",
+  "processing_failed",
+];
+
+function humanSize(bytes: number): string {
+  if (!bytes) return "—";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 10 || unit === 0 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+/**
+ * The Refiner Files screen.
+ *
+ * This is the screen that answers "why isn't this file processing?". Refiner used to
+ * decide and move on — the reason existed only inside the scan — so a file that was
+ * held, out of schedule, or waiting on an import simply never appeared anywhere (#334).
+ */
+export function RefinerFilesSection() {
+  const me = useMeQuery();
+  const libraries = useRefinerLibrariesQuery();
+  const [libraryId, setLibraryId] = useState<number | undefined>(undefined);
+  const [fileStatus, setFileStatus] = useState<RefinerFileStatus | undefined>(
+    undefined,
+  );
+  const [pathContains, setPathContains] = useState("");
+  const [limit, setLimit] = useState(200);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const files = useRefinerFilesQuery({
+    library_id: libraryId,
+    file_status: fileStatus,
+    path_contains: pathContains.trim() || undefined,
+    limit,
+  });
+  const forget = useForgetRefinerFile();
+  const editable = canEdit(me.data?.role);
+
+  if (files.isLoading) return <PageLoading label="Loading files" />;
+
+  const page = files.data;
+  const counts = page?.status_counts ?? {};
+  const rows = page?.files ?? [];
+
+  const removeFile = async (file: RefinerFile) => {
+    setNotice(null);
+    try {
+      await forget.mutateAsync(file.id);
+    } catch {
+      setNotice("That file could not be removed from the list.");
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="refiner-files-section">
+      <p className="text-sm text-[var(--mm-text2)]">
+        Every file Refiner has looked at, and what it decided. A file that is
+        not being processed says why.
+      </p>
+
+      <div className="flex flex-wrap gap-2" data-testid="refiner-files-buckets">
+        <button
+          type="button"
+          className={mmActionButtonClass({
+            variant: fileStatus === undefined ? "primary" : "tertiary",
+          })}
+          onClick={() => setFileStatus(undefined)}
+        >
+          All (
+          {rows.length === 0 && !page
+            ? 0
+            : Object.values(counts).reduce((a, b) => a + b, 0)}
+          )
+        </button>
+        {BUCKETS.map((status) => (
+          <button
+            key={status}
+            type="button"
+            className={mmActionButtonClass({
+              variant: fileStatus === status ? "primary" : "tertiary",
+            })}
+            onClick={() => setFileStatus(status)}
+            data-testid={`refiner-files-bucket-${status}`}
+          >
+            {REFINER_FILE_STATUS_LABELS[status]} ({counts[status] ?? 0})
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <label className="block text-sm">
+          <span className="text-[var(--mm-text2)]">Library</span>
+          <select
+            className={mmSelectFieldClass}
+            value={libraryId ?? ""}
+            onChange={(e) =>
+              setLibraryId(e.target.value ? Number(e.target.value) : undefined)
+            }
+          >
+            <option value="">All libraries</option>
+            {(libraries.data ?? []).map((library) => (
+              <option key={library.id} value={library.id}>
+                {library.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="block text-sm">
+          <span className="text-[var(--mm-text2)]">Path contains</span>
+          <input
+            className={mmEditableTextFieldClass}
+            value={pathContains}
+            placeholder="part of a file or folder name"
+            onChange={(e) => setPathContains(e.target.value)}
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="text-[var(--mm-text2)]">Show at most</span>
+          <select
+            className={mmSelectFieldClass}
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value))}
+          >
+            {[50, 200, 500, 1000].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {notice ? (
+        <p
+          className="rounded border border-[var(--mm-border)] px-3 py-2 text-sm"
+          role="status"
+          data-testid="refiner-files-notice"
+        >
+          {notice}
+        </p>
+      ) : null}
+
+      {rows.length === 0 ? (
+        <p className="text-sm text-[var(--mm-text3)]">
+          No files match. Refiner records a file the first time a scan looks at
+          it.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {rows.map((file) => (
+            <li
+              key={file.id}
+              className="rounded border border-[var(--mm-border)] p-3"
+              data-testid={`refiner-file-${file.id}`}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="truncate font-medium text-[var(--mm-text1)]">
+                    {file.relative_path}
+                  </p>
+                  <p className="text-xs text-[var(--mm-text3)]">
+                    {file.library_name} ·{" "}
+                    {REFINER_FILE_STATUS_LABELS[file.status]} ·{" "}
+                    {humanSize(file.size_bytes)}
+                  </p>
+                  {/* The reason is the whole point of this screen, so it is not hidden
+                      behind a detail view. */}
+                  <p className="mt-1 text-sm text-[var(--mm-text2)]">
+                    {file.status_reason}
+                  </p>
+                </div>
+                {editable ? (
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "tertiary" })}
+                    onClick={() => void removeFile(file)}
+                    data-testid={`refiner-file-forget-${file.id}`}
+                    title="Removes MediaMop's record of this file. The file on disk is untouched."
+                  >
+                    Remove from list
+                  </button>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/pages/refiner/refiner-page.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { mmSectionTabClass } from "../../lib/ui/mm-control-roles";
 import { RefinerProcessSettingsSection } from "./refiner-process-settings-section";
+import { RefinerFilesSection } from "./refiner-files-section";
 import { RefinerJobsInspectionSection } from "./refiner-jobs-inspection-section";
 import {
   RefinerOverviewTab,
@@ -19,6 +20,7 @@ type RefinerPageTabId =
   | "overview"
   | "libraries"
   | "audio-subtitles"
+  | "files"
   | "jobs"
   | "schedules";
 
@@ -26,11 +28,13 @@ const REFINER_TAB_BLURBS: Record<RefinerPageTabId, string> = {
   overview:
     "Review remux throughput, recent outcomes, and overall Refiner status.",
   libraries:
-    "Set TV and Movies watched, work, and output folders, plus per-library scan controls.",
+    "Add and configure Refiner libraries — folders, file types, schedule and guardrails, one set per library.",
   "audio-subtitles":
     "Choose default audio and subtitle remux rules separately for TV and Movies.",
   schedules:
     "Set optional schedule windows and run manual watched-folder scans when needed.",
+  files:
+    "Every file Refiner has looked at, and why it is or is not being processed.",
   jobs: "View queued, running, and recent Refiner jobs for troubleshooting and progress.",
 };
 
@@ -42,6 +46,7 @@ export function RefinerPage() {
     { id: "libraries", label: "Libraries" },
     { id: "audio-subtitles", label: "Audio & subtitles" },
     { id: "schedules", label: "Schedules" },
+    { id: "files", label: "Files" },
     { id: "jobs", label: "Jobs" },
   ];
 
@@ -122,6 +127,7 @@ export function RefinerPage() {
           {tab === "audio-subtitles" ? <RefinerRemuxSection /> : null}
 
           {tab === "schedules" ? <RefinerSchedulesSection /> : null}
+          {tab === "files" ? <RefinerFilesSection /> : null}
           {tab === "jobs" ? <RefinerJobsInspectionSection /> : null}
         </div>
       </div>


### PR DESCRIPTION
Closes #334. Part of #347. Milestone v2.5.0.

Refiner had one file vocabulary — a job is pending, leased, completed or failed — and none of it expresses a deliberate decision *not* to process a file. The scan reached those conclusions and simply did not enqueue, so the reason lived and died inside one function.

## The states, and why the order matters

`decide_file_state` runs most-absolute first, so the operator is shown the **first** thing standing in the way rather than whichever check happened to run last:

1. **Disabled** — the library is off. Nothing else about the file matters.
2. **Out Of Schedule** — the library is on, but not now.
3. **On Hold** — too new, or still being written to. The reason says how much longer.
4. **Blocked Upstream** — a manager is still importing it.

A test pins this: a file in a disabled library that is *also* too new *and also* blocked reports **Disabled**, because that is the one the operator has to fix first.

**Blocked Upstream names the connection, not the vendor** — "Deluno (Main) is still importing this file" — consistent with #350. The issue's AC says "name the *arr instance"; naming the connection is strictly better and is what the rest of the codebase now does, since the manager may not be an arr at all. The scan outcome carries the connection label so the screen doesn't re-parse prose.

## Persistence

`refiner_files`, one row per file per library, upserted on every scan. Migration `0012` **backfills nothing** — a file's state is whatever the next scan concludes, and inventing history for files nobody has looked at yet would mean inventing reasons.

## The screen

A **Files** tab beside Jobs rather than replacing it: Jobs shows the queue, Files answers the question. Buckets with live counts for every state (including empty ones, so a zero renders rather than a gap), filters by library / status / path / limit, and the reason **on the row** rather than behind a detail view — hiding it would defeat the point.

"Remove from list" carries a title saying the file on disk is untouched.

## Validation

`ruff check`/`format --check`, `mypy`, `pytest -q` — **919 passed**, 2 skipped, coverage **79.03%**. `alembic upgrade head` + `check` clean on a fresh database. Web lint/format/build/test (**178 passed**), OpenAPI regenerated, dead-code guard clean.

21 new tests: every transition into each state, the precedence rule, idempotent re-recording across scans, clearing the blocked connection on transition, bucket counts covering empty states, filters, and forgetting a record.

## Note

This is the screen #335 (hold timer), #337 (schedules gate), #338 (concurrency) and #339 (retry) are meant to land against — the state vocabulary and the reason string are the contract they'll extend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
