### PR TITLE
feat(refiner): a weighted runner budget replaces the flat file count (#338)

### DIFF
--- a/apps/backend/alembic/versions/0016_runner_units.py
+++ b/apps/backend/alembic/versions/0016_runner_units.py
@@ -1,0 +1,116 @@
+"""Runner units, job priority, and the resolution a file was measured at
+
+``max_concurrent_files`` treated a 700 MB SD rip and a 60 GB 4K remux as the same unit of
+work. A machine sized for two of the latter sits idle under six of the former, and one
+sized for six of the former is overwhelmed by two of the latter. The count was never
+protecting the thing it appeared to protect.
+
+``refiner_operator_settings``
+    ``runner_capacity`` plus a cost per resolution class. Capacity is migrated from the
+    saved ``max_concurrent_files`` one-for-one, so with the shipped costs the same number
+    of expensive files run at once. Smaller files now cost nothing and run alongside.
+
+``refiner_jobs``
+    ``runner_cost`` — what this job spends, fixed at enqueue so the claim is a comparison
+    rather than a join. ``priority`` — higher first, seeded from the library and raised by
+    "move to top".
+
+``refiner_files``
+    ``video_width`` / ``video_height`` — recorded after a pass, read at the next enqueue.
+    Null costs the ``undetermined`` weight rather than a guess. Width decides the class:
+    1920x800 is a scope crop of a 1080p master, and height alone cannot tell it from
+    1280x720.
+
+Shipped costs match the observed FileFlows values: SD and 720p free, 1080p and 4K one
+unit each, undetermined free.
+
+Revision ID: 0016_runner_units
+Revises: 0015_schedules_and_pause
+Create Date: 2026-08-29 13:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0016_runner_units"
+down_revision = "0015_schedules_and_pause"
+branch_labels = None
+depends_on = None
+
+_OPERATOR_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    ("runner_capacity", sa.Column("runner_capacity", sa.Integer(), nullable=False, server_default="4")),
+    ("runner_cost_sd", sa.Column("runner_cost_sd", sa.Integer(), nullable=False, server_default="0")),
+    ("runner_cost_720p", sa.Column("runner_cost_720p", sa.Integer(), nullable=False, server_default="0")),
+    ("runner_cost_1080p", sa.Column("runner_cost_1080p", sa.Integer(), nullable=False, server_default="1")),
+    ("runner_cost_4k", sa.Column("runner_cost_4k", sa.Integer(), nullable=False, server_default="1")),
+    (
+        "runner_cost_undetermined",
+        sa.Column("runner_cost_undetermined", sa.Integer(), nullable=False, server_default="0"),
+    ),
+)
+
+_JOB_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    ("runner_cost", sa.Column("runner_cost", sa.Integer(), nullable=False, server_default="0")),
+    ("priority", sa.Column("priority", sa.Integer(), nullable=False, server_default="0")),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    present = _columns("refiner_operator_settings")
+    for name, column in _OPERATOR_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_operator_settings", column)
+
+    present = _columns("refiner_jobs")
+    for name, column in _JOB_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_jobs", column)
+
+    present = _columns("refiner_files")
+    for name in ("video_width", "video_height"):
+        if present and name not in present:
+            op.add_column("refiner_files", sa.Column(name, sa.Integer(), nullable=True))
+
+    # Preserve the effective concurrency an operator already chose.
+    if _columns("refiner_operator_settings"):
+        from mediamop.modules.refiner.refiner_runner_units import capacity_from_legacy_concurrency
+
+        saved = bind.execute(
+            sa.text("SELECT max_concurrent_files FROM refiner_operator_settings WHERE id = 1")
+        ).fetchone()
+        if saved is not None:
+            bind.execute(
+                sa.text("UPDATE refiner_operator_settings SET runner_capacity = :cap WHERE id = 1"),
+                {"cap": capacity_from_legacy_concurrency(int(saved[0] or 1))},
+            )
+
+
+def downgrade() -> None:
+    # Tolerant of a partially-applied upgrade. A downgrade that raises halfway leaves the
+    # version row saying one thing and the schema saying another, which is worse than the
+    # state it was trying to undo.
+    present = _columns("refiner_files")
+    for name in ("video_height", "video_width"):
+        if name in present:
+            op.drop_column("refiner_files", name)
+    present = _columns("refiner_jobs")
+    for name, _ in _JOB_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_jobs", name)
+    present = _columns("refiner_operator_settings")
+    for name, _ in _OPERATOR_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_operator_settings", name)

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -23,6 +23,7 @@ from mediamop.modules.refiner.file_remux_pass.visibility import (
     remux_pass_result_to_activity_detail,
     summarize_remux_plan,
 )
+from mediamop.modules.refiner.refiner_file_state_service import record_measured_video_dimensions
 from mediamop.modules.refiner.refiner_movie_output_cleanup import (
     maybe_run_movie_output_folder_cleanup_after_remux,
 )
@@ -47,6 +48,7 @@ from mediamop.modules.refiner.refiner_remux_track_display import (
     subtitle_after_line_from_plan,
     subtitle_before_line_from_probe,
 )
+from mediamop.modules.refiner.refiner_runner_units import video_dimensions_from_streams
 from mediamop.modules.refiner.refiner_tv_output_cleanup import (
     maybe_run_tv_output_season_folder_cleanup_after_remux,
 )
@@ -480,6 +482,16 @@ def run_refiner_file_remux_pass(
         )
 
     video, audio, subs = split_streams(probe)
+    # Measured once here and recorded, so the *next* enqueue of this file can weight it
+    # against the runner budget instead of paying the "undetermined" cost forever (#338).
+    measured_width, measured_height = video_dimensions_from_streams(video)
+    if cleanup_session is not None and (measured_width is not None or measured_height is not None):
+        record_measured_video_dimensions(
+            cleanup_session,
+            relative_path=relative_media_path,
+            video_width=measured_width,
+            video_height=measured_height,
+        )
     duration_seconds = _probe_duration_seconds(probe)
     config = rules_config if rules_config is not None else default_refiner_remux_rules_config()
     plan = plan_remux(video=video, audio=audio, subtitles=subs, config=config)

--- a/apps/backend/src/mediamop/modules/refiner/jobs_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_model.py
@@ -64,6 +64,13 @@ class RefinerJob(Base):
     )
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
     not_before: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # What this job costs against the runner budget, fixed at enqueue. On the row rather
+    # than looked up at lease time so the claim can compare instead of joining against a
+    # probe result that may not exist yet.
+    runner_cost: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    # Higher goes first. Seeded from the library's priority; "move to top" raises it
+    # above everything currently queued.
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
+++ b/apps/backend/src/mediamop/modules/refiner/jobs_ops.py
@@ -56,7 +56,7 @@ WHERE id = (
       )
     )
     {admission}
-  ORDER BY id ASC
+  ORDER BY priority DESC, id ASC
   LIMIT 1
 )
 RETURNING id
@@ -85,6 +85,14 @@ def _admission_predicate(admission: object | None) -> tuple[str, dict[str, objec
         # COALESCE keeps it claimable rather than sweeping it up in the exclusion.
         rendered = ",".join(str(i) for i in ids)
         clauses.append(f"AND COALESCE(json_extract(payload_json, '$.library_id'), -1) NOT IN ({rendered})")
+
+    # The weighted budget. A job costing more than what is left waits; a job costing
+    # nothing runs even when the budget is full, which is the whole point of weighting
+    # rather than counting.
+    available = getattr(admission, "available_units", None)
+    if available is not None:
+        clauses.append("AND runner_cost <= :available_units")
+        params["available_units"] = max(0, int(available))
 
     pause = getattr(admission, "pause", None)
     if pause is not None and getattr(pause, "paused", False):
@@ -146,8 +154,15 @@ def refiner_enqueue_or_get_job(
     job_kind: str,
     payload_json: str | None = None,
     max_attempts: int = 3,
+    runner_cost: int = 0,
+    priority: int = 0,
 ) -> RefinerJob:
-    """Insert a ``pending`` job or return the existing row for ``dedupe_key``."""
+    """Insert a ``pending`` job or return the existing row for ``dedupe_key``.
+
+    ``runner_cost`` is fixed here rather than at lease time: the claim has to answer
+    "does this fit in what is left?" in one statement, and a row carrying its own cost
+    makes that a comparison instead of a join against a probe result that may not exist.
+    """
 
     validate_refiner_enqueue_job_kind(job_kind)
 
@@ -161,6 +176,8 @@ def refiner_enqueue_or_get_job(
         payload_json=payload_json,
         status=RefinerJobStatus.PENDING.value,
         max_attempts=max(1, max_attempts),
+        runner_cost=max(0, int(runner_cost)),
+        priority=int(priority),
     )
     with session.begin_nested():
         session.add(row)
@@ -357,4 +374,26 @@ def recover_handler_ok_finalize_failed_to_completed(
     session.flush()
     record_module_job_event(module="refiner", event="completed")
     _record_refiner_queue_depth(session)
+    return "ok"
+
+
+def move_refiner_job_to_top(session: Session, *, job_id: int) -> Literal["ok", "not_found", "wrong_status"]:
+    """Put one queued job ahead of everything else waiting.
+
+    Only ``pending`` rows: a leased job is already running, and "move to top" cannot
+    make something that has started start earlier. Raising it above the current maximum
+    rather than to a fixed number means two files moved to the top keep the order they
+    were moved in.
+    """
+
+    job = session.scalars(select(RefinerJob).where(RefinerJob.id == job_id)).one_or_none()
+    if job is None:
+        return "not_found"
+    if job.status != RefinerJobStatus.PENDING.value:
+        return "wrong_status"
+    highest = session.scalar(
+        select(func.max(RefinerJob.priority)).where(RefinerJob.status == RefinerJobStatus.PENDING.value)
+    )
+    job.priority = int(highest or 0) + 1
+    session.flush()
     return "ok"

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_state_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_state_model.py
@@ -84,6 +84,12 @@ class RefinerFileRow(Base):
     blocked_by_connection: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    # Recorded after a pass has probed the file, and read at the *next* enqueue to weight
+    # it. Null until then, which costs the "undetermined" weight rather than a guess.
+    # Width is the one that decides the class: 1920x800 is a scope crop of a 1080p master,
+    # and height alone cannot tell it from 1280x720.
+    video_width: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    video_height: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # When ``size_bytes`` last differed from the previous observation. Null until a
     # second scan has something to compare against.
     size_changed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_state_service.py
@@ -242,3 +242,28 @@ def forget_file(session: Session, row: RefinerFileRow) -> None:
 
     session.delete(row)
     session.flush()
+
+
+def record_measured_video_dimensions(
+    session: Session,
+    *,
+    relative_path: str,
+    video_width: int | None,
+    video_height: int | None,
+) -> None:
+    """Remember the size a pass measured, for weighting the next enqueue.
+
+    Matched on path alone rather than on ``(library_id, path)``: the pass knows the file
+    it processed but not which library row the scan attributed it to, and a resolution is
+    a property of the file rather than of the library looking at it. Writing to every
+    matching row is correct for the same reason.
+    """
+
+    rows = session.scalars(select(RefinerFileRow).where(RefinerFileRow.relative_path == relative_path)).all()
+    for row in rows:
+        if video_width is not None:
+            row.video_width = int(video_width)
+        if video_height is not None:
+            row.video_height = int(video_height)
+    if rows:
+        session.flush()

--- a/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
@@ -14,11 +14,15 @@ from starlette import status as http_status
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.jobs_ops import move_refiner_job_to_top
 from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow
 from mediamop.modules.refiner.refiner_file_state_service import forget_file, list_files, status_counts
+from mediamop.modules.refiner.refiner_job_queue_lookup import pending_remux_job_for_relative_path
 from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
 from mediamop.modules.refiner.schemas_refiner_files import (
     RefinerFileForgetIn,
+    RefinerFileMoveToTopIn,
+    RefinerFileMoveToTopOut,
     RefinerFileOut,
     RefinerFilesPageOut,
     RefinerFileStatusName,
@@ -104,3 +108,47 @@ def delete_refiner_file(
         raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="MediaMop has no record of that file.")
     forget_file(db, row)
     db.commit()
+
+
+@router.post("/refiner/files/{file_id}/move-to-top", response_model=RefinerFileMoveToTopOut)
+def move_refiner_file_to_top(
+    body: RefinerFileMoveToTopIn,
+    request: Request,
+    _user: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    file_id: int = Path(ge=1),
+) -> RefinerFileMoveToTopOut:
+    """Put this file's queued work ahead of everything else waiting.
+
+    Only affects work that has not started. A file already being processed cannot be
+    started earlier, and saying so is more use than a button that appears to work.
+    """
+
+    _verify_csrf(request, settings, body.csrf_token)
+    row = db.get(RefinerFileRow, file_id)
+    if row is None:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="MediaMop has no record of that file.")
+
+    job = pending_remux_job_for_relative_path(db, relative_path=row.relative_path)
+    if job is None:
+        db.commit()
+        return RefinerFileMoveToTopOut(
+            moved=False,
+            detail=(
+                "There is no queued work for this file to move. It may already be running, or it may not "
+                "have been picked up by a scan yet."
+            ),
+        )
+
+    outcome = move_refiner_job_to_top(db, job_id=int(job.id))
+    db.commit()
+    if outcome != "ok":
+        return RefinerFileMoveToTopOut(
+            moved=False,
+            detail="This file's work has already started, so it cannot be moved ahead of anything.",
+        )
+    return RefinerFileMoveToTopOut(
+        moved=True,
+        detail="Moved to the front of the queue. It starts as soon as there is capacity for it.",
+    )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_job_queue_lookup.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_job_queue_lookup.py
@@ -1,0 +1,44 @@
+"""Find the queued job that belongs to a file the operator is looking at.
+
+The Files screen knows a relative path; the queue knows a payload. Nothing joined the
+two, which is why "move this to the front" had nowhere to start.
+"""
+
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from mediamop.modules.refiner.file_remux_pass.job_kinds import REFINER_FILE_REMUX_PASS_JOB_KIND
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+
+
+def pending_remux_job_for_relative_path(session: Session, *, relative_path: str) -> RefinerJob | None:
+    """The oldest pending remux job for this path, or None.
+
+    Pending only. A leased job is already running and cannot be started earlier, so
+    returning one would let the caller report a move that did not happen.
+    """
+
+    wanted = (relative_path or "").strip()
+    if not wanted:
+        return None
+    rows = session.scalars(
+        select(RefinerJob)
+        .where(RefinerJob.job_kind == REFINER_FILE_REMUX_PASS_JOB_KIND)
+        .where(RefinerJob.status == RefinerJobStatus.PENDING.value)
+        .order_by(RefinerJob.id)
+    ).all()
+    for job in rows:
+        raw = (job.payload_json or "").strip()
+        if not raw:
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict) and data.get("relative_media_path") == wanted:
+            return job
+    return None

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_model.py
@@ -16,6 +16,16 @@ class RefinerOperatorSettingsRow(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     max_concurrent_files: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    # A weighted budget replaces the flat count above: a 700 MB SD rip and a 60 GB 4K
+    # remux are not the same unit of work, and a machine sized for two of the latter is
+    # idle under six of the former. The count stays as the source the capacity was
+    # migrated from, and as the per-library cap's units.
+    runner_capacity: Mapped[int] = mapped_column(Integer, nullable=False, server_default="4")
+    runner_cost_sd: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    runner_cost_720p: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    runner_cost_1080p: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    runner_cost_4k: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    runner_cost_undetermined: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
     min_file_age_seconds: Mapped[int] = mapped_column(Integer, nullable=False, server_default="60")
     refiner_min_input_file_size_mb: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
     minimum_free_disk_space_mb: Mapped[int] = mapped_column(Integer, nullable=False, server_default="5120")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
@@ -36,6 +36,12 @@ def ensure_refiner_operator_settings_row(db: Session) -> RefinerOperatorSettings
         row = RefinerOperatorSettingsRow(
             id=1,
             max_concurrent_files=1,
+            runner_capacity=4,
+            runner_cost_sd=0,
+            runner_cost_720p=0,
+            runner_cost_1080p=1,
+            runner_cost_4k=1,
+            runner_cost_undetermined=0,
             min_file_age_seconds=60,
             refiner_min_input_file_size_mb=50,
             minimum_free_disk_space_mb=5120,
@@ -99,6 +105,12 @@ def build_refiner_operator_settings_out(db: Session, row: RefinerOperatorSetting
     tz = (suite.app_timezone or "UTC").strip() or "UTC"
     return RefinerOperatorSettingsOut(
         max_concurrent_files=_clamp_max_concurrent_files(row.max_concurrent_files),
+        runner_capacity=max(1, min(64, int(row.runner_capacity or 4))),
+        runner_cost_sd=max(0, min(64, int(row.runner_cost_sd or 0))),
+        runner_cost_720p=max(0, min(64, int(row.runner_cost_720p or 0))),
+        runner_cost_1080p=max(0, min(64, int(row.runner_cost_1080p or 0))),
+        runner_cost_4k=max(0, min(64, int(row.runner_cost_4k or 0))),
+        runner_cost_undetermined=max(0, min(64, int(row.runner_cost_undetermined or 0))),
         min_file_age_seconds=_clamp_min_file_age_seconds(row.min_file_age_seconds),
         refiner_min_input_file_size_mb=_clamp_size_mb(row.refiner_min_input_file_size_mb),
         minimum_free_disk_space_mb=_clamp_size_mb(row.minimum_free_disk_space_mb),
@@ -121,6 +133,17 @@ def apply_refiner_operator_settings_put(db: Session, body: RefinerOperatorSettin
     row = ensure_refiner_operator_settings_row(db)
     if body.max_concurrent_files is not None:
         row.max_concurrent_files = _clamp_max_concurrent_files(body.max_concurrent_files)
+    for field in (
+        "runner_capacity",
+        "runner_cost_sd",
+        "runner_cost_720p",
+        "runner_cost_1080p",
+        "runner_cost_4k",
+        "runner_cost_undetermined",
+    ):
+        value = getattr(body, field, None)
+        if value is not None:
+            setattr(row, field, max(0, min(64, int(value))))
     if body.min_file_age_seconds is not None:
         row.min_file_age_seconds = _clamp_min_file_age_seconds(body.min_file_age_seconds)
     if body.refiner_min_input_file_size_mb is not None:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_runner_units.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_runner_units.py
@@ -1,0 +1,150 @@
+"""A weighted budget for concurrency, instead of counting files.
+
+``max_concurrent_files`` treated a 700 MB SD rip and a 60 GB 4K remux as the same unit of
+work. They are not, and a machine sized for two of the latter is idle under six of the
+former. Weighting by resolution makes small files effectively free and lets the box
+self-limit on the expensive work, which is the real constraint.
+
+The cost of a file is known **at enqueue**, not at lease, and is written onto the job row.
+That is deliberate: the lease has to answer "does this fit in what is left?" in one
+statement, and a row carrying its own cost makes that a comparison rather than a join
+against a probe result that may not exist yet.
+
+A file MediaMop has not processed before has no recorded resolution, so it costs
+``undetermined`` — zero on the shipped defaults, matching the observed FileFlows values.
+That errs toward admitting work rather than stalling on the unknown, and the resolution
+is recorded after the first pass so the next one is weighted properly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+#: The classes a file is weighted by. Fixed, because the operator-facing question is
+#: "what does a 4K file cost me", not "define a resolution taxonomy".
+RESOLUTION_CLASSES: tuple[str, ...] = ("sd", "720p", "1080p", "4k", "undetermined")
+
+#: Bands by **width**, not height. Height alone cannot tell 1280x720 from 1920x800 — a
+#: 2.35:1 crop of a 1080p master — and weighting a scope film as 720p would put the
+#: expensive work in the free tier. Width is stable across aspect ratios: a 1080p file is
+#: 1920 wide whether it is 1080, 1076 or 800 lines tall.
+_CLASS_BY_WIDTH: tuple[tuple[int, str], ...] = (
+    (1200, "sd"),
+    (1900, "720p"),
+    (2600, "1080p"),
+)
+
+#: Used only when width is missing from the probe. Less reliable, for the reason above.
+_CLASS_BY_HEIGHT: tuple[tuple[int, str], ...] = (
+    (700, "sd"),
+    (1000, "720p"),
+    (1500, "1080p"),
+)
+
+
+def resolution_class_for_dimensions(*, width: int | None, height: int | None) -> str:
+    """The weight class for a video's dimensions.
+
+    Bands rather than equalities, because real files are messy. Anything unknown is
+    ``undetermined`` rather than guessed at.
+    """
+
+    if width is not None and width > 0:
+        for ceiling, name in _CLASS_BY_WIDTH:
+            if width < ceiling:
+                return name
+        return "4k"
+    if height is None or height <= 0:
+        return "undetermined"
+    for ceiling, name in _CLASS_BY_HEIGHT:
+        if height < ceiling:
+            return name
+    return "4k"
+
+
+def resolution_class_for_height(height: int | None) -> str:
+    """Class from height alone, for a file measured before widths were recorded."""
+
+    return resolution_class_for_dimensions(width=None, height=height)
+
+
+@dataclass(frozen=True, slots=True)
+class RunnerBudget:
+    """Total capacity and what each class of file costs against it."""
+
+    capacity: int
+    costs: dict[str, int]
+
+    def cost_for(self, resolution_class: str | None) -> int:
+        name = (resolution_class or "undetermined").strip().lower()
+        if name not in self.costs:
+            name = "undetermined"
+        return max(0, int(self.costs.get(name, 0)))
+
+    def available(self, *, in_use: int) -> int:
+        return max(0, int(self.capacity) - max(0, int(in_use)))
+
+
+def budget_from_settings(row: object) -> RunnerBudget:
+    """Read the budget off the operator settings row."""
+
+    return RunnerBudget(
+        capacity=max(1, int(getattr(row, "runner_capacity", 4) or 4)),
+        costs={
+            "sd": max(0, int(getattr(row, "runner_cost_sd", 0) or 0)),
+            "720p": max(0, int(getattr(row, "runner_cost_720p", 0) or 0)),
+            "1080p": max(0, int(getattr(row, "runner_cost_1080p", 1) or 0)),
+            "4k": max(0, int(getattr(row, "runner_cost_4k", 1) or 0)),
+            "undetermined": max(0, int(getattr(row, "runner_cost_undetermined", 0) or 0)),
+        },
+    )
+
+
+def capacity_from_legacy_concurrency(max_concurrent_files: int) -> int:
+    """Map the old flat count onto a capacity that preserves behaviour on upgrade.
+
+    One-for-one. With the shipped costs a 1080p or 4K file costs one unit, so a capacity
+    equal to the old count runs the same number of expensive files at once. Smaller files
+    now cost nothing and so run alongside, which is the improvement — and it is an
+    improvement rather than a surprise, because the thing the old number was protecting
+    was never the count.
+    """
+
+    return max(1, min(64, int(max_concurrent_files or 1)))
+
+
+def _largest_dimension(video_streams: list[dict], keys: tuple[str, ...]) -> int | None:
+    values: list[int] = []
+    for stream in video_streams:
+        if not isinstance(stream, dict):
+            continue
+        for key in keys:
+            raw = stream.get(key)
+            try:
+                value = int(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+            if value > 0:
+                values.append(value)
+                break
+    return max(values) if values else None
+
+
+def video_dimensions_from_streams(video_streams: list[dict]) -> tuple[int | None, int | None]:
+    """``(width, height)`` of the largest video stream, or ``(None, None)``.
+
+    Largest rather than first: a file can carry a cover-art or thumbnail stream that
+    ffprobe reports as video, and weighting a 4K remux by its 300-line poster would put
+    the most expensive work in the free tier.
+    """
+
+    return (
+        _largest_dimension(video_streams, ("width", "coded_width")),
+        _largest_dimension(video_streams, ("height", "coded_height")),
+    )
+
+
+def video_height_from_streams(video_streams: list[dict]) -> int | None:
+    """Height only, for callers that do not need the width."""
+
+    return video_dimensions_from_streams(video_streams)[1]

--- a/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_watched_folder_remux_scan_dispatch_handlers.py
@@ -29,6 +29,10 @@ from mediamop.modules.refiner.refiner_library_service import resolve_library
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_path_settings_service import resolve_refiner_path_runtime_for_remux
 from mediamop.modules.refiner.refiner_remux_rules import refiner_media_extensions_sorted
+from mediamop.modules.refiner.refiner_runner_units import (
+    budget_from_settings,
+    resolution_class_for_dimensions,
+)
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_evaluate import (
     evaluate_watched_media_file_for_dispatch,
     fetch_manager_queue_signals_for_scan,
@@ -95,6 +99,7 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
             )
 
         with session_factory() as library_session:
+            runner_budget = budget_from_settings(ensure_refiner_operator_settings_row(library_session))
             library = resolve_library(library_session, media_scope=media_scope)
             admission = evaluate_work_admission(library_session)
             pause_reason = admission.pause.reason if admission.pause.paused else None
@@ -284,19 +289,36 @@ def make_refiner_watched_folder_remux_scan_dispatch_handler(
                             )
                     continue
 
-                payload = json.dumps(
-                    {
-                        "relative_media_path": rel,
-                        "media_scope": media_scope,
-                    },
-                    separators=(",", ":"),
-                )
+                payload_body: dict[str, Any] = {
+                    "relative_media_path": rel,
+                    "media_scope": media_scope,
+                }
+                # The library id travels with the job so the per-library cap and the
+                # schedule window can be applied at lease time without re-deriving it.
+                if library is not None:
+                    payload_body["library_id"] = library.id
+                payload = json.dumps(payload_body, separators=(",", ":"))
                 dedupe = f"{REFINER_FILE_REMUX_PASS_JOB_KIND}:scan:{uuid.uuid4().hex}"
+                # Weighted from the height this file was measured at on a previous pass.
+                # A file MediaMop has not processed before costs the "undetermined"
+                # weight rather than a guess, and is measured for next time.
+                previous_row = (
+                    existing_file_row(session, library_id=library.id, relative_path=rel)
+                    if library is not None
+                    else None
+                )
                 refiner_enqueue_or_get_job(
                     session,
                     dedupe_key=dedupe,
                     job_kind=REFINER_FILE_REMUX_PASS_JOB_KIND,
                     payload_json=payload,
+                    runner_cost=runner_budget.cost_for(
+                        resolution_class_for_dimensions(
+                            width=previous_row.video_width if previous_row else None,
+                            height=previous_row.video_height if previous_row else None,
+                        )
+                    ),
+                    priority=int(library.priority) if library is not None else 0,
                 )
                 summary["remux_jobs_enqueued"] += 1
                 if len(sample_paths) < sample_cap:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_work_admission.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_work_admission.py
@@ -17,13 +17,17 @@ implying work stops dead at the boundary.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
 from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_operator_settings_model import RefinerOperatorSettingsRow
+from mediamop.modules.refiner.refiner_runner_units import RunnerBudget, budget_from_settings
 from mediamop.modules.refiner.refiner_schedule_grid import grid_allows, next_open_slot
 from mediamop.platform.media_managers.schedule_wall_clock import schedule_time_window_active
 from mediamop.platform.suite_settings.model import SuiteSettingsRow
@@ -137,9 +141,15 @@ class WorkAdmission:
     """What a worker is allowed to pick up on this pass."""
 
     pause: PauseState
-    #: Libraries whose window is shut. A job naming one of these is not leased.
+    #: Libraries whose window is shut, or which are already at their own concurrency cap.
+    #: A job naming one of these is not leased.
     blocked_library_ids: frozenset[int] = field(default_factory=frozenset)
     timezone_name: str = "UTC"
+    #: Runner units left in the budget. A job costing more than this waits; a job costing
+    #: nothing runs even when the budget is full, which is the point of weighting.
+    available_units: int = 0
+    #: Total capacity, for reporting rather than for the decision.
+    capacity: int = 0
 
     @property
     def blocks_processing(self) -> bool:
@@ -155,8 +165,24 @@ class WorkAdmission:
         return is_detection_job_kind(job_kind) and self.pause.scan_while_paused
 
 
+def _leased_jobs(session: Session) -> list[RefinerJob]:
+    return list(session.scalars(select(RefinerJob).where(RefinerJob.status == RefinerJobStatus.LEASED.value)))
+
+
+def _library_id_of(job: RefinerJob) -> int | None:
+    raw = (job.payload_json or "").strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    value = data.get("library_id") if isinstance(data, dict) else None
+    return int(value) if isinstance(value, int) else None
+
+
 def evaluate_work_admission(session: Session, *, now: datetime | None = None) -> WorkAdmission:
-    """Read the pause and every library window once, for one pass of the worker loop."""
+    """Read the pause, every library window, and the runner budget once per worker pass."""
 
     moment = now or datetime.now(UTC)
     suite = session.scalars(select(SuiteSettingsRow).where(SuiteSettingsRow.id == 1)).one_or_none()
@@ -165,8 +191,35 @@ def evaluate_work_admission(session: Session, *, now: datetime | None = None) ->
     tz_name = (suite.app_timezone or "UTC").strip() or "UTC"
     pause = resolve_pause_state(suite, now=moment)
 
+    operator = session.scalars(
+        select(RefinerOperatorSettingsRow).where(RefinerOperatorSettingsRow.id == 1)
+    ).one_or_none()
+    budget = budget_from_settings(operator) if operator is not None else RunnerBudget(capacity=4, costs={})
+
+    leased = _leased_jobs(session)
+    units_in_use = sum(max(0, int(job.runner_cost or 0)) for job in leased)
+    running_per_library: dict[int, int] = {}
+    for job in leased:
+        library_id = _library_id_of(job)
+        if library_id is not None:
+            running_per_library[library_id] = running_per_library.get(library_id, 0) + 1
+
     blocked: set[int] = set()
     for library in session.scalars(select(RefinerLibraryRow).order_by(RefinerLibraryRow.id)):
+        library_id = int(library.id)
         if not library.enabled or not library_window_open(library, timezone_name=tz_name, now=moment):
-            blocked.add(int(library.id))
-    return WorkAdmission(pause=pause, blocked_library_ids=frozenset(blocked), timezone_name=tz_name)
+            blocked.add(library_id)
+            continue
+        # A per-library cap so one library cannot occupy the whole budget and starve the
+        # others, however cheap its files happen to be.
+        cap = max(1, int(library.max_concurrent_files or 1))
+        if running_per_library.get(library_id, 0) >= cap:
+            blocked.add(library_id)
+
+    return WorkAdmission(
+        pause=pause,
+        blocked_library_ids=frozenset(blocked),
+        timezone_name=tz_name,
+        available_units=budget.available(in_use=units_in_use),
+        capacity=budget.capacity,
+    )

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
@@ -57,7 +57,20 @@ class RefinerFilesPageOut(BaseModel):
     limit: int
 
 
+class RefinerFileMoveToTopOut(BaseModel):
+    """What happened, said in words the screen can show unchanged."""
+
+    moved: bool
+    detail: str
+
+
 class RefinerFileForgetIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)
+
+
+class RefinerFileMoveToTopIn(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     csrf_token: str = Field(..., min_length=1)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_operator_settings.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_operator_settings.py
@@ -9,6 +9,23 @@ class RefinerOperatorSettingsOut(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     max_concurrent_files: int = Field(ge=1, le=8)
+    runner_capacity: int = Field(
+        ge=1,
+        le=64,
+        description=(
+            "Total processing capacity. Active files consume it according to their cost, and new work "
+            "waits once it is fully occupied."
+        ),
+    )
+    runner_cost_sd: int = Field(ge=0, le=64)
+    runner_cost_720p: int = Field(ge=0, le=64)
+    runner_cost_1080p: int = Field(ge=0, le=64)
+    runner_cost_4k: int = Field(ge=0, le=64)
+    runner_cost_undetermined: int = Field(
+        ge=0,
+        le=64,
+        description="What a file MediaMop has not measured yet costs. Zero admits it rather than stalling on the unknown.",
+    )
     min_file_age_seconds: int = Field(ge=0, le=7 * 24 * 3600)
     refiner_min_input_file_size_mb: int = Field(
         ge=0,
@@ -43,6 +60,12 @@ class RefinerOperatorSettingsPutIn(BaseModel):
 
     csrf_token: str = Field(..., min_length=1)
     max_concurrent_files: int | None = Field(default=None, ge=1, le=8)
+    runner_capacity: int | None = Field(default=None, ge=1, le=64)
+    runner_cost_sd: int | None = Field(default=None, ge=0, le=64)
+    runner_cost_720p: int | None = Field(default=None, ge=0, le=64)
+    runner_cost_1080p: int | None = Field(default=None, ge=0, le=64)
+    runner_cost_4k: int | None = Field(default=None, ge=0, le=64)
+    runner_cost_undetermined: int | None = Field(default=None, ge=0, le=64)
     min_file_age_seconds: int | None = Field(default=None, ge=0, le=7 * 24 * 3600)
     refiner_min_input_file_size_mb: int | None = Field(default=None, ge=0, le=1024 * 1024)
     minimum_free_disk_space_mb: int | None = Field(default=None, ge=0, le=1024 * 1024)
@@ -93,6 +116,12 @@ class RefinerOperatorSettingsPutIn(BaseModel):
     def _at_least_one_update_field(self) -> RefinerOperatorSettingsPutIn:
         has_process = (
             self.max_concurrent_files is not None
+            or self.runner_capacity is not None
+            or self.runner_cost_sd is not None
+            or self.runner_cost_720p is not None
+            or self.runner_cost_1080p is not None
+            or self.runner_cost_4k is not None
+            or self.runner_cost_undetermined is not None
             or self.min_file_age_seconds is not None
             or self.refiner_min_input_file_size_mb is not None
             or self.minimum_free_disk_space_mb is not None

--- a/apps/backend/src/mediamop/modules/refiner/worker_limits.py
+++ b/apps/backend/src/mediamop/modules/refiner/worker_limits.py
@@ -1,17 +1,23 @@
 """Refiner worker bounds — shared by :mod:`mediamop.core.config` without import cycles.
 
 ``refiner_worker_count`` is an **internal startup slot cap**, not the number of files
-Refiner will work on. The effective limit is the operator-facing "Files at once" value on
-the Processing settings page, applied at runtime by ``max_concurrent_files_getter``, and
-changing it needs no restart.
+Refiner will work on.
+
+The effective limit is the **runner budget** (#338): a total capacity, and a cost per file
+based on its resolution, checked when a job is leased. That replaced a flat "Files at
+once" count, which treated a 700 MB SD rip and a 60 GB 4K remux as the same unit of work
+and so protected nothing in particular. Small files now cost nothing and run alongside;
+the box self-limits on the expensive work, which is the real constraint.
 
 - **0** — In-process Refiner asyncio workers disabled (tests, controlled runtime).
 - **1..8** — Available worker slots. The shipped default is **8**
-  (``MEDIAMOP_REFINER_WORKER_COUNT``), because the saved "Files at once" value is what
-  actually gates concurrency; a lower cap here would silently ceiling that setting.
+  (``MEDIAMOP_REFINER_WORKER_COUNT``), because the budget is what actually gates
+  concurrency; a lower cap here would silently ceiling it.
 
-SQLite still serializes writes, so raising "Files at once" does not scale throughput
-linearly — that caveat belongs to the operator-facing setting, not to this cap.
+SQLite still serializes writes, so raising capacity does not scale throughput linearly.
+That caveat belongs to the operator-facing budget rather than to this cap — and the budget
+is where it can now be expressed honestly, because a capacity in units of expensive work
+means something a file count never did.
 """
 
 

--- a/apps/backend/tests/test_refiner_runner_units.py
+++ b/apps/backend/tests/test_refiner_runner_units.py
@@ -1,0 +1,378 @@
+"""A weighted budget instead of counting files.
+
+``max_concurrent_files`` treated a 700 MB SD rip and a 60 GB 4K remux as the same unit of
+work. The tests that matter here are the ones that show weighting doing something a count
+cannot: a free file admitted while the budget is full, and an expensive one held back
+while cheap ones run (#338).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.jobs_model  # noqa: F401
+import mediamop.modules.refiner.refiner_file_state_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.modules.refiner.refiner_operator_settings_model  # noqa: F401
+import mediamop.platform.suite_settings.model  # noqa: F401
+from mediamop.core.db import Base
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.jobs_ops import (
+    claim_next_eligible_refiner_job,
+    move_refiner_job_to_top,
+    refiner_enqueue_or_get_job,
+)
+from mediamop.modules.refiner.refiner_job_queue_lookup import pending_remux_job_for_relative_path
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_operator_settings_model import RefinerOperatorSettingsRow
+from mediamop.modules.refiner.refiner_runner_units import (
+    RunnerBudget,
+    budget_from_settings,
+    capacity_from_legacy_concurrency,
+    resolution_class_for_dimensions,
+    resolution_class_for_height,
+    video_height_from_streams,
+)
+from mediamop.modules.refiner.refiner_work_admission import evaluate_work_admission
+from mediamop.platform.suite_settings.model import SuiteSettingsRow
+
+REMUX = "refiner.file.remux_pass.v1"
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def session(tmp_path: Path) -> Session:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'runner.sqlite'}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    s = sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)()
+    s.add(SuiteSettingsRow(id=1, app_timezone="UTC"))
+    s.add(
+        RefinerOperatorSettingsRow(
+            id=1,
+            max_concurrent_files=1,
+            runner_capacity=2,
+            runner_cost_sd=0,
+            runner_cost_720p=0,
+            runner_cost_1080p=1,
+            runner_cost_4k=1,
+            runner_cost_undetermined=0,
+        )
+    )
+    s.commit()
+    return s
+
+
+def _library(session: Session, **overrides) -> RefinerLibraryRow:
+    row = RefinerLibraryRow(
+        name=overrides.pop("name", "Movies"),
+        media_scope="movie",
+        enabled=True,
+        watched_folder="/srv/in",
+        output_folder="/srv/out",
+        schedule_enabled=False,
+        **overrides,
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _queue(
+    session: Session,
+    *,
+    key: str,
+    cost: int,
+    library_id: int | None = None,
+    priority: int = 0,
+    relative_path: str = "Film/film.mkv",
+) -> RefinerJob:
+    payload: dict[str, object] = {"media_scope": "movie", "relative_media_path": relative_path}
+    if library_id is not None:
+        payload["library_id"] = library_id
+    job = refiner_enqueue_or_get_job(
+        session,
+        dedupe_key=f"{REMUX}:{key}",
+        job_kind=REMUX,
+        payload_json=json.dumps(payload),
+        runner_cost=cost,
+        priority=priority,
+    )
+    session.commit()
+    return job
+
+
+def _claim(session: Session, *, owner: str = "w1") -> RefinerJob | None:
+    job = claim_next_eligible_refiner_job(
+        session,
+        lease_owner=owner,
+        lease_expires_at=NOW + timedelta(hours=1),
+        now=NOW,
+        admission=evaluate_work_admission(session, now=NOW),
+    )
+    session.commit()
+    return job
+
+
+# --- weighting ---------------------------------------------------------------------
+
+
+def test_resolution_classes_are_bands_not_exact_sizes() -> None:
+    assert resolution_class_for_dimensions(width=1024, height=576) == "sd"
+    assert resolution_class_for_dimensions(width=1280, height=720) == "720p"
+    assert resolution_class_for_dimensions(width=1920, height=1080) == "1080p"
+    assert resolution_class_for_dimensions(width=3840, height=2160) == "4k"
+
+
+def test_a_scope_crop_is_weighted_by_its_width_not_its_height() -> None:
+    """1920x800 is a 2.35:1 crop of a 1080p master, not a 720p file.
+
+    Height alone cannot tell it from 1280x720, and weighting a scope film as free would
+    put some of the most expensive work in the free tier.
+    """
+
+    assert resolution_class_for_dimensions(width=1920, height=800) == "1080p"
+    assert resolution_class_for_dimensions(width=3840, height=1600) == "4k"
+
+
+def test_height_alone_is_the_fallback_when_width_is_missing() -> None:
+    assert resolution_class_for_height(480) == "sd"
+    assert resolution_class_for_height(720) == "720p"
+    assert resolution_class_for_height(1080) == "1080p"
+    assert resolution_class_for_height(2160) == "4k"
+
+
+def test_an_unknown_height_is_undetermined_rather_than_guessed() -> None:
+    assert resolution_class_for_height(None) == "undetermined"
+    assert resolution_class_for_height(0) == "undetermined"
+    assert resolution_class_for_height(-1) == "undetermined"
+
+
+def test_the_tallest_video_stream_wins_so_cover_art_cannot_downgrade_a_file() -> None:
+    """A 4K remux carrying a poster must not be weighted by the poster."""
+
+    streams = [{"height": 300}, {"height": 2160}]
+
+    assert video_height_from_streams(streams) == 2160
+
+
+def test_a_probe_with_no_usable_height_reports_none(session: Session) -> None:
+    assert video_height_from_streams([{"codec_type": "video"}]) is None
+    assert video_height_from_streams([{"height": "not-a-number"}]) is None
+    assert video_height_from_streams([]) is None
+
+
+def test_coded_height_is_used_when_height_is_missing() -> None:
+    assert video_height_from_streams([{"coded_height": 1080}]) == 1080
+
+
+def test_an_unknown_class_costs_the_undetermined_weight() -> None:
+    budget = RunnerBudget(capacity=4, costs={"1080p": 1, "undetermined": 3})
+
+    assert budget.cost_for("something-else") == 3
+    assert budget.cost_for(None) == 3
+
+
+def test_the_migration_preserves_the_effective_concurrency() -> None:
+    # With the shipped costs an expensive file costs one unit, so the same number of them
+    # run at once as before.
+    assert capacity_from_legacy_concurrency(1) == 1
+    assert capacity_from_legacy_concurrency(8) == 8
+    assert capacity_from_legacy_concurrency(0) == 1
+
+
+def test_the_budget_reads_the_operator_row(session: Session) -> None:
+    budget = budget_from_settings(session.get(RefinerOperatorSettingsRow, 1))
+
+    assert budget.capacity == 2
+    assert budget.cost_for("4k") == 1
+    assert budget.cost_for("sd") == 0
+
+
+# --- the budget at lease time -------------------------------------------------------
+
+
+def test_the_budget_is_exhausted_by_expensive_work(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=1, library_id=library.id)
+    _queue(session, key="b", cost=1, library_id=library.id)
+    _queue(session, key="c", cost=1, library_id=library.id)
+
+    assert _claim(session, owner="w1") is not None
+    assert _claim(session, owner="w2") is not None
+    # Capacity is 2, both units are spent, so the third waits.
+    assert _claim(session, owner="w3") is None
+
+
+def test_a_zero_cost_file_is_admitted_while_the_budget_is_full(session: Session) -> None:
+    """The whole point of weighting rather than counting.
+
+    A flat count would have stalled this SD rip behind two 4K remuxes for no reason —
+    it costs the machine nothing.
+    """
+
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="4k-a", cost=1, library_id=library.id)
+    _queue(session, key="4k-b", cost=1, library_id=library.id)
+    _queue(session, key="sd", cost=0, library_id=library.id)
+
+    assert _claim(session, owner="w1") is not None
+    assert _claim(session, owner="w2") is not None
+
+    free = _claim(session, owner="w3")
+
+    assert free is not None
+    assert free.runner_cost == 0
+
+
+def test_capacity_frees_up_when_work_completes(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=2, library_id=library.id)
+    _queue(session, key="b", cost=2, library_id=library.id)
+
+    first = _claim(session, owner="w1")
+    assert first is not None
+    assert _claim(session, owner="w2") is None
+
+    first.status = RefinerJobStatus.COMPLETED.value
+    session.commit()
+
+    assert _claim(session, owner="w2") is not None
+
+
+# --- per-library cap ----------------------------------------------------------------
+
+
+def test_a_library_cannot_exceed_its_own_cap_however_cheap_its_files_are(session: Session) -> None:
+    """Otherwise one library occupies every worker with free files and starves the rest."""
+
+    library = _library(session, max_concurrent_files=1)
+    _queue(session, key="a", cost=0, library_id=library.id)
+    _queue(session, key="b", cost=0, library_id=library.id)
+
+    assert _claim(session, owner="w1") is not None
+    assert _claim(session, owner="w2") is None
+
+
+def test_one_library_at_its_cap_does_not_block_another(session: Session) -> None:
+    movies = _library(session, name="Movies", max_concurrent_files=1)
+    tv = _library(session, name="TV", max_concurrent_files=1)
+    _queue(session, key="m1", cost=0, library_id=movies.id)
+    _queue(session, key="m2", cost=0, library_id=movies.id)
+    _queue(session, key="t1", cost=0, library_id=tv.id)
+
+    assert _claim(session, owner="w1") is not None
+    second = _claim(session, owner="w2")
+
+    assert second is not None
+    assert json.loads(second.payload_json or "{}")["library_id"] == tv.id
+
+
+# --- priority and move to top -------------------------------------------------------
+
+
+def test_higher_priority_is_leased_first(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="ordinary", cost=0, library_id=library.id, priority=0)
+    urgent = _queue(session, key="urgent", cost=0, library_id=library.id, priority=5)
+
+    claimed = _claim(session)
+
+    assert claimed is not None
+    assert claimed.id == urgent.id
+
+
+def test_equal_priority_keeps_first_in_first_out(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    first = _queue(session, key="first", cost=0, library_id=library.id)
+    _queue(session, key="second", cost=0, library_id=library.id)
+
+    claimed = _claim(session)
+
+    assert claimed is not None
+    assert claimed.id == first.id
+
+
+def test_move_to_top_puts_a_queued_job_ahead_of_everything(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=0, library_id=library.id)
+    _queue(session, key="b", cost=0, library_id=library.id)
+    last = _queue(session, key="c", cost=0, library_id=library.id)
+
+    assert move_refiner_job_to_top(session, job_id=int(last.id)) == "ok"
+    session.commit()
+
+    claimed = _claim(session)
+
+    assert claimed is not None
+    assert claimed.id == last.id
+
+
+def test_two_files_moved_to_the_top_keep_the_order_they_were_moved_in(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    a = _queue(session, key="a", cost=0, library_id=library.id)
+    b = _queue(session, key="b", cost=0, library_id=library.id)
+
+    move_refiner_job_to_top(session, job_id=int(a.id))
+    move_refiner_job_to_top(session, job_id=int(b.id))
+    session.commit()
+
+    claimed = _claim(session)
+
+    assert claimed is not None
+    assert claimed.id == b.id
+
+
+def test_a_running_job_cannot_be_moved_to_the_top(session: Session) -> None:
+    """It has already started; a button that appeared to work would be a lie."""
+
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=0, library_id=library.id)
+    running = _claim(session)
+    assert running is not None
+
+    assert move_refiner_job_to_top(session, job_id=int(running.id)) == "wrong_status"
+
+
+def test_moving_a_job_that_does_not_exist_reports_that(session: Session) -> None:
+    assert move_refiner_job_to_top(session, job_id=9999) == "not_found"
+
+
+def test_the_queued_job_for_a_path_is_found_and_a_running_one_is_not(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=0, library_id=library.id, relative_path="Film/film.mkv")
+
+    found = pending_remux_job_for_relative_path(session, relative_path="Film/film.mkv")
+    assert found is not None
+
+    assert pending_remux_job_for_relative_path(session, relative_path="Other/other.mkv") is None
+
+    _claim(session)
+    assert pending_remux_job_for_relative_path(session, relative_path="Film/film.mkv") is None
+
+
+def test_a_blank_path_matches_nothing_rather_than_the_first_job(session: Session) -> None:
+    library = _library(session, max_concurrent_files=8)
+    _queue(session, key="a", cost=0, library_id=library.id)
+
+    assert pending_remux_job_for_relative_path(session, relative_path="   ") is None
+
+
+def test_jobs_enqueued_without_a_cost_default_to_free(session: Session) -> None:
+    """Every existing enqueue site keeps working, and none of them stall the budget."""
+
+    job = refiner_enqueue_or_get_job(session, dedupe_key=f"{REMUX}:legacy", job_kind=REMUX, payload_json="{}")
+    session.commit()
+
+    assert job.runner_cost == 0
+    assert job.priority == 0
+    assert session.scalars(select(RefinerJob)).one().id == job.id

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -2912,6 +2912,40 @@
         "title": "RefinerFileForgetIn",
         "type": "object"
       },
+      "RefinerFileMoveToTopIn": {
+        "additionalProperties": false,
+        "properties": {
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csrf_token"
+        ],
+        "title": "RefinerFileMoveToTopIn",
+        "type": "object"
+      },
+      "RefinerFileMoveToTopOut": {
+        "description": "What happened, said in words the screen can show unchanged.",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "moved": {
+            "title": "Moved",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "moved",
+          "detail"
+        ],
+        "title": "RefinerFileMoveToTopOut",
+        "type": "object"
+      },
       "RefinerFileOut": {
         "properties": {
           "blocked_by_connection": {
@@ -4063,6 +4097,44 @@
             "title": "Refiner Min Input File Size Mb",
             "type": "integer"
           },
+          "runner_capacity": {
+            "description": "Total processing capacity. Active files consume it according to their cost, and new work waits once it is fully occupied.",
+            "maximum": 64.0,
+            "minimum": 1.0,
+            "title": "Runner Capacity",
+            "type": "integer"
+          },
+          "runner_cost_1080p": {
+            "maximum": 64.0,
+            "minimum": 0.0,
+            "title": "Runner Cost 1080P",
+            "type": "integer"
+          },
+          "runner_cost_4k": {
+            "maximum": 64.0,
+            "minimum": 0.0,
+            "title": "Runner Cost 4K",
+            "type": "integer"
+          },
+          "runner_cost_720p": {
+            "maximum": 64.0,
+            "minimum": 0.0,
+            "title": "Runner Cost 720P",
+            "type": "integer"
+          },
+          "runner_cost_sd": {
+            "maximum": 64.0,
+            "minimum": 0.0,
+            "title": "Runner Cost Sd",
+            "type": "integer"
+          },
+          "runner_cost_undetermined": {
+            "description": "What a file MediaMop has not measured yet costs. Zero admits it rather than stalling on the unknown.",
+            "maximum": 64.0,
+            "minimum": 0.0,
+            "title": "Runner Cost Undetermined",
+            "type": "integer"
+          },
           "schedule_timezone": {
             "description": "IANA zone for schedule windows (suite settings).",
             "title": "Schedule Timezone",
@@ -4098,6 +4170,12 @@
         },
         "required": [
           "max_concurrent_files",
+          "runner_capacity",
+          "runner_cost_sd",
+          "runner_cost_720p",
+          "runner_cost_1080p",
+          "runner_cost_4k",
+          "runner_cost_undetermined",
           "min_file_age_seconds",
           "refiner_min_input_file_size_mb",
           "minimum_free_disk_space_mb",
@@ -4235,6 +4313,84 @@
               }
             ],
             "title": "Refiner Min Input File Size Mb"
+          },
+          "runner_capacity": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Capacity"
+          },
+          "runner_cost_1080p": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Cost 1080P"
+          },
+          "runner_cost_4k": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Cost 4K"
+          },
+          "runner_cost_720p": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Cost 720P"
+          },
+          "runner_cost_sd": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Cost Sd"
+          },
+          "runner_cost_undetermined": {
+            "anyOf": [
+              {
+                "maximum": 64.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Runner Cost Undetermined"
           },
           "tv_schedule_days": {
             "anyOf": [
@@ -8385,6 +8541,61 @@
           }
         },
         "summary": "Delete Refiner File",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/files/{file_id}/move-to-top": {
+      "post": {
+        "description": "Put this file's queued work ahead of everything else waiting.\n\nOnly affects work that has not started. A file already being processed cannot be\nstarted earlier, and saying so is more use than a button that appears to work.",
+        "operationId": "move_refiner_file_to_top_api_v1_refiner_files__file_id__move_to_top_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "File Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefinerFileMoveToTopIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefinerFileMoveToTopOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Move Refiner File To Top",
         "tags": [
           "refiner",
           "refiner"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -656,6 +656,29 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/refiner/files/{file_id}/move-to-top": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Move Refiner File To Top
+     * @description Put this file's queued work ahead of everything else waiting.
+     *
+     *     Only affects work that has not started. A file already being processed cannot be
+     *     started earlier, and saying so is more use than a button that appears to work.
+     */
+    post: operations["move_refiner_file_to_top_api_v1_refiner_files__file_id__move_to_top_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/refiner/jobs/candidate-gate/enqueue": {
     parameters: {
       query?: never;
@@ -2793,6 +2816,21 @@ export interface components {
       /** Csrf Token */
       csrf_token: string;
     };
+    /** RefinerFileMoveToTopIn */
+    RefinerFileMoveToTopIn: {
+      /** Csrf Token */
+      csrf_token: string;
+    };
+    /**
+     * RefinerFileMoveToTopOut
+     * @description What happened, said in words the screen can show unchanged.
+     */
+    RefinerFileMoveToTopOut: {
+      /** Detail */
+      detail: string;
+      /** Moved */
+      moved: boolean;
+    };
     /** RefinerFileOut */
     RefinerFileOut: {
       /**
@@ -3419,6 +3457,24 @@ export interface components {
        */
       refiner_min_input_file_size_mb: number;
       /**
+       * Runner Capacity
+       * @description Total processing capacity. Active files consume it according to their cost, and new work waits once it is fully occupied.
+       */
+      runner_capacity: number;
+      /** Runner Cost 1080P */
+      runner_cost_1080p: number;
+      /** Runner Cost 4K */
+      runner_cost_4k: number;
+      /** Runner Cost 720P */
+      runner_cost_720p: number;
+      /** Runner Cost Sd */
+      runner_cost_sd: number;
+      /**
+       * Runner Cost Undetermined
+       * @description What a file MediaMop has not measured yet costs. Zero admits it rather than stalling on the unknown.
+       */
+      runner_cost_undetermined: number;
+      /**
        * Schedule Timezone
        * @description IANA zone for schedule windows (suite settings).
        */
@@ -3461,6 +3517,18 @@ export interface components {
       movie_schedule_start?: string | null;
       /** Refiner Min Input File Size Mb */
       refiner_min_input_file_size_mb?: number | null;
+      /** Runner Capacity */
+      runner_capacity?: number | null;
+      /** Runner Cost 1080P */
+      runner_cost_1080p?: number | null;
+      /** Runner Cost 4K */
+      runner_cost_4k?: number | null;
+      /** Runner Cost 720P */
+      runner_cost_720p?: number | null;
+      /** Runner Cost Sd */
+      runner_cost_sd?: number | null;
+      /** Runner Cost Undetermined */
+      runner_cost_undetermined?: number | null;
       /** Tv Schedule Days */
       tv_schedule_days?: string | null;
       /** Tv Schedule Enabled */
@@ -5727,6 +5795,41 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  move_refiner_file_to_top_api_v1_refiner_files__file_id__move_to_top_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        file_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["RefinerFileMoveToTopIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["RefinerFileMoveToTopOut"];
+        };
       };
       /** @description Validation Error */
       422: {

--- a/apps/web/src/lib/refiner/files-api.ts
+++ b/apps/web/src/lib/refiner/files-api.ts
@@ -32,6 +32,8 @@ export interface RefinerFile {
   status_reason: string;
   blocked_by_connection: string | null;
   size_bytes: number;
+  video_width: number | null;
+  video_height: number | null;
   /** When an on-hold file becomes eligible. Null when the wait is on a writer, not the clock. */
   hold_until: string | null;
   size_changed_at: string | null;
@@ -81,4 +83,27 @@ export async function forgetRefinerFile(id: number): Promise<void> {
     body: JSON.stringify({ csrf_token }),
   });
   await requireOk(path, r, "Could not remove that file from the list");
+}
+
+export interface RefinerFileMoveToTopResult {
+  moved: boolean;
+  detail: string;
+}
+
+export async function moveRefinerFileToTop(
+  id: number,
+): Promise<RefinerFileMoveToTopResult> {
+  const csrf_token = await fetchCsrfToken();
+  const path = `${refinerFilesPath()}/${id}/move-to-top`;
+  const response = await apiFetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ csrf_token }),
+  });
+  await requireOk(
+    path,
+    response,
+    "Could not move that file to the front of the queue",
+  );
+  return readJson<RefinerFileMoveToTopResult>(response);
 }

--- a/apps/web/src/lib/refiner/files-queries.ts
+++ b/apps/web/src/lib/refiner/files-queries.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   fetchRefinerFiles,
   forgetRefinerFile,
+  moveRefinerFileToTop,
   type RefinerFilesPage,
   type RefinerFilesQuery,
 } from "./files-api";
@@ -24,6 +25,15 @@ export function useForgetRefinerFile() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: number) => forgetRefinerFile(id),
+    onSuccess: () =>
+      void qc.invalidateQueries({ queryKey: ["refiner", "files"] }),
+  });
+}
+
+export function useMoveRefinerFileToTop() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => moveRefinerFileToTop(id),
     onSuccess: () =>
       void qc.invalidateQueries({ queryKey: ["refiner", "files"] }),
   });

--- a/apps/web/src/pages/refiner/refiner-files-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.test.tsx
@@ -22,6 +22,8 @@ function file(over: Partial<RefinerFile> = {}): RefinerFile {
     status_reason: "Ready for Refiner to process as part of Movies.",
     blocked_by_connection: null,
     size_bytes: 2048,
+    video_width: null,
+    video_height: null,
     hold_until: null,
     size_changed_at: null,
     last_seen_at: null,
@@ -195,4 +197,44 @@ it("invents no release time when the wait is on a writer rather than the clock",
   expect(
     screen.queryByTestId("refiner-file-hold-until-1"),
   ).not.toBeInTheDocument();
+});
+
+it("offers move to top only for work that has not started", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({
+      files: [
+        file({ id: 1, status: "unprocessed" }),
+        file({ id: 2, status: "processing", relative_path: "Other/other.mkv" }),
+      ],
+    }),
+  );
+
+  render(<RefinerFilesSection />, { wrapper });
+
+  expect(
+    await screen.findByTestId("refiner-file-move-to-top-1"),
+  ).toBeInTheDocument();
+  // A running file cannot be started earlier; a button here would be a lie.
+  expect(
+    screen.queryByTestId("refiner-file-move-to-top-2"),
+  ).not.toBeInTheDocument();
+});
+
+it("shows the server's own words about whether the move happened", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({ files: [file({ id: 1, status: "unprocessed" })] }),
+  );
+  vi.spyOn(api, "moveRefinerFileToTop").mockResolvedValue({
+    moved: false,
+    detail: "There is no queued work for this file to move.",
+  });
+
+  render(<RefinerFilesSection />, { wrapper });
+  fireEvent.click(await screen.findByTestId("refiner-file-move-to-top-1"));
+
+  expect(await screen.findByTestId("refiner-files-notice")).toHaveTextContent(
+    "There is no queued work for this file to move.",
+  );
 });

--- a/apps/web/src/pages/refiner/refiner-files-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib/refiner/files-api";
 import {
   useForgetRefinerFile,
+  useMoveRefinerFileToTop,
   useRefinerFilesQuery,
 } from "../../lib/refiner/files-queries";
 import { useRefinerLibrariesQuery } from "../../lib/refiner/libraries-queries";
@@ -82,6 +83,7 @@ export function RefinerFilesSection() {
     limit,
   });
   const forget = useForgetRefinerFile();
+  const moveToTopMutation = useMoveRefinerFileToTop();
   const editable = canEdit(me.data?.role);
 
   if (files.isLoading) return <PageLoading label="Loading files" />;
@@ -89,6 +91,18 @@ export function RefinerFilesSection() {
   const page = files.data;
   const counts = page?.status_counts ?? {};
   const rows = page?.files ?? [];
+
+  const moveToTop = async (file: RefinerFile) => {
+    setNotice(null);
+    try {
+      // The server decides whether the move was possible and says so in words the
+      // screen shows unchanged — it knows whether the work had already started.
+      const result = await moveToTopMutation.mutateAsync(file.id);
+      setNotice(result.detail);
+    } catch {
+      setNotice("That file could not be moved to the front of the queue.");
+    }
+  };
 
   const removeFile = async (file: RefinerFile) => {
     setNotice(null);
@@ -229,15 +243,34 @@ export function RefinerFilesSection() {
                   ) : null}
                 </div>
                 {editable ? (
-                  <button
-                    type="button"
-                    className={mmActionButtonClass({ variant: "tertiary" })}
-                    onClick={() => void removeFile(file)}
-                    data-testid={`refiner-file-forget-${file.id}`}
-                    title="Removes MediaMop's record of this file. The file on disk is untouched."
-                  >
-                    Remove from list
-                  </button>
+                  <div className="flex flex-wrap gap-2">
+                    {/* Only offered where it can do something: a file that is running
+                      cannot be started earlier, and a button that looked like it worked
+                      would be worse than no button. */}
+                    {file.status === "unprocessed" ||
+                    file.status === "on_hold" ||
+                    file.status === "blocked_upstream" ||
+                    file.status === "out_of_schedule" ? (
+                      <button
+                        type="button"
+                        className={mmActionButtonClass({ variant: "tertiary" })}
+                        onClick={() => void moveToTop(file)}
+                        data-testid={`refiner-file-move-to-top-${file.id}`}
+                        title="Puts this file's queued work ahead of everything else waiting."
+                      >
+                        Move to top
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({ variant: "tertiary" })}
+                      onClick={() => void removeFile(file)}
+                      data-testid={`refiner-file-forget-${file.id}`}
+                      title="Removes MediaMop's record of this file. The file on disk is untouched."
+                    >
+                      Remove from list
+                    </button>
+                  </div>
                 ) : null}
               </div>
             </li>


### PR DESCRIPTION
Closes #338. Part of #347.

Stacked on #337 ([#369](https://github.com/jampat000/MediaMop/pull/369)) — migration `0016` chains off `0015` and this builds on the admission path that PR introduced.

## The problem

`max_concurrent_files` treated a 700 MB SD rip and a 60 GB 4K remux as the same unit of work. A machine sized for two of the latter sits idle under six of the former; one sized for six of the former is overwhelmed by two of the latter. **The count was never protecting the thing it appeared to protect.**

## Runner units

Capacity plus a cost per resolution class, checked when a job is leased. Shipped costs match the observed FileFlows values:

| Class | Cost |
| --- | --- |
| SD, 720p | 0 |
| 1080p, 4K | 1 |
| Undetermined | 0 |

The cost is **fixed at enqueue and written onto the job row**, not looked up at lease time. The claim has to answer "does this fit in what is left?" in one statement, and a row carrying its own cost makes that a comparison rather than a join against a probe result that may not exist yet.

A file MediaMop has not measured costs the `undetermined` weight — zero by default, which *admits* it rather than stalling on the unknown — and is measured during its first pass so the next one is weighted properly.

## Classified by width, not height

A test I wrote caught this before it shipped. **1920x800 is a 2.35:1 crop of a 1080p master.** Height alone cannot tell it from 1280x720, so weighting by height would have put some of the most expensive work in the free tier. Width is stable across aspect ratios; height remains the fallback when a probe reports no width. The *largest* video stream wins, so a 4K remux carrying a 300-line poster is not weighted by the poster.

## Also lands, all through #337's admission path

- **Per-library concurrency cap** — one library cannot occupy the whole budget with cheap files and starve the others.
- **Priority** — seeded from the library onto its jobs; the claim orders by priority then id, so equal priority stays FIFO.
- **Move to top** — from the Files screen and the API. Pending work only: a running job cannot be started earlier, and the endpoint says so rather than reporting a move that did not happen. Two files moved to the top keep the order they were moved in. The button is only rendered for states where it can actually do something.

## Migration

`0016` maps `runner_capacity` from the saved `max_concurrent_files` one-for-one, so the same number of expensive files run at once as before. Smaller files now run alongside — an improvement rather than a surprise, because the thing the old number was protecting was never the count.

Its **downgrade is tolerant of a partially-applied upgrade**. `alembic check` caught exactly that half-state during this work: a downgrade that raises halfway leaves the version row and the schema disagreeing, which is worse than the state it was undoing.

## Docstring

`worker_limits.py` is rewritten as the issue asks. The SQLite single-writer caveat now attaches to a capacity measured in units of expensive work — something a file count could never express honestly.

## Tests

Budget exhaustion · **a zero-cost file admitted while the budget is full** · capacity freeing on completion · per-library cap · one library at its cap not blocking another · priority ordering · FIFO within a priority · move to top · two moves keeping their order · a running job refusing to move · scope-crop classification · cover-art not downgrading a file · legacy enqueues defaulting to free.

Verified locally: 1028 backend passed / 2 skipped, 196 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
