### PR TITLE
feat(refiner): filesystem watcher with the periodic scan as backstop (#336)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -104,9 +104,17 @@ MEDIAMOP_PRUNER_WORKER_COUNT=1
 
 # Refiner — watched-folder remux scan dispatch (``refiner.watched_folder.remux_scan_dispatch.v1``) periodic enqueue.
 # Whether each scope is scanned, and how often, lives on the Refiner Libraries tab (per scope, in the
-# database, no restart needed) — there is no environment variable for it. Not a filesystem watcher.
+# database, no restart needed) — there is no environment variable for it.
 # Whether those periodic ticks may also queue file work is set here. Default is 1 (they do). Restart API after changes:
 # MEDIAMOP_REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_PERIODIC_ENQUEUE_REMUX_JOBS=1
+
+# Refiner — filesystem watcher. Events are the trigger; the periodic scan above is the backstop and always
+# runs, so switching this off makes MediaMop slower to notice a new file, never blind to it. A watcher that
+# cannot start (Docker bind mounts, SMB and NFS often deliver no events) falls back to the scan on its own,
+# says so once in the log, and reports itself on /readiness. Per-library opt-out is on the Libraries tab.
+# MEDIAMOP_REFINER_WATCHER_ENABLED=1
+# How long a watched tree must be quiet before a burst of writes becomes one scan. 1..300s; default 3.
+# MEDIAMOP_REFINER_WATCHER_DEBOUNCE_SECONDS=3
 
 # Refiner — work/temp stale sweep (``refiner.work_temp_stale_sweep.v1``) periodic enqueue — **per scope** (Movies vs TV).
 # Each scope has its own enable + interval dedupe row. Legacy vars apply to **both** scopes when per-scope vars are unset:

--- a/apps/backend/alembic/versions/0014_refiner_watcher.py
+++ b/apps/backend/alembic/versions/0014_refiner_watcher.py
@@ -1,0 +1,45 @@
+"""Per-library switch for filesystem events
+
+Refiner walked the whole watched tree on a timer. Watching the filesystem makes a new
+file a candidate within seconds instead of within an interval, but it cannot be the only
+mechanism: Docker bind mounts, SMB and NFS frequently deliver no events at all.
+
+So the periodic scan stays as the backstop, and this column is the opt-out for shares
+where watching is unreliable enough that an operator would rather not be told about it.
+It defaults on, because a watcher that fails to start already degrades to polling and
+reports itself — the switch is for the case where that report is noise rather than news.
+
+Revision ID: 0014_refiner_watcher
+Revises: 0013_refiner_file_settling
+Create Date: 2026-08-29 11:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0014_refiner_watcher"
+down_revision = "0013_refiner_file_settling"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = inspect(op.get_bind())
+    if "refiner_libraries" not in set(inspector.get_table_names()):
+        return
+    # 0001 builds every table from the models of its day, so a fresh database can reach
+    # this migration already carrying the column.
+    if "file_system_events_enabled" in {c["name"] for c in inspector.get_columns("refiner_libraries")}:
+        return
+    op.add_column(
+        "refiner_libraries",
+        sa.Column("file_system_events_enabled", sa.Boolean(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("refiner_libraries", "file_system_events_enabled")

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -20,6 +20,10 @@ dependencies = [
   "cryptography>=44.0.0",
   "httpx>=0.27",
   "tzdata>=2025.1",
+  # Filesystem events are the trigger for Refiner work; the periodic scan is the
+  # backstop. Import failure is handled as a fallback to polling, not as a hard
+  # requirement, because container mounts and network shares often deliver no events.
+  "watchdog>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/apps/backend/src/mediamop/core/config.py
+++ b/apps/backend/src/mediamop/core/config.py
@@ -142,6 +142,11 @@ class MediaMopSettings:
     sqlalchemy_database_url: str
     # 0 = no in-process Refiner workers (Refiner-owned refiner_jobs only); >0 when Refiner queues durable work.
     refiner_worker_count: int
+    # Filesystem watcher: whether to run it at all, and how long a watched tree must be
+    # quiet before a burst of events becomes one scan. Off makes the periodic scan the
+    # only trigger, which is the pre-watcher behaviour and still finds every file.
+    refiner_watcher_enabled: bool
+    refiner_watcher_debounce_seconds: float
     # 0 = no in-process Pruner workers (Pruner-owned pruner_jobs only); >0 when Pruner queues durable work.
     pruner_worker_count: int
     # Pruner per-scope scheduled preview enqueue loop (reads ``pruner_scope_settings``; independent of worker count).
@@ -353,6 +358,10 @@ class MediaMopSettings:
         assert_sqlite_db_location_usable(db_p)
         db_url = sqlalchemy_sqlite_url(db_p)
         refiner_workers = clamp_refiner_worker_count(_env_int("MEDIAMOP_REFINER_WORKER_COUNT", 8))
+        refiner_watcher_on = _env_bool("MEDIAMOP_REFINER_WATCHER_ENABLED", True)
+        refiner_watcher_debounce = max(
+            0.25, min(300.0, float(_env_int("MEDIAMOP_REFINER_WATCHER_DEBOUNCE_SECONDS", 3)))
+        )
         pruner_workers = clamp_pruner_worker_count(_env_int("MEDIAMOP_PRUNER_WORKER_COUNT", 1))
         pruner_preview_sched_enq = _env_bool("MEDIAMOP_PRUNER_PREVIEW_SCHEDULE_ENQUEUE_ENABLED", True)
         pruner_preview_sched_scan_iv = max(
@@ -513,6 +522,8 @@ class MediaMopSettings:
             temp_dir=str(temp_p),
             sqlalchemy_database_url=db_url,
             refiner_worker_count=refiner_workers,
+            refiner_watcher_enabled=refiner_watcher_on,
+            refiner_watcher_debounce_seconds=refiner_watcher_debounce,
             pruner_worker_count=pruner_workers,
             pruner_preview_schedule_enqueue_enabled=pruner_preview_sched_enq,
             pruner_preview_schedule_scan_interval_seconds=pruner_preview_sched_scan_iv,

--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -42,6 +42,10 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodi
     start_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks,
     stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks,
 )
+from mediamop.modules.refiner.refiner_watched_folder_watcher import (
+    start_refiner_watched_folder_watcher_tasks,
+    stop_refiner_watched_folder_watcher_tasks,
+)
 from mediamop.modules.refiner.refiner_work_temp_stale_sweep_periodic_enqueue import (
     start_refiner_work_temp_stale_sweep_enqueue_tasks,
     stop_refiner_work_temp_stale_sweep_enqueue_tasks,
@@ -156,6 +160,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     job_rows_retention_tasks: list[asyncio.Task[None]] = []
     refiner_supplied_payload_eval_tasks: list[asyncio.Task[None]] = []
     refiner_watched_folder_scan_dispatch_tasks: list[asyncio.Task[None]] = []
+    refiner_watched_folder_watcher_tasks: list[asyncio.Task[None]] = []
     refiner_work_temp_stale_sweep_tasks: list[asyncio.Task[None]] = []
     refiner_failure_cleanup_tasks: list[asyncio.Task[None]] = []
     refiner_handlers = build_refiner_job_handlers(settings, session_factory)
@@ -196,6 +201,16 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     def _start_refiner_watched_folder_scan_dispatch_tasks() -> None:
         nonlocal refiner_watched_folder_scan_dispatch_tasks
         refiner_watched_folder_scan_dispatch_tasks = start_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_watched_folder_watcher_tasks() -> None:
+        nonlocal refiner_watched_folder_watcher_tasks
+        if not settings.refiner_watcher_enabled:
+            return
+        refiner_watched_folder_watcher_tasks = start_refiner_watched_folder_watcher_tasks(
             session_factory,
             stop_event=stop,
             settings=settings,
@@ -260,6 +275,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         "refiner_watched_folder_scan_dispatch_start",
         _start_refiner_watched_folder_scan_dispatch_tasks,
     )
+    _run_non_essential_startup_step(
+        "refiner_watched_folder_watcher_start",
+        _start_refiner_watched_folder_watcher_tasks,
+    )
     _run_non_essential_startup_step("refiner_work_temp_stale_sweep_start", _start_refiner_work_temp_stale_sweep_tasks)
     _run_non_essential_startup_step("refiner_failure_cleanup_start", _start_refiner_failure_cleanup_tasks)
     _run_non_essential_startup_step("refiner_worker_start", _start_refiner_workers)
@@ -281,6 +300,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             lambda: stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
                 refiner_watched_folder_scan_dispatch_tasks
             ),
+        )
+        await _stop_task_group(
+            "refiner_watched_folder_watcher_stop",
+            lambda: stop_refiner_watched_folder_watcher_tasks(refiner_watched_folder_watcher_tasks),
         )
         await _stop_task_group(
             "refiner_work_temp_stale_sweep_stop",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -90,6 +90,7 @@ def _library_out(db, row: RefinerLibraryRow) -> RefinerLibraryOut:
         file_detection_interval_seconds=row.file_detection_interval_seconds,
         ignore_size_changes=row.ignore_size_changes,
         skip_access_tests=row.skip_access_tests,
+        file_system_events_enabled=row.file_system_events_enabled,
         schedule_enabled=row.schedule_enabled,
         schedule_hours_limited=row.schedule_hours_limited,
         schedule_days=row.schedule_days,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
@@ -139,6 +139,7 @@ def _apply_fields(session: Session, row: RefinerLibraryRow, body: object) -> Non
         "file_detection_interval_seconds",
         "ignore_size_changes",
         "skip_access_tests",
+        "file_system_events_enabled",
         "schedule_enabled",
         "schedule_hours_limited",
         "schedule_days",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
@@ -104,6 +104,10 @@ class RefinerLibraryRow(Base):
     # observes writing having stopped rather than predicting when it will.
     file_detection_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, server_default="30")
     ignore_size_changes: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    # Filesystem events are the trigger and the periodic scan is the backstop, so this
+    # switches off the trigger, never the safety net. Defaults on; a watcher that cannot
+    # start degrades to the scan and says so.
+    file_system_events_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     # The read/write probe before queueing. On by default: discovering a file is locked
     # after a job has been enqueued is a failure, discovering it before is a wait.
     skip_access_tests: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -67,7 +67,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
         body = _parse_job_payload(ctx.payload_json)
         enqueue_remux_jobs = bool(body.get("enqueue_remux_jobs", False))
         scan_trigger = body.get("scan_trigger", "manual")
-        if scan_trigger not in ("manual", "periodic"):
+        if scan_trigger not in ("manual", "periodic", "filesystem_event"):
             scan_trigger = "manual"
         media_scope_raw = body.get("media_scope", "movie")
         media_scope: MediaScope = "tv" if media_scope_raw == "tv" else "movie"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_watcher.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_watcher.py
@@ -1,0 +1,340 @@
+"""Filesystem events as the trigger; the periodic scan as the backstop.
+
+Refiner found work by walking the whole watched tree on a timer. That means latency of up
+to a full interval between a file landing and Refiner noticing, and a full-tree stat storm
+every tick whether or not anything changed.
+
+This watches instead. What it deliberately does **not** do is decide anything about a
+file: an event debounces into exactly the same
+``refiner.watched_folder.remux_scan_dispatch.v1`` job the timer enqueues, carrying
+``scan_trigger="filesystem_event"``. Extension checks, exclusions, size limits, the hold
+timer and size settling all stay in the one handler that already owns them. A second
+admission path that agreed with the first today would disagree with it within a release.
+
+The periodic scan is unchanged and still runs. Docker bind mounts, SMB and NFS frequently
+deliver no inotify events at all, so the fallback is not a nicety — it is the primary
+compatibility story, and a watcher that cannot start degrades to it loudly rather than
+leaving an operator with a Refiner that has quietly stopped finding work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_enqueue import (
+    enqueue_watched_folder_remux_scan_dispatch_job,
+    refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan,
+)
+from mediamop.modules.refiner.refiner_watcher_state import (
+    WatcherReport,
+    WatcherStatus,
+    clear_watcher_state,
+    record_watcher_state,
+)
+
+logger = logging.getLogger(__name__)
+
+#: How long the tree must be quiet before an event turns into a scan. A copy lands as a
+#: burst of write events, and one candidate per burst is the point.
+DEFAULT_DEBOUNCE_SECONDS = 3.0
+#: How often the debounce timer is examined. Small enough to keep the promise of "within
+#: seconds", large enough not to spin.
+_TICK_SECONDS = 0.5
+
+
+class PendingChanges:
+    """Thread-safe handoff from watchdog's threads to the asyncio task.
+
+    watchdog calls handlers on its own threads, so the event side and the drain side
+    never touch the same state without this lock.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._libraries: dict[int, float] = {}
+
+    def note(self, library_id: int, at_monotonic: float) -> None:
+        with self._lock:
+            self._libraries[library_id] = at_monotonic
+
+    def drain_quiet(self, *, now_monotonic: float, debounce_seconds: float) -> list[int]:
+        """Library ids whose last event is older than the debounce window."""
+
+        with self._lock:
+            ready = [lib for lib, last in self._libraries.items() if now_monotonic - last >= debounce_seconds]
+            for lib in ready:
+                self._libraries.pop(lib, None)
+            return sorted(ready)
+
+    def pending_count(self) -> int:
+        with self._lock:
+            return len(self._libraries)
+
+
+def _watchdog_modules() -> tuple[Any, Any] | None:
+    """``(Observer, FileSystemEventHandler)``, or None when watchdog is unavailable.
+
+    Imported here rather than at module scope so a missing or broken watchdog is a
+    fallback to polling, not an import error that takes the whole application down.
+    """
+
+    try:
+        from watchdog.events import FileSystemEventHandler
+        from watchdog.observers import Observer
+    except Exception:  # pragma: no cover - exercised via the unavailable-watcher test
+        return None
+    return Observer, FileSystemEventHandler
+
+
+def libraries_to_watch(session: Session) -> list[RefinerLibraryRow]:
+    """Enabled libraries with a watched folder and events switched on."""
+
+    rows = session.scalars(
+        select(RefinerLibraryRow).where(RefinerLibraryRow.enabled.is_(True)).order_by(RefinerLibraryRow.id)
+    ).all()
+    return [row for row in rows if (row.watched_folder or "").strip() and row.file_system_events_enabled]
+
+
+def disabled_watch_reports(session: Session) -> list[WatcherReport]:
+    """Reports for libraries that deliberately are not watched, so the screen can say so."""
+
+    rows = session.scalars(
+        select(RefinerLibraryRow).where(RefinerLibraryRow.enabled.is_(True)).order_by(RefinerLibraryRow.id)
+    ).all()
+    return [
+        WatcherReport(
+            library_id=row.id,
+            library_name=row.name,
+            watched_folder=row.watched_folder or "",
+            status=WatcherStatus.DISABLED,
+            detail=(
+                f"Filesystem events are switched off for {row.name}, so MediaMop finds new files on the scan interval."
+            ),
+        )
+        for row in rows
+        if (row.watched_folder or "").strip() and not row.file_system_events_enabled
+    ]
+
+
+def _debounce_seconds(settings: MediaMopSettings) -> float:
+    raw = getattr(settings, "refiner_watcher_debounce_seconds", DEFAULT_DEBOUNCE_SECONDS)
+    return max(0.25, min(float(raw), 300.0))
+
+
+def enqueue_scan_for_library(
+    session: Session,
+    settings: MediaMopSettings,
+    *,
+    library: RefinerLibraryRow,
+) -> tuple[bool, str | None]:
+    """Turn a settled burst of events into one scan job.
+
+    Identical to what the timer enqueues apart from ``scan_trigger``, which is the whole
+    design: there is one admission implementation and this is not a second one.
+    """
+
+    scope = "tv" if library.media_scope == "tv" else "movie"
+    if refiner_watched_folder_remux_scan_dispatch_queue_has_active_scan(session, media_scope=scope):
+        # A queued scan will already look at this file. Adding another would mean two
+        # walks of the same tree for one arrival.
+        return False, "active_scan_already_queued"
+    if (
+        not (library.output_folder or "").strip()
+        and settings.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs
+    ):
+        return False, "missing_output_for_live_remux"
+    enqueue_watched_folder_remux_scan_dispatch_job(
+        session,
+        enqueue_remux_jobs=settings.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue_remux_jobs,
+        scan_trigger="filesystem_event",
+        media_scope=scope,
+        library_id=library.id,
+    )
+    return True, None
+
+
+def _start_observer(
+    observer_cls: Any,
+    handler_cls: Any,
+    *,
+    libraries: list[RefinerLibraryRow],
+    pending: PendingChanges,
+) -> tuple[Any, list[WatcherReport]]:
+    """One observer, one scheduled watch per library. Failures become reports, not raises."""
+
+    class _Handler(handler_cls):
+        def __init__(self, library_id: int) -> None:
+            super().__init__()
+            self._library_id = library_id
+
+        def on_any_event(self, event: Any) -> None:
+            # Deletions are not work appearing, and a directory event is always
+            # accompanied by the file event that matters.
+            if getattr(event, "is_directory", False):
+                return
+            if getattr(event, "event_type", "") == "deleted":
+                return
+            import time as _time
+
+            pending.note(self._library_id, _time.monotonic())
+
+    observer = observer_cls()
+    reports: list[WatcherReport] = []
+    scheduled = 0
+    for library in libraries:
+        folder = Path((library.watched_folder or "").strip())
+        try:
+            if not folder.is_dir():
+                raise OSError(f"{folder} is not a folder MediaMop can see")
+            observer.schedule(_Handler(library.id), str(folder), recursive=True)
+        except Exception as exc:
+            reports.append(
+                WatcherReport(
+                    library_id=library.id,
+                    library_name=library.name,
+                    watched_folder=str(folder),
+                    status=WatcherStatus.POLLING_FALLBACK,
+                    detail=(
+                        f"MediaMop could not watch {folder} for changes, so it is finding new files on the "
+                        f"scan interval instead. This is normal for network shares and some container mounts. "
+                        f"The system reported: {exc}."
+                    ),
+                )
+            )
+            continue
+        scheduled += 1
+        reports.append(
+            WatcherReport(
+                library_id=library.id,
+                library_name=library.name,
+                watched_folder=str(folder),
+                status=WatcherStatus.WATCHING,
+                detail=f"Watching {folder} for changes. The periodic scan still runs as a backstop.",
+            )
+        )
+
+    if scheduled == 0:
+        return None, reports
+    observer.start()
+    return observer, reports
+
+
+def start_refiner_watched_folder_watcher_tasks(
+    session_factory: sessionmaker[Session],
+    *,
+    stop_event: asyncio.Event,
+    settings: MediaMopSettings,
+) -> list[asyncio.Task[None]]:
+    """Background filesystem watcher for Refiner's watched folders."""
+
+    task = asyncio.create_task(
+        _run_refiner_watched_folder_watcher(session_factory, stop_event=stop_event, settings=settings),
+        name="refiner-watched-folder-watcher",
+    )
+    return [task]
+
+
+async def _run_refiner_watched_folder_watcher(
+    session_factory: sessionmaker[Session],
+    *,
+    stop_event: asyncio.Event,
+    settings: MediaMopSettings,
+) -> None:
+    pending = PendingChanges()
+    observer: Any = None
+    watched: dict[int, RefinerLibraryRow] = {}
+
+    try:
+        with session_factory() as session:
+            libraries = libraries_to_watch(session)
+            watched = {row.id: row for row in libraries}
+            for report in disabled_watch_reports(session):
+                record_watcher_state(report)
+
+        modules = _watchdog_modules()
+        if modules is None:
+            # One line, once. A per-tick warning about a machine that will never deliver
+            # events is noise that buries the next real problem.
+            logger.warning(
+                "Refiner is finding new files on the scan interval because the filesystem watcher is "
+                "unavailable in this environment. Nothing is missed; new files are picked up more slowly."
+            )
+            for row in libraries:
+                record_watcher_state(
+                    WatcherReport(
+                        library_id=row.id,
+                        library_name=row.name,
+                        watched_folder=row.watched_folder or "",
+                        status=WatcherStatus.POLLING_FALLBACK,
+                        detail=(
+                            "The filesystem watcher is not available in this environment, so MediaMop finds "
+                            "new files on the scan interval."
+                        ),
+                    )
+                )
+            await stop_event.wait()
+            return
+
+        observer_cls, handler_cls = modules
+        observer, reports = _start_observer(observer_cls, handler_cls, libraries=libraries, pending=pending)
+        for report in reports:
+            record_watcher_state(report)
+            if report.degraded:
+                logger.warning("Refiner filesystem watcher: %s", report.detail)
+
+        if observer is None:
+            await stop_event.wait()
+            return
+
+        debounce = _debounce_seconds(settings)
+        loop = asyncio.get_running_loop()
+        while not stop_event.is_set():
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(stop_event.wait(), timeout=_TICK_SECONDS)
+            if stop_event.is_set():
+                break
+            ready = pending.drain_quiet(now_monotonic=loop.time(), debounce_seconds=debounce)
+            if not ready:
+                continue
+            try:
+                with session_factory() as session, session.begin():
+                    for library_id in ready:
+                        library = watched.get(library_id)
+                        if library is None:
+                            continue
+                        fresh = session.get(RefinerLibraryRow, library_id)
+                        if fresh is None or not fresh.enabled:
+                            continue
+                        inserted, skip = enqueue_scan_for_library(session, settings, library=fresh)
+                        if inserted:
+                            logger.info("Refiner queued a scan of %s because its watched folder changed.", fresh.name)
+                        else:
+                            logger.debug("Refiner did not queue a watcher scan for %s: %s", fresh.name, skip)
+            except Exception:
+                # A failed enqueue must not kill the watcher: the periodic scan is still
+                # running, and the next event gets another attempt.
+                logger.exception("Refiner filesystem watcher could not queue a scan.")
+    finally:
+        if observer is not None:
+            with contextlib.suppress(Exception):
+                observer.stop()
+                observer.join(timeout=5)
+        clear_watcher_state()
+
+
+async def stop_refiner_watched_folder_watcher_tasks(tasks: list[asyncio.Task[None]]) -> None:
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await task

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watcher_state.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watcher_state.py
@@ -1,0 +1,101 @@
+"""What the filesystem watcher is actually doing, for anything that needs to report it.
+
+Kept apart from the watcher itself, and deliberately free of any ``watchdog`` import, so
+readiness can ask "is the watcher working?" on a machine where the library is missing or
+the platform backend refused to start. A readiness probe that cannot run without the
+thing it is probing is not a probe.
+
+Process-local on purpose. This is the state of *this* process's observers; persisting it
+would make a stale row from a previous run look like the current answer.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class WatcherStatus(StrEnum):
+    """How a library's watched folder is being monitored."""
+
+    #: Filesystem events are arriving. The periodic scan still runs as the backstop.
+    WATCHING = "watching"
+    #: The watcher could not start or has stopped. The periodic scan is the only
+    #: mechanism finding work, which still works — it is just slower.
+    POLLING_FALLBACK = "polling_fallback"
+    #: Switched off for this library by an operator.
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True, slots=True)
+class WatcherReport:
+    """One library's watcher state and the sentence explaining it."""
+
+    library_id: int
+    library_name: str
+    watched_folder: str
+    status: WatcherStatus
+    detail: str
+
+    @property
+    def degraded(self) -> bool:
+        """True only for a watcher that was meant to run and is not.
+
+        A library an operator switched off is not degraded, and reporting it as such
+        would train people to ignore the signal.
+        """
+
+        return self.status is WatcherStatus.POLLING_FALLBACK
+
+
+_lock = threading.Lock()
+_reports: dict[int, WatcherReport] = {}
+
+
+def record_watcher_state(report: WatcherReport) -> None:
+    with _lock:
+        _reports[report.library_id] = report
+
+
+def forget_watcher_state(library_id: int) -> None:
+    with _lock:
+        _reports.pop(library_id, None)
+
+
+def clear_watcher_state() -> None:
+    """Drop everything. Called on shutdown, and by tests between cases."""
+
+    with _lock:
+        _reports.clear()
+
+
+def watcher_reports() -> tuple[WatcherReport, ...]:
+    with _lock:
+        return tuple(sorted(_reports.values(), key=lambda r: r.library_id))
+
+
+def watcher_summary() -> tuple[bool, str]:
+    """``(ok, sentence)`` for readiness.
+
+    Falling back to polling is *not* a failure — MediaMop still finds every file, just on
+    the scan interval rather than within seconds. So this reports "ok" with a sentence
+    naming the affected libraries rather than failing readiness and taking an instance
+    out of a load balancer over a slower path to the same result.
+    """
+
+    reports = watcher_reports()
+    if not reports:
+        return True, "No libraries are being watched for filesystem events."
+    degraded = [r for r in reports if r.degraded]
+    watching = [r for r in reports if r.status is WatcherStatus.WATCHING]
+    if not degraded:
+        return True, f"Watching {len(watching)} folder(s) for changes; the periodic scan is the backstop."
+    names = ", ".join(r.library_name for r in degraded)
+    return (
+        True,
+        (
+            f"Falling back to the periodic scan for {names}. MediaMop still finds every file, "
+            "but new ones are picked up on the scan interval instead of within seconds."
+        ),
+    )

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -78,6 +78,7 @@ class RefinerLibraryOut(BaseModel):
     file_detection_interval_seconds: int
     ignore_size_changes: bool
     skip_access_tests: bool
