### PR TITLE
feat(refiner): a durable per-file processing record with its own retention (#340)

### DIFF
--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -31,6 +31,7 @@ from mediamop.modules.pruner import pruner_preview_run_model as _pruner_preview_
 from mediamop.modules.pruner import pruner_scope_settings_model as _pruner_scope_settings_orm  # noqa: F401
 from mediamop.modules.pruner import pruner_server_instance_model as _pruner_server_instance_orm  # noqa: F401
 from mediamop.modules.refiner import jobs_model as _refiner_jobs_orm  # noqa: F401
+from mediamop.modules.refiner import refiner_file_log_model as _refiner_file_log_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_file_state_model as _refiner_file_state_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_library_model as _refiner_library_orm  # noqa: F401
 from mediamop.modules.refiner import refiner_operator_settings_model as _refiner_operator_settings_orm  # noqa: F401

--- a/apps/backend/alembic/versions/0018_file_processing_log.py
+++ b/apps/backend/alembic/versions/0018_file_processing_log.py
@@ -1,0 +1,92 @@
+"""A durable per-file processing record, with its own retention
+
+Refiner computed every decision it made about a file and put it in an activity detail
+payload — which then aged out under the suite's log retention along with everything else.
+"Why did this file come out like that, three weeks ago" had no answer.
+
+The two questions have different lifetimes. A suite log is for diagnosing the
+application; a per-file record is for diagnosing a *file*, which somebody may only ask
+about long after the fact. So the record gets its own table and its own retention.
+
+One row per completed pass, not per file: a file that failed twice and then succeeded has
+three things worth reading.
+
+``refiner_operator_settings`` gains ``file_log_retention_days`` (90, and **0 means keep
+forever**) and ``verbose_detection_logging`` (off — the switch to turn on while debugging
+detection and off again afterwards).
+
+Revision ID: 0018_file_processing_log
+Revises: 0017_retry_and_sweeps
+Create Date: 2026-08-29 15:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0018_file_processing_log"
+down_revision = "0017_retry_and_sweeps"
+branch_labels = None
+depends_on = None
+
+_OPERATOR_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    (
+        "file_log_retention_days",
+        sa.Column("file_log_retention_days", sa.Integer(), nullable=False, server_default="90"),
+    ),
+    (
+        "verbose_detection_logging",
+        sa.Column("verbose_detection_logging", sa.Boolean(), nullable=False, server_default="0"),
+    ),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    if "refiner_file_logs" not in set(inspect(op.get_bind()).get_table_names()):
+        op.create_table(
+            "refiner_file_logs",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            # SET NULL, not CASCADE: forgetting a file from the Files screen must not
+            # destroy the record of what was done to it. That is the opposite of why the
+            # record exists.
+            sa.Column("file_id", sa.Integer(), sa.ForeignKey("refiner_files.id", ondelete="SET NULL"), nullable=True),
+            sa.Column(
+                "library_id",
+                sa.Integer(),
+                sa.ForeignKey("refiner_libraries.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("relative_path", sa.Text(), nullable=False),
+            sa.Column("library_name", sa.Text(), nullable=False, server_default=""),
+            sa.Column("outcome", sa.Text(), nullable=False, server_default=""),
+            sa.Column("title", sa.Text(), nullable=False, server_default=""),
+            sa.Column("detail_json", sa.Text(), nullable=False, server_default="{}"),
+            sa.Column("recorded_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        )
+        op.create_index("ix_refiner_file_logs_path", "refiner_file_logs", ["relative_path"])
+        op.create_index("ix_refiner_file_logs_recorded_at", "refiner_file_logs", ["recorded_at"])
+        op.create_index("ix_refiner_file_logs_file", "refiner_file_logs", ["file_id"])
+
+    present = _columns("refiner_operator_settings")
+    for name, column in _OPERATOR_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_operator_settings", column)
+
+
+def downgrade() -> None:
+    present = _columns("refiner_operator_settings")
+    for name, _ in _OPERATOR_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_operator_settings", name)
+    if "refiner_file_logs" in set(inspect(op.get_bind()).get_table_names()):
+        op.drop_table("refiner_file_logs")

--- a/apps/backend/src/mediamop/core/lifespan.py
+++ b/apps/backend/src/mediamop/core/lifespan.py
@@ -32,6 +32,10 @@ from mediamop.modules.refiner.refiner_failure_cleanup_periodic_enqueue import (
     start_refiner_failure_cleanup_enqueue_tasks,
     stop_refiner_failure_cleanup_enqueue_tasks,
 )
+from mediamop.modules.refiner.refiner_file_log_retention_periodic import (
+    start_refiner_file_log_retention_tasks,
+    stop_refiner_file_log_retention_tasks,
+)
 from mediamop.modules.refiner.refiner_job_handlers import build_refiner_job_handlers
 from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_watched_folder_remux_scan_dispatch_periodic_enqueue import (
@@ -156,6 +160,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     job_rows_retention_tasks: list[asyncio.Task[None]] = []
     refiner_watched_folder_scan_dispatch_tasks: list[asyncio.Task[None]] = []
     refiner_watched_folder_watcher_tasks: list[asyncio.Task[None]] = []
+    refiner_file_log_retention_tasks: list[asyncio.Task[None]] = []
     refiner_work_temp_stale_sweep_tasks: list[asyncio.Task[None]] = []
     refiner_failure_cleanup_tasks: list[asyncio.Task[None]] = []
     refiner_handlers = build_refiner_job_handlers(settings, session_factory)
@@ -188,6 +193,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     def _start_refiner_watched_folder_scan_dispatch_tasks() -> None:
         nonlocal refiner_watched_folder_scan_dispatch_tasks
         refiner_watched_folder_scan_dispatch_tasks = start_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
+            session_factory,
+            stop_event=stop,
+            settings=settings,
+        )
+
+    def _start_refiner_file_log_retention_tasks() -> None:
+        nonlocal refiner_file_log_retention_tasks
+        refiner_file_log_retention_tasks = start_refiner_file_log_retention_tasks(
             session_factory,
             stop_event=stop,
             settings=settings,
@@ -262,6 +275,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         _start_refiner_watched_folder_scan_dispatch_tasks,
     )
     _run_non_essential_startup_step(
+        "refiner_file_log_retention_start",
+        _start_refiner_file_log_retention_tasks,
+    )
+    _run_non_essential_startup_step(
         "refiner_watched_folder_watcher_start",
         _start_refiner_watched_folder_watcher_tasks,
     )
@@ -282,6 +299,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             lambda: stop_refiner_watched_folder_remux_scan_dispatch_enqueue_tasks(
                 refiner_watched_folder_scan_dispatch_tasks
             ),
+        )
+        await _stop_task_group(
+            "refiner_file_log_retention_stop",
+            lambda: stop_refiner_file_log_retention_tasks(refiner_file_log_retention_tasks),
         )
         await _stop_task_group(
             "refiner_watched_folder_watcher_stop",

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/handlers.py
@@ -16,6 +16,7 @@ from mediamop.modules.refiner.file_remux_pass.visibility import (
     remux_pass_activity_title,
     remux_pass_result_to_activity_detail,
 )
+from mediamop.modules.refiner.refiner_file_log_service import record_file_log
 from mediamop.modules.refiner.refiner_file_remux_pass_activity import (
     complete_refiner_file_processing_activity,
     record_refiner_file_processing_started,
@@ -64,6 +65,18 @@ def _record(session_factory: sessionmaker[Session], *, payload: dict[str, Any], 
     detail = remux_pass_result_to_activity_detail(payload)
     title = remux_pass_activity_title(payload)
     with session_factory() as session, session.begin():
+        # The durable per-file record is written here, beside the activity row, so the
+        # two cannot disagree about what happened. It outlives the activity feed under
+        # its own retention (#340).
+        relative_path = payload.get("relative_media_path")
+        if isinstance(relative_path, str) and relative_path.strip():
+            try:
+                record_file_log(session, relative_path=relative_path, title=title, detail=payload)
+            except Exception:
+                # A record that cannot be written must not fail the pass that produced
+                # it: the work is done either way, and losing the job is worse than
+                # losing the note about it.
+                logger.exception("Refiner could not write the processing record for %s.", relative_path)
         if activity_id is not None:
             updated = complete_refiner_file_processing_activity(
                 session,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_log_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_log_model.py
@@ -1,0 +1,68 @@
+"""A durable record of what Refiner did to one file, and why.
+
+Refiner's live telemetry is good — real percent and ETA per file while ffmpeg runs. What
+it had no answer for is "why did this file come out like that, three weeks ago". Every
+decision was already computed and put into an activity detail payload, and then aged out
+under the suite's log retention along with everything else.
+
+So this is a home for that payload with **its own retention**, because the two questions
+have different lifetimes: a suite log is for diagnosing the application, and a per-file
+record is for diagnosing a *file*, which someone may only ask about long after the fact.
+
+One row per completed pass rather than one per file: a file that failed twice and then
+succeeded has three things worth reading, and collapsing them would throw away exactly
+the history that makes the record worth keeping.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Text,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from mediamop.core.db import Base
+
+
+class RefinerFileLogRow(Base):
+    """One completed Refiner pass over one file."""
+
+    __tablename__ = "refiner_file_logs"
+    __table_args__ = (
+        Index("ix_refiner_file_logs_path", "relative_path"),
+        Index("ix_refiner_file_logs_recorded_at", "recorded_at"),
+        Index("ix_refiner_file_logs_file", "file_id"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Nullable, and deliberately ``SET NULL`` rather than ``CASCADE``: forgetting a file
+    # from the Files screen must not destroy the record of what was done to it. That is
+    # the opposite of why the record exists.
+    file_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("refiner_files.id", ondelete="SET NULL"), nullable=True
+    )
+    library_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("refiner_libraries.id", ondelete="SET NULL"), nullable=True
+    )
+    # The path is stored flat as well as the ids, so a record stays readable after the
+    # library it belonged to is gone.
+    relative_path: Mapped[str] = mapped_column(Text, nullable=False)
+    library_name: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+
+    outcome: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    title: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    #: The whole payload as JSON — admission decisions, probe, plan, argv, cleanup gates,
+    #: timings, sizes. Kept whole rather than split into columns, because the shape is
+    #: the pass's own and pinning it into a schema would make every future field a
+    #: migration.
+    detail_json: Mapped[str] = mapped_column(Text, nullable=False, server_default="{}")
+
+    recorded_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_log_retention_periodic.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_log_retention_periodic.py
@@ -1,0 +1,77 @@
+"""Periodic pruning of the per-file processing record.
+
+Separate from the suite's log retention on purpose. A suite log is for diagnosing the
+application and a per-file record is for diagnosing a *file*, and somebody may only ask
+about a file long after the fact — so the two need different lifetimes, and one setting
+could not give them that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.refiner_file_log_service import prune_file_logs
+from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
+
+logger = logging.getLogger(__name__)
+
+#: Records are pruned by age, so checking often buys nothing. Hourly keeps the window
+#: honest without a sweep that runs more than the thing it is sweeping.
+PRUNE_INTERVAL_SECONDS = 3600.0
+
+
+def prune_once(session_factory: sessionmaker[Session]) -> int:
+    """One pruning pass. Returns how many records were removed."""
+
+    with session_factory() as session, session.begin():
+        operator = ensure_refiner_operator_settings_row(session)
+        days = int(operator.file_log_retention_days)
+        # 0 means keep forever, matching the setting's own wording. Reading it the other
+        # way would silently destroy the history the feature exists to keep, which is the
+        # worst possible direction for that ambiguity.
+        if days <= 0:
+            return 0
+        return prune_file_logs(session, retention_days=days)
+
+
+async def _run_forever(session_factory: sessionmaker[Session], *, stop_event: asyncio.Event) -> None:
+    while not stop_event.is_set():
+        try:
+            removed = await asyncio.to_thread(prune_once, session_factory)
+            if removed:
+                logger.info("Refiner removed %s processing record(s) past their retention window.", removed)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Retention failing must not take the task down: the next tick tries again,
+            # and a stopped pruner is a database that grows silently.
+            logger.exception("Refiner processing-record retention failed.")
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop_event.wait(), timeout=PRUNE_INTERVAL_SECONDS)
+
+
+def start_refiner_file_log_retention_tasks(
+    session_factory: sessionmaker[Session],
+    *,
+    stop_event: asyncio.Event,
+    settings: MediaMopSettings,
+) -> list[asyncio.Task[None]]:
+    return [
+        asyncio.create_task(
+            _run_forever(session_factory, stop_event=stop_event),
+            name="refiner-file-log-retention",
+        )
+    ]
+
+
+async def stop_refiner_file_log_retention_tasks(tasks: list[asyncio.Task[None]]) -> None:
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_file_log_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_file_log_service.py
@@ -1,0 +1,162 @@
+"""Writing, reading, rendering and pruning the per-file processing record."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from mediamop.modules.refiner.refiner_file_log_model import RefinerFileLogRow
+from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+
+#: A single record is bounded so one pathological payload cannot fill the database. The
+#: cap is generous — a full pass detail is a few kilobytes — and truncation is recorded
+#: in the row rather than happening silently.
+MAX_DETAIL_CHARS = 200_000
+
+
+def _resolve_file_and_library(
+    session: Session, *, relative_path: str
+) -> tuple[RefinerFileRow | None, RefinerLibraryRow | None]:
+    row = session.scalars(
+        select(RefinerFileRow).where(RefinerFileRow.relative_path == relative_path).order_by(RefinerFileRow.id)
+    ).first()
+    if row is None:
+        return None, None
+    return row, session.get(RefinerLibraryRow, row.library_id)
+
+
+def record_file_log(
+    session: Session,
+    *,
+    relative_path: str,
+    title: str,
+    detail: dict[str, Any] | str,
+    recorded_at: datetime | None = None,
+) -> RefinerFileLogRow:
+    """Persist one completed pass.
+
+    Called from the same place the activity row is written, so the two cannot disagree
+    about what happened.
+    """
+
+    payload = detail if isinstance(detail, dict) else _loads(detail)
+    text = json.dumps(payload, separators=(",", ":"), ensure_ascii=False, default=str)
+    truncated = len(text) > MAX_DETAIL_CHARS
+    if truncated:
+        # Say so in the record rather than leaving a reader to wonder why the JSON stops.
+        payload = {
+            "truncated": True,
+            "truncated_note": (
+                f"This record was longer than {MAX_DETAIL_CHARS} characters and was shortened when it was saved."
+            ),
+            "outcome": payload.get("outcome") if isinstance(payload, dict) else None,
+            "detail_excerpt": text[: MAX_DETAIL_CHARS // 2],
+        }
+        text = json.dumps(payload, separators=(",", ":"), ensure_ascii=False, default=str)
+
+    file_row, library = _resolve_file_and_library(session, relative_path=relative_path)
+    row = RefinerFileLogRow(
+        file_id=file_row.id if file_row is not None else None,
+        library_id=library.id if library is not None else None,
+        relative_path=relative_path,
+        library_name=library.name if library is not None else "",
+        outcome=str(payload.get("outcome") or "") if isinstance(payload, dict) else "",
+        title=title,
+        detail_json=text,
+        recorded_at=recorded_at or datetime.now(UTC),
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _loads(raw: str | None) -> dict[str, Any]:
+    if not raw or not raw.strip():
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"unparsed_detail": raw[:MAX_DETAIL_CHARS]}
+    return parsed if isinstance(parsed, dict) else {"detail": parsed}
+
+
+def logs_for_file(session: Session, *, file_id: int, limit: int = 50) -> list[RefinerFileLogRow]:
+    """Every retained pass over this file, newest first.
+
+    Matched on the file's path as well as its id, so records written before a file row
+    was recreated — or after it was forgotten and seen again — still belong to it.
+    """
+
+    row = session.get(RefinerFileRow, file_id)
+    if row is None:
+        return []
+    return list(
+        session.scalars(
+            select(RefinerFileLogRow)
+            .where(RefinerFileLogRow.relative_path == row.relative_path)
+            .order_by(RefinerFileLogRow.recorded_at.desc(), RefinerFileLogRow.id.desc())
+            .limit(max(1, min(limit, 500)))
+        )
+    )
+
+
+def render_log_text(rows: list[RefinerFileLogRow]) -> str:
+    """A plain-text rendering, for attaching to a bug report.
+
+    Text rather than the raw JSON: the reason someone downloads this is to send it to
+    somebody else, and a wall of minified JSON is not something a person can read in a
+    forum post.
+    """
+
+    if not rows:
+        return "MediaMop has no retained processing records for this file.\n"
+
+    lines: list[str] = []
+    first = rows[0]
+    lines.append(f"MediaMop — processing record for {first.relative_path}")
+    if first.library_name:
+        lines.append(f"Library: {first.library_name}")
+    lines.append(f"Records retained: {len(rows)} (newest first)")
+    lines.append("")
+
+    for row in rows:
+        stamp = row.recorded_at
+        if stamp is not None and stamp.tzinfo is None:
+            stamp = stamp.replace(tzinfo=UTC)
+        lines.append("=" * 78)
+        lines.append(f"{stamp.isoformat() if stamp else 'unknown time'}  —  {row.outcome or 'no outcome recorded'}")
+        if row.title:
+            lines.append(row.title)
+        lines.append("-" * 78)
+        detail = _loads(row.detail_json)
+        for key in sorted(detail):
+            value = detail[key]
+            rendered = json.dumps(value, ensure_ascii=False, default=str) if isinstance(value, (dict, list)) else value
+            lines.append(f"{key}: {rendered}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def prune_file_logs(session: Session, *, retention_days: int, now: datetime | None = None) -> int:
+    """Delete records older than the retention window. ``0`` keeps everything.
+
+    Zero means forever rather than "delete immediately", matching the setting's own
+    wording. Reading it the other way round would silently destroy the history the
+    feature exists to keep, which is the worst possible direction for that ambiguity.
+    """
+
+    days = int(retention_days)
+    if days <= 0:
+        return 0
+    cutoff = (now or datetime.now(UTC)) - timedelta(days=days)
+    doomed = list(session.scalars(select(RefinerFileLogRow.id).where(RefinerFileLogRow.recorded_at < cutoff)))
+    if not doomed:
+        return 0
+    session.execute(delete(RefinerFileLogRow).where(RefinerFileLogRow.id.in_(doomed)))
+    session.flush()
+    return len(doomed)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_files_api.py
@@ -11,17 +11,22 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi import APIRouter, HTTPException, Path, Query, Request
 from starlette import status as http_status
+from starlette.responses import PlainTextResponse
 
 from mediamop.api.deps import DbSessionDep, SettingsDep
 from mediamop.core.config import MediaMopSettings
 from mediamop.modules.refiner.jobs_ops import move_refiner_job_to_top
+from mediamop.modules.refiner.refiner_file_log_service import logs_for_file, render_log_text
 from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow
 from mediamop.modules.refiner.refiner_file_state_service import forget_file, list_files, status_counts
 from mediamop.modules.refiner.refiner_job_queue_lookup import pending_remux_job_for_relative_path
 from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
 from mediamop.modules.refiner.refiner_requeue_service import requeue_file, requeue_files
 from mediamop.modules.refiner.schemas_refiner_files import (
     RefinerFileForgetIn,
+    RefinerFileLogEntryOut,
+    RefinerFileLogOut,
     RefinerFileMoveToTopIn,
     RefinerFileMoveToTopOut,
     RefinerFileOut,
@@ -41,6 +46,19 @@ from mediamop.platform.auth.csrf import (
 from mediamop.platform.auth.deps_auth import UserPublicDep
 
 router = APIRouter(tags=["refiner"])
+
+
+def _log_detail(raw: str) -> dict[str, object]:
+    """Parse a stored payload, never raising: a record that cannot be parsed is still
+    worth showing, and an exception here would hide the whole file's history."""
+
+    import json as _json
+
+    try:
+        parsed = _json.loads(raw or "{}")
+    except _json.JSONDecodeError:
+        return {"unparsed_detail": raw}
+    return parsed if isinstance(parsed, dict) else {"detail": parsed}
 
 
 def _verify_csrf(request: Request, settings: MediaMopSettings, token: str) -> None:
@@ -208,3 +226,60 @@ def requeue_refiner_files(
     result = requeue_files(db, rows=rows)
     db.commit()
     return RefinerRequeueOut(requeued=result.requeued, skipped=result.skipped, detail=result.detail)
+
+
+@router.get("/refiner/files/{file_id}/log", response_model=RefinerFileLogOut)
+def get_refiner_file_log(
+    _user: UserPublicDep,
+    db: DbSessionDep,
+    file_id: int = Path(ge=1),
+    limit: int = Query(default=50, ge=1, le=500),
+) -> RefinerFileLogOut:
+    """Everything MediaMop retained about what it did to this file, newest first."""
+
+    row = db.get(RefinerFileRow, file_id)
+    if row is None:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="MediaMop has no record of that file.")
+    operator = ensure_refiner_operator_settings_row(db)
+    rows = logs_for_file(db, file_id=file_id, limit=limit)
+    db.commit()
+    return RefinerFileLogOut(
+        file_id=file_id,
+        relative_path=row.relative_path,
+        retention_days=int(operator.file_log_retention_days),
+        entries=[
+            RefinerFileLogEntryOut(
+                id=entry.id,
+                recorded_at=entry.recorded_at,
+                outcome=entry.outcome,
+                title=entry.title,
+                library_name=entry.library_name,
+                detail=_log_detail(entry.detail_json),
+            )
+            for entry in rows
+        ],
+    )
+
+
+@router.get("/refiner/files/{file_id}/log/download")
+def download_refiner_file_log(
+    _user: UserPublicDep,
+    db: DbSessionDep,
+    file_id: int = Path(ge=1),
+) -> PlainTextResponse:
+    """The same record as plain text, for attaching to a bug report.
+
+    Text rather than raw JSON: the reason anyone downloads this is to send it to somebody
+    else, and minified JSON is not something a person reads in a forum post.
+    """
+
+    row = db.get(RefinerFileRow, file_id)
+    if row is None:
+        raise HTTPException(status_code=http_status.HTTP_404_NOT_FOUND, detail="MediaMop has no record of that file.")
+    rows = logs_for_file(db, file_id=file_id, limit=500)
+    db.commit()
+    safe = "".join(ch if ch.isalnum() or ch in "-_." else "-" for ch in row.relative_path)[-80:].strip("-") or "file"
+    return PlainTextResponse(
+        render_log_text(rows),
+        headers={"Content-Disposition": f'attachment; filename="mediamop-{safe}.log.txt"'},
+    )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_model.py
@@ -36,6 +36,14 @@ class RefinerOperatorSettingsRow(Base):
     # Keep a failed run's working files so they can be inspected instead of swept.
     keep_failed_work_files: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
 
+    # The per-file processing record's own retention, independent of the suite log's:
+    # diagnosing the application and diagnosing a file are different questions with
+    # different lifetimes. 0 means keep forever.
+    file_log_retention_days: Mapped[int] = mapped_column(Integer, nullable=False, server_default="90")
+    # Extra detail from the file-detection stage. Off by default, and meant to be turned
+    # off again — it is loud, and that is the point of it.
+    verbose_detection_logging: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+
     min_file_age_seconds: Mapped[int] = mapped_column(Integer, nullable=False, server_default="60")
     refiner_min_input_file_size_mb: Mapped[int] = mapped_column(Integer, nullable=False, server_default="50")
     minimum_free_disk_space_mb: Mapped[int] = mapped_column(Integer, nullable=False, server_default="5120")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_operator_settings_service.py
@@ -45,6 +45,8 @@ def ensure_refiner_operator_settings_row(db: Session) -> RefinerOperatorSettings
             work_temp_stale_sweep_enabled=True,
             failure_cleanup_enabled=False,
             keep_failed_work_files=False,
+            file_log_retention_days=90,
+            verbose_detection_logging=False,
             min_file_age_seconds=60,
             refiner_min_input_file_size_mb=50,
             minimum_free_disk_space_mb=5120,
@@ -117,6 +119,8 @@ def build_refiner_operator_settings_out(db: Session, row: RefinerOperatorSetting
         work_temp_stale_sweep_enabled=bool(row.work_temp_stale_sweep_enabled),
         failure_cleanup_enabled=bool(row.failure_cleanup_enabled),
         keep_failed_work_files=bool(row.keep_failed_work_files),
+        file_log_retention_days=max(0, min(3650, int(row.file_log_retention_days))),
+        verbose_detection_logging=bool(row.verbose_detection_logging),
         min_file_age_seconds=_clamp_min_file_age_seconds(row.min_file_age_seconds),
         refiner_min_input_file_size_mb=_clamp_size_mb(row.refiner_min_input_file_size_mb),
         minimum_free_disk_space_mb=_clamp_size_mb(row.minimum_free_disk_space_mb),
@@ -150,7 +154,14 @@ def apply_refiner_operator_settings_put(db: Session, body: RefinerOperatorSettin
         value = getattr(body, field, None)
         if value is not None:
             setattr(row, field, max(0, min(64, int(value))))
-    for flag in ("work_temp_stale_sweep_enabled", "failure_cleanup_enabled", "keep_failed_work_files"):
+    if body.file_log_retention_days is not None:
+        row.file_log_retention_days = max(0, min(3650, int(body.file_log_retention_days)))
+    for flag in (
+        "work_temp_stale_sweep_enabled",
+        "failure_cleanup_enabled",
+        "keep_failed_work_files",
+        "verbose_detection_logging",
+    ):
         toggled = getattr(body, flag, None)
         if toggled is not None:
             setattr(row, flag, bool(toggled))

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_files.py
@@ -112,3 +112,26 @@ class RefinerRequeueOut(BaseModel):
     requeued: int
     skipped: int
     detail: str
+
+
+class RefinerFileLogEntryOut(BaseModel):
+    """One completed pass over this file."""
+
+    id: int
+    recorded_at: datetime
+    outcome: str
+    title: str
+    library_name: str
+    detail: dict[str, object] = Field(
+        default_factory=dict,
+        description="The whole pass payload: admission decisions, probe, plan, ffmpeg argv, cleanup gates, timings.",
+    )
+
+
+class RefinerFileLogOut(BaseModel):
+    file_id: int
+    relative_path: str
+    retention_days: int = Field(
+        description="How long these records are kept. 0 means they are kept forever.",
+    )
+    entries: list[RefinerFileLogEntryOut]

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_operator_settings.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_operator_settings.py
@@ -33,6 +33,17 @@ class RefinerOperatorSettingsOut(BaseModel):
     keep_failed_work_files: bool = Field(
         description="Keep a failed run's working files so they can be inspected instead of swept.",
     )
+    file_log_retention_days: int = Field(
+        ge=0,
+        le=3650,
+        description="How long to keep the per-file processing record. 0 keeps it forever.",
+    )
+    verbose_detection_logging: bool = Field(
+        description=(
+            "Record extra detail from the file-detection stage. Turn this on while working out why a file "
+            "is or is not being picked up, and turn it off again afterwards — it is loud."
+        ),
+    )
     runner_cost_undetermined: int = Field(
         ge=0,
         le=64,
@@ -81,6 +92,8 @@ class RefinerOperatorSettingsPutIn(BaseModel):
     work_temp_stale_sweep_enabled: bool | None = None
     failure_cleanup_enabled: bool | None = None
     keep_failed_work_files: bool | None = None
+    file_log_retention_days: int | None = Field(default=None, ge=0, le=3650)
+    verbose_detection_logging: bool | None = None
     min_file_age_seconds: int | None = Field(default=None, ge=0, le=7 * 24 * 3600)
     refiner_min_input_file_size_mb: int | None = Field(default=None, ge=0, le=1024 * 1024)
     minimum_free_disk_space_mb: int | None = Field(default=None, ge=0, le=1024 * 1024)
@@ -140,6 +153,8 @@ class RefinerOperatorSettingsPutIn(BaseModel):
             or self.work_temp_stale_sweep_enabled is not None
             or self.failure_cleanup_enabled is not None
             or self.keep_failed_work_files is not None
+            or self.file_log_retention_days is not None
+            or self.verbose_detection_logging is not None
             or self.min_file_age_seconds is not None
             or self.refiner_min_input_file_size_mb is not None
             or self.minimum_free_disk_space_mb is not None

--- a/apps/backend/tests/test_refiner_file_log.py
+++ b/apps/backend/tests/test_refiner_file_log.py
@@ -1,0 +1,313 @@
+"""The durable per-file processing record, and its own retention.
+
+Refiner computed every decision it made about a file and put it in an activity payload
+that then aged out under the suite's log retention. "Why did this file come out like
+that, three weeks ago" had no answer (#340).
+
+The case worth being careful about is retention ``0``. The setting says it keeps records
+forever; reading it as "delete everything" would silently destroy the history the feature
+exists to keep, which is the worst possible direction for that ambiguity — so it has its
+own test rather than being covered incidentally.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import mediamop.modules.refiner.refiner_file_log_model  # noqa: F401
+import mediamop.modules.refiner.refiner_file_state_model  # noqa: F401
+import mediamop.modules.refiner.refiner_library_model  # noqa: F401
+import mediamop.modules.refiner.refiner_operator_settings_model  # noqa: F401
+from mediamop.core.db import Base
+from mediamop.modules.refiner.refiner_file_log_model import RefinerFileLogRow
+from mediamop.modules.refiner.refiner_file_log_service import (
+    MAX_DETAIL_CHARS,
+    logs_for_file,
+    prune_file_logs,
+    record_file_log,
+    render_log_text,
+)
+from mediamop.modules.refiner.refiner_file_state_model import RefinerFileRow
+from mediamop.modules.refiner.refiner_library_model import RefinerLibraryRow
+
+NOW = datetime(2026, 8, 26, 14, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def session(tmp_path: Path) -> Session:
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'log.sqlite'}",
+        connect_args={"check_same_thread": False},
+        future=True,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, class_=Session, autoflush=False, autocommit=False, future=True)()
+
+
+def _library(session: Session, name: str = "Movies") -> RefinerLibraryRow:
+    row = RefinerLibraryRow(
+        name=name,
+        media_scope="movie",
+        enabled=True,
+        watched_folder="/srv/in",
+        output_folder="/srv/out",
+    )
+    session.add(row)
+    session.commit()
+    return row
+
+
+def _file(session: Session, library: RefinerLibraryRow, path: str = "Film/film.mkv") -> RefinerFileRow:
+    row = RefinerFileRow(library_id=library.id, relative_path=path)
+    session.add(row)
+    session.commit()
+    return row
+
+
+# --- writing ------------------------------------------------------------------------
+
+
+def test_a_record_keeps_the_whole_pass_payload(session: Session) -> None:
+    library = _library(session)
+    _file(session, library)
+
+    record_file_log(
+        session,
+        relative_path="Film/film.mkv",
+        title="Remuxed Film",
+        detail={
+            "outcome": "live_output_written",
+            "ffmpeg_argv": ["ffmpeg", "-i", "in.mkv"],
+            "audio_before": "eng, fra",
+            "size_before_bytes": 1000,
+            "size_after_bytes": 900,
+        },
+        recorded_at=NOW,
+    )
+    session.commit()
+
+    row = session.scalars(select(RefinerFileLogRow)).one()
+    assert row.outcome == "live_output_written"
+    assert row.library_name == "Movies"
+    detail = json.loads(row.detail_json)
+    # Whole, not summarised: the point is answering questions nobody has asked yet.
+    assert detail["ffmpeg_argv"] == ["ffmpeg", "-i", "in.mkv"]
+    assert detail["size_after_bytes"] == 900
+
+
+def test_each_pass_is_its_own_record_so_the_history_survives(session: Session) -> None:
+    """A file that failed twice and then succeeded has three things worth reading."""
+
+    library = _library(session)
+    _file(session, library)
+    for outcome in ("failed_during_execution", "failed_during_execution", "live_output_written"):
+        record_file_log(
+            session,
+            relative_path="Film/film.mkv",
+            title="Pass",
+            detail={"outcome": outcome},
+            recorded_at=NOW,
+        )
+    session.commit()
+
+    assert len(session.scalars(select(RefinerFileLogRow)).all()) == 3
+
+
+def test_a_record_is_written_even_when_no_file_row_exists(session: Session) -> None:
+    """The pass produced something worth keeping; a missing index row is not a reason to lose it."""
+
+    record_file_log(session, relative_path="Orphan/orphan.mkv", title="Pass", detail={"outcome": "ok"}, recorded_at=NOW)
+    session.commit()
+
+    row = session.scalars(select(RefinerFileLogRow)).one()
+    assert row.file_id is None
+    assert row.relative_path == "Orphan/orphan.mkv"
+
+
+def test_an_enormous_payload_is_shortened_and_says_so(session: Session) -> None:
+    library = _library(session)
+    _file(session, library)
+
+    record_file_log(
+        session,
+        relative_path="Film/film.mkv",
+        title="Pass",
+        detail={"outcome": "ok", "noise": "x" * (MAX_DETAIL_CHARS + 10)},
+        recorded_at=NOW,
+    )
+    session.commit()
+
+    detail = json.loads(session.scalars(select(RefinerFileLogRow)).one().detail_json)
+    assert detail["truncated"] is True
+    # Said in the record rather than leaving a reader to wonder why the JSON stops.
+    assert "shortened when it was saved" in detail["truncated_note"]
+    assert detail["outcome"] == "ok"
+
+
+def test_a_string_payload_is_accepted_as_well_as_a_mapping(session: Session) -> None:
+    record_file_log(
+        session,
+        relative_path="Film/film.mkv",
+        title="Pass",
+        detail=json.dumps({"outcome": "ok"}),
+        recorded_at=NOW,
+    )
+    session.commit()
+
+    assert session.scalars(select(RefinerFileLogRow)).one().outcome == "ok"
+
+
+def test_unparseable_stored_detail_is_kept_rather_than_dropped(session: Session) -> None:
+    record_file_log(session, relative_path="a.mkv", title="Pass", detail="not json at all", recorded_at=NOW)
+    session.commit()
+
+    detail = json.loads(session.scalars(select(RefinerFileLogRow)).one().detail_json)
+    assert "unparsed_detail" in detail
+
+
+# --- reading ------------------------------------------------------------------------
+
+
+def test_records_are_returned_newest_first(session: Session) -> None:
+    library = _library(session)
+    file_row = _file(session, library)
+    record_file_log(session, relative_path="Film/film.mkv", title="Old", detail={"outcome": "a"}, recorded_at=NOW)
+    record_file_log(
+        session,
+        relative_path="Film/film.mkv",
+        title="New",
+        detail={"outcome": "b"},
+        recorded_at=NOW + timedelta(hours=1),
+    )
+    session.commit()
+
+    rows = logs_for_file(session, file_id=file_row.id)
+
+    assert [r.title for r in rows] == ["New", "Old"]
+
+
+def test_records_survive_the_file_being_forgotten_and_seen_again(session: Session) -> None:
+    """Forgetting a file from the screen must not destroy the record of what was done to it."""
+
+    library = _library(session)
+    first = _file(session, library)
+    record_file_log(session, relative_path="Film/film.mkv", title="Pass", detail={"outcome": "ok"}, recorded_at=NOW)
+    session.commit()
+
+    session.delete(first)
+    session.commit()
+    assert session.scalars(select(RefinerFileLogRow)).one() is not None
+
+    # Seen again by a later scan: the history reattaches by path.
+    again = _file(session, library)
+    assert len(logs_for_file(session, file_id=again.id)) == 1
+
+
+def test_a_file_that_does_not_exist_has_no_records(session: Session) -> None:
+    assert logs_for_file(session, file_id=9999) == []
+
+
+def test_the_text_rendering_is_readable_rather_than_minified_json(session: Session) -> None:
+    library = _library(session)
+    file_row = _file(session, library)
+    record_file_log(
+        session,
+        relative_path="Film/film.mkv",
+        title="Remuxed Film",
+        detail={"outcome": "live_output_written", "ffmpeg_argv": ["ffmpeg", "-i", "in.mkv"]},
+        recorded_at=NOW,
+    )
+    session.commit()
+
+    text = render_log_text(logs_for_file(session, file_id=file_row.id))
+
+    assert "Film/film.mkv" in text
+    assert "Library: Movies" in text
+    assert "live_output_written" in text
+    assert "ffmpeg" in text
+
+
+def test_the_text_rendering_says_so_when_there_is_nothing(session: Session) -> None:
+    assert "no retained processing records" in render_log_text([])
+
+
+# --- retention ----------------------------------------------------------------------
+
+
+def test_records_past_the_retention_window_are_removed(session: Session) -> None:
+    record_file_log(
+        session, relative_path="a.mkv", title="Old", detail={"outcome": "a"}, recorded_at=NOW - timedelta(days=100)
+    )
+    record_file_log(
+        session, relative_path="b.mkv", title="Recent", detail={"outcome": "b"}, recorded_at=NOW - timedelta(days=10)
+    )
+    session.commit()
+
+    removed = prune_file_logs(session, retention_days=90, now=NOW)
+    session.commit()
+
+    assert removed == 1
+    remaining = session.scalars(select(RefinerFileLogRow)).all()
+    assert [r.title for r in remaining] == ["Recent"]
+
+
+def test_zero_retention_keeps_everything_forever(session: Session) -> None:
+    """The setting says 0 keeps records forever.
+
+    Reading it as "delete everything" would silently destroy the history this feature
+    exists to keep — the worst possible direction for that ambiguity, so it is asserted
+    directly rather than covered incidentally.
+    """
+
+    record_file_log(
+        session,
+        relative_path="ancient.mkv",
+        title="Ancient",
+        detail={"outcome": "a"},
+        recorded_at=NOW - timedelta(days=3650),
+    )
+    session.commit()
+
+    removed = prune_file_logs(session, retention_days=0, now=NOW)
+    session.commit()
+
+    assert removed == 0
+    assert len(session.scalars(select(RefinerFileLogRow)).all()) == 1
+
+
+def test_a_negative_retention_is_treated_as_forever_too(session: Session) -> None:
+    record_file_log(
+        session,
+        relative_path="ancient.mkv",
+        title="Ancient",
+        detail={"outcome": "a"},
+        recorded_at=NOW - timedelta(days=3650),
+    )
+    session.commit()
+
+    assert prune_file_logs(session, retention_days=-1, now=NOW) == 0
+
+
+def test_pruning_an_empty_table_is_not_an_error(session: Session) -> None:
+    assert prune_file_logs(session, retention_days=30, now=NOW) == 0
+
+
+def test_a_record_exactly_on_the_boundary_is_kept(session: Session) -> None:
+    # Strictly older than the cutoff, so "exactly 90 days" survives rather than being
+    # removed by a rounding decision nobody made deliberately.
+    record_file_log(
+        session,
+        relative_path="edge.mkv",
+        title="Edge",
+        detail={"outcome": "a"},
+        recorded_at=NOW - timedelta(days=90),
+    )
+    session.commit()
+
+    assert prune_file_logs(session, retention_days=90, now=NOW) == 0

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -2818,6 +2818,79 @@
         "title": "RefinerFileForgetIn",
         "type": "object"
       },
+      "RefinerFileLogEntryOut": {
+        "description": "One completed pass over this file.",
+        "properties": {
+          "detail": {
+            "additionalProperties": true,
+            "description": "The whole pass payload: admission decisions, probe, plan, ffmpeg argv, cleanup gates, timings.",
+            "title": "Detail",
+            "type": "object"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "library_name": {
+            "title": "Library Name",
+            "type": "string"
+          },
+          "outcome": {
+            "title": "Outcome",
+            "type": "string"
+          },
+          "recorded_at": {
+            "format": "date-time",
+            "title": "Recorded At",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "recorded_at",
+          "outcome",
+          "title",
+          "library_name"
+        ],
+        "title": "RefinerFileLogEntryOut",
+        "type": "object"
+      },
+      "RefinerFileLogOut": {
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/RefinerFileLogEntryOut"
+            },
+            "title": "Entries",
+            "type": "array"
+          },
+          "file_id": {
+            "title": "File Id",
+            "type": "integer"
+          },
+          "relative_path": {
+            "title": "Relative Path",
+            "type": "string"
+          },
+          "retention_days": {
+            "description": "How long these records are kept. 0 means they are kept forever.",
+            "title": "Retention Days",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file_id",
+          "relative_path",
+          "retention_days",
+          "entries"
+        ],
+        "title": "RefinerFileLogOut",
+        "type": "object"
+      },
       "RefinerFileMoveToTopIn": {
         "additionalProperties": false,
         "properties": {
@@ -4148,6 +4221,13 @@
             "title": "Failure Cleanup Enabled",
             "type": "boolean"
           },
+          "file_log_retention_days": {
+            "description": "How long to keep the per-file processing record. 0 keeps it forever.",
+            "maximum": 3650.0,
+            "minimum": 0.0,
+            "title": "File Log Retention Days",
+            "type": "integer"
+          },
           "keep_failed_work_files": {
             "description": "Keep a failed run's working files so they can be inspected instead of swept.",
             "title": "Keep Failed Work Files",
@@ -4273,6 +4353,11 @@
             "title": "Updated At",
             "type": "string"
           },
+          "verbose_detection_logging": {
+            "description": "Record extra detail from the file-detection stage. Turn this on while working out why a file is or is not being picked up, and turn it off again afterwards \u2014 it is loud.",
+            "title": "Verbose Detection Logging",
+            "type": "boolean"
+          },
           "work_temp_stale_sweep_enabled": {
             "description": "Reclaim MediaMop's own stale working files. Safe, and on by default.",
             "title": "Work Temp Stale Sweep Enabled",
@@ -4289,6 +4374,8 @@
           "work_temp_stale_sweep_enabled",
           "failure_cleanup_enabled",
           "keep_failed_work_files",
+          "file_log_retention_days",
+          "verbose_detection_logging",
           "runner_cost_undetermined",
           "min_file_age_seconds",
           "refiner_min_input_file_size_mb",
@@ -4328,6 +4415,19 @@
               }
             ],
             "title": "Failure Cleanup Enabled"
+          },
+          "file_log_retention_days": {
+            "anyOf": [
+              {
+                "maximum": 3650.0,
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Log Retention Days"
           },
           "keep_failed_work_files": {
             "anyOf": [
@@ -4585,6 +4685,17 @@
               }
             ],
             "title": "Tv Schedule Start"
+          },
+          "verbose_detection_logging": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verbose Detection Logging"
           },
           "work_temp_stale_sweep_enabled": {
             "anyOf": [
@@ -8812,6 +8923,106 @@
           }
         },
         "summary": "Delete Refiner File",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/files/{file_id}/log": {
+      "get": {
+        "description": "Everything MediaMop retained about what it did to this file, newest first.",
+        "operationId": "get_refiner_file_log_api_v1_refiner_files__file_id__log_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "File Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefinerFileLogOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Refiner File Log",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/files/{file_id}/log/download": {
+      "get": {
+        "description": "The same record as plain text, for attaching to a bug report.\n\nText rather than raw JSON: the reason anyone downloads this is to send it to somebody\nelse, and minified JSON is not something a person reads in a forum post.",
+        "operationId": "download_refiner_file_log_api_v1_refiner_files__file_id__log_download_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "file_id",
+            "required": true,
+            "schema": {
+              "minimum": 1,
+              "title": "File Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Download Refiner File Log",
         "tags": [
           "refiner",
           "refiner"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -679,6 +679,49 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/refiner/files/{file_id}/log": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Refiner File Log
+     * @description Everything MediaMop retained about what it did to this file, newest first.
+     */
+    get: operations["get_refiner_file_log_api_v1_refiner_files__file_id__log_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/files/{file_id}/log/download": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Download Refiner File Log
+     * @description The same record as plain text, for attaching to a bug report.
+     *
+     *     Text rather than raw JSON: the reason anyone downloads this is to send it to somebody
+     *     else, and minified JSON is not something a person reads in a forum post.
+     */
+    get: operations["download_refiner_file_log_api_v1_refiner_files__file_id__log_download_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/refiner/files/{file_id}/move-to-top": {
     parameters: {
       query?: never;
@@ -2805,6 +2848,46 @@ export interface components {
       /** Csrf Token */
       csrf_token: string;
     };
+    /**
+     * RefinerFileLogEntryOut
+     * @description One completed pass over this file.
+     */
+    RefinerFileLogEntryOut: {
+      /**
+       * Detail
+       * @description The whole pass payload: admission decisions, probe, plan, ffmpeg argv, cleanup gates, timings.
+       */
+      detail?: {
+        [key: string]: unknown;
+      };
+      /** Id */
+      id: number;
+      /** Library Name */
+      library_name: string;
+      /** Outcome */
+      outcome: string;
+      /**
+       * Recorded At
+       * Format: date-time
+       */
+      recorded_at: string;
+      /** Title */
+      title: string;
+    };
+    /** RefinerFileLogOut */
+    RefinerFileLogOut: {
+      /** Entries */
+      entries: components["schemas"]["RefinerFileLogEntryOut"][];
+      /** File Id */
+      file_id: number;
+      /** Relative Path */
+      relative_path: string;
+      /**
+       * Retention Days
+       * @description How long these records are kept. 0 means they are kept forever.
+       */
+      retention_days: number;
+    };
     /** RefinerFileMoveToTopIn */
     RefinerFileMoveToTopIn: {
       /** Csrf Token */
@@ -3531,6 +3614,11 @@ export interface components {
        */
       failure_cleanup_enabled: boolean;
       /**
+       * File Log Retention Days
+       * @description How long to keep the per-file processing record. 0 keeps it forever.
+       */
+      file_log_retention_days: number;
+      /**
        * Keep Failed Work Files
        * @description Keep a failed run's working files so they can be inspected instead of swept.
        */
@@ -3598,6 +3686,11 @@ export interface components {
       /** Updated At */
       updated_at: string;
       /**
+       * Verbose Detection Logging
+       * @description Record extra detail from the file-detection stage. Turn this on while working out why a file is or is not being picked up, and turn it off again afterwards — it is loud.
+       */
+      verbose_detection_logging: boolean;
+      /**
        * Work Temp Stale Sweep Enabled
        * @description Reclaim MediaMop's own stale working files. Safe, and on by default.
        */
@@ -3612,6 +3705,8 @@ export interface components {
       csrf_token: string;
       /** Failure Cleanup Enabled */
       failure_cleanup_enabled?: boolean | null;
+      /** File Log Retention Days */
+      file_log_retention_days?: number | null;
       /** Keep Failed Work Files */
       keep_failed_work_files?: boolean | null;
       /** Max Concurrent Files */
@@ -3654,6 +3749,8 @@ export interface components {
       tv_schedule_hours_limited?: boolean | null;
       /** Tv Schedule Start */
       tv_schedule_start?: string | null;
+      /** Verbose Detection Logging */
+      verbose_detection_logging?: boolean | null;
       /** Work Temp Stale Sweep Enabled */
       work_temp_stale_sweep_enabled?: boolean | null;
     };
@@ -5985,6 +6082,70 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_refiner_file_log_api_v1_refiner_files__file_id__log_get: {
+    parameters: {
+      query?: {
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        file_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["RefinerFileLogOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  download_refiner_file_log_api_v1_refiner_files__file_id__log_download_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        file_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": unknown;
+        };
       };
       /** @description Validation Error */
       422: {

--- a/apps/web/src/lib/refiner/files-api.ts
+++ b/apps/web/src/lib/refiner/files-api.ts
@@ -175,3 +175,36 @@ export async function fetchRefinerWhyHeld(id: number): Promise<RefinerWhyHeld> {
   await requireOk(path, response, "Could not ask why that file is held");
   return readJson<RefinerWhyHeld>(response);
 }
+
+export interface RefinerFileLogEntry {
+  id: number;
+  recorded_at: string;
+  outcome: string;
+  title: string;
+  library_name: string;
+  detail: Record<string, unknown>;
+}
+
+export interface RefinerFileLog {
+  file_id: number;
+  relative_path: string;
+  /** 0 means these records are kept forever. */
+  retention_days: number;
+  entries: RefinerFileLogEntry[];
+}
+
+export async function fetchRefinerFileLog(id: number): Promise<RefinerFileLog> {
+  const path = `${refinerFilesPath()}/${id}/log`;
+  const response = await apiFetch(path);
+  await requireOk(
+    path,
+    response,
+    "Could not read that file's processing record",
+  );
+  return readJson<RefinerFileLog>(response);
+}
+
+/** The plain-text record, for attaching to a bug report. */
+export function refinerFileLogDownloadPath(id: number): string {
+  return `${refinerFilesPath()}/${id}/log/download`;
+}

--- a/apps/web/src/lib/refiner/files-queries.ts
+++ b/apps/web/src/lib/refiner/files-queries.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   fetchRefinerFiles,
   forgetRefinerFile,
+  fetchRefinerFileLog,
   fetchRefinerWhyHeld,
   moveRefinerFileToTop,
   requeueRefinerFile,
@@ -65,4 +66,10 @@ export function useRefinerWhyHeld() {
   // A mutation rather than a query: this asks the managers *right now*, and only when
   // someone asks. Running it on render would poll every connection for every file.
   return useMutation({ mutationFn: (id: number) => fetchRefinerWhyHeld(id) });
+}
+
+export function useRefinerFileLog() {
+  // A mutation rather than a query: a processing record is read when someone opens it,
+  // not for every row on every render.
+  return useMutation({ mutationFn: (id: number) => fetchRefinerFileLog(id) });
 }

--- a/apps/web/src/pages/refiner/refiner-files-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.test.tsx
@@ -314,3 +314,88 @@ it("asks the managers why a file is held and shows their own words", async () =>
     "Deluno (Main) is still importing this file.",
   );
 });
+
+it("opens a processing record and offers it as a download", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({ files: [file({ id: 1, status: "processed" })] }),
+  );
+  vi.spyOn(api, "fetchRefinerFileLog").mockResolvedValue({
+    file_id: 1,
+    relative_path: "Some Film/film.mkv",
+    retention_days: 90,
+    entries: [
+      {
+        id: 5,
+        recorded_at: "2026-08-26T14:00:00Z",
+        outcome: "live_output_written",
+        title: "Remuxed Some Film",
+        library_name: "Movies",
+        detail: { ffmpeg_argv: ["ffmpeg", "-i", "in.mkv"] },
+      },
+    ],
+  });
+
+  render(<RefinerFilesSection />, { wrapper });
+  fireEvent.click(await screen.findByTestId("refiner-file-log-1"));
+
+  const panel = await screen.findByTestId("refiner-file-log-panel");
+  expect(panel).toHaveTextContent("live_output_written");
+  expect(panel).toHaveTextContent("kept for 90 days");
+  expect(screen.getByTestId("refiner-file-log-download")).toHaveAttribute(
+    "href",
+    "/api/v1/refiner/files/1/log/download",
+  );
+});
+
+it("says zero retention keeps records forever rather than showing a bare 0", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({ files: [file({ id: 1, status: "processed" })] }),
+  );
+  vi.spyOn(api, "fetchRefinerFileLog").mockResolvedValue({
+    file_id: 1,
+    relative_path: "Some Film/film.mkv",
+    retention_days: 0,
+    entries: [
+      {
+        id: 5,
+        recorded_at: "2026-08-26T14:00:00Z",
+        outcome: "live_output_written",
+        title: "",
+        library_name: "Movies",
+        detail: {},
+      },
+    ],
+  });
+
+  render(<RefinerFilesSection />, { wrapper });
+  fireEvent.click(await screen.findByTestId("refiner-file-log-1"));
+
+  expect(await screen.findByTestId("refiner-file-log-panel")).toHaveTextContent(
+    "kept forever",
+  );
+});
+
+it("explains an empty record instead of opening a blank panel", async () => {
+  asOperator();
+  vi.spyOn(api, "fetchRefinerFiles").mockResolvedValue(
+    page({ files: [file({ id: 1, status: "unprocessed" })] }),
+  );
+  vi.spyOn(api, "fetchRefinerFileLog").mockResolvedValue({
+    file_id: 1,
+    relative_path: "Some Film/film.mkv",
+    retention_days: 90,
+    entries: [],
+  });
+
+  render(<RefinerFilesSection />, { wrapper });
+  fireEvent.click(await screen.findByTestId("refiner-file-log-1"));
+
+  expect(await screen.findByTestId("refiner-files-notice")).toHaveTextContent(
+    /has not processed this file yet/,
+  );
+  expect(
+    screen.queryByTestId("refiner-file-log-panel"),
+  ).not.toBeInTheDocument();
+});

--- a/apps/web/src/pages/refiner/refiner-files-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.tsx
@@ -4,12 +4,15 @@ import { PageLoading } from "../../components/shared/page-loading";
 import { useMeQuery } from "../../lib/auth/queries";
 import {
   REFINER_FILE_STATUS_LABELS,
+  refinerFileLogDownloadPath,
   type RefinerFile,
+  type RefinerFileLog,
   type RefinerFileStatus,
 } from "../../lib/refiner/files-api";
 import {
   useForgetRefinerFile,
   useMoveRefinerFileToTop,
+  useRefinerFileLog,
   useRefinerWhyHeld,
   useRequeueRefinerFile,
   useRequeueRefinerFiles,
@@ -90,6 +93,8 @@ export function RefinerFilesSection() {
   const requeueOne = useRequeueRefinerFile();
   const requeueMany = useRequeueRefinerFiles();
   const whyHeld = useRefinerWhyHeld();
+  const fileLog = useRefinerFileLog();
+  const [openLog, setOpenLog] = useState<RefinerFileLog | null>(null);
   const editable = canEdit(me.data?.role);
 
   if (files.isLoading) return <PageLoading label="Loading files" />;
@@ -137,6 +142,22 @@ export function RefinerFilesSection() {
       );
     } catch {
       setNotice("MediaMop could not ask why that file is held.");
+    }
+  };
+
+  const showLog = async (file: RefinerFile) => {
+    setNotice(null);
+    try {
+      const log = await fileLog.mutateAsync(file.id);
+      if (log.entries.length === 0) {
+        setNotice(
+          "MediaMop has not processed this file yet, so there is no record to show.",
+        );
+        return;
+      }
+      setOpenLog(log);
+    } catch {
+      setNotice("MediaMop could not read that file's processing record.");
     }
   };
 
@@ -262,6 +283,67 @@ export function RefinerFilesSection() {
         </div>
       ) : null}
 
+      {openLog ? (
+        <div
+          className="rounded border border-[var(--mm-border)] p-3"
+          data-testid="refiner-file-log-panel"
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate font-medium text-[var(--mm-text1)]">
+                {openLog.relative_path}
+              </p>
+              <p className="text-xs text-[var(--mm-text3)]">
+                {openLog.entries.length} record(s) ·{" "}
+                {openLog.retention_days === 0
+                  ? "kept forever"
+                  : `kept for ${openLog.retention_days} days`}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              {/* A real link, not a scripted save: the browser handles the download and
+                  the filename comes from the server. */}
+              <a
+                className={mmActionButtonClass({ variant: "tertiary" })}
+                href={refinerFileLogDownloadPath(openLog.file_id)}
+                data-testid="refiner-file-log-download"
+              >
+                Download
+              </a>
+              <button
+                type="button"
+                className={mmActionButtonClass({ variant: "tertiary" })}
+                onClick={() => setOpenLog(null)}
+                data-testid="refiner-file-log-close"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+          <ul className="mt-2 space-y-2">
+            {openLog.entries.map((entry) => (
+              <li
+                key={entry.id}
+                className="rounded border border-[var(--mm-border)] p-2"
+              >
+                <p className="text-xs text-[var(--mm-text3)]">
+                  {new Date(entry.recorded_at).toLocaleString()} ·{" "}
+                  {entry.outcome || "no outcome recorded"}
+                </p>
+                {entry.title ? (
+                  <p className="text-sm text-[var(--mm-text2)]">
+                    {entry.title}
+                  </p>
+                ) : null}
+                <pre className="mt-1 max-h-64 overflow-auto text-xs text-[var(--mm-text3)]">
+                  {JSON.stringify(entry.detail, null, 2)}
+                </pre>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
       {notice ? (
         <p
           className="rounded border border-[var(--mm-border)] px-3 py-2 text-sm"
@@ -356,6 +438,15 @@ export function RefinerFilesSection() {
                         Why is this held?
                       </button>
                     ) : null}
+                    <button
+                      type="button"
+                      className={mmActionButtonClass({ variant: "tertiary" })}
+                      onClick={() => void showLog(file)}
+                      data-testid={`refiner-file-log-${file.id}`}
+                      title="What MediaMop did to this file, and why. Kept beyond the activity feed."
+                    >
+                      Processing record
+                    </button>
                     <button
                       type="button"
                       className={mmActionButtonClass({ variant: "tertiary" })}


### PR DESCRIPTION
Closes #340. Part of #347.

## The gap

Refiner's live telemetry is genuinely good — real percent and ETA per file while ffmpeg runs, which FileFlows does not show at all. What it had no answer for is **"why did this file come out like that, three weeks ago"**. Every decision was already computed and put into an activity detail payload, which then aged out under the suite's log retention along with everything else.

## Its own table, its own retention

The two questions have different lifetimes. A suite log is for diagnosing the **application**; a per-file record is for diagnosing a **file**, which somebody may only ask about long after the fact. One retention number could not serve both.

**One row per completed pass, not per file.** A file that failed twice and then succeeded has three things worth reading; collapsing them would throw away exactly the history that makes the record worth keeping.

Written from the same place the activity row is written, so the two cannot disagree about what happened — and wrapped in a try, because a record that cannot be saved must not fail the pass that produced it. The work is done either way, and losing the job is worse than losing the note about it.

## Forgetting a file does not forget its history

Both foreign keys are `SET NULL`, not `CASCADE`. Forgetting a file from the Files screen must not destroy the record of what was done to it — that is the opposite of why the record exists. The path is stored flat alongside the ids, so a record stays readable after its library is gone, and a file forgotten and later seen again reattaches to its own history.

## Retention `0` means forever

Matching the setting's own wording. Reading zero the other way would **silently destroy the history the feature exists to keep** — the worst possible direction for that ambiguity — so it has its own test rather than being covered incidentally, as does the exact-boundary case.

Enforced by an hourly task. Records are pruned by age, so checking more often buys nothing.

## Download is plain text

The reason anyone downloads this is to send it to somebody else, and minified JSON is not something a person reads in a forum post. It is a real `<a href>`, so the browser handles the save and the filename comes from the server.

## Also

The **verbose detection-logging** switch, off by default, described the way FileFlows describes its own: turn it on while working out why a file is or is not being picked up, and turn it off again afterwards.

## `alembic check` earned its place again

It caught the new model missing from the metadata import list, which would have left the table invisible to future autogeneration — a problem that only surfaces much later, as a migration that silently does nothing.

## Tests

Whole payload retained · one record per pass · record written with no file row · oversized payload truncated *and says so* · unparseable detail kept rather than dropped · newest first · **survives forget-and-rediscover** · text rendering readable · **retention 0 keeps everything** · negative treated as forever · exact boundary kept · empty table · plus 3 web tests including the "kept forever" wording.

Verified locally: 1054 backend passed / 2 skipped, 202 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

Stacked on #339, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
