### PR TITLE
feat(refiner): the schedule gates work, plus a suite-wide pause (#337)

### DIFF
--- a/apps/backend/alembic/versions/0015_schedules_and_pause.py
+++ b/apps/backend/alembic/versions/0015_schedules_and_pause.py
@@ -1,0 +1,97 @@
+"""A 7x24 schedule grid per library, and a suite-wide pause
+
+Refiner's schedule gated **enqueue** only. Once a job was queued it ran to completion
+regardless of the window, so a 4K remux started two minutes before closing ran into the
+morning — the outcome the window existed to prevent. And there was no pause of any kind
+on a tool whose whole job is sustained disk and CPU load on a machine someone is using.
+
+``refiner_libraries.schedule_grid``
+    7 days x 96 quarter-hours as 672 characters of ``0``/``1``. Empty means no
+    restriction. Backfilled from each library's existing days/start/end so an upgrade
+    changes nothing about when work runs; the trio stays as the fallback for any row this
+    could not express, and is not dropped here.
+
+``suite_settings.processing_paused`` / ``processing_paused_until`` / ``scan_while_paused``
+    Pause lives on the suite rather than on Refiner so Pruner can honour the same switch
+    later instead of growing a second one beside it. ``scan_while_paused`` defaults on,
+    because the useful pause is "stop working on files", not "stop noticing them".
+
+Revision ID: 0015_schedules_and_pause
+Revises: 0014_refiner_watcher
+Create Date: 2026-08-29 12:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0015_schedules_and_pause"
+down_revision = "0014_refiner_watcher"
+branch_labels = None
+depends_on = None
+
+_SUITE_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    ("processing_paused", sa.Column("processing_paused", sa.Boolean(), nullable=False, server_default="0")),
+    (
+        "processing_paused_until",
+        sa.Column("processing_paused_until", sa.DateTime(timezone=True), nullable=True),
+    ),
+    ("scan_while_paused", sa.Column("scan_while_paused", sa.Boolean(), nullable=False, server_default="1")),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    present = _columns("suite_settings")
+    for name, column in _SUITE_COLUMNS:
+        if present and name not in present:
+            op.add_column("suite_settings", column)
+
+    present = _columns("refiner_libraries")
+    if not present:
+        return
+    if "schedule_grid" not in present:
+        op.add_column(
+            "refiner_libraries",
+            sa.Column("schedule_grid", sa.Text(), nullable=False, server_default=""),
+        )
+
+    # Backfill from the window each library already has, so an upgrade preserves exactly
+    # when work runs. A library with no hour limit keeps an empty grid, which means no
+    # restriction — not an all-zero grid, which would mean never.
+    from mediamop.modules.refiner.refiner_schedule_grid import grid_from_days_and_times
+
+    rows = bind.execute(
+        sa.text("SELECT id, schedule_hours_limited, schedule_days, schedule_start, schedule_end FROM refiner_libraries")
+    ).fetchall()
+    for row in rows:
+        if not row[1]:
+            continue
+        grid = grid_from_days_and_times(
+            days=row[2] or "",
+            start=row[3] or "00:00",
+            end=row[4] or "23:59",
+        )
+        if not grid:
+            continue
+        bind.execute(
+            sa.text("UPDATE refiner_libraries SET schedule_grid = :grid WHERE id = :id"),
+            {"grid": grid, "id": row[0]},
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("refiner_libraries", "schedule_grid")
+    for name, _ in _SUITE_COLUMNS:
+        op.drop_column("suite_settings", name)

--- a/apps/backend/src/mediamop/api/router.py
+++ b/apps/backend/src/mediamop/api/router.py
@@ -23,6 +23,7 @@ from mediamop.platform.media_managers.connections_api import router as media_man
 from mediamop.platform.media_managers.intake_api import router as media_manager_intake_router
 from mediamop.platform.notifications.router import router as notifications_router
 from mediamop.platform.reconciliation.router import router as reconciliation_router
+from mediamop.platform.suite_settings.pause_api import router as suite_pause_router
 from mediamop.platform.suite_settings.router import router as suite_settings_router
 from mediamop.platform.system_configuration.router import router as system_configuration_router
 
@@ -37,6 +38,7 @@ def build_v1_router() -> APIRouter:
     router.include_router(local_browse_router)
     router.include_router(reconciliation_router)
     router.include_router(suite_settings_router)
+    router.include_router(suite_pause_router)
     router.include_router(dashboard_router)
     router.include_router(activity_router)
     router.include_router(refiner_router)

--- a/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
@@ -35,7 +35,10 @@ def _record_refiner_queue_depth(session: Session) -> None:
     set_module_queue_depth(module="refiner", depth=int(depth or 0))
 
 
-_CLAIM_NEXT_SQL = """
+# ``{admission}`` is a predicate built by :func:`_admission_predicate` from ids and job
+# kinds this pass may not take. It narrows *which row is chosen*, so a job the schedule
+# excludes is never leased — the window gates work, not only enqueue (#337).
+_CLAIM_NEXT_SQL_TEMPLATE = """
 UPDATE refiner_jobs
 SET
   status = :leased,
@@ -45,16 +48,64 @@ SET
   attempt_count = attempt_count + 1
 WHERE id = (
   SELECT id FROM refiner_jobs
-  WHERE (status = :pending AND (not_before IS NULL OR not_before <= :now))
-     OR (
-       status = :leased
-       AND (lease_expires_at IS NULL OR lease_expires_at < :now)
-     )
+  WHERE (
+      (status = :pending AND (not_before IS NULL OR not_before <= :now))
+      OR (
+        status = :leased
+        AND (lease_expires_at IS NULL OR lease_expires_at < :now)
+      )
+    )
+    {admission}
   ORDER BY id ASC
   LIMIT 1
 )
 RETURNING id
 """
+
+
+def _admission_predicate(admission: object | None) -> tuple[str, dict[str, object]]:
+    """SQL narrowing the claim to work this pass is allowed to start.
+
+    Library ids are formatted into the statement rather than bound, because a variable
+    length ``IN`` list cannot be one bound parameter. They are integers read from the
+    primary key of a row this process just selected, and each is re-coerced with ``int()``
+    here so nothing but a number can reach the string.
+    """
+
+    if admission is None:
+        return "", {}
+
+    clauses: list[str] = []
+    params: dict[str, object] = {}
+
+    blocked: frozenset[int] = getattr(admission, "blocked_library_ids", frozenset())
+    ids = sorted({int(x) for x in blocked})
+    if ids:
+        # A job with no library_id in its payload predates libraries or is suite-wide, so
+        # COALESCE keeps it claimable rather than sweeping it up in the exclusion.
+        rendered = ",".join(str(i) for i in ids)
+        clauses.append(f"AND COALESCE(json_extract(payload_json, '$.library_id'), -1) NOT IN ({rendered})")
+
+    pause = getattr(admission, "pause", None)
+    if pause is not None and getattr(pause, "paused", False):
+        from mediamop.modules.refiner.refiner_work_admission import DETECTION_JOB_KIND_PREFIXES
+
+        if getattr(pause, "scan_while_paused", False):
+            # Detection continues; processing does not. Prefix matching keeps this in step
+            # with the job-kind naming rather than an enumerated list that drifts.
+            likes = []
+            for index, prefix in enumerate(DETECTION_JOB_KIND_PREFIXES):
+                key = f"detect_{index}"
+                likes.append(f"job_kind LIKE :{key}")
+                params[key] = f"{prefix}%"
+            clauses.append(f"AND ({' OR '.join(likes)})")
+        else:
+            # Nothing at all.
+            clauses.append("AND 1 = 0")
+
+    if not clauses:
+        return "", params
+    return "\n    " + "\n    ".join(clauses), params
 
 
 def _tombstone_cancelled_dedupe_key(*, original: str, job_id: int) -> str:
@@ -134,22 +185,29 @@ def claim_next_eligible_refiner_job(
     lease_owner: str,
     lease_expires_at: datetime,
     now: datetime | None = None,
+    admission: object | None = None,
 ) -> RefinerJob | None:
     """Atomically lease the next ``pending`` or **expired** ``leased`` row.
 
     Increments ``attempt_count`` on every successful claim (including reclaim).
     Returns ``None`` if no eligible row exists.
+
+    ``admission`` narrows what may be claimed to what the schedule and the suite pause
+    currently allow. Passing ``None`` claims exactly as before, which is what every
+    caller that has nothing to do with scheduling wants.
     """
 
     when = now if now is not None else _utc_now()
+    predicate, extra = _admission_predicate(admission)
     result = session.execute(
-        text(_CLAIM_NEXT_SQL),
+        text(_CLAIM_NEXT_SQL_TEMPLATE.format(admission=predicate)),
         {
             "leased": RefinerJobStatus.LEASED.value,
             "pending": RefinerJobStatus.PENDING.value,
             "owner": lease_owner,
             "lease_exp": lease_expires_at,
             "now": when,
+            **extra,
         },
     )
     row = result.fetchone()

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
@@ -5,7 +5,7 @@ first, so the reason an operator is shown is the *first* thing standing in the w
 than whichever check happened to run last:
 
 1. **Disabled** — the library is switched off. Nothing else about the file is relevant.
-2. **Out of schedule** — the library is on, but not right now.
+2. **Out of schedule** — MediaMop is paused, or the library is on but not right now.
 3. **On hold** — the file is still being written to, is too new, or cannot be opened.
 4. **Blocked upstream** — a manager is still importing it.
 
@@ -27,9 +27,6 @@ from sqlalchemy.orm import Session
 
 from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow, RefinerFileStatus
 from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
-from mediamop.modules.refiner.refiner_operator_settings_service import (
-    refiner_periodic_scope_in_schedule_window,
-)
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +54,9 @@ def decide_file_state(
     library: RefinerLibraryRow,
     in_schedule_window: bool,
     file_age_seconds: float | None,
+    paused_reason: str | None = None,
+    paused_until: datetime | None = None,
+    window_reopens_at: datetime | None = None,
     size_is_settling: bool = False,
     settling_reason: str | None = None,
     settling_stable_at: datetime | None = None,
@@ -71,6 +71,12 @@ def decide_file_state(
             f"The {library.name} library is switched off, so MediaMop is leaving its files alone.",
         )
 
+    if paused_reason:
+        # A paused instance is out of schedule in the only sense that matters to someone
+        # looking at the screen: MediaMop is deliberately not working on this right now,
+        # and this says why and until when.
+        return FileStateVerdict(RefinerFileStatus.OUT_OF_SCHEDULE, paused_reason, hold_until=paused_until)
+
     if library.schedule_enabled and not in_schedule_window:
         return FileStateVerdict(
             RefinerFileStatus.OUT_OF_SCHEDULE,
@@ -78,6 +84,7 @@ def decide_file_state(
                 f"The {library.name} library only runs inside its scheduled hours, and now is outside them. "
                 "MediaMop will pick this up when the window opens."
             ),
+            hold_until=window_reopens_at,
         )
 
     hold_seconds = max(0, int(library.min_file_age_seconds)) + max(0, int(library.hold_minutes)) * 60
@@ -114,25 +121,6 @@ def decide_file_state(
         RefinerFileStatus.UNPROCESSED,
         f"Ready for Refiner to process as part of {_scope_word(library)}.",
     )
-
-
-def library_in_schedule_window(session: Session, library: RefinerLibraryRow) -> bool:
-    """Whether this library's schedule window is open right now.
-
-    Falls back to the per-scope operator window while a library's own days and times are
-    still seeded from it, so an upgrade does not silently change when work runs.
-    """
-
-    if not library.schedule_enabled:
-        return True
-    if not library.schedule_hours_limited:
-        return True
-    from mediamop.modules.refiner.refiner_operator_settings_service import (
-        ensure_refiner_operator_settings_row,
-    )
-
-    row = ensure_refiner_operator_settings_row(session)
-    return refiner_periodic_scope_in_schedule_window(session, row, media_scope=library.media_scope)
 
 
 def existing_file_row(session: Session, *, library_id: int, relative_path: str) -> RefinerFileRow | None:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -91,6 +91,7 @@ def _library_out(db, row: RefinerLibraryRow) -> RefinerLibraryOut:
         ignore_size_changes=row.ignore_size_changes,
         skip_access_tests=row.skip_access_tests,
         file_system_events_enabled=row.file_system_events_enabled,
+        schedule_grid=row.schedule_grid or "",
         schedule_enabled=row.schedule_enabled,
         schedule_hours_limited=row.schedule_hours_limited,
         schedule_days=row.schedule_days,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
@@ -29,6 +29,7 @@ from mediamop.modules.refiner.refiner_library_service import (
     list_libraries,
     manager_connection_ids_for,
 )
+from mediamop.modules.refiner.refiner_schedule_grid import ScheduleGridError, normalize_grid
 from mediamop.platform.media_managers.connection_model import MediaManagerConnectionRow
 
 _ACTIVE_JOB_STATUSES = (RefinerJobStatus.PENDING.value, RefinerJobStatus.LEASED.value)
@@ -149,6 +150,13 @@ def _apply_fields(session: Session, row: RefinerLibraryRow, body: object) -> Non
         "priority",
     ):
         setattr(row, field, getattr(body, field))
+    # Validated rather than stored as given: a grid of the wrong length would switch work
+    # on or off at times nobody chose, and failing the save is the honest outcome.
+    grid = getattr(body, "schedule_grid", "")
+    try:
+        row.schedule_grid = normalize_grid(grid)
+    except ScheduleGridError as exc:
+        raise RefinerLibraryError(str(exc)) from exc
     row.rule_set_id = _validate_rule_set(session, getattr(body, "rule_set_id", None))
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
@@ -114,6 +114,11 @@ class RefinerLibraryRow(Base):
     schedule_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     schedule_hours_limited: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
     schedule_days: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    # 7x24 at 15-minute resolution, as 672 characters of 0/1. Empty means no restriction,
+    # which is what every library has until someone draws a grid. This supersedes the
+    # day/start/end trio below, which cannot express "overnight on weeknights, all day at
+    # the weekend" — the shape most operators actually want.
+    schedule_grid: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     schedule_start: Mapped[str] = mapped_column(Text, nullable=False, server_default="00:00")
     schedule_end: Mapped[str] = mapped_column(Text, nullable=False, server_default="23:59")
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_schedule_grid.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_schedule_grid.py
@@ -1,0 +1,163 @@
+"""A 7x24 schedule at 15-minute resolution, stored as 672 characters.
+
+The existing schedule is one start time, one end time and a set of days. That cannot say
+"overnight on weeknights and all day at the weekend", which is the shape most operators
+actually want from a tool that saturates a disk. A grid can, and a grid at 15-minute
+resolution is the same thing FileFlows exposes.
+
+Stored as a string of ``'0'``/``'1'`` rather than a table of slots, because it is read on
+every lease decision and a single column read beats 672 rows. An empty string means "no
+restriction", which is what every existing library has, so nothing changes on upgrade
+until someone draws a grid.
+
+Day 0 is Monday, matching ``datetime.weekday()`` and the existing ``DAY_NAMES`` order, so
+there is one weekday convention in the codebase rather than two.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+#: 15-minute resolution. 4 slots an hour, 96 a day, 672 a week.
+SLOTS_PER_HOUR = 4
+SLOTS_PER_DAY = 24 * SLOTS_PER_HOUR
+SLOTS_PER_WEEK = 7 * SLOTS_PER_DAY
+SLOT_MINUTES = 60 // SLOTS_PER_HOUR
+
+
+class ScheduleGridError(ValueError):
+    """The grid text is not a usable schedule."""
+
+
+def empty_grid() -> str:
+    """No restriction. Distinct from an all-zero grid, which means "never"."""
+
+    return ""
+
+
+def full_grid() -> str:
+    return "1" * SLOTS_PER_WEEK
+
+
+def normalize_grid(raw: str | None) -> str:
+    """Validate and canonicalise stored grid text.
+
+    Anything that is not exactly 672 characters of ``0``/``1`` is rejected rather than
+    coerced: a grid silently padded to a length it did not have would switch work on or
+    off at times the operator never chose.
+    """
+
+    text = (raw or "").strip()
+    if not text:
+        return ""
+    if len(text) != SLOTS_PER_WEEK:
+        raise ScheduleGridError(
+            f"A schedule grid must be exactly {SLOTS_PER_WEEK} characters "
+            f"(7 days x {SLOTS_PER_DAY} quarter-hours); this one has {len(text)}."
+        )
+    if set(text) - {"0", "1"}:
+        raise ScheduleGridError("A schedule grid may only contain 0 and 1.")
+    return text
+
+
+def slot_index(*, weekday: int, hour: int, minute: int) -> int:
+    """Index into the grid for a wall-clock moment. Monday is 0."""
+
+    return (weekday % 7) * SLOTS_PER_DAY + hour * SLOTS_PER_HOUR + minute // SLOT_MINUTES
+
+
+def grid_allows(grid: str | None, *, timezone_name: str, now: datetime) -> bool:
+    """Whether this moment is inside the grid.
+
+    An empty grid allows everything. A grid that fails to parse also allows everything:
+    refusing to work because a stored string is malformed would turn a display bug into
+    a stoppage, and the malformed value is reported elsewhere.
+    """
+
+    try:
+        text = normalize_grid(grid)
+    except ScheduleGridError:
+        return True
+    if not text:
+        return True
+    try:
+        tz = ZoneInfo((timezone_name or "UTC").strip() or "UTC")
+    except Exception:
+        tz = ZoneInfo("UTC")
+    moment = now.replace(tzinfo=UTC) if now.tzinfo is None else now
+    local = moment.astimezone(tz)
+    return text[slot_index(weekday=local.weekday(), hour=local.hour, minute=local.minute)] == "1"
+
+
+def grid_from_days_and_times(*, days: str, start: str, end: str) -> str:
+    """Build a grid from the day/start/end fields it replaces.
+
+    Used by the migration so an upgrade preserves exactly the window a library already
+    had. Anything this cannot express faithfully returns an empty grid — no restriction —
+    rather than a grid that is nearly right, because a schedule that is nearly right runs
+    heavy work at a time the operator excluded.
+    """
+
+    from mediamop.platform.media_managers.schedule_wall_clock import DAY_NAMES
+
+    wanted = {d.strip().lower()[:3] for d in (days or "").split(",") if d.strip()}
+    if not wanted:
+        return ""
+    try:
+        start_h, start_m = (int(x) for x in (start or "00:00").split(":", 1))
+        end_h, end_m = (int(x) for x in (end or "23:59").split(":", 1))
+    except (ValueError, TypeError):
+        return ""
+
+    start_slot = start_h * SLOTS_PER_HOUR + start_m // SLOT_MINUTES
+    # 23:59 means "to the end of the day", so the final slot is inclusive.
+    end_slot = end_h * SLOTS_PER_HOUR + end_m // SLOT_MINUTES
+    if not (0 <= start_slot < SLOTS_PER_DAY and 0 <= end_slot < SLOTS_PER_DAY):
+        return ""
+
+    slots = ["0"] * SLOTS_PER_WEEK
+    for day_index, name in enumerate(DAY_NAMES):
+        if name.strip().lower()[:3] not in wanted:
+            continue
+        base = day_index * SLOTS_PER_DAY
+        if start_slot <= end_slot:
+            for s in range(start_slot, end_slot + 1):
+                slots[base + s] = "1"
+        else:
+            # An overnight window runs to midnight and continues on the following day,
+            # which is what the start<=end comparison in the old evaluator did too.
+            for s in range(start_slot, SLOTS_PER_DAY):
+                slots[base + s] = "1"
+            for s in range(0, end_slot + 1):
+                slots[((day_index + 1) % 7) * SLOTS_PER_DAY + s] = "1"
+    return "".join(slots)
+
+
+def next_open_slot(grid: str | None, *, timezone_name: str, now: datetime) -> datetime | None:
+    """When the grid next allows work, or None if it never does or is unrestricted.
+
+    An operator told "outside its scheduled hours" and nothing else has to go and read
+    the grid to find out how long that means.
+    """
+
+    try:
+        text = normalize_grid(grid)
+    except ScheduleGridError:
+        return None
+    if not text or "1" not in text:
+        return None
+    try:
+        tz = ZoneInfo((timezone_name or "UTC").strip() or "UTC")
+    except Exception:
+        tz = ZoneInfo("UTC")
+    moment = now.replace(tzinfo=UTC) if now.tzinfo is None else now
+    local = moment.astimezone(tz)
+    start = slot_index(weekday=local.weekday(), hour=local.hour, minute=local.minute)
+    from datetime import timedelta
+
+    for ahead in range(1, SLOTS_PER_WEEK + 1):
+        if text[(start + ahead) % SLOTS_PER_WEEK] == "1":
+            aligned = local.replace(minute=(local.minute // SLOT_MINUTES) * SLOT_MINUTES, second=0, microsecond=0)
+            return (aligned + timedelta(minutes=SLOT_MINUTES * ahead)).astimezone(UTC)
+    return None

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -23,7 +23,6 @@ from mediamop.modules.refiner.refiner_file_settling import (
 from mediamop.modules.refiner.refiner_file_state_service import (
     decide_file_state,
     existing_file_row,
-    library_in_schedule_window,
     record_file_state,
 )
 from mediamop.modules.refiner.refiner_library_service import resolve_library
@@ -40,6 +39,11 @@ from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_ops imp
     refiner_completed_remux_output_exists_for_relative_path,
     relative_posix_path_under_watched,
     retry_completed_movie_source_cleanup,
+)
+from mediamop.modules.refiner.refiner_work_admission import (
+    evaluate_work_admission,
+    library_window_open,
+    library_window_reopens_at,
 )
 from mediamop.modules.refiner.worker_loop import RefinerJobWorkContext
 from mediamop.platform.media_managers.manager_port import MediaScope
@@ -92,7 +96,17 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
 
         with session_factory() as library_session:
             library = resolve_library(library_session, media_scope=media_scope)
-            in_window = library_in_schedule_window(library_session, library) if library is not None else True
+            admission = evaluate_work_admission(library_session)
+            pause_reason = admission.pause.reason if admission.pause.paused else None
+            pause_until = admission.pause.paused_until if admission.pause.paused else None
+            if library is not None:
+                in_window = library_window_open(library, timezone_name=admission.timezone_name)
+                reopens_at = (
+                    None if in_window else library_window_reopens_at(library, timezone_name=admission.timezone_name)
+                )
+            else:
+                in_window = True
+                reopens_at = None
 
         watched_path = Path(watched_root)
         candidates = iter_watched_folder_media_candidates(
@@ -198,6 +212,9 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                         library=library,
                         in_schedule_window=in_window,
                         file_age_seconds=_file_age_seconds(file_path),
+                        paused_reason=pause_reason,
+                        paused_until=pause_until,
+                        window_reopens_at=reopens_at,
                         size_is_settling=settling.is_settling,
                         settling_reason=settling.reason,
                         settling_stable_at=settling.stable_at,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_work_admission.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_work_admission.py
@@ -1,0 +1,172 @@
+"""Whether Refiner may take on new work right now, and why not.
+
+The schedule used to gate **enqueue** only. Once a job was queued it ran to completion
+regardless, so a 4K remux started two minutes before the window closed ran into the
+morning — which is exactly the outcome the window existed to prevent. And there was no
+pause of any kind, on a tool whose whole job is sustained disk and CPU load on a machine
+someone is also using.
+
+So admission is evaluated at **lease** time, not only at enqueue time.
+
+**In-flight policy: a job already running finishes.** Killing a transcode partway through
+wastes the work done and leaves a partial file to reason about, and the alternative —
+checkpoint and requeue — is a much larger promise than a schedule needs to make. The
+window therefore means "start nothing new", and the UI says exactly that rather than
+implying work stops dead at the boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_schedule_grid import grid_allows, next_open_slot
+from mediamop.platform.media_managers.schedule_wall_clock import schedule_time_window_active
+from mediamop.platform.suite_settings.model import SuiteSettingsRow
+
+#: Job kinds that are detection rather than processing. These keep running through a
+#: pause when "scan while paused" is on, because noticing a file costs nothing and
+#: refusing to notice it only hides work that is arriving anyway.
+DETECTION_JOB_KIND_PREFIXES: tuple[str, ...] = (
+    "refiner.watched_folder.remux_scan_dispatch",
+    "refiner.supplied_payload_evaluation",
+)
+
+
+def is_detection_job_kind(job_kind: str) -> bool:
+    return any(job_kind.startswith(prefix) for prefix in DETECTION_JOB_KIND_PREFIXES)
+
+
+@dataclass(frozen=True, slots=True)
+class PauseState:
+    """The suite-wide pause, already resolved against the clock."""
+
+    paused: bool
+    paused_until: datetime | None
+    scan_while_paused: bool
+    #: True when a ``paused_until`` in the past means this pause has lapsed. The stored
+    #: flag is left alone; expiry is evaluated on read so a stopped process cannot leave
+    #: an instance paused forever.
+    expired: bool = False
+
+    @property
+    def reason(self) -> str:
+        if not self.paused:
+            return ""
+        if self.paused_until is not None:
+            return (
+                "Processing is paused. MediaMop will start work again automatically at "
+                f"{self.paused_until.astimezone(UTC).strftime('%Y-%m-%d %H:%M')} UTC."
+            )
+        return "Processing is paused. MediaMop will start work again when you resume it."
+
+
+def resolve_pause_state(row: SuiteSettingsRow, *, now: datetime | None = None) -> PauseState:
+    """Read the pause, honouring its expiry.
+
+    Expiry is applied here rather than by a background task, so a pause set before a
+    restart still lapses on time.
+    """
+
+    moment = now or datetime.now(UTC)
+    until = row.processing_paused_until
+    if until is not None and until.tzinfo is None:
+        until = until.replace(tzinfo=UTC)
+    if not row.processing_paused:
+        return PauseState(paused=False, paused_until=None, scan_while_paused=bool(row.scan_while_paused))
+    if until is not None and moment >= until:
+        return PauseState(
+            paused=False,
+            paused_until=until,
+            scan_while_paused=bool(row.scan_while_paused),
+            expired=True,
+        )
+    return PauseState(paused=True, paused_until=until, scan_while_paused=bool(row.scan_while_paused))
+
+
+def library_window_open(
+    library: RefinerLibraryRow,
+    *,
+    timezone_name: str,
+    now: datetime | None = None,
+) -> bool:
+    """Whether this library's schedule allows work at this moment.
+
+    The grid wins when one is drawn. Falling back to the day/start/end trio keeps every
+    library that has not been given a grid behaving exactly as it did.
+    """
+
+    if not library.schedule_enabled:
+        return True
+    moment = now or datetime.now(UTC)
+    grid = (library.schedule_grid or "").strip()
+    if grid:
+        return grid_allows(grid, timezone_name=timezone_name, now=moment)
+    if not library.schedule_hours_limited:
+        return True
+    return schedule_time_window_active(
+        schedule_enabled=True,
+        schedule_days=(library.schedule_days or "").strip(),
+        schedule_start=(library.schedule_start or "00:00").strip(),
+        schedule_end=(library.schedule_end or "23:59").strip(),
+        timezone_name=timezone_name,
+        now=moment,
+    )
+
+
+def library_window_reopens_at(
+    library: RefinerLibraryRow,
+    *,
+    timezone_name: str,
+    now: datetime | None = None,
+) -> datetime | None:
+    """When a closed window next opens, when that is knowable from a grid."""
+
+    grid = (library.schedule_grid or "").strip()
+    if not grid:
+        return None
+    return next_open_slot(grid, timezone_name=timezone_name, now=now or datetime.now(UTC))
+
+
+@dataclass(frozen=True, slots=True)
+class WorkAdmission:
+    """What a worker is allowed to pick up on this pass."""
+
+    pause: PauseState
+    #: Libraries whose window is shut. A job naming one of these is not leased.
+    blocked_library_ids: frozenset[int] = field(default_factory=frozenset)
+    timezone_name: str = "UTC"
+
+    @property
+    def blocks_processing(self) -> bool:
+        return self.pause.paused
+
+    @property
+    def blocks_detection(self) -> bool:
+        return self.pause.paused and not self.pause.scan_while_paused
+
+    def allows_job_kind(self, job_kind: str) -> bool:
+        if not self.pause.paused:
+            return True
+        return is_detection_job_kind(job_kind) and self.pause.scan_while_paused
+
+
+def evaluate_work_admission(session: Session, *, now: datetime | None = None) -> WorkAdmission:
+    """Read the pause and every library window once, for one pass of the worker loop."""
+
+    moment = now or datetime.now(UTC)
+    suite = session.scalars(select(SuiteSettingsRow).where(SuiteSettingsRow.id == 1)).one_or_none()
+    if suite is None:
+        return WorkAdmission(pause=PauseState(paused=False, paused_until=None, scan_while_paused=True))
+    tz_name = (suite.app_timezone or "UTC").strip() or "UTC"
+    pause = resolve_pause_state(suite, now=moment)
+
+    blocked: set[int] = set()
+    for library in session.scalars(select(RefinerLibraryRow).order_by(RefinerLibraryRow.id)):
+        if not library.enabled or not library_window_open(library, timezone_name=tz_name, now=moment):
+            blocked.add(int(library.id))
+    return WorkAdmission(pause=pause, blocked_library_ids=frozenset(blocked), timezone_name=tz_name)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -79,6 +79,7 @@ class RefinerLibraryOut(BaseModel):
     ignore_size_changes: bool
     skip_access_tests: bool
     file_system_events_enabled: bool
+    schedule_grid: str
     schedule_enabled: bool
     schedule_hours_limited: bool
     schedule_days: str
@@ -136,6 +137,13 @@ class RefinerLibraryCreateIn(BaseModel):
     skip_access_tests: bool = Field(
         False,
         description="Skip the read/write probe that runs before a file is queued.",
+    )
+    schedule_grid: str = Field(
+        "",
+        description=(
+            "7 days x 96 quarter-hours as 672 characters of 0/1, Monday first. Empty means no restriction. "
+            "Work already running finishes when a window closes; the window stops MediaMop starting anything new."
+        ),
     )
     file_system_events_enabled: bool = Field(
         True,

--- a/apps/backend/src/mediamop/modules/refiner/worker_loop.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_loop.py
@@ -29,6 +29,7 @@ from mediamop.modules.refiner.jobs_ops import (
     fail_claimed_refiner_job,
     fail_leased_refiner_job_after_complete_failure,
 )
+from mediamop.modules.refiner.refiner_work_admission import evaluate_work_admission
 from mediamop.platform.http.request_context import job_logging_context
 from mediamop.platform.jobs.worker_health import worker_heartbeat, worker_started, worker_stopped
 from mediamop.platform.notifications.dispatch import dispatch_job_notification
@@ -84,11 +85,17 @@ def process_one_refiner_job(
     lease_until = when + timedelta(seconds=lease_seconds)
 
     with session_factory() as session, session.begin():
+        # The schedule and the suite pause are evaluated here, at lease time, rather than
+        # only at enqueue. A window that gated enqueue alone let a job queued two minutes
+        # before closing run all night, which is the outcome the window exists to prevent
+        # (#337). A job already leased is left to finish — see refiner_work_admission.
+        admission = evaluate_work_admission(session, now=when)
         job = claim_next_eligible_refiner_job(
             session,
             lease_owner=lease_owner,
             lease_expires_at=lease_until,
             now=when,
+            admission=admission,
         )
         if job is None:
             return "idle"

--- a/apps/backend/src/mediamop/platform/suite_settings/model.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/model.py
@@ -26,6 +26,16 @@ class SuiteSettingsRow(Base):
     configuration_backup_interval_hours: Mapped[int] = mapped_column(Integer, nullable=False, server_default="24")
     configuration_backup_preferred_time: Mapped[str] = mapped_column(Text, nullable=False, server_default="02:00")
     configuration_backup_last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Pause lives on the suite, not on Refiner, so Pruner can honour the same switch
+    # without a second one appearing next to it.
+    processing_paused: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    # A pause with an expiry is one an operator cannot forget to lift. Null means
+    # "until I say otherwise", which is a deliberate choice rather than the only option.
+    processing_paused_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # Usually you want to keep noticing files while declining to work on them, so this
+    # defaults on: pausing stops processing, not detection.
+    scan_while_paused: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/apps/backend/src/mediamop/platform/suite_settings/pause_api.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/pause_api.py
@@ -1,0 +1,86 @@
+"""Suite HTTP: pause and resume processing — ``/api/v1/suite/pause``.
+
+Pause is a suite control rather than a Refiner one, so a second switch does not appear
+beside it when Pruner grows the same need. It is deliberately small: paused or not, an
+optional expiry, and whether detection keeps running.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, HTTPException, Request
+from starlette import status as http_status
+
+from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_work_admission import resolve_pause_state
+from mediamop.platform.auth.authorization import RequireOperatorDep
+from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
+    require_session_secret,
+    validate_browser_post_origin,
+    verify_csrf_token,
+)
+from mediamop.platform.auth.deps_auth import UserPublicDep
+from mediamop.platform.suite_settings.pause_schemas import SuitePauseIn, SuitePauseOut
+from mediamop.platform.suite_settings.service import ensure_suite_settings_row
+
+router = APIRouter(tags=["suite"])
+
+
+def _verify_csrf(request: Request, settings: MediaMopSettings, token: str) -> None:
+    validate_browser_post_origin(request, settings)
+    secret = require_session_secret(settings)
+    if not verify_csrf_token(secret, token, raw_session_token=current_raw_session_token(request, settings)):
+        raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail="Invalid or expired CSRF token.")
+
+
+def _out(db: DbSessionDep) -> SuitePauseOut:
+    row = ensure_suite_settings_row(db)
+    state = resolve_pause_state(row)
+    if state.expired:
+        # The pause lapsed while nothing was looking. Clear the stored flag so the screen
+        # and the database agree, rather than reporting "not paused" over a row that
+        # still says otherwise.
+        row.processing_paused = False
+        row.processing_paused_until = None
+        db.flush()
+    return SuitePauseOut(
+        paused=state.paused,
+        paused_until=state.paused_until if state.paused else None,
+        scan_while_paused=state.scan_while_paused,
+        reason=state.reason,
+        # Said plainly because the alternative reading — that a pause stops work dead —
+        # is the one an operator will otherwise assume and be surprised by.
+        in_flight_policy=("Work already running finishes. Pausing stops MediaMop starting anything new."),
+    )
+
+
+@router.get("/suite/pause", response_model=SuitePauseOut)
+def get_suite_pause(_user: UserPublicDep, db: DbSessionDep) -> SuitePauseOut:
+    return _out(db)
+
+
+@router.put("/suite/pause", response_model=SuitePauseOut)
+def put_suite_pause(
+    request: Request,
+    _operator: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    body: SuitePauseIn,
+) -> SuitePauseOut:
+    _verify_csrf(request, settings, body.csrf_token)
+    row = ensure_suite_settings_row(db)
+    row.processing_paused = bool(body.paused)
+    row.scan_while_paused = bool(body.scan_while_paused)
+    if not body.paused:
+        row.processing_paused_until = None
+    elif body.pause_for_minutes is not None:
+        row.processing_paused_until = datetime.now(UTC) + timedelta(minutes=int(body.pause_for_minutes))
+    else:
+        # An indefinite pause is a deliberate choice, so it clears any previous expiry
+        # rather than inheriting one the operator did not ask for again.
+        row.processing_paused_until = None
+    db.flush()
+    return _out(db)

--- a/apps/backend/src/mediamop/platform/suite_settings/pause_schemas.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/pause_schemas.py
@@ -1,0 +1,36 @@
+"""Request and response shapes for the suite pause control."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SuitePauseOut(BaseModel):
+    paused: bool
+    paused_until: datetime | None = Field(
+        default=None,
+        description="When the pause lifts on its own. Null for a pause that lasts until it is lifted by hand.",
+    )
+    scan_while_paused: bool = Field(
+        description="Whether MediaMop keeps noticing new files while it is not working on them.",
+    )
+    reason: str = Field(description="What to show an operator, written for them rather than for the code.")
+    in_flight_policy: str = Field(
+        description="What happens to work that is already running when a pause or a schedule window starts.",
+    )
+
+
+class SuitePauseIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)
+    paused: bool
+    pause_for_minutes: int | None = Field(
+        default=None,
+        ge=1,
+        le=10080,
+        description="Lift the pause automatically after this many minutes. Omit for a pause with no expiry.",
+    )
+    scan_while_paused: bool = True

--- a/apps/backend/tests/test_refiner_schedules_and_pause.py
+++ b/apps/backend/tests/test_refiner_schedules_and_pause.py
@@ -1,0 +1,400 @@
+"""The schedule gates work, not only enqueue — and a pause that expires on its own.
+
+The bug this closes is specific: a window that gated enqueue let a job queued two minutes
+before closing run all night, which is the exact outcome the window existed to prevent.
+So the tests that matter here are about **leasing**, not about enqueueing (#337).
+
+In-flight policy is "a running job finishes". That is asserted too, because it is a
+promise the UI makes and a promise nobody should be able to change by accident.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.platform.suite_settings.model  # noqa: F401
+from mediamop.core.db import Base
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.jobs_ops import claim_next_eligible_refiner_job, refiner_enqueue_or_get_job
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_schedule_grid import (
+    SLOTS_PER_DAY,
+    SLOTS_PER_WEEK,
+    ScheduleGridError,
+    grid_allows,
+    grid_from_days_and_times,
+    next_open_slot,
+    normalize_grid,
+    slot_index,
+)
+from mediamop.modules.refiner.refiner_work_admission import (
+    evaluate_work_admission,
+    is_detection_job_kind,
+    library_window_open,
+    resolve_pause_state,
+)
+from mediamop.platform.suite_settings.model import SuiteSettingsRow
+
+REMUX = "refiner.file.remux_pass.v1"
+SCAN = "refiner.watched_folder.remux_scan_dispatch.v1"
+
+# A Wednesday at 14:00 UTC.
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def session(tmp_path: Path) -> Session:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'sched.sqlite'}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)()
+    s.add(SuiteSettingsRow(id=1, app_timezone="UTC"))
+    s.commit()
+    return s
+
+
+def _library(session: Session, **overrides) -> RefinerLibraryRow:
+    row = RefinerLibraryRow(
+        name=overrides.pop("name", "Movies"),
+        media_scope="movie",
+        enabled=overrides.pop("enabled", True),
+        watched_folder="/srv/in",
+        output_folder="/srv/out",
+        schedule_enabled=overrides.pop("schedule_enabled", True),
+        **overrides,
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _queue(session: Session, *, kind: str, library_id: int | None = None, key: str = "k") -> RefinerJob:
+    payload: dict[str, object] = {"media_scope": "movie"}
+    if library_id is not None:
+        payload["library_id"] = library_id
+    job = refiner_enqueue_or_get_job(
+        session, dedupe_key=f"{kind}:{key}", job_kind=kind, payload_json=json.dumps(payload)
+    )
+    session.commit()
+    return job
+
+
+def _claim(session: Session, admission, *, owner: str = "w1") -> RefinerJob | None:
+    job = claim_next_eligible_refiner_job(
+        session,
+        lease_owner=owner,
+        lease_expires_at=NOW + timedelta(hours=1),
+        now=NOW,
+        admission=admission,
+    )
+    session.commit()
+    return job
+
+
+# --- the grid ----------------------------------------------------------------------
+
+
+def test_an_empty_grid_means_no_restriction_and_an_all_zero_grid_means_never() -> None:
+    # These must not be conflated: every existing library has no grid, and reading that
+    # as "never" would stop all work on upgrade.
+    assert grid_allows("", timezone_name="UTC", now=NOW) is True
+    assert grid_allows(None, timezone_name="UTC", now=NOW) is True
+    assert grid_allows("0" * SLOTS_PER_WEEK, timezone_name="UTC", now=NOW) is False
+
+
+def test_a_grid_of_the_wrong_length_is_refused_rather_than_padded() -> None:
+    with pytest.raises(ScheduleGridError, match="672 characters"):
+        normalize_grid("101")
+    with pytest.raises(ScheduleGridError, match="only contain 0 and 1"):
+        normalize_grid("2" * SLOTS_PER_WEEK)
+
+
+def test_a_malformed_stored_grid_allows_work_rather_than_stopping_it() -> None:
+    """A display bug must not become a stoppage."""
+
+    assert grid_allows("nonsense", timezone_name="UTC", now=NOW) is True
+
+
+def test_the_grid_is_read_at_quarter_hour_resolution() -> None:
+    slots = ["0"] * SLOTS_PER_WEEK
+    # Wednesday is weekday 2. 14:15 only.
+    slots[slot_index(weekday=2, hour=14, minute=15)] = "1"
+    grid = "".join(slots)
+
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(minute=14)) is False
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(minute=15)) is True
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(minute=29)) is True
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(minute=30)) is False
+
+
+def test_the_grid_is_evaluated_in_the_suite_timezone() -> None:
+    slots = ["0"] * SLOTS_PER_WEEK
+    # 14:00 UTC is 10:00 in New York on this date.
+    slots[slot_index(weekday=2, hour=10, minute=0)] = "1"
+    grid = "".join(slots)
+
+    assert grid_allows(grid, timezone_name="America/New_York", now=NOW) is True
+    assert grid_allows(grid, timezone_name="UTC", now=NOW) is False
+
+
+def test_an_unknown_timezone_falls_back_to_utc_rather_than_raising() -> None:
+    slots = ["0"] * SLOTS_PER_WEEK
+    slots[slot_index(weekday=2, hour=14, minute=0)] = "1"
+
+    assert grid_allows("".join(slots), timezone_name="Mars/Olympus", now=NOW) is True
+
+
+def test_a_grid_built_from_days_and_times_reproduces_that_window() -> None:
+    grid = grid_from_days_and_times(days="mon,wed", start="09:00", end="17:00")
+
+    assert grid_allows(grid, timezone_name="UTC", now=NOW) is True  # Wednesday 14:00
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(hour=18)) is False
+    assert grid_allows(grid, timezone_name="UTC", now=NOW + timedelta(days=1)) is False  # Thursday
+
+
+def test_an_overnight_window_carries_into_the_next_day() -> None:
+    grid = grid_from_days_and_times(days="wed", start="22:00", end="04:00")
+
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(hour=23)) is True
+    # Thursday 02:00 is inside a window that started on Wednesday night.
+    assert grid_allows(grid, timezone_name="UTC", now=(NOW + timedelta(days=1)).replace(hour=2)) is True
+    assert grid_allows(grid, timezone_name="UTC", now=NOW.replace(hour=12)) is False
+
+
+def test_days_that_cannot_be_parsed_become_no_restriction_not_a_wrong_window() -> None:
+    # "Nearly right" is worse than "unrestricted" here: it would run heavy work at a time
+    # the operator deliberately excluded.
+    assert grid_from_days_and_times(days="", start="09:00", end="17:00") == ""
+    assert grid_from_days_and_times(days="mon", start="nonsense", end="17:00") == ""
+
+
+def test_a_closed_window_reports_when_it_next_opens() -> None:
+    slots = ["0"] * SLOTS_PER_WEEK
+    slots[slot_index(weekday=2, hour=16, minute=0)] = "1"
+
+    opens = next_open_slot("".join(slots), timezone_name="UTC", now=NOW)
+
+    assert opens == datetime(2026, 8, 26, 16, 0, tzinfo=UTC)
+
+
+def test_a_grid_that_never_opens_reports_no_time_rather_than_a_wrong_one() -> None:
+    assert next_open_slot("0" * SLOTS_PER_WEEK, timezone_name="UTC", now=NOW) is None
+    assert next_open_slot("", timezone_name="UTC", now=NOW) is None
+
+
+# --- the pause ---------------------------------------------------------------------
+
+
+def test_a_pause_with_no_expiry_stays_paused(session: Session) -> None:
+    row = session.get(SuiteSettingsRow, 1)
+    row.processing_paused = True
+    session.commit()
+
+    state = resolve_pause_state(row, now=NOW)
+
+    assert state.paused is True
+    assert state.expired is False
+    assert "when you resume it" in state.reason
+
+
+def test_a_pause_expires_on_its_own_without_a_background_task(session: Session) -> None:
+    """A pause set before a restart must still lapse on time."""
+
+    row = session.get(SuiteSettingsRow, 1)
+    row.processing_paused = True
+    row.processing_paused_until = NOW - timedelta(minutes=1)
+    session.commit()
+
+    state = resolve_pause_state(row, now=NOW)
+
+    assert state.paused is False
+    assert state.expired is True
+
+
+def test_a_pause_that_has_not_yet_expired_is_still_a_pause_and_says_when(session: Session) -> None:
+    row = session.get(SuiteSettingsRow, 1)
+    row.processing_paused = True
+    row.processing_paused_until = NOW + timedelta(hours=2)
+    session.commit()
+
+    state = resolve_pause_state(row, now=NOW)
+
+    assert state.paused is True
+    assert "2026-08-26 16:00 UTC" in state.reason
+
+
+def test_detection_job_kinds_are_recognised() -> None:
+    assert is_detection_job_kind(SCAN) is True
+    assert is_detection_job_kind(REMUX) is False
+
+
+# --- leasing: the point of the issue ------------------------------------------------
+
+
+def test_a_job_is_not_leased_for_a_library_outside_its_window(session: Session) -> None:
+    """Queued before the window closed, and still not started after it did."""
+
+    library = _library(session, schedule_grid="0" * SLOTS_PER_WEEK)
+    _queue(session, kind=REMUX, library_id=library.id)
+
+    admission = evaluate_work_admission(session, now=NOW)
+
+    assert library.id in admission.blocked_library_ids
+    assert _claim(session, admission) is None
+    assert session.scalars(select(RefinerJob)).one().status == RefinerJobStatus.PENDING.value
+
+
+def test_a_job_is_leased_once_the_window_opens(session: Session) -> None:
+    slots = ["0"] * SLOTS_PER_WEEK
+    for slot in range(SLOTS_PER_DAY):
+        slots[2 * SLOTS_PER_DAY + slot] = "1"  # all Wednesday
+    library = _library(session, schedule_grid="".join(slots))
+    _queue(session, kind=REMUX, library_id=library.id)
+
+    claimed = _claim(session, evaluate_work_admission(session, now=NOW))
+
+    assert claimed is not None
+    assert claimed.status == RefinerJobStatus.LEASED.value
+
+
+def test_one_library_being_shut_does_not_block_another(session: Session) -> None:
+    shut = _library(session, name="Movies", schedule_grid="0" * SLOTS_PER_WEEK)
+    open_lib = _library(session, name="TV")
+    _queue(session, kind=REMUX, library_id=shut.id, key="shut")
+    _queue(session, kind=REMUX, library_id=open_lib.id, key="open")
+
+    claimed = _claim(session, evaluate_work_admission(session, now=NOW))
+
+    assert claimed is not None
+    assert json.loads(claimed.payload_json or "{}")["library_id"] == open_lib.id
+
+
+def test_a_job_naming_no_library_is_still_claimable(session: Session) -> None:
+    """Suite-wide and pre-library jobs must not be swept up by an exclusion list."""
+
+    shut = _library(session, schedule_grid="0" * SLOTS_PER_WEEK)
+    _queue(session, kind=REMUX, library_id=shut.id, key="shut")
+    _queue(session, kind=SCAN, key="nolib")
+
+    claimed = _claim(session, evaluate_work_admission(session, now=NOW))
+
+    assert claimed is not None
+    assert claimed.job_kind == SCAN
+
+
+def test_a_running_job_finishes_when_the_window_closes(session: Session) -> None:
+    """The documented in-flight policy, asserted so nobody changes it by accident.
+
+    Killing a transcode partway through wastes the work and leaves a partial file. The
+    window means "start nothing new".
+    """
+
+    library = _library(session)
+    _queue(session, kind=REMUX, library_id=library.id)
+    leased = _claim(session, evaluate_work_admission(session, now=NOW))
+    assert leased is not None
+
+    # Now the window shuts underneath the running job.
+    library.schedule_grid = "0" * SLOTS_PER_WEEK
+    session.commit()
+
+    admission = evaluate_work_admission(session, now=NOW)
+    assert library.id in admission.blocked_library_ids
+    # Untouched, and still owned by the worker that leased it.
+    still = session.scalars(select(RefinerJob)).one()
+    assert still.status == RefinerJobStatus.LEASED.value
+    assert still.lease_owner == "w1"
+    # And nothing new starts.
+    assert _claim(session, admission, owner="w2") is None
+
+
+def test_a_disabled_library_blocks_leasing_too(session: Session) -> None:
+    library = _library(session, enabled=False)
+    _queue(session, kind=REMUX, library_id=library.id)
+
+    assert _claim(session, evaluate_work_admission(session, now=NOW)) is None
+
+
+def test_a_library_with_scheduling_off_is_never_blocked(session: Session) -> None:
+    library = _library(session, schedule_enabled=False, schedule_grid="0" * SLOTS_PER_WEEK)
+
+    assert library_window_open(library, timezone_name="UTC", now=NOW) is True
+
+
+# --- leasing under a pause ----------------------------------------------------------
+
+
+def _pause(session: Session, *, scan_while_paused: bool, until: datetime | None = None) -> None:
+    row = session.get(SuiteSettingsRow, 1)
+    row.processing_paused = True
+    row.scan_while_paused = scan_while_paused
+    row.processing_paused_until = until
+    session.commit()
+
+
+def test_a_pause_stops_processing_but_scanning_continues_by_default(session: Session) -> None:
+    """The right decomposition: keep noticing files while declining to work on them."""
+
+    library = _library(session)
+    _queue(session, kind=REMUX, library_id=library.id, key="remux")
+    _queue(session, kind=SCAN, library_id=library.id, key="scan")
+    _pause(session, scan_while_paused=True)
+
+    claimed = _claim(session, evaluate_work_admission(session, now=NOW))
+
+    assert claimed is not None
+    assert claimed.job_kind == SCAN
+    # And the remux stays put.
+    assert _claim(session, evaluate_work_admission(session, now=NOW), owner="w2") is None
+
+
+def test_scan_while_paused_off_stops_everything(session: Session) -> None:
+    library = _library(session)
+    _queue(session, kind=SCAN, library_id=library.id, key="scan")
+    _pause(session, scan_while_paused=False)
+
+    assert _claim(session, evaluate_work_admission(session, now=NOW)) is None
+
+
+def test_work_resumes_once_the_pause_expires(session: Session) -> None:
+    library = _library(session)
+    _queue(session, kind=REMUX, library_id=library.id)
+    _pause(session, scan_while_paused=True, until=NOW + timedelta(hours=1))
+
+    assert _claim(session, evaluate_work_admission(session, now=NOW)) is None
+
+    later = NOW + timedelta(hours=2)
+    admission = evaluate_work_admission(session, now=later)
+    assert admission.pause.paused is False
+    claimed = claim_next_eligible_refiner_job(
+        session,
+        lease_owner="w1",
+        lease_expires_at=later + timedelta(hours=1),
+        now=later,
+        admission=admission,
+    )
+    session.commit()
+
+    assert claimed is not None
+    assert claimed.job_kind == REMUX
+
+
+def test_no_admission_claims_exactly_as_before(session: Session) -> None:
+    """Callers with nothing to do with scheduling keep the old behaviour."""
+
+    library = _library(session, schedule_grid="0" * SLOTS_PER_WEEK)
+    _queue(session, kind=REMUX, library_id=library.id)
+    _pause(session, scan_while_paused=False)
+
+    assert _claim(session, None) is not None

--- a/apps/backend/tests/test_suite_pause_api.py
+++ b/apps/backend/tests/test_suite_pause_api.py
@@ -1,0 +1,110 @@
+"""The pause endpoint — ``/api/v1/suite/pause``.
+
+Pause is on the suite rather than on Refiner so Pruner can honour the same switch later
+instead of a second one appearing beside it (#337).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.integration_helpers import auth_get, auth_post, auth_put, csrf
+
+
+@pytest.fixture
+def signed_in(client_with_admin: TestClient) -> TestClient:
+    token = csrf(client_with_admin)
+    response = auth_post(
+        client_with_admin,
+        "/api/v1/auth/login",
+        json={"username": "alice", "password": "test-password-strong", "csrf_token": token},
+    )
+    assert response.status_code == 200, response.text
+    return client_with_admin
+
+
+def test_processing_starts_unpaused_and_says_what_a_pause_would_do(signed_in: TestClient) -> None:
+    body = auth_get(signed_in, "/api/v1/suite/pause").json()
+
+    assert body["paused"] is False
+    # The in-flight policy is stated up front, because the assumption otherwise is that
+    # a pause stops work dead.
+    assert "already running finishes" in body["in_flight_policy"]
+
+
+def test_a_pause_with_an_expiry_reports_when_it_lifts(signed_in: TestClient) -> None:
+    response = auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={"csrf_token": csrf(signed_in), "paused": True, "pause_for_minutes": 120},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["paused"] is True
+    assert body["paused_until"] is not None
+    assert "automatically at" in body["reason"]
+
+
+def test_a_pause_with_no_expiry_says_so_rather_than_implying_one(signed_in: TestClient) -> None:
+    body = auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={"csrf_token": csrf(signed_in), "paused": True},
+    ).json()
+
+    assert body["paused"] is True
+    assert body["paused_until"] is None
+    assert "when you resume it" in body["reason"]
+
+
+def test_resuming_clears_the_expiry(signed_in: TestClient) -> None:
+    auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={"csrf_token": csrf(signed_in), "paused": True, "pause_for_minutes": 30},
+    )
+
+    body = auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={"csrf_token": csrf(signed_in), "paused": False},
+    ).json()
+
+    assert body["paused"] is False
+    assert body["paused_until"] is None
+
+
+def test_scan_while_paused_can_be_turned_off(signed_in: TestClient) -> None:
+    body = auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={
+            "csrf_token": csrf(signed_in),
+            "paused": True,
+            "scan_while_paused": False,
+        },
+    ).json()
+
+    assert body["scan_while_paused"] is False
+
+
+def test_a_pause_change_without_a_csrf_token_is_refused(signed_in: TestClient) -> None:
+    response = auth_put(signed_in, "/api/v1/suite/pause", json={"paused": True, "scan_while_paused": True})
+
+    assert response.status_code == 422
+
+
+def test_an_out_of_range_duration_is_refused(signed_in: TestClient) -> None:
+    response = auth_put(
+        signed_in,
+        "/api/v1/suite/pause",
+        json={
+            "csrf_token": csrf(signed_in),
+            "paused": True,
+            "pause_for_minutes": 0,
+        },
+    )
+
+    assert response.status_code == 422

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -3455,6 +3455,12 @@
             "title": "Schedule End",
             "type": "string"
           },