+    file_system_events_enabled: bool
     schedule_enabled: bool
     schedule_hours_limited: bool
     schedule_days: str
@@ -135,6 +136,13 @@ class RefinerLibraryCreateIn(BaseModel):
     skip_access_tests: bool = Field(
         False,
         description="Skip the read/write probe that runs before a file is queued.",
+    )
+    file_system_events_enabled: bool = Field(
+        True,
+        description=(
+            "Watch this folder for changes so new files are picked up within seconds. The periodic scan "
+            "runs regardless, so switching this off makes MediaMop slower to notice a file, never blind to it."
+        ),
     )
     schedule_enabled: bool = True
     schedule_hours_limited: bool = False

--- a/apps/backend/src/mediamop/platform/readiness/service.py
+++ b/apps/backend/src/mediamop/platform/readiness/service.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import asdict
 from typing import Any
 
+from mediamop.modules.refiner.refiner_watcher_state import watcher_summary
 from mediamop.platform.health.service import database_is_connected
 from mediamop.platform.jobs.worker_health import build_worker_health_snapshot
 from mediamop.platform.readiness.schemas import ReadinessResponse, ReadinessStep, ReadinessWorkerOut
@@ -55,6 +56,19 @@ def build_readiness(app_state: Any) -> ReadinessResponse:
             ),
         ),
     ]
+
+    # Falling back to the periodic scan is slower, not broken, so this reports rather
+    # than fails: taking an instance out of a load balancer because inotify is
+    # unavailable on an SMB share would be a worse outcome than the delay it describes.
+    watcher_ok, watcher_detail = watcher_summary()
+    steps.append(
+        ReadinessStep(
+            name="filesystem_watcher",
+            status="ready" if watcher_ok else "failed",
+            detail=watcher_detail,
+        )
+    )
+
     ready = all(step.status == "ready" for step in steps)
     status = "ready" if ready else "failed" if any(step.status == "failed" for step in steps) else "starting"
     return ReadinessResponse(

--- a/apps/backend/tests/test_csrf_unit.py
+++ b/apps/backend/tests/test_csrf_unit.py
@@ -53,6 +53,8 @@ def _csrf_settings(**overrides: object) -> MediaMopSettings:
         temp_dir=str(home / "temp"),
         sqlalchemy_database_url="sqlite:///" + db.as_posix(),
         refiner_worker_count=0,
+        refiner_watcher_enabled=False,
+        refiner_watcher_debounce_seconds=3.0,
         pruner_worker_count=0,
         pruner_preview_schedule_enqueue_enabled=False,
         pruner_preview_schedule_scan_interval_seconds=45,

--- a/apps/backend/tests/test_health.py
+++ b/apps/backend/tests/test_health.py
@@ -36,7 +36,11 @@ def test_ready_ok_after_lifespan_startup() -> None:
     body = response.json()
     assert body["ready"] is True
     assert body["status"] == "ready"
-    assert {step["name"] for step in body["steps"]} == {"database", "workers"}
+    assert {step["name"] for step in body["steps"]} == {
+        "database",
+        "workers",
+        "filesystem_watcher",
+    }
     assert response.headers.get("Cache-Control", "").startswith("no-store")
 
 

--- a/apps/backend/tests/test_refiner_watched_folder_watcher.py
+++ b/apps/backend/tests/test_refiner_watched_folder_watcher.py
@@ -1,0 +1,461 @@
+"""Filesystem events as the trigger, the periodic scan as the backstop.
+
+The load-bearing claim of this feature is that events and scans share **one** admission
+implementation. That is tested directly: an event produces the same job kind the timer
+produces, and every decision about a file stays in the handler that already owned it.
+
+The second claim is that a watcher which cannot start is a slower MediaMop rather than a
+broken one. Docker bind mounts, SMB and NFS frequently deliver no events at all, so that
+path is not an edge case here — it is the compatibility story (#336).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_file_state_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.modules.refiner.refiner_path_settings_model  # noqa: F401
+import mediamop.platform.activity.models  # noqa: F401
+import mediamop.platform.media_managers.connection_model  # noqa: F401
+from mediamop.core.config import MediaMopSettings
+from mediamop.core.db import Base
+from mediamop.modules.refiner.jobs_model import RefinerJob
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_job_kinds import (
+    REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND,
+)
+from mediamop.modules.refiner.refiner_watched_folder_watcher import (
+    PendingChanges,
+    _run_refiner_watched_folder_watcher,
+    disabled_watch_reports,
+    enqueue_scan_for_library,
+    libraries_to_watch,
+)
+from mediamop.modules.refiner.refiner_watcher_state import (
+    WatcherStatus,
+    clear_watcher_state,
+    watcher_reports,
+    watcher_summary,
+)
+
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    clear_watcher_state()
+    yield
+    clear_watcher_state()
+
+
+@pytest.fixture
+def session_factory(tmp_path: Path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'watcher.sqlite'}",
+        connect_args={"check_same_thread": False, "timeout": 30.0},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(
+        bind=engine, class_=Session, autoflush=False, autocommit=False, expire_on_commit=False, future=True
+    )
+
+
+def _library(session_factory, *, watch: Path, out: Path, **overrides) -> RefinerLibraryRow:
+    with session_factory() as s:
+        row = RefinerLibraryRow(
+            name=overrides.pop("name", "Movies"),
+            media_scope=overrides.pop("media_scope", "movie"),
+            enabled=overrides.pop("enabled", True),
+            watched_folder=str(watch.resolve()),
+            output_folder=str(out.resolve()),
+            schedule_enabled=False,
+            **overrides,
+        )
+        s.add(row)
+        s.commit()
+        return row
+
+
+def _settings(monkeypatch: pytest.MonkeyPatch) -> MediaMopSettings:
+    monkeypatch.setenv("MEDIAMOP_REFINER_WATCHER_DEBOUNCE_SECONDS", "1")
+    return MediaMopSettings.load()
+
+
+def _scan_jobs(session_factory) -> list[RefinerJob]:
+    with session_factory() as s:
+        return [
+            j
+            for j in s.scalars(select(RefinerJob)).all()
+            if j.job_kind == REFINER_WATCHED_FOLDER_REMUX_SCAN_DISPATCH_JOB_KIND
+        ]
+
+
+# --- debounce ---------------------------------------------------------------------
+
+
+def test_a_burst_of_writes_to_one_file_produces_one_candidate() -> None:
+    """A chunked write — a PVR writing a recording in pieces — is one arrival, not twenty."""
+
+    pending = PendingChanges()
+    for tick in range(20):
+        pending.note(1, 100.0 + tick * 0.1)
+
+    # Still inside the debounce window: nothing is ready.
+    assert pending.drain_quiet(now_monotonic=102.0, debounce_seconds=3.0) == []
+    assert pending.pending_count() == 1
+
+    # Quiet for long enough, and the whole burst becomes exactly one library id.
+    assert pending.drain_quiet(now_monotonic=105.0, debounce_seconds=3.0) == [1]
+    assert pending.pending_count() == 0
+
+
+def test_the_debounce_window_restarts_while_writing_continues() -> None:
+    pending = PendingChanges()
+    pending.note(1, 100.0)
+    assert pending.drain_quiet(now_monotonic=104.0, debounce_seconds=3.0) == [1]
+
+    pending.note(1, 110.0)
+    assert pending.drain_quiet(now_monotonic=111.0, debounce_seconds=3.0) == []
+    assert pending.drain_quiet(now_monotonic=114.0, debounce_seconds=3.0) == [1]
+
+
+def test_separate_libraries_debounce_independently() -> None:
+    pending = PendingChanges()
+    pending.note(1, 100.0)
+    pending.note(2, 110.0)
+
+    assert pending.drain_quiet(now_monotonic=104.0, debounce_seconds=3.0) == [1]
+    assert pending.drain_quiet(now_monotonic=114.0, debounce_seconds=3.0) == [2]
+
+
+# --- one admission implementation -------------------------------------------------
+
+
+def test_an_event_enqueues_the_same_job_kind_the_timer_enqueues(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The load-bearing claim. The watcher decides nothing about a file.
+
+    It enqueues the job the periodic timer enqueues, so extension checks, exclusions,
+    size limits, the hold timer and size settling all stay in the one handler that
+    already owns them.
+    """
+
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    library = _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    with session_factory() as s, s.begin():
+        fresh = s.get(RefinerLibraryRow, library.id)
+        inserted, skip = enqueue_scan_for_library(s, settings, library=fresh)
+
+    assert inserted is True
+    assert skip is None
+
+    jobs = _scan_jobs(session_factory)
+    assert len(jobs) == 1
+    body = json.loads(jobs[0].payload_json or "{}")
+    # The only thing distinguishing it from a timer scan is why it happened.
+    assert body["scan_trigger"] == "filesystem_event"
+    assert body["media_scope"] == "movie"
+    assert body["library_id"] == library.id
+
+
+def test_an_event_does_not_pile_a_second_scan_onto_a_queued_one(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    library = _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    with session_factory() as s, s.begin():
+        enqueue_scan_for_library(s, settings, library=s.get(RefinerLibraryRow, library.id))
+    with session_factory() as s, s.begin():
+        inserted, skip = enqueue_scan_for_library(s, settings, library=s.get(RefinerLibraryRow, library.id))
+
+    assert inserted is False
+    assert skip == "active_scan_already_queued"
+    assert len(_scan_jobs(session_factory)) == 1
+
+
+def test_a_tv_library_enqueues_a_tv_scoped_scan(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    library = _library(session_factory, watch=watch, out=out, name="TV", media_scope="tv")
+    settings = _settings(monkeypatch)
+
+    with session_factory() as s, s.begin():
+        enqueue_scan_for_library(s, settings, library=s.get(RefinerLibraryRow, library.id))
+
+    body = json.loads(_scan_jobs(session_factory)[0].payload_json or "{}")
+    assert body["media_scope"] == "tv"
+
+
+# --- which libraries get watched ---------------------------------------------------
+
+
+def test_a_library_with_events_switched_off_is_not_watched_but_is_reported(session_factory, tmp_path: Path) -> None:
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=watch, out=out, file_system_events_enabled=False)
+
+    with session_factory() as s:
+        assert libraries_to_watch(s) == []
+        reports = disabled_watch_reports(s)
+
+    assert len(reports) == 1
+    assert reports[0].status is WatcherStatus.DISABLED
+    # Switched off deliberately is not degraded; treating it as such trains people to
+    # ignore the signal.
+    assert reports[0].degraded is False
+    assert "scan interval" in reports[0].detail
+
+
+def test_a_disabled_library_is_not_watched(session_factory, tmp_path: Path) -> None:
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=watch, out=out, enabled=False)
+
+    with session_factory() as s:
+        assert libraries_to_watch(s) == []
+
+
+def test_a_library_with_no_watched_folder_is_not_watched(session_factory, tmp_path: Path) -> None:
+    out = tmp_path / "out"
+    out.mkdir()
+    with session_factory() as s:
+        s.add(
+            RefinerLibraryRow(
+                name="Unconfigured",
+                media_scope="movie",
+                enabled=True,
+                watched_folder="",
+                output_folder=str(out.resolve()),
+            )
+        )
+        s.commit()
+        assert libraries_to_watch(s) == []
+
+
+# --- the fallback ------------------------------------------------------------------
+
+
+def test_an_unavailable_watcher_falls_back_to_polling_and_logs_once(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The Docker bind mount / SMB share case, which is common rather than exotic.
+
+    MediaMop must keep finding work on the scan interval, say so once, and not fail
+    readiness over a slower path to the same result.
+    """
+
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    monkeypatch.setattr(
+        "mediamop.modules.refiner.refiner_watched_folder_watcher._watchdog_modules",
+        lambda: None,
+    )
+    # Record what the module logs by standing in for its logger. Handler- and
+    # caplog-based capture both depend on how the suite configures logging; this asserts
+    # the call itself, which is the property that matters — once, not once per tick.
+    warnings: list[str] = []
+
+    class _RecordingLogger:
+        def warning(self, message: str, *args: object) -> None:
+            warnings.append(message % args if args else message)
+
+        def info(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def debug(self, *args: object, **kwargs: object) -> None:
+            pass
+
+        def exception(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr("mediamop.modules.refiner.refiner_watched_folder_watcher.logger", _RecordingLogger())
+
+    async def _drive_and_capture() -> tuple:
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            _run_refiner_watched_folder_watcher(session_factory, stop_event=stop, settings=settings)
+        )
+        # Read the state before the task's own shutdown clears it.
+        await asyncio.sleep(0.2)
+        captured = watcher_reports()
+        summary = watcher_summary()
+        stop.set()
+        await asyncio.wait_for(task, timeout=5)
+        return captured, summary
+
+    reports, (ok, detail) = asyncio.run(_drive_and_capture())
+
+    assert len(reports) == 1
+    assert reports[0].status is WatcherStatus.POLLING_FALLBACK
+    assert reports[0].degraded is True
+
+    # Slower, not broken: readiness still passes and the sentence says what it means.
+    assert ok is True
+    assert "scan interval" in detail
+
+    assert len(warnings) == 1, "the fallback must log once, not once per tick"
+    assert "scan interval" in warnings[0]
+
+
+def test_a_folder_that_cannot_be_watched_reports_itself_and_does_not_raise(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    missing = tmp_path / "gone"
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=missing, out=out)
+    settings = _settings(monkeypatch)
+
+    async def _drive_and_capture() -> tuple:
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            _run_refiner_watched_folder_watcher(session_factory, stop_event=stop, settings=settings)
+        )
+        await asyncio.sleep(0.2)
+        captured = watcher_reports()
+        stop.set()
+        await asyncio.wait_for(task, timeout=5)
+        return captured
+
+    reports = asyncio.run(_drive_and_capture())
+
+    assert len(reports) == 1
+    assert reports[0].status is WatcherStatus.POLLING_FALLBACK
+    assert "network shares" in reports[0].detail
+
+
+def test_readiness_says_nothing_alarming_when_no_library_is_watched() -> None:
+    ok, detail = watcher_summary()
+
+    assert ok is True
+    assert "No libraries" in detail
+
+
+# --- real filesystem events --------------------------------------------------------
+
+
+def _run_watcher_until_scan(session_factory, settings, *, act, timeout: float = 20.0) -> list[RefinerJob]:
+    """Start the watcher, perform ``act`` on the tree, wait for a scan job to appear."""
+
+    async def _drive() -> None:
+        stop = asyncio.Event()
+        task = asyncio.create_task(
+            _run_refiner_watched_folder_watcher(session_factory, stop_event=stop, settings=settings)
+        )
+        try:
+            # Let the observer schedule its watches before touching the tree.
+            await asyncio.sleep(1.0)
+            act()
+            deadline = asyncio.get_running_loop().time() + timeout
+            while asyncio.get_running_loop().time() < deadline:
+                if _scan_jobs(session_factory):
+                    return
+                await asyncio.sleep(0.25)
+        finally:
+            stop.set()
+            await asyncio.wait_for(task, timeout=10)
+
+    asyncio.run(_drive())
+    return _scan_jobs(session_factory)
+
+
+def test_a_file_appearing_becomes_a_candidate_without_waiting_for_the_scan_interval(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    jobs = _run_watcher_until_scan(
+        session_factory,
+        settings,
+        act=lambda: (watch / "Gate Test 2001.mkv").write_bytes(b"x" * 2048),
+    )
+
+    assert len(jobs) == 1
+    assert json.loads(jobs[0].payload_json or "{}")["scan_trigger"] == "filesystem_event"
+
+
+def test_a_file_moved_into_a_watched_folder_becomes_a_candidate(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The common shape: a download client writes elsewhere and moves the finished file in."""
+
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    staged = staging / "Gate Test 2001.mkv"
+    staged.write_bytes(b"x" * 2048)
+    _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    jobs = _run_watcher_until_scan(
+        session_factory,
+        settings,
+        act=lambda: staged.replace(watch / "Gate Test 2001.mkv"),
+    )
+
+    assert len(jobs) == 1
+
+
+def test_a_chunked_write_produces_one_scan_not_one_per_chunk(
+    session_factory, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A PVR writing parts of a recording every few seconds is one arrival."""
+
+    watch = tmp_path / "watch"
+    watch.mkdir()
+    out = tmp_path / "out"
+    out.mkdir()
+    _library(session_factory, watch=watch, out=out)
+    settings = _settings(monkeypatch)
+
+    def _chunked() -> None:
+        target = watch / "Recording.mkv"
+        with target.open("wb") as handle:
+            for _ in range(10):
+                handle.write(b"x" * 4096)
+                handle.flush()
+
+    jobs = _run_watcher_until_scan(session_factory, settings, act=_chunked)
+
+    assert len(jobs) == 1, "ten writes must debounce into one scan"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -3327,6 +3327,12 @@
             "title": "File Detection Interval Seconds",
             "type": "integer"
           },
+          "file_system_events_enabled": {
+            "default": true,
+            "description": "Watch this folder for changes so new files are picked up within seconds. The periodic scan runs regardless, so switching this off makes MediaMop slower to notice a file, never blind to it.",
+            "title": "File System Events Enabled",
+            "type": "boolean"
+          },
           "hold_minutes": {
             "default": 0,
             "maximum": 10080.0,
@@ -3586,6 +3592,10 @@
             "title": "File Detection Interval Seconds",
             "type": "integer"
           },
+          "file_system_events_enabled": {
+            "title": "File System Events Enabled",
+            "type": "boolean"
+          },
           "hold_minutes": {
             "title": "Hold Minutes",
             "type": "integer"
@@ -3737,6 +3747,7 @@
           "file_detection_interval_seconds",
           "ignore_size_changes",
           "skip_access_tests",
+          "file_system_events_enabled",
           "schedule_enabled",
           "schedule_hours_limited",
           "schedule_days",
@@ -3810,6 +3821,12 @@
             "minimum": 0.0,
             "title": "File Detection Interval Seconds",
             "type": "integer"
+          },
+          "file_system_events_enabled": {
+            "default": true,
+            "description": "Watch this folder for changes so new files are picked up within seconds. The periodic scan runs regardless, so switching this off makes MediaMop slower to notice a file, never blind to it.",
+            "title": "File System Events Enabled",
+            "type": "boolean"
           },
           "hold_minutes": {
             "default": 0,

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -2978,6 +2978,12 @@ export interface components {
        */
       file_detection_interval_seconds: number;
       /**
+       * File System Events Enabled
+       * @description Watch this folder for changes so new files are picked up within seconds. The periodic scan runs regardless, so switching this off makes MediaMop slower to notice a file, never blind to it.
+       * @default true
+       */
+      file_system_events_enabled: boolean;
+      /**
        * Hold Minutes
        * @default 0
        */
@@ -3130,6 +3136,8 @@ export interface components {
       exclude_patterns_csv: string;
       /** File Detection Interval Seconds */
       file_detection_interval_seconds: number;
+      /** File System Events Enabled */
+      file_system_events_enabled: boolean;
       /** Hold Minutes */
       hold_minutes: number;
       /** Id */
@@ -3229,6 +3237,12 @@ export interface components {
        * @default 30
        */
       file_detection_interval_seconds: number;
+      /**
+       * File System Events Enabled
+       * @description Watch this folder for changes so new files are picked up within seconds. The periodic scan runs regardless, so switching this off makes MediaMop slower to notice a file, never blind to it.
+       * @default true
+       */
+      file_system_events_enabled: boolean;
       /**
        * Hold Minutes
        * @default 0

--- a/apps/web/src/lib/refiner/libraries-api.ts
+++ b/apps/web/src/lib/refiner/libraries-api.ts
@@ -35,6 +35,7 @@ export interface RefinerLibrary {
   file_detection_interval_seconds: number;
   ignore_size_changes: boolean;
   skip_access_tests: boolean;
+  file_system_events_enabled: boolean;
   schedule_enabled: boolean;
   schedule_hours_limited: boolean;
   schedule_days: string;
@@ -74,6 +75,7 @@ export interface RefinerLibraryWrite {
   file_detection_interval_seconds?: number;
   ignore_size_changes?: boolean;
   skip_access_tests?: boolean;
+  file_system_events_enabled?: boolean;
   schedule_enabled?: boolean;
   schedule_hours_limited?: boolean;
   schedule_days?: string;

--- a/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
@@ -32,6 +32,7 @@ function library(over: Partial<RefinerLibrary> = {}): RefinerLibrary {
     file_detection_interval_seconds: 30,
     ignore_size_changes: false,
     skip_access_tests: false,
+    file_system_events_enabled: true,
     schedule_enabled: true,
     schedule_hours_limited: false,
     schedule_days: "",

--- a/apps/web/src/pages/refiner/refiner-libraries-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-libraries-section.tsx
@@ -46,6 +46,7 @@ type FormState = {
   top_level_only: boolean;
   ignore_size_changes: boolean;
   skip_access_tests: boolean;
+  file_system_events_enabled: boolean;
 };
 
 const EMPTY_FORM: FormState = {
@@ -66,6 +67,7 @@ const EMPTY_FORM: FormState = {
   top_level_only: false,
   ignore_size_changes: false,
   skip_access_tests: false,
+  file_system_events_enabled: true,
 };
 
 function formFrom(library: RefinerLibrary): FormState {
@@ -89,6 +91,7 @@ function formFrom(library: RefinerLibrary): FormState {
     top_level_only: library.top_level_only,
     ignore_size_changes: library.ignore_size_changes,
     skip_access_tests: library.skip_access_tests,
+    file_system_events_enabled: library.file_system_events_enabled,
   };
 }
 
@@ -122,6 +125,7 @@ function writeFrom(
     top_level_only: form.top_level_only,
     ignore_size_changes: form.ignore_size_changes,
     skip_access_tests: form.skip_access_tests,
+    file_system_events_enabled: form.file_system_events_enabled,
     rule_set_id: library?.rule_set_id ?? null,
     manager_connection_ids: library?.manager_connection_ids ?? [],
   };
@@ -503,6 +507,20 @@ export function RefinerLibrariesSection() {
                 disabled={!editable}
               />
               Skip the read and write check
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[var(--mm-text2)]">
+              <input
+                type="checkbox"
+                checked={form.file_system_events_enabled}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    file_system_events_enabled: e.target.checked,
+                  })
+                }
+                disabled={!editable}
+              />
+              Watch this folder for changes
             </label>
           </div>
           <div className="flex gap-2">

--- a/docker/README.md
+++ b/docker/README.md
@@ -110,6 +110,29 @@ Migration note:
 
 The image exposes `GET /health` and includes a Docker `HEALTHCHECK`.
 
+## Filesystem events on bind mounts
+
+Refiner watches its watched folders so a new file becomes a candidate within seconds, and
+runs its periodic scan as a backstop. **Bind mounts frequently deliver no inotify events**,
+and neither do most SMB and NFS shares — the events happen on the host, and nothing
+forwards them into the container.
+
+This is expected and handled. When the watcher cannot start, MediaMop:
+
+- falls back to the periodic scan, which finds every file exactly as it did before;
+- logs the reason **once**, not once per tick;
+- reports it on `GET /readiness` under the `filesystem_watcher` step.
+
+That step stays `ready`. Falling back is slower, not broken, and failing readiness would
+take a working instance out of a load balancer over a delay.
+
+If you would rather not be told about it for a given library, switch off
+**Watch this folder for changes** on the Refiner Libraries tab. To turn the watcher off
+for the whole instance, set `MEDIAMOP_REFINER_WATCHER_ENABLED=0`.
+
+When events *do* work, `MEDIAMOP_REFINER_WATCHER_DEBOUNCE_SECONDS` (default 3) controls how
+long the tree must be quiet before a burst of writes becomes one scan.
+
 ## Release alignment
 
 - `compose.yaml` defaults to `ghcr.io/jampat000/mediamop:latest`


### PR DESCRIPTION
Closes #336. Part of #347.

## The problem

Refiner found work by walking the whole watched tree on a timer:

```python
for p in sorted(root.rglob("*")):
```

Latency between a file landing and Refiner noticing was up to a full interval, and every tick was a full-tree stat storm whether or not anything had changed.

## Events are the trigger, the scan is the safety net

The load-bearing design decision: **the watcher decides nothing about a file.** An event debounces into exactly the same `refiner.watched_folder.remux_scan_dispatch.v1` job the timer enqueues, carrying `scan_trigger="filesystem_event"`.

Extension checks, exclusions, size limits, the hold timer and size settling all stay in the one handler that already owns them. A second admission path that agreed with the first today would disagree with it within a release. There is a test asserting exactly this — an event produces the timer's job kind, differing only in *why* it happened.

Coalescing comes free from a check that already existed: if a scan is queued for that scope, an event does not add a second one.

## Falling back is the compatibility story, not an edge case

Docker bind mounts, SMB and NFS frequently deliver **no inotify events at all** — the events happen on the host and nothing forwards them in. So a watcher that cannot start:

- falls back to the periodic scan, which finds every file exactly as before;
- logs the reason **once**, not once per tick (asserted);
- reports itself on `GET /readiness` under a new `filesystem_watcher` step.

That step stays `ready`. Slower is not broken, and failing readiness would take a working instance out of a load balancer over a delay. `watchdog` is imported lazily for the same reason — a missing or broken install is a fallback, not an import error that takes the application down.

## Controls

| Control | Scope |
| --- | --- |
| `MEDIAMOP_REFINER_WATCHER_ENABLED` | whole instance |
| `MEDIAMOP_REFINER_WATCHER_DEBOUNCE_SECONDS` (default 3) | whole instance |
| **Watch this folder for changes** on the Libraries tab | one library |

`0014` adds `file_system_events_enabled` to `refiner_libraries`, defaulting on, exposed over the v1 API and the generated OpenAPI schema (#346).

Watcher state is process-local and deliberately free of any `watchdog` import, so readiness can report on a watcher that never started — a probe that cannot run without the thing it is probing is not a probe.

## Docs

`.env.example` no longer claims "Not a filesystem watcher". `docker/README.md` gains a section on bind-mount behaviour, since that is the case operators will actually hit.

## Two existing tests changed deliberately

- `test_health` asserted the exact readiness step set. The new step is an acceptance criterion of this issue.
- `test_csrf_unit` constructs `MediaMopSettings` field by field, so it needed the two new fields.

Neither was adjusted to hide a regression; both encode a shape this issue changes on purpose.

## Tests

Create · move-into-folder · chunked write — all three against a **real observer on a real temp tree**, not a mock. Plus debounce (including restart-while-writing and per-library independence), watcher unavailable, a folder that cannot be watched, events switched off, a disabled library, and TV scoping.

Verified locally: 971 backend passed / 2 skipped, 180 web tests, ruff, mypy, bandit, `pip-audit --strict` (clean with watchdog added), `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build.

Stacked on #335, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