+          "schedule_grid": {
+            "default": "",
+            "description": "7 days x 96 quarter-hours as 672 characters of 0/1, Monday first. Empty means no restriction. Work already running finishes when a window closes; the window stops MediaMop starting anything new.",
+            "title": "Schedule Grid",
+            "type": "string"
+          },
           "schedule_hours_limited": {
             "default": false,
             "title": "Schedule Hours Limited",
@@ -3687,6 +3693,10 @@
             "title": "Schedule End",
             "type": "string"
           },
+          "schedule_grid": {
+            "title": "Schedule Grid",
+            "type": "string"
+          },
           "schedule_hours_limited": {
             "title": "Schedule Hours Limited",
             "type": "boolean"
@@ -3748,6 +3758,7 @@
           "ignore_size_changes",
           "skip_access_tests",
           "file_system_events_enabled",
+          "schedule_grid",
           "schedule_enabled",
           "schedule_hours_limited",
           "schedule_days",
@@ -3948,6 +3959,12 @@
             "default": "23:59",
             "maxLength": 5,
             "title": "Schedule End",
+            "type": "string"
+          },
+          "schedule_grid": {
+            "default": "",
+            "description": "7 days x 96 quarter-hours as 672 characters of 0/1, Monday first. Empty means no restriction. Work already running finishes when a window closes; the window stops MediaMop starting anything new.",
+            "title": "Schedule Grid",
             "type": "string"
           },
           "schedule_hours_limited": {
@@ -5585,6 +5602,89 @@
           "total_deleted"
         ],
         "title": "SuiteOperationalHistoryResetOut",
+        "type": "object"
+      },
+      "SuitePauseIn": {
+        "additionalProperties": false,
+        "properties": {
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          },
+          "pause_for_minutes": {
+            "anyOf": [
+              {
+                "maximum": 10080.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Lift the pause automatically after this many minutes. Omit for a pause with no expiry.",
+            "title": "Pause For Minutes"
+          },
+          "paused": {
+            "title": "Paused",
+            "type": "boolean"
+          },
+          "scan_while_paused": {
+            "default": true,
+            "title": "Scan While Paused",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "csrf_token",
+          "paused"
+        ],
+        "title": "SuitePauseIn",
+        "type": "object"
+      },
+      "SuitePauseOut": {
+        "properties": {
+          "in_flight_policy": {
+            "description": "What happens to work that is already running when a pause or a schedule window starts.",
+            "title": "In Flight Policy",
+            "type": "string"
+          },
+          "paused": {
+            "title": "Paused",
+            "type": "boolean"
+          },
+          "paused_until": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the pause lifts on its own. Null for a pause that lasts until it is lifted by hand.",
+            "title": "Paused Until"
+          },
+          "reason": {
+            "description": "What to show an operator, written for them rather than for the code.",
+            "title": "Reason",
+            "type": "string"
+          },
+          "scan_while_paused": {
+            "description": "Whether MediaMop keeps noticing new files while it is not working on them.",
+            "title": "Scan While Paused",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "paused",
+          "scan_while_paused",
+          "reason",
+          "in_flight_policy"
+        ],
+        "title": "SuitePauseOut",
         "type": "object"
       },
       "SuiteSecurityOverviewOut": {
@@ -9971,6 +10071,66 @@
           }
         },
         "summary": "Post Suite Operational History Reset",
+        "tags": [
+          "suite"
+        ]
+      }
+    },
+    "/api/v1/suite/pause": {
+      "get": {
+        "operationId": "get_suite_pause_api_v1_suite_pause_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuitePauseOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Suite Pause",
+        "tags": [
+          "suite"
+        ]
+      },
+      "put": {
+        "operationId": "put_suite_pause_api_v1_suite_pause_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SuitePauseIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuitePauseOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put Suite Pause",
         "tags": [
           "suite"
         ]

--- a/apps/web/src/components/shell/pause-control.test.tsx
+++ b/apps/web/src/components/shell/pause-control.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import * as authQueries from "../../lib/auth/queries";
+import type { SuitePause } from "../../lib/suite/pause-api";
+import * as pauseQueries from "../../lib/suite/pause-queries";
+import { PauseControl } from "./pause-control";
+
+const mutate = vi.fn();
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function state(over: Partial<SuitePause> = {}): SuitePause {
+  return {
+    paused: false,
+    paused_until: null,
+    scan_while_paused: true,
+    reason: "",
+    in_flight_policy:
+      "Work already running finishes. Pausing stops MediaMop starting anything new.",
+    ...over,
+  };
+}
+
+function setup(pause: SuitePause, role = "operator") {
+  vi.spyOn(authQueries, "useMeQuery").mockReturnValue({
+    data: { role },
+  } as ReturnType<typeof authQueries.useMeQuery>);
+  vi.spyOn(pauseQueries, "useSuitePauseQuery").mockReturnValue({
+    data: pause,
+  } as ReturnType<typeof pauseQueries.useSuitePauseQuery>);
+  vi.spyOn(pauseQueries, "useSaveSuitePause").mockReturnValue({
+    mutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof pauseQueries.useSaveSuitePause>);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mutate.mockReset();
+});
+
+it("offers a pause with an expiry, so it cannot be forgotten", () => {
+  setup(state());
+
+  render(<PauseControl />, { wrapper });
+  fireEvent.click(screen.getByTestId("pause-open"));
+  fireEvent.click(screen.getByTestId("pause-for-120"));
+
+  expect(mutate).toHaveBeenCalledWith({
+    paused: true,
+    pause_for_minutes: 120,
+    scan_while_paused: true,
+  });
+});
+
+it("still allows a pause with no expiry", () => {
+  setup(state());
+
+  render(<PauseControl />, { wrapper });
+  fireEvent.click(screen.getByTestId("pause-open"));
+  fireEvent.click(screen.getByTestId("pause-for-indefinite"));
+
+  expect(mutate).toHaveBeenCalledWith({
+    paused: true,
+    pause_for_minutes: null,
+    scan_while_paused: true,
+  });
+});
+
+it("says what happens to work already running rather than leaving it to be assumed", () => {
+  setup(state());
+
+  render(<PauseControl />, { wrapper });
+  fireEvent.click(screen.getByTestId("pause-open"));
+
+  expect(screen.getByTestId("pause-policy")).toHaveTextContent(
+    /already running finishes/i,
+  );
+});
+
+it("shows the reason, which carries when the pause lifts", () => {
+  setup(
+    state({
+      paused: true,
+      paused_until: "2026-08-26T16:00:00Z",
+      reason:
+        "Processing is paused. MediaMop will start work again automatically at 2026-08-26 16:00 UTC.",
+    }),
+  );
+
+  render(<PauseControl />, { wrapper });
+
+  expect(screen.getByTestId("pause-badge")).toHaveTextContent("Paused");
+  expect(screen.getByTestId("pause-reason")).toHaveTextContent(
+    "2026-08-26 16:00 UTC",
+  );
+});
+
+it("resumes without inventing a duration", () => {
+  setup(state({ paused: true, reason: "Processing is paused." }));
+
+  render(<PauseControl />, { wrapper });
+  fireEvent.click(screen.getByTestId("pause-resume"));
+
+  expect(mutate).toHaveBeenCalledWith({
+    paused: false,
+    scan_while_paused: true,
+  });
+});
+
+it("lets a viewer see a pause but not change it", () => {
+  setup(state({ paused: true, reason: "Processing is paused." }), "viewer");
+
+  render(<PauseControl />, { wrapper });
+
+  expect(screen.getByTestId("pause-badge")).toBeInTheDocument();
+  expect(screen.queryByTestId("pause-resume")).not.toBeInTheDocument();
+});
+
+it("shows a viewer nothing at all when processing is running normally", () => {
+  setup(state(), "viewer");
+
+  const { container } = render(<PauseControl />, { wrapper });
+
+  expect(container).toBeEmptyDOMElement();
+});

--- a/apps/web/src/components/shell/pause-control.tsx
+++ b/apps/web/src/components/shell/pause-control.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+
+import { useMeQuery } from "../../lib/auth/queries";
+import {
+  useSaveSuitePause,
+  useSuitePauseQuery,
+} from "../../lib/suite/pause-queries";
+
+/** Minutes offered for a pause that lifts itself. */
+const DURATIONS: { label: string; minutes: number | null }[] = [
+  { label: "30 minutes", minutes: 30 },
+  { label: "2 hours", minutes: 120 },
+  { label: "8 hours", minutes: 480 },
+  { label: "Until I resume", minutes: null },
+];
+
+function canEdit(role: string | undefined): boolean {
+  return role === "admin" || role === "operator";
+}
+
+/**
+ * Pause processing, from anywhere in the app.
+ *
+ * It lives in the shell rather than on the Refiner page because the reason to reach for
+ * it — the machine is busy and you want it back — has nothing to do with which screen
+ * you happen to be on.
+ */
+export function PauseControl() {
+  const me = useMeQuery();
+  const pause = useSuitePauseQuery();
+  const save = useSaveSuitePause();
+  const [open, setOpen] = useState(false);
+
+  const editable = canEdit(me.data?.role);
+  const state = pause.data;
+  if (!state) return null;
+
+  const resume = () =>
+    save.mutate({
+      paused: false,
+      scan_while_paused: state.scan_while_paused,
+    });
+
+  if (state.paused) {
+    return (
+      <div className="mm-pause-control" data-testid="pause-control">
+        <span className="mm-pause-badge" data-testid="pause-badge">
+          Paused
+        </span>
+        {/* The reason carries the expiry, so an operator never has to guess how long. */}
+        <span className="mm-pause-reason" data-testid="pause-reason">
+          {state.reason}
+        </span>
+        {editable ? (
+          <button
+            type="button"
+            className="mm-theme-toggle"
+            data-testid="pause-resume"
+            disabled={save.isPending}
+            onClick={resume}
+          >
+            {save.isPending ? "Resuming…" : "Resume"}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (!editable) return null;
+
+  return (
+    <div className="mm-pause-control" data-testid="pause-control">
+      <button
+        type="button"
+        className="mm-theme-toggle"
+        data-testid="pause-open"
+        aria-expanded={open}
+        onClick={() => setOpen(!open)}
+      >
+        Pause processing
+      </button>
+      {open ? (
+        <div className="mm-pause-menu" data-testid="pause-menu">
+          {DURATIONS.map((d) => (
+            <button
+              key={d.label}
+              type="button"
+              className="mm-theme-toggle"
+              data-testid={`pause-for-${d.minutes ?? "indefinite"}`}
+              disabled={save.isPending}
+              onClick={() => {
+                save.mutate({
+                  paused: true,
+                  pause_for_minutes: d.minutes,
+                  scan_while_paused: state.scan_while_paused,
+                });
+                setOpen(false);
+              }}
+            >
+              {d.label}
+            </button>
+          ))}
+          <label className="mm-pause-scan-toggle">
+            <input
+              type="checkbox"
+              data-testid="pause-scan-while-paused"
+              checked={state.scan_while_paused}
+              onChange={(e) =>
+                save.mutate({
+                  paused: state.paused,
+                  scan_while_paused: e.target.checked,
+                })
+              }
+            />
+            Keep looking for new files while paused
+          </label>
+          {/* Said out loud, because the assumption otherwise is that work stops dead. */}
+          <p className="mm-pause-policy" data-testid="pause-policy">
+            {state.in_flight_policy}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/layouts/app-shell.test.tsx
+++ b/apps/web/src/layouts/app-shell.test.tsx
@@ -10,6 +10,22 @@ vi.mock("../lib/auth/queries", () => ({
     mutate: logoutMutate,
     isPending: false,
   }),
+  // The shell now carries the pause control, which needs to know whether the signed-in
+  // person may change it.
+  useMeQuery: () => ({ data: { role: "operator" } }),
+}));
+
+vi.mock("../lib/suite/pause-queries", () => ({
+  useSuitePauseQuery: () => ({
+    data: {
+      paused: false,
+      paused_until: null,
+      scan_while_paused: true,
+      reason: "",
+      in_flight_policy: "Work already running finishes.",
+    },
+  }),
+  useSaveSuitePause: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("../lib/dashboard/queries", () => ({

--- a/apps/web/src/layouts/app-shell.tsx
+++ b/apps/web/src/layouts/app-shell.tsx
@@ -8,6 +8,7 @@ import {
   NavIconSettings,
   NavIconPruner,
 } from "../components/shell/nav-icons";
+import { PauseControl } from "../components/shell/pause-control";
 import { useLogoutMutation } from "../lib/auth/queries";
 import { useDashboardStatusQuery } from "../lib/dashboard/queries";
 import { useSuiteSettingsQuery } from "../lib/suite/queries";
@@ -105,6 +106,7 @@ export function AppShell() {
       <main className="mm-main" id="mm-main-content" tabIndex={-1}>
         <div className="mm-main-inner">
           <div className="mm-shell-toolbar" aria-label="Display controls">
+            <PauseControl />
             <button
               type="button"
               className="mm-theme-toggle"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -1246,6 +1246,24 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/suite/pause": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Suite Pause */
+    get: operations["get_suite_pause_api_v1_suite_pause_get"];
+    /** Put Suite Pause */
+    put: operations["put_suite_pause_api_v1_suite_pause_put"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/suite/security-overview": {
     parameters: {
       query?: never;
@@ -3066,6 +3084,12 @@ export interface components {
        */
       schedule_end: string;
       /**
+       * Schedule Grid
+       * @description 7 days x 96 quarter-hours as 672 characters of 0/1, Monday first. Empty means no restriction. Work already running finishes when a window closes; the window stops MediaMop starting anything new.
+       * @default
+       */
+      schedule_grid: string;
+      /**
        * Schedule Hours Limited
        * @default false
        */
@@ -3182,6 +3206,8 @@ export interface components {
       schedule_enabled: boolean;
       /** Schedule End */
       schedule_end: string;
+      /** Schedule Grid */
+      schedule_grid: string;
       /** Schedule Hours Limited */
       schedule_hours_limited: boolean;
       /** Schedule Start */
@@ -3325,6 +3351,12 @@ export interface components {
        * @default 23:59
        */
       schedule_end: string;
+      /**
+       * Schedule Grid
+       * @description 7 days x 96 quarter-hours as 672 characters of 0/1, Monday first. Empty means no restriction. Work already running finishes when a window closes; the window stops MediaMop starting anything new.
+       * @default
+       */
+      schedule_grid: string;
       /**
        * Schedule Hours Limited
        * @default false
@@ -4087,6 +4119,48 @@ export interface components {
       status: string;
       /** Total Deleted */
       total_deleted: number;
+    };
+    /** SuitePauseIn */
+    SuitePauseIn: {
+      /** Csrf Token */
+      csrf_token: string;
+      /**
+       * Pause For Minutes
+       * @description Lift the pause automatically after this many minutes. Omit for a pause with no expiry.
+       */
+      pause_for_minutes?: number | null;
+      /** Paused */
+      paused: boolean;
+      /**
+       * Scan While Paused
+       * @default true
+       */
+      scan_while_paused: boolean;
+    };
+    /** SuitePauseOut */
+    SuitePauseOut: {
+      /**
+       * In Flight Policy
+       * @description What happens to work that is already running when a pause or a schedule window starts.
+       */
+      in_flight_policy: string;
+      /** Paused */
+      paused: boolean;
+      /**
+       * Paused Until
+       * @description When the pause lifts on its own. Null for a pause that lasts until it is lifted by hand.
+       */
+      paused_until?: string | null;
+      /**
+       * Reason
+       * @description What to show an operator, written for them rather than for the code.
+       */
+      reason: string;
+      /**
+       * Scan While Paused
+       * @description Whether MediaMop keeps noticing new files while it is not working on them.
+       */
+      scan_while_paused: boolean;
     };
     /**
      * SuiteSecurityOverviewOut
@@ -6870,6 +6944,59 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SuiteOperationalHistoryResetOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_suite_pause_api_v1_suite_pause_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SuitePauseOut"];
+        };
+      };
+    };
+  };
+  put_suite_pause_api_v1_suite_pause_put: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SuitePauseIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SuitePauseOut"];
         };
       };
       /** @description Validation Error */

--- a/apps/web/src/lib/refiner/libraries-api.ts
+++ b/apps/web/src/lib/refiner/libraries-api.ts
@@ -36,6 +36,7 @@ export interface RefinerLibrary {
   ignore_size_changes: boolean;
   skip_access_tests: boolean;
   file_system_events_enabled: boolean;
+  schedule_grid: string;
   schedule_enabled: boolean;
   schedule_hours_limited: boolean;
   schedule_days: string;
@@ -76,6 +77,7 @@ export interface RefinerLibraryWrite {
   ignore_size_changes?: boolean;
   skip_access_tests?: boolean;
   file_system_events_enabled?: boolean;
+  schedule_grid?: string;
   schedule_enabled?: boolean;
   schedule_hours_limited?: boolean;
   schedule_days?: string;

--- a/apps/web/src/lib/suite/pause-api.ts
+++ b/apps/web/src/lib/suite/pause-api.ts
@@ -1,0 +1,49 @@
+import { fetchCsrfToken } from "../api/auth-api";
+import { apiFetch, readJson, requireOk } from "../api/client";
+
+export interface SuitePause {
+  paused: boolean;
+  /** When the pause lifts on its own. Null for one that lasts until it is lifted by hand. */
+  paused_until: string | null;
+  scan_while_paused: boolean;
+  reason: string;
+  /** What happens to work already running. Shown, not assumed. */
+  in_flight_policy: string;
+}
+
+export interface SuitePauseWrite {
+  paused: boolean;
+  pause_for_minutes?: number | null;
+  scan_while_paused: boolean;
+}
+
+export const suitePausePath = () => "/api/v1/suite/pause";
+
+export async function fetchSuitePause(): Promise<SuitePause> {
+  const path = suitePausePath();
+  const response = await apiFetch(path);
+  await requireOk(
+    path,
+    response,
+    "Could not read whether processing is paused",
+  );
+  return readJson<SuitePause>(response);
+}
+
+export async function saveSuitePause(
+  body: SuitePauseWrite,
+): Promise<SuitePause> {
+  const csrf_token = await fetchCsrfToken();
+  const path = suitePausePath();
+  const response = await apiFetch(path, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ ...body, csrf_token }),
+  });
+  await requireOk(
+    path,
+    response,
+    "Could not change whether processing is paused",
+  );
+  return readJson<SuitePause>(response);
+}

--- a/apps/web/src/lib/suite/pause-queries.ts
+++ b/apps/web/src/lib/suite/pause-queries.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchSuitePause,
+  saveSuitePause,
+  type SuitePause,
+  type SuitePauseWrite,
+} from "./pause-api";
+
+export const suitePauseKey = () => ["suite", "pause"];
+
+export function useSuitePauseQuery() {
+  return useQuery<SuitePause>({
+    queryKey: suitePauseKey(),
+    queryFn: fetchSuitePause,
+    // A pause with an expiry lifts on its own, so the shell has to notice without a
+    // reload. One minute is well inside the smallest pause anyone can set.
+    refetchInterval: 60_000,
+  });
+}
+
+export function useSaveSuitePause() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: SuitePauseWrite) => saveSuitePause(body),
+    onSuccess: (data) => {
+      qc.setQueryData(suitePauseKey(), data);
+      // Pausing changes why files are in the state they are in, so the Files screen is
+      // stale the moment this succeeds.
+      void qc.invalidateQueries({ queryKey: ["refiner", "files"] });
+    },
+  });
+}

--- a/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
@@ -33,6 +33,7 @@ function library(over: Partial<RefinerLibrary> = {}): RefinerLibrary {
     ignore_size_changes: false,
     skip_access_tests: false,
     file_system_events_enabled: true,
+    schedule_grid: "",
     schedule_enabled: true,
     schedule_hours_limited: false,
     schedule_days: "",

--- a/apps/web/src/pages/refiner/refiner-libraries-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-libraries-section.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { MmOnOffSwitch } from "../../components/ui/mm-on-off-switch";
 import { PageLoading } from "../../components/shared/page-loading";
+import { ScheduleGridEditor } from "./schedule-grid-editor";
 import { useMeQuery } from "../../lib/auth/queries";
 import {
   REFINER_MEDIA_SCOPE_LABELS,
@@ -47,6 +48,7 @@ type FormState = {
   ignore_size_changes: boolean;
   skip_access_tests: boolean;
   file_system_events_enabled: boolean;
+  schedule_grid: string;
 };
 
 const EMPTY_FORM: FormState = {
@@ -68,6 +70,7 @@ const EMPTY_FORM: FormState = {
   ignore_size_changes: false,
   skip_access_tests: false,
   file_system_events_enabled: true,
+  schedule_grid: "",
 };
 
 function formFrom(library: RefinerLibrary): FormState {
@@ -92,6 +95,7 @@ function formFrom(library: RefinerLibrary): FormState {
     ignore_size_changes: library.ignore_size_changes,
     skip_access_tests: library.skip_access_tests,
     file_system_events_enabled: library.file_system_events_enabled,
+    schedule_grid: library.schedule_grid,
   };
 }
 
@@ -126,6 +130,7 @@ function writeFrom(
     ignore_size_changes: form.ignore_size_changes,
     skip_access_tests: form.skip_access_tests,
     file_system_events_enabled: form.file_system_events_enabled,
+    schedule_grid: form.schedule_grid,
     rule_set_id: library?.rule_set_id ?? null,
     manager_connection_ids: library?.manager_connection_ids ?? [],
   };
@@ -522,6 +527,16 @@ export function RefinerLibrariesSection() {
               />
               Watch this folder for changes
             </label>
+          </div>
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-[var(--mm-text1)]">
+              When this library may run
+            </span>
+            <ScheduleGridEditor
+              value={form.schedule_grid}
+              onChange={(schedule_grid) => setForm({ ...form, schedule_grid })}
+              disabled={!editable}
+            />
           </div>
           <div className="flex gap-2">
             <button

--- a/apps/web/src/pages/refiner/schedule-grid-editor.test.tsx
+++ b/apps/web/src/pages/refiner/schedule-grid-editor.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+
+import { ScheduleGridEditor } from "./schedule-grid-editor";
+
+const SLOTS_PER_WEEK = 7 * 24 * 4;
+
+it("treats an empty grid as no restriction rather than as never", () => {
+  render(<ScheduleGridEditor value="" onChange={vi.fn()} />);
+
+  expect(screen.getByTestId("schedule-grid")).toHaveTextContent(
+    /runs at any time/i,
+  );
+});
+
+it("writes all four quarters of an hour, so nothing is lost in the round trip", () => {
+  const onChange = vi.fn();
+  render(
+    <ScheduleGridEditor
+      value={"0".repeat(SLOTS_PER_WEEK)}
+      onChange={onChange}
+    />,
+  );
+
+  // Wednesday (day 2) at 14:00.
+  fireEvent.pointerDown(screen.getByTestId("schedule-cell-2-14"));
+
+  const written: string = onChange.mock.calls[0][0];
+  const start = 2 * 96 + 14 * 4;
+  expect(written.slice(start, start + 4)).toBe("1111");
+  expect(written).toHaveLength(SLOTS_PER_WEEK);
+});
+
+it("turns an hour back off", () => {
+  const onChange = vi.fn();
+  render(
+    <ScheduleGridEditor
+      value={"1".repeat(SLOTS_PER_WEEK)}
+      onChange={onChange}
+    />,
+  );
+
+  fireEvent.pointerDown(screen.getByTestId("schedule-cell-0-9"));
+
+  const written: string = onChange.mock.calls[0][0];
+  expect(written.slice(9 * 4, 9 * 4 + 4)).toBe("0000");
+});
+
+it("clears back to an empty grid rather than an all-zero one", () => {
+  const onChange = vi.fn();
+  render(
+    <ScheduleGridEditor
+      value={"0".repeat(SLOTS_PER_WEEK)}
+      onChange={onChange}
+    />,
+  );
+
+  fireEvent.click(screen.getByTestId("schedule-clear"));
+
+  // "" means any time; "000…" would mean never, and confusing the two would stop all work.
+  expect(onChange).toHaveBeenCalledWith("");
+});
+
+it("can select nothing at all, which is a different thing from no schedule", () => {
+  const onChange = vi.fn();
+  render(<ScheduleGridEditor value="" onChange={onChange} />);
+
+  fireEvent.click(screen.getByTestId("schedule-none"));
+
+  expect(onChange).toHaveBeenCalledWith("0".repeat(SLOTS_PER_WEEK));
+});
+
+it("draws a malformed grid as unrestricted instead of inventing a schedule", () => {
+  render(<ScheduleGridEditor value="not-a-grid" onChange={vi.fn()} />);
+
+  expect(screen.getByTestId("schedule-cell-3-12")).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+});
+
+it("does not let a viewer change the grid", () => {
+  const onChange = vi.fn();
+  render(<ScheduleGridEditor value="" onChange={onChange} disabled />);
+
+  fireEvent.pointerDown(screen.getByTestId("schedule-cell-1-8"));
+
+  expect(onChange).not.toHaveBeenCalled();
+});

--- a/apps/web/src/pages/refiner/schedule-grid-editor.tsx
+++ b/apps/web/src/pages/refiner/schedule-grid-editor.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useState } from "react";
+
+const SLOTS_PER_HOUR = 4;
+const SLOTS_PER_DAY = 24 * SLOTS_PER_HOUR;
+const SLOTS_PER_WEEK = 7 * SLOTS_PER_DAY;
+/** Monday first, matching the backend's weekday convention. */
+const DAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function emptyGrid(): string {
+  return "";
+}
+
+function normalized(grid: string): string {
+  if (grid.length === SLOTS_PER_WEEK && !/[^01]/.test(grid)) return grid;
+  // Anything unusable is drawn as "no restriction", which is what the backend does with
+  // it too — a display that invented a schedule would be worse than one that shows none.
+  return "1".repeat(SLOTS_PER_WEEK);
+}
+
+function withSlot(grid: string, index: number, on: boolean): string {
+  const base = normalized(grid);
+  return `${base.slice(0, index)}${on ? "1" : "0"}${base.slice(index + 1)}`;
+}
+
+function hourIsOn(grid: string, day: number, hour: number): boolean {
+  const base = normalized(grid);
+  const start = day * SLOTS_PER_DAY + hour * SLOTS_PER_HOUR;
+  for (let i = 0; i < SLOTS_PER_HOUR; i += 1) {
+    if (base[start + i] === "1") return true;
+  }
+  return false;
+}
+
+function setHour(grid: string, day: number, hour: number, on: boolean): string {
+  let next = normalized(grid);
+  const start = day * SLOTS_PER_DAY + hour * SLOTS_PER_HOUR;
+  for (let i = 0; i < SLOTS_PER_HOUR; i += 1) {
+    next = withSlot(next, start + i, on);
+  }
+  return next;
+}
+
+export interface ScheduleGridEditorProps {
+  value: string;
+  onChange: (grid: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * A 7x24 schedule.
+ *
+ * The stored grid is quarter-hour resolution, but the *editor* works in whole hours:
+ * 168 targets are usable with a mouse and 672 are not, and an hour toggle writes all
+ * four of its quarters so nothing is lost in the round trip. Anyone needing a 15-minute
+ * boundary can still set it through the API, which is the honest trade rather than
+ * pretending the grid is hourly.
+ */
+export function ScheduleGridEditor({
+  value,
+  onChange,
+  disabled = false,
+}: ScheduleGridEditorProps) {
+  const [painting, setPainting] = useState<boolean | null>(null);
+
+  const toggle = useCallback(
+    (day: number, hour: number, on: boolean) => {
+      if (disabled) return;
+      onChange(setHour(value, day, hour, on));
+    },
+    [disabled, onChange, value],
+  );
+
+  const unrestricted = value.length !== SLOTS_PER_WEEK;
+
+  return (
+    <div className="mm-schedule-grid" data-testid="schedule-grid">
+      <p className="text-xs text-[var(--mm-text3)]">
+        {unrestricted
+          ? "No schedule set — this library runs at any time. Select hours to limit it."
+          : "Selected hours are when MediaMop may start work. Work already running finishes."}
+      </p>
+      <div
+        className="mm-schedule-grid-body"
+        onPointerUp={() => setPainting(null)}
+        onPointerLeave={() => setPainting(null)}
+      >
+        <div className="mm-schedule-grid-hours" aria-hidden="true">
+          <span />
+          {Array.from({ length: 24 }, (_, hour) => (
+            <span key={hour}>{hour % 6 === 0 ? hour : ""}</span>
+          ))}
+        </div>
+        {DAYS.map((label, day) => (
+          <div className="mm-schedule-grid-row" key={label}>
+            <span className="mm-schedule-grid-day">{label}</span>
+            {Array.from({ length: 24 }, (_, hour) => {
+              const on = hourIsOn(value, day, hour);
+              return (
+                <button
+                  key={hour}
+                  type="button"
+                  disabled={disabled}
+                  className={
+                    on
+                      ? "mm-schedule-cell mm-schedule-cell-on"
+                      : "mm-schedule-cell"
+                  }
+                  aria-pressed={on}
+                  aria-label={`${label} ${String(hour).padStart(2, "0")}:00`}
+                  data-testid={`schedule-cell-${day}-${hour}`}
+                  onPointerDown={() => {
+                    setPainting(!on);
+                    toggle(day, hour, !on);
+                  }}
+                  // Dragging across the grid is how anyone actually draws a window;
+                  // clicking 40 cells one at a time is not a schedule editor.
+                  onPointerEnter={() => {
+                    if (painting !== null) toggle(day, hour, painting);
+                  }}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+      <div className="mm-schedule-grid-actions">
+        <button
+          type="button"
+          disabled={disabled}
+          className="mm-theme-toggle"
+          data-testid="schedule-clear"
+          onClick={() => onChange(emptyGrid())}
+        >
+          Any time
+        </button>
+        <button
+          type="button"
+          disabled={disabled}
+          className="mm-theme-toggle"
+          data-testid="schedule-none"
+          onClick={() => onChange("0".repeat(SLOTS_PER_WEEK))}
+        >
+          Clear all
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/styles/mediamop-shell.css
+++ b/apps/web/src/styles/mediamop-shell.css
@@ -80,9 +80,68 @@ body.mm-body {
 
 .mm-shell-toolbar {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
+  gap: calc(8px * var(--mm-density-ui-scale));
   min-height: var(--mm-control-height);
   margin: 0 0 calc(12px * var(--mm-density-ui-scale));
+}
+
+/* Pause lives in the toolbar so it is reachable from any screen: the reason to want it
+   is that the machine is busy, which has nothing to do with the page you are on. */
+.mm-pause-control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: calc(8px * var(--mm-density-ui-scale));
+  margin-right: auto;
+}
+
+.mm-pause-badge {
+  border-radius: 999px;
+  border: 1px solid var(--mm-warning-border, var(--mm-border));
+  background: var(--mm-warning-bg, transparent);
+  color: var(--mm-warning-text, var(--mm-text1));
+  padding: 2px calc(10px * var(--mm-density-ui-scale));
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.mm-pause-reason {
+  font-size: 0.8125rem;
+  color: var(--mm-text2);
+}
+
+.mm-pause-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: calc(6px * var(--mm-density-ui-scale));
+  min-width: 260px;
+  padding: calc(12px * var(--mm-density-ui-scale));
+  border: 1px solid var(--mm-border);
+  border-radius: 8px;
+  background: var(--mm-surface1, var(--mm-bg, #fff));
+  box-shadow: 0 8px 24px rgb(0 0 0 / 18%);
+}
+
+.mm-pause-scan-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.8125rem;
+  color: var(--mm-text2);
+}
+
+.mm-pause-policy {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--mm-text3);
 }
 
 .mm-theme-toggle {
@@ -1873,4 +1932,66 @@ select.mm-input::-ms-expand {
     margin: 0;
     border-radius: var(--mm-radius-sm);
   }
+}
+
+/* 7x24 schedule editor. The stored grid is quarter-hour resolution; the editor works in
+   whole hours because 168 targets are usable with a mouse and 672 are not. */
+.mm-schedule-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mm-schedule-grid-body {
+  overflow-x: auto;
+  touch-action: none;
+  user-select: none;
+}
+
+.mm-schedule-grid-hours,
+.mm-schedule-grid-row {
+  display: grid;
+  grid-template-columns: 42px repeat(24, minmax(14px, 1fr));
+  gap: 2px;
+  align-items: center;
+  min-width: 420px;
+}
+
+.mm-schedule-grid-hours span {
+  font-size: 0.625rem;
+  color: var(--mm-text3);
+  text-align: left;
+}
+
+.mm-schedule-grid-row + .mm-schedule-grid-row {
+  margin-top: 2px;
+}
+
+.mm-schedule-grid-day {
+  font-size: 0.6875rem;
+  color: var(--mm-text2);
+}
+
+.mm-schedule-cell {
+  height: 18px;
+  border: 1px solid var(--mm-border);
+  border-radius: 2px;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+.mm-schedule-cell:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.mm-schedule-cell-on {
+  background: var(--mm-accent, #2563eb);
+  border-color: var(--mm-accent, #2563eb);
+}
+
+.mm-schedule-grid-actions {
+  display: flex;
+  gap: 8px;
 }


### PR DESCRIPTION
Closes #337. Part of #347.

Stacked on #336 (open as [#368](https://github.com/jampat000/MediaMop/pull/368)) — migration `0015` chains off `0014`.

## The problem

The schedule gated **enqueue** only. Once a job was queued it ran to completion regardless of the window, so a 4K remux started two minutes before the window closed ran into the morning — the exact outcome the window existed to prevent. And there was **no pause of any kind**, on a tool whose whole job is sustained disk and CPU load on a machine someone is also using.

## Admission moves to lease time

`claim_next_eligible_refiner_job` takes an optional `admission` that narrows *which row is chosen*. A job for a library outside its window is never leased. Passing nothing claims exactly as before, which is what every caller unrelated to scheduling wants.

**In-flight policy: a job already running finishes.** Killing a transcode partway wastes the work done and leaves a partial file to reason about; the alternative — checkpoint and requeue — is a far larger promise than a schedule needs to make. So the window means *start nothing new*, and both the API (`in_flight_policy`) and the UI say so rather than letting it be assumed. There is a test asserting the promise so nobody changes it by accident.

## Per-library 7x24 grid

15-minute resolution, stored as 672 characters of `0`/`1`, Monday first.

| Value | Meaning |
| --- | --- |
| `""` | no restriction — what every existing library has |
| `"000…"` | never |

These are deliberately **not** conflated: reading empty as "never" would stop all work on upgrade. `0015` backfills each library's grid from the days/start/end it already had, so an upgrade changes nothing about when work runs, and the old trio stays as the fallback for anything the grid could not express faithfully.

A grid that fails to parse **allows** work. A display bug must not become a stoppage.

The editor works in whole hours (168 targets are usable with a mouse; 672 are not) and writes all four quarters of an hour, so nothing is lost in the round trip. A 15-minute boundary is still settable through the API — the honest trade rather than pretending the grid is hourly.

## Pause

On `suite_settings`, not on Refiner, so Pruner can honour the same switch later instead of a second one appearing beside it.

- **Optional expiry**, resolved on read — a pause set before a restart still lapses on time, with no background task to miss it.
- **`scan_while_paused`** defaults on. The useful pause is "stop working on files", not "stop noticing them".
- The control sits in the **shell toolbar**, reachable from any screen, because the reason to want it — the machine is busy and you want it back — has nothing to do with which page you are on.

Files blocked by a pause or a closed window report `Out Of Schedule` with the reason and, where it is knowable from a grid, when they are due.

## Removed rather than left behind

`library_in_schedule_window` is superseded by `library_window_open` and is deleted. A superseded function left in the tree is exactly the #328 pattern the dead-code guard exists to catch.

## Tests

Window closing with work queued · **window closing mid-run** (the in-flight promise) · pause · pause expiry · scan-while-paused both ways · one library shut not blocking another · a job naming no library staying claimable · timezone handling · quarter-hour resolution · the grid built from the fields it replaces · overnight windows · malformed grids · 7 endpoint tests · 14 web tests.

Verified locally: 1004 backend passed / 2 skipped, 194 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
