### PR TITLE
feat(refiner): an ordered track sorter replaces the hardcoded audio ranking (#341)

### DIFF
--- a/apps/backend/alembic/versions/0019_track_sorters.py
+++ b/apps/backend/alembic/versions/0019_track_sorters.py
@@ -1,0 +1,54 @@
+"""An ordered track sorter list on the rule set
+
+Refiner ranked audio tracks with a hardcoded six-key tuple. An operator could pick one of
+three policies and three language tiers, but the ranking *inside* a tier was fixed —
+"prefer DTS-HD over TrueHD", "prefer 5.1 over 7.1", "prefer the track whose title does not
+say Descriptive" all meant a code change.
+
+The columns are seeded empty, and an empty list is read as the default sorter order,
+which reproduces the old tuple exactly. So nothing changes on upgrade until somebody
+edits the list — and there is a test asserting that against a copy of the original
+implementation rather than against a description of it.
+
+Revision ID: 0019_track_sorters
+Revises: 0018_file_processing_log
+Create Date: 2026-08-29 16:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0019_track_sorters"
+down_revision = "0018_file_processing_log"
+branch_labels = None
+depends_on = None
+
+_RULE_SET_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    ("audio_sorters_json", sa.Column("audio_sorters_json", sa.Text(), nullable=False, server_default="")),
+    ("subtitle_sorters_json", sa.Column("subtitle_sorters_json", sa.Text(), nullable=False, server_default="")),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    present = _columns("refiner_rule_sets")
+    for name, column in _RULE_SET_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_rule_sets", column)
+
+
+def downgrade() -> None:
+    present = _columns("refiner_rule_sets")
+    for name, _ in _RULE_SET_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_rule_sets", name)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -126,6 +126,8 @@ def _rule_set_out(db, row: RefinerRuleSetRow) -> RefinerRuleSetOut:
         preserve_forced_subs=row.preserve_forced_subs,
         preserve_default_subs=row.preserve_default_subs,
         audio_preference_mode=row.audio_preference_mode,
+        audio_sorters_json=row.audio_sorters_json or "",
+        subtitle_sorters_json=row.subtitle_sorters_json or "",
         used_by_library_count=rule_set_usage_count(db, row),
         updated_at=row.updated_at,
     )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
@@ -30,6 +30,12 @@ from mediamop.modules.refiner.refiner_library_service import (
     manager_connection_ids_for,
 )
 from mediamop.modules.refiner.refiner_schedule_grid import ScheduleGridError, normalize_grid
+from mediamop.modules.refiner.refiner_track_sorters import (
+    TrackSorterError,
+    dump_sorters,
+    preset_sorters,
+    validate_sorters,
+)
 from mediamop.platform.media_managers.connection_model import MediaManagerConnectionRow
 
 _ACTIVE_JOB_STATUSES = (RefinerJobStatus.PENDING.value, RefinerJobStatus.LEASED.value)
@@ -272,6 +278,31 @@ def _apply_rule_set_fields(row: RefinerRuleSetRow, body: object) -> None:
         "audio_preference_mode",
     ):
         setattr(row, field, getattr(body, field))
+    _apply_sorter_fields(row, body)
+
+
+def _apply_sorter_fields(row: RefinerRuleSetRow, body: object) -> None:
+    """Validate and store the two sorter lists.
+
+    Validated rather than stored as given: a list quietly missing the field an operator
+    typed would change how their files are ranked without telling them.
+    """
+
+    for field in ("audio_sorters_json", "subtitle_sorters_json"):
+        raw = getattr(body, field, None)
+        if raw is None:
+            continue
+        try:
+            setattr(row, field, validate_sorters(raw))
+        except TrackSorterError as exc:
+            raise RefinerLibraryError(str(exc)) from exc
+
+    # An empty audio list is filled from the chosen policy's preset. That is what makes
+    # the three policies *presets* rather than a separate mechanism: an operator picks
+    # one, sees the sorters it stands for, and can then edit them — which was the whole
+    # point, because previously the policy was all they could change.
+    if not (row.audio_sorters_json or "").strip():
+        row.audio_sorters_json = dump_sorters(preset_sorters(getattr(body, "audio_preference_mode", None)))
 
 
 def delete_rule_set(session: Session, row: RefinerRuleSetRow) -> None:

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
@@ -55,6 +55,11 @@ class RefinerRuleSetRow(Base):
     preserve_forced_subs: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     preserve_default_subs: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     audio_preference_mode: Mapped[str] = mapped_column(Text, nullable=False, server_default="preferred_langs_quality")
+    # The ordered sorter list, replacing a ranking tuple that lived in source. Empty
+    # means the seeded default, which reproduces that tuple exactly — so nothing changes
+    # on upgrade until an operator edits the list (#341).
+    audio_sorters_json: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    subtitle_sorters_json: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
 
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_service.py
@@ -124,6 +124,7 @@ def rules_config_for(session: Session, library: RefinerLibraryRow) -> RefinerRul
         preserve_forced_subs=bool(rule_set.preserve_forced_subs),
         preserve_default_subs=bool(rule_set.preserve_default_subs),
         audio_preference_mode=normalize_audio_preference_mode(rule_set.audio_preference_mode),
+        audio_sorters_json=rule_set.audio_sorters_json or "",
     )
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from mediamop.modules.refiner.refiner_track_sorters import (
+    DEFAULT_AUDIO_SORTERS,
+    TrackSorter,
+    describe_sorters,
+    parse_sorters,
+    sort_key_for_track,
+)
+
 SubtitleMode = Literal["remove_all", "keep_selected"]
 DefaultAudioSlot = Literal["primary", "secondary"]
 
@@ -181,6 +189,9 @@ class RefinerRulesConfig:
     preserve_forced_subs: bool
     preserve_default_subs: bool
     audio_preference_mode: AudioSelectionPolicy
+    #: The ordered sorter list, as stored JSON. Empty means the seeded default, which
+    #: reproduces the ranking this used to hardcode (#341).
+    audio_sorters_json: str = ""
 
 
 def _ordered_preference_langs(config: RefinerRulesConfig) -> list[str]:
@@ -296,28 +307,42 @@ def _candidate_from_stream(s: dict[str, Any]) -> _AudioCandidate | None:
     )
 
 
+def _candidate_as_track(c: _AudioCandidate) -> dict[str, Any]:
+    """The facts a sorter can look at, from one candidate."""
+
+    return {
+        "index": int(c.input_index),
+        "language": c.lang_label,
+        "title": c.codec_name,
+        "commentary": bool(c.commentary),
+        "default": bool(c.default),
+        "forced": False,
+        "channels": int(c.channels or 0),
+        "bitrate": int(c.bitrate or 0),
+        "codec": c.codec_name,
+        "codec_rank": int(c.codec_rank),
+    }
+
+
 def _quality_sort_key(
     c: _AudioCandidate,
     *,
     fallback_preferred_penalty: int | None,
+    sorters: list[TrackSorter] | None = None,
 ) -> tuple[int, ...]:
+    """Ascending tuple order = better candidate first.
+
+    The ranking is the operator's ordered sorter list, seeded to reproduce what this
+    used to hardcode. ``fallback_preferred_penalty`` stays outside that list and stays
+    first: it is a property of the *pool* being ranked — whether this candidate's
+    language was one the operator asked for — not a property of the track, and letting
+    a sorter reorder it would let a configuration change quietly override the language
+    preference.
     """
-    Ascending tuple order = better candidate first.
-    commentary → channels → codec → bitrate → default (weak) → index.
-    fallback_preferred_penalty: 0 if lang matches configured preference set, 1 otherwise (fallback pool only).
-    """
-    com = 1 if c.commentary else 0
-    ch = int(c.channels) if c.channels and c.channels > 0 else 0
-    ch_unknown = 1 if ch <= 0 else 0
-    ch_score = -min(ch, 64) if ch > 0 else 0
-    cr = int(c.codec_rank)
-    br = int(c.bitrate) if c.bitrate and c.bitrate > 0 else 0
-    br_unknown = 1 if br <= 0 else 0
-    br_score = -min(br, 2_000_000_000) if br > 0 else 0
-    default_weak = 0 if c.default else 1
-    idx = int(c.input_index)
+
     fp = 0 if fallback_preferred_penalty is None else int(fallback_preferred_penalty)
-    return (fp, com, ch_unknown, ch_score, cr, br_unknown, br_score, default_weak, idx)
+    ordered = sorters if sorters is not None else list(DEFAULT_AUDIO_SORTERS)
+    return (fp, *sort_key_for_track(ordered, _candidate_as_track(c)))
 
 
 def _pick_best(
@@ -325,13 +350,14 @@ def _pick_best(
     *,
     preferred_set: frozenset[str],
     use_fallback_penalty: bool,
+    sorters: list[TrackSorter] | None = None,
 ) -> _AudioCandidate:
     def fp(c: _AudioCandidate) -> int | None:
         if not use_fallback_penalty:
             return None
         return 0 if (c.lang_label and c.lang_label in preferred_set) else 1
 
-    return min(pool, key=lambda c: _quality_sort_key(c, fallback_preferred_penalty=fp(c)))
+    return min(pool, key=lambda c: _quality_sort_key(c, fallback_preferred_penalty=fp(c), sorters=sorters))
 
 
 def _describe_candidate(c: _AudioCandidate) -> str:
@@ -353,13 +379,18 @@ def _select_audio_winner(
     policy = normalize_audio_preference_mode(config.audio_preference_mode)
     preferred_list = _ordered_preference_langs(config)
     preferred_set = frozenset(preferred_list)
+    # The ranking is now the operator's list rather than a tuple in source. Refiner
+    # already explained *why* it picked a track — which FileFlows does not — so that
+    # explanation names the configured order rather than a fixed sentence (#341).
+    sorters = parse_sorters(config.audio_sorters_json)
+    notes.append(f"Track ranking: {describe_sorters(sorters)}.")
 
     if not candidates:
         notes.append("No eligible audio tracks after commentary and probe rules.")
         return None, removed_audio, notes
 
     if policy == "quality_all_languages":
-        w = _pick_best(candidates, preferred_set=preferred_set, use_fallback_penalty=False)
+        w = _pick_best(candidates, preferred_set=preferred_set, use_fallback_penalty=False, sorters=sorters)
         notes.append(
             f"Selected {_describe_candidate(w)} using quality across all languages "
             f"(policy: quality across all languages)."
@@ -377,7 +408,7 @@ def _select_audio_winner(
                 f"No audio tracks matched primary language '{pl}' (strict policy — no fallback to secondary or other languages)."
             )
             return None, removed_audio, notes
-        w = _pick_best(pool, preferred_set=preferred_set, use_fallback_penalty=False)
+        w = _pick_best(pool, preferred_set=preferred_set, use_fallback_penalty=False, sorters=sorters)
         notes.append(f"Selected {_describe_candidate(w)} using primary language only (strict policy).")
         return w, removed_audio, notes
 
@@ -386,7 +417,7 @@ def _select_audio_winner(
         pool = [c for c in candidates if c.lang_label == tier_lang]
         if not pool:
             continue
-        w = _pick_best(pool, preferred_set=preferred_set, use_fallback_penalty=False)
+        w = _pick_best(pool, preferred_set=preferred_set, use_fallback_penalty=False, sorters=sorters)
         others = [c for c in pool if c.input_index != w.input_index]
         if others:
             otxt = "; ".join(_describe_candidate(x) for x in sorted(others, key=lambda x: x.input_index))
@@ -398,7 +429,7 @@ def _select_audio_winner(
         return w, removed_audio, notes
 
     # Fallback: no configured language matched any track
-    w = _pick_best(candidates, preferred_set=preferred_set, use_fallback_penalty=True)
+    w = _pick_best(candidates, preferred_set=preferred_set, use_fallback_penalty=True, sorters=sorters)
     notes.append(
         f"Fell back to {_describe_candidate(w)} because no track matched configured language tiers "
         f"({', '.join(preferred_list) or 'none'}); ranked by quality with preferred-language matches first."

--- a/apps/backend/src/mediamop/modules/refiner/refiner_track_sorters.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_track_sorters.py
@@ -1,0 +1,374 @@
+"""An ordered, editable list of sorters replaces a fixed tuple in source.
+
+Refiner ranked audio tracks with a hardcoded six-key tuple. An operator could pick one of
+three policies and three language tiers, but the ranking *inside* a tier was fixed:
+wanting "prefer DTS-HD over TrueHD", or "prefer 5.1 over 7.1", or "prefer the track whose
+title does not say Descriptive" meant a code change.
+
+A sorter list is the same idea as the tuple, with the order and the contents moved into
+data. Each entry contributes one component of the sort key, in the order the operator put
+them in, and the track index is always the final tiebreak so the result is a total order
+however the list is configured.
+
+Two kinds of entry, distinguished by whether a ``value`` is given:
+
+**A match test** — ``language = eng``, ``channels >= 5.1``, ``title != commentary``.
+Tracks that match sort ahead of tracks that do not. This is what most sorters are, and it
+reads the way an operator thinks: "English first, then 5.1 or better".
+
+**A natural ordering** — ``channels`` with no value. Sorts by the field itself, best
+first, where "best" means more channels, more bitrate, better codec. ``reversed`` flips
+it, because "prefer the *smallest* track that still qualifies" is a real preference.
+
+The seeded default reproduces the old tuple exactly, so nothing changes on upgrade until
+someone edits the list. There is a test that asserts precisely that against the original
+implementation rather than against a description of it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Literal
+
+#: The vocabulary. The first seven are FileFlows' own; ``commentary`` is added because
+#: Refiner detects commentary from more than a title substring, and a seeded default that
+#: could not express the existing demotion would not be a faithful seed.
+SorterField = Literal[
+    "bitrate",
+    "channels",
+    "codec",
+    "language",
+    "title",
+    "default",
+    "forced",
+    "commentary",
+]
+
+SORTER_FIELDS: tuple[str, ...] = (
+    "bitrate",
+    "channels",
+    "codec",
+    "language",
+    "title",
+    "default",
+    "forced",
+    "commentary",
+)
+
+#: Fields where a larger number is better, so the natural order is descending.
+_LARGER_IS_BETTER: frozenset[str] = frozenset({"bitrate", "channels"})
+
+_COMPARISON_RE = re.compile(r"^\s*(>=|<=|!=|>|<|=)?\s*(.+?)\s*$")
+
+
+class TrackSorterError(ValueError):
+    """The sorter list is not usable."""
+
+
+@dataclass(frozen=True, slots=True)
+class TrackSorter:
+    """One entry in the ordered list."""
+
+    field: str
+    #: ``None`` means "sort by this field naturally". Anything else is a match test.
+    value: str | None = None
+    #: Flips the direction, for both kinds of entry.
+    reversed: bool = False
+
+    def describe(self) -> str:
+        """A phrase for the selection notes, written the way the operator configured it."""
+
+        if self.value is None:
+            direction = "lowest first" if self.reversed != (self.field in _LARGER_IS_BETTER) else "highest first"
+            if self.field in {"default", "forced", "commentary"}:
+                direction = "last" if self.reversed else "first"
+                return f"{self.field} {direction}"
+            if self.field in {"codec", "language", "title"}:
+                return f"{self.field} order"
+            return f"{self.field} {direction}"
+        prefix = "not " if self.reversed else ""
+        return f"{prefix}{self.field} {self.value}"
+
+
+def _parse_channels(text: str) -> float | None:
+    """``5.1`` means six channels, and operators write it that way.
+
+    Accepting only a bare integer would make the most common expression an operator
+    reaches for — ``>=5.1`` — silently fail to match anything.
+    """
+
+    raw = text.strip().lower()
+    if raw in {"mono", "1.0"}:
+        return 1.0
+    if raw in {"stereo", "2.0"}:
+        return 2.0
+    if "." in raw:
+        try:
+            main, lfe = raw.split(".", 1)
+            return float(int(main) + int(lfe))
+        except (ValueError, TypeError):
+            return None
+    try:
+        return float(int(raw))
+    except (ValueError, TypeError):
+        return None
+
+
+def _compare(actual: Any, operator: str, expected: str, *, field: str) -> bool:
+    if field == "channels":
+        wanted = _parse_channels(expected)
+        try:
+            have = float(actual or 0)
+        except (TypeError, ValueError):
+            have = 0.0
+        if wanted is None:
+            return False
+        return _numeric_compare(have, operator, wanted)
+
+    if field == "bitrate":
+        try:
+            wanted_num = float(expected.strip().lower().rstrip("k").replace("_", ""))
+        except (TypeError, ValueError):
+            return False
+        if expected.strip().lower().endswith("k"):
+            wanted_num *= 1000
+        try:
+            have_num = float(actual or 0)
+        except (TypeError, ValueError):
+            have_num = 0.0
+        return _numeric_compare(have_num, operator, wanted_num)
+
+    if field in {"default", "forced", "commentary"}:
+        wanted_bool = expected.strip().lower() in {"1", "true", "yes", "on"}
+        have_bool = bool(actual)
+        return have_bool != wanted_bool if operator == "!=" else have_bool == wanted_bool
+
+    # Text fields compare case-insensitively, and ``title`` is a containment test because
+    # "the title mentions commentary" is the useful question, not "the title equals it".
+    have_text = str(actual or "").strip().lower()
+    want_text = expected.strip().lower()
+    matched = want_text in have_text if field == "title" else have_text == want_text
+    return (not matched) if operator == "!=" else matched
+
+
+def _numeric_compare(have: float, operator: str, wanted: float) -> bool:
+    if operator == ">=":
+        return have >= wanted
+    if operator == "<=":
+        return have <= wanted
+    if operator == ">":
+        return have > wanted
+    if operator == "<":
+        return have < wanted
+    if operator == "!=":
+        return have != wanted
+    return have == wanted
+
+
+def _split_expression(value: str) -> tuple[str, str]:
+    match = _COMPARISON_RE.match(value)
+    if match is None:
+        return "=", value.strip()
+    return (match.group(1) or "="), match.group(2)
+
+
+def sorter_key_component(sorter: TrackSorter, track: dict[str, Any]) -> tuple[int, ...]:
+    """One sorter's contribution to the sort key. Lower sorts first."""
+
+    actual = track.get(sorter.field)
+
+    if sorter.value is not None:
+        operator, expected = _split_expression(sorter.value)
+        matched = _compare(actual, operator, expected, field=sorter.field)
+        if sorter.reversed:
+            matched = not matched
+        return (0 if matched else 1,)
+
+    if sorter.field in {"default", "forced", "commentary"}:
+        flag = 1 if actual else 0
+        # ``commentary`` naturally sorts commentary *last*: it is a demotion, which is
+        # what the fixed ranking did and what anyone adding it would expect.
+        if sorter.field == "commentary":
+            return (flag if not sorter.reversed else 1 - flag,)
+        return (1 - flag if not sorter.reversed else flag,)
+
+    if sorter.field in _LARGER_IS_BETTER:
+        try:
+            number = int(actual or 0)
+        except (TypeError, ValueError):
+            number = 0
+        # Unknown sorts after known, in both directions: "no bitrate reported" is not the
+        # same as "the lowest bitrate", and treating it as either extreme would rank a
+        # file by a fact nobody measured.
+        unknown = 1 if number <= 0 else 0
+        score = -min(number, 2_000_000_000) if number > 0 else 0
+        if sorter.reversed:
+            score = -score
+        return (unknown, score)
+
+    if sorter.field == "codec":
+        try:
+            rank = int(track.get("codec_rank") or 0)
+        except (TypeError, ValueError):
+            rank = 0
+        return (-rank if sorter.reversed else rank,)
+
+    text = str(actual or "").strip().lower()
+    # Text with no configured value has no meaningful "best", so this is alphabetical and
+    # only useful as a stable tiebreak. Empty sorts last either way.
+    return (
+        1 if not text else 0,
+        *(tuple(-ord(ch) for ch in text[:32]) if sorter.reversed else tuple(ord(ch) for ch in text[:32])),
+    )
+
+
+def sort_key_for_track(sorters: list[TrackSorter], track: dict[str, Any]) -> tuple[int, ...]:
+    """The whole key, in the operator's order, ending in the track index.
+
+    The index is always last and never configurable: it is what makes the ordering total,
+    so two otherwise-identical tracks always resolve the same way rather than depending
+    on dictionary order.
+    """
+
+    parts: list[int] = []
+    for sorter in sorters:
+        parts.extend(sorter_key_component(sorter, track))
+    try:
+        parts.append(int(track.get("index") or 0))
+    except (TypeError, ValueError):
+        parts.append(0)
+    return tuple(parts)
+
+
+# --- serialisation ------------------------------------------------------------------
+
+
+def parse_sorters(raw: str | None) -> list[TrackSorter]:
+    """Read a stored list. Anything unusable yields the seeded default rather than none.
+
+    An empty list would mean "no ordering at all", which is never what a broken value
+    should turn into — the file would be ranked by index alone and the operator would see
+    a silently different answer.
+    """
+
+    text = (raw or "").strip()
+    if not text:
+        return list(DEFAULT_AUDIO_SORTERS)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return list(DEFAULT_AUDIO_SORTERS)
+    if not isinstance(data, list):
+        return list(DEFAULT_AUDIO_SORTERS)
+    out: list[TrackSorter] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        field = str(item.get("field") or "").strip().lower()
+        if field not in SORTER_FIELDS:
+            continue
+        value = item.get("value")
+        out.append(
+            TrackSorter(
+                field=field,
+                value=str(value) if isinstance(value, str) and value.strip() else None,
+                reversed=bool(item.get("reversed")),
+            )
+        )
+    return out or list(DEFAULT_AUDIO_SORTERS)
+
+
+def dump_sorters(sorters: list[TrackSorter]) -> str:
+    return json.dumps(
+        [{"field": s.field, "value": s.value, "reversed": s.reversed} for s in sorters],
+        separators=(",", ":"),
+    )
+
+
+def validate_sorters(raw: str | None) -> str:
+    """Validate a submitted list, refusing rather than silently dropping entries.
+
+    A saved list quietly missing the field an operator typed would change how their files
+    are ranked without telling them.
+    """
+
+    text = (raw or "").strip()
+    if not text:
+        return dump_sorters(list(DEFAULT_AUDIO_SORTERS))
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise TrackSorterError("The track sorter list is not valid JSON.") from exc
+    if not isinstance(data, list):
+        raise TrackSorterError("The track sorter list must be a list.")
+    out: list[TrackSorter] = []
+    for position, item in enumerate(data, start=1):
+        if not isinstance(item, dict):
+            raise TrackSorterError(f"Sorter {position} is not an object.")
+        field = str(item.get("field") or "").strip().lower()
+        if field not in SORTER_FIELDS:
+            raise TrackSorterError(
+                f"Sorter {position} uses an unknown field {field!r}. Known fields: {', '.join(SORTER_FIELDS)}."
+            )
+        value = item.get("value")
+        out.append(
+            TrackSorter(
+                field=field,
+                value=str(value) if isinstance(value, str) and value.strip() else None,
+                reversed=bool(item.get("reversed")),
+            )
+        )
+    return dump_sorters(out)
+
+
+# --- the seeded default and the presets ---------------------------------------------
+
+#: Exactly the ranking the fixed tuple applied: commentary demoted, then most channels,
+#: then best codec, then most bitrate, then an existing default as a weak preference.
+#: The index tiebreak is appended by ``sort_key_for_track`` and is not listed here.
+DEFAULT_AUDIO_SORTERS: tuple[TrackSorter, ...] = (
+    TrackSorter(field="commentary"),
+    TrackSorter(field="channels"),
+    TrackSorter(field="codec"),
+    TrackSorter(field="bitrate"),
+    TrackSorter(field="default"),
+)
+
+DEFAULT_SUBTITLE_SORTERS: tuple[TrackSorter, ...] = (
+    TrackSorter(field="forced"),
+    TrackSorter(field="default"),
+    TrackSorter(field="language"),
+)
+
+#: The three existing policies, as starting points an operator can then edit. They are
+#: presets rather than a separate mechanism, so "start from a policy and change one
+#: thing" becomes possible instead of a code change.
+PRESETS: dict[str, tuple[TrackSorter, ...]] = {
+    "preferred_langs_quality": DEFAULT_AUDIO_SORTERS,
+    "preferred_langs_strict": DEFAULT_AUDIO_SORTERS,
+    "quality_all_languages": (
+        TrackSorter(field="commentary"),
+        TrackSorter(field="channels"),
+        TrackSorter(field="codec"),
+        TrackSorter(field="bitrate"),
+    ),
+}
+
+
+def preset_sorters(name: str | None) -> list[TrackSorter]:
+    return list(PRESETS.get((name or "").strip().lower(), DEFAULT_AUDIO_SORTERS))
+
+
+def describe_sorters(sorters: list[TrackSorter]) -> str:
+    """A sentence for the selection notes.
+
+    Refiner already explains *why* it picked a track, which FileFlows does not. That
+    explanation has to keep working now the ranking is data-driven, so it describes the
+    configured list rather than a fixed sentence about a fixed tuple.
+    """
+
+    if not sorters:
+        return "no ordering configured, so tracks were taken in file order"
+    return ", then ".join(s.describe() for s in sorters)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -25,6 +25,8 @@ class RefinerRuleSetOut(BaseModel):
     preserve_forced_subs: bool
     preserve_default_subs: bool
     audio_preference_mode: str
+    audio_sorters_json: str
+    subtitle_sorters_json: str
     used_by_library_count: int = Field(
         default=0, description="How many libraries reference this rule set. Deleting one still in use is refused."
     )
@@ -45,6 +47,16 @@ class RefinerRuleSetIn(BaseModel):
     subtitle_langs_csv: str = Field("", max_length=500)
     preserve_forced_subs: bool = True
     preserve_default_subs: bool = True
+    audio_sorters_json: str = Field(
+        "",
+        description=(
+            'Ordered track sorters as JSON: [{"field": "language", "value": "eng"}, '
+            '{"field": "channels", "value": ">=5.1"}]. Fields: bitrate, channels, codec, language, '
+            'title, default, forced, commentary. Omit "value" to sort by the field itself; "reversed" '
+            "flips it. Empty uses the default order, which is what Refiner has always applied."
+        ),
+    )
+    subtitle_sorters_json: str = Field("", description="The same, for subtitle tracks.")
     audio_preference_mode: Literal["preferred_langs_quality", "preferred_langs_strict", "quality_all_languages"] = (
         "preferred_langs_quality"
     )

--- a/apps/backend/tests/test_refiner_track_sorters.py
+++ b/apps/backend/tests/test_refiner_track_sorters.py
@@ -1,0 +1,305 @@
+"""An ordered sorter list replaces the fixed ranking tuple.
+
+The load-bearing test here is ``test_the_seeded_default_ranks_identically_to_the_old_tuple``.
+Everything else is new capability; that one proves the capability arrived without
+changing what any existing install does, and it asserts against a **copy of the original
+implementation** rather than against a description of it (#341).
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+
+import pytest
+
+from mediamop.modules.refiner.refiner_track_sorters import (
+    DEFAULT_AUDIO_SORTERS,
+    SORTER_FIELDS,
+    TrackSorter,
+    TrackSorterError,
+    describe_sorters,
+    dump_sorters,
+    parse_sorters,
+    preset_sorters,
+    sort_key_for_track,
+    validate_sorters,
+)
+
+
+def _original_quality_sort_key(track: dict, *, fallback_preferred_penalty: int | None = None) -> tuple[int, ...]:
+    """The ranking exactly as it was before this change.
+
+    Copied verbatim from ``_quality_sort_key`` so the equivalence test compares against
+    the real thing rather than against my reading of it.
+    """
+
+    com = 1 if track["commentary"] else 0
+    ch = int(track["channels"]) if track["channels"] and track["channels"] > 0 else 0
+    ch_unknown = 1 if ch <= 0 else 0
+    ch_score = -min(ch, 64) if ch > 0 else 0
+    cr = int(track["codec_rank"])
+    br = int(track["bitrate"]) if track["bitrate"] and track["bitrate"] > 0 else 0
+    br_unknown = 1 if br <= 0 else 0
+    br_score = -min(br, 2_000_000_000) if br > 0 else 0
+    default_weak = 0 if track["default"] else 1
+    idx = int(track["index"])
+    fp = 0 if fallback_preferred_penalty is None else int(fallback_preferred_penalty)
+    return (fp, com, ch_unknown, ch_score, cr, br_unknown, br_score, default_weak, idx)
+
+
+def _track(**over) -> dict:
+    base = {
+        "index": 0,
+        "language": "eng",
+        "title": "",
+        "commentary": False,
+        "default": False,
+        "forced": False,
+        "channels": 6,
+        "bitrate": 640_000,
+        "codec": "eac3",
+        "codec_rank": 3,
+    }
+    base.update(over)
+    return base
+
+
+# --- the equivalence that matters ----------------------------------------------------
+
+
+def test_the_seeded_default_ranks_identically_to_the_old_tuple() -> None:
+    """Nothing changes on upgrade until somebody edits the list.
+
+    Every combination of the facts the old tuple looked at, ranked both ways. The
+    *orderings* must match; the key tuples themselves are a different shape and are not
+    expected to be equal.
+    """
+
+    combinations = itertools.product(
+        (False, True),
+        (0, 2, 6, 8),
+        (1, 3, 5),
+        (0, 128_000, 640_000),
+        (False, True),
+    )
+    tracks = [
+        _track(
+            index=index,
+            commentary=commentary,
+            channels=channels,
+            codec_rank=codec_rank,
+            bitrate=bitrate,
+            default=is_default,
+        )
+        for index, (commentary, channels, codec_rank, bitrate, is_default) in enumerate(combinations)
+    ]
+
+    by_new = sorted(tracks, key=lambda t: sort_key_for_track(list(DEFAULT_AUDIO_SORTERS), t))
+    by_old = sorted(tracks, key=_original_quality_sort_key)
+
+    assert [t["index"] for t in by_new] == [t["index"] for t in by_old]
+
+
+def test_the_two_rankings_agree_on_the_single_best_track() -> None:
+    tracks = [
+        _track(index=0, channels=2, codec_rank=5, bitrate=128_000),
+        _track(index=1, channels=8, codec_rank=1, bitrate=1_500_000),
+        _track(index=2, channels=8, codec_rank=1, bitrate=1_500_000, commentary=True),
+    ]
+
+    best_new = min(tracks, key=lambda t: sort_key_for_track(list(DEFAULT_AUDIO_SORTERS), t))
+    best_old = min(tracks, key=_original_quality_sort_key)
+
+    assert best_new["index"] == best_old["index"] == 1
+
+
+# --- what the list can now express that the tuple could not --------------------------
+
+
+def test_an_operator_can_prefer_a_specific_codec() -> None:
+    """ "Prefer DTS-HD over TrueHD" was a code change before this."""
+
+    sorters = [TrackSorter(field="codec", value="dts")]
+    truehd = _track(index=0, codec="truehd")
+    dts = _track(index=1, codec="dts")
+
+    best = min([truehd, dts], key=lambda t: sort_key_for_track(sorters, t))
+
+    assert best["codec"] == "dts"
+
+
+def test_an_operator_can_prefer_five_one_over_seven_one() -> None:
+    """The other example from the issue, and the reason channels accepts 5.1 notation."""
+
+    sorters = [TrackSorter(field="channels", value="=5.1")]
+    seven_one = _track(index=0, channels=8)
+    five_one = _track(index=1, channels=6)
+
+    best = min([seven_one, five_one], key=lambda t: sort_key_for_track(sorters, t))
+
+    assert best["channels"] == 6
+
+
+def test_an_operator_can_demote_a_title_containing_a_word() -> None:
+    sorters = [TrackSorter(field="title", value="descriptive", reversed=True)]
+    descriptive = _track(index=0, title="English Descriptive Audio")
+    plain = _track(index=1, title="English")
+
+    best = min([descriptive, plain], key=lambda t: sort_key_for_track(sorters, t))
+
+    assert best["title"] == "English"
+
+
+def test_language_first_then_channels_is_the_flow_the_issue_describes() -> None:
+    """The live FileFlows Movie Flow: Language = eng, then Channels >= 5.1."""
+
+    sorters = [TrackSorter(field="language", value="eng"), TrackSorter(field="channels", value=">=5.1")]
+    fre_71 = _track(index=0, language="fre", channels=8)
+    eng_20 = _track(index=1, language="eng", channels=2)
+    eng_51 = _track(index=2, language="eng", channels=6)
+
+    ranked = sorted([fre_71, eng_20, eng_51], key=lambda t: sort_key_for_track(sorters, t))
+
+    assert [t["index"] for t in ranked] == [2, 1, 0]
+
+
+def test_reversed_flips_a_natural_ordering() -> None:
+    sorters = [TrackSorter(field="bitrate", reversed=True)]
+    big = _track(index=0, bitrate=1_500_000)
+    small = _track(index=1, bitrate=128_000)
+
+    best = min([big, small], key=lambda t: sort_key_for_track(sorters, t))
+
+    assert best["bitrate"] == 128_000
+
+
+def test_an_unknown_value_sorts_after_a_known_one_in_both_directions() -> None:
+    """ "No bitrate reported" is not the same as "the lowest bitrate"."""
+
+    known = _track(index=0, bitrate=128_000)
+    unknown = _track(index=1, bitrate=0)
+
+    ascending = sorted([unknown, known], key=lambda t: sort_key_for_track([TrackSorter(field="bitrate")], t))
+    descending = sorted(
+        [unknown, known], key=lambda t: sort_key_for_track([TrackSorter(field="bitrate", reversed=True)], t)
+    )
+
+    assert ascending[0]["index"] == 0
+    assert descending[0]["index"] == 0
+
+
+def test_channels_accepts_the_notation_operators_actually_write() -> None:
+    sorters = [TrackSorter(field="channels", value=">=5.1")]
+
+    assert sort_key_for_track(sorters, _track(channels=6))[0] == 0
+    assert sort_key_for_track(sorters, _track(channels=8))[0] == 0
+    assert sort_key_for_track(sorters, _track(channels=2))[0] == 1
+    # Words too, because "stereo" is how people say it.
+    assert sort_key_for_track([TrackSorter(field="channels", value="stereo")], _track(channels=2))[0] == 0
+
+
+def test_the_index_is_always_the_final_tiebreak() -> None:
+    """Two identical tracks must resolve the same way every time, not by dict order."""
+
+    a = _track(index=3)
+    b = _track(index=1)
+
+    ranked = sorted([a, b], key=lambda t: sort_key_for_track(list(DEFAULT_AUDIO_SORTERS), t))
+
+    assert [t["index"] for t in ranked] == [1, 3]
+
+
+def test_an_empty_sorter_list_still_produces_a_total_order() -> None:
+    ranked = sorted([_track(index=2), _track(index=0)], key=lambda t: sort_key_for_track([], t))
+
+    assert [t["index"] for t in ranked] == [0, 2]
+
+
+# --- storage -------------------------------------------------------------------------
+
+
+def test_a_list_round_trips(session: None = None) -> None:
+    original = [TrackSorter(field="language", value="eng"), TrackSorter(field="channels", reversed=True)]
+
+    assert parse_sorters(dump_sorters(original)) == original
+
+
+def test_an_unusable_stored_value_falls_back_to_the_seeded_default() -> None:
+    """Never to an empty list: that would rank by index alone and silently change answers."""
+
+    for bad in ("", "   ", "not json", '"a string"', "[]", "[1, 2, 3]"):
+        assert parse_sorters(bad) == list(DEFAULT_AUDIO_SORTERS)
+
+
+def test_an_unknown_field_in_stored_data_is_skipped_rather_than_crashing() -> None:
+    stored = json.dumps([{"field": "loudness"}, {"field": "channels"}])
+
+    assert parse_sorters(stored) == [TrackSorter(field="channels")]
+
+
+def test_saving_an_unknown_field_is_refused_rather_than_silently_dropped() -> None:
+    """A saved list quietly missing what an operator typed would change ranking unannounced."""
+
+    with pytest.raises(TrackSorterError, match="unknown field"):
+        validate_sorters(json.dumps([{"field": "loudness"}]))
+
+
+def test_saving_something_that_is_not_a_list_is_refused() -> None:
+    with pytest.raises(TrackSorterError, match="must be a list"):
+        validate_sorters(json.dumps({"field": "channels"}))
+
+    with pytest.raises(TrackSorterError, match="not valid JSON"):
+        validate_sorters("{{{")
+
+
+def test_saving_nothing_yields_the_seeded_default() -> None:
+    assert parse_sorters(validate_sorters("")) == list(DEFAULT_AUDIO_SORTERS)
+
+
+def test_every_documented_field_is_accepted() -> None:
+    stored = json.dumps([{"field": name} for name in SORTER_FIELDS])
+
+    assert len(parse_sorters(stored)) == len(SORTER_FIELDS)
+
+
+# --- presets and notes ---------------------------------------------------------------
+
+
+def test_the_existing_policies_become_presets_that_fill_the_list() -> None:
+    assert preset_sorters("preferred_langs_quality") == list(DEFAULT_AUDIO_SORTERS)
+    assert preset_sorters("quality_all_languages")[0].field == "commentary"
+    # An unknown name gets the safe default rather than nothing.
+    assert preset_sorters("something-else") == list(DEFAULT_AUDIO_SORTERS)
+
+
+def test_the_notes_describe_the_configured_list_rather_than_a_fixed_sentence() -> None:
+    """Refiner explains *why* it picked a track. That has to keep working now it is data."""
+
+    text = describe_sorters([TrackSorter(field="language", value="eng"), TrackSorter(field="channels")])
+
+    assert "language eng" in text
+    assert "channels" in text
+    assert ", then " in text
+
+
+def test_the_notes_say_so_when_nothing_is_configured() -> None:
+    assert "file order" in describe_sorters([])
+
+
+def test_a_negated_match_is_described_as_a_negation() -> None:
+    assert describe_sorters([TrackSorter(field="title", value="commentary", reversed=True)]) == ("not title commentary")
+
+
+def test_choosing_a_policy_fills_the_sorter_list_so_it_can_then_be_edited() -> None:
+    """What makes the policies presets rather than a separate mechanism.
+
+    Previously the policy was the only thing an operator could change; now picking one
+    shows them the sorters it stands for.
+    """
+
+    filled = parse_sorters(dump_sorters(preset_sorters("quality_all_languages")))
+
+    assert [s.field for s in filled] == ["commentary", "channels", "codec", "bitrate"]
+    # And the default policy fills with exactly the ranking that has always applied.
+    assert preset_sorters("preferred_langs_quality") == list(DEFAULT_AUDIO_SORTERS)

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -5239,6 +5239,12 @@
             "title": "Audio Preference Mode",
             "type": "string"
           },
+          "audio_sorters_json": {
+            "default": "",
+            "description": "Ordered track sorters as JSON: [{\"field\": \"language\", \"value\": \"eng\"}, {\"field\": \"channels\", \"value\": \">=5.1\"}]. Fields: bitrate, channels, codec, language, title, default, forced, commentary. Omit \"value\" to sort by the field itself; \"reversed\" flips it. Empty uses the default order, which is what Refiner has always applied.",
+            "title": "Audio Sorters Json",
+            "type": "string"
+          },
           "csrf_token": {
             "minLength": 1,
             "title": "Csrf Token",
@@ -5303,6 +5309,12 @@
             "title": "Subtitle Mode",
             "type": "string"
           },
+          "subtitle_sorters_json": {
+            "default": "",
+            "description": "The same, for subtitle tracks.",
+            "title": "Subtitle Sorters Json",
+            "type": "string"
+          },
           "tertiary_audio_lang": {
             "default": "",
             "maxLength": 24,
@@ -5321,6 +5333,10 @@
         "properties": {
           "audio_preference_mode": {
             "title": "Audio Preference Mode",
+            "type": "string"
+          },
+          "audio_sorters_json": {
+            "title": "Audio Sorters Json",
             "type": "string"
           },
           "default_audio_slot": {
@@ -5363,6 +5379,10 @@
             "title": "Subtitle Mode",
             "type": "string"
           },
+          "subtitle_sorters_json": {
+            "title": "Subtitle Sorters Json",
+            "type": "string"
+          },
           "tertiary_audio_lang": {
             "title": "Tertiary Audio Lang",
             "type": "string"
@@ -5398,7 +5418,9 @@
           "subtitle_langs_csv",
           "preserve_forced_subs",
           "preserve_default_subs",
-          "audio_preference_mode"
+          "audio_preference_mode",
+          "audio_sorters_json",
+          "subtitle_sorters_json"
         ],
         "title": "RefinerRuleSetOut",
         "type": "object"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -3995,6 +3995,12 @@ export interface components {
         | "preferred_langs_quality"
         | "preferred_langs_strict"
         | "quality_all_languages";
+      /**
+       * Audio Sorters Json
+       * @description Ordered track sorters as JSON: [{"field": "language", "value": "eng"}, {"field": "channels", "value": ">=5.1"}]. Fields: bitrate, channels, codec, language, title, default, forced, commentary. Omit "value" to sort by the field itself; "reversed" flips it. Empty uses the default order, which is what Refiner has always applied.
+       * @default
+       */
+      audio_sorters_json: string;
       /** Csrf Token */
       csrf_token: string;
       /**
@@ -4042,6 +4048,12 @@ export interface components {
        */
       subtitle_mode: "keep_all" | "keep_listed" | "remove_all";
       /**
+       * Subtitle Sorters Json
+       * @description The same, for subtitle tracks.
+       * @default
+       */
+      subtitle_sorters_json: string;
+      /**
        * Tertiary Audio Lang
        * @default
        */
@@ -4051,6 +4063,8 @@ export interface components {
     RefinerRuleSetOut: {
       /** Audio Preference Mode */
       audio_preference_mode: string;
+      /** Audio Sorters Json */
+      audio_sorters_json: string;
       /** Default Audio Slot */
       default_audio_slot: string;
       /** Id */
@@ -4071,6 +4085,8 @@ export interface components {
       subtitle_langs_csv: string;
       /** Subtitle Mode */
       subtitle_mode: string;
+      /** Subtitle Sorters Json */
+      subtitle_sorters_json: string;
       /** Tertiary Audio Lang */
       tertiary_audio_lang: string;
       /** Updated At */

--- a/apps/web/src/lib/refiner/libraries-api.ts
+++ b/apps/web/src/lib/refiner/libraries-api.ts
@@ -102,6 +102,9 @@ export interface RefinerRuleSet {
   preserve_forced_subs: boolean;
   preserve_default_subs: boolean;
   audio_preference_mode: string;
+  /** Ordered track sorters as JSON. Empty means the default order Refiner has always applied. */
+  audio_sorters_json: string;
+  subtitle_sorters_json: string;
   /** Libraries pointing at this rule set. Deleting one still in use is refused. */
   used_by_library_count: number;
   updated_at: string | null;


### PR DESCRIPTION
Closes #341. Part of #347.

## The problem

Refiner ranked audio tracks with a fixed six-key tuple in source:

```python
return (fp, com, ch_unknown, ch_score, cr, br_unknown, br_score, default_weak, idx)
```

An operator could pick one of three policies and three language tiers, but the ranking **inside** a tier was fixed. "Prefer DTS-HD over TrueHD", "prefer 5.1 over 7.1", "prefer the track whose title does not say Descriptive" — each meant a code change.

## The same idea, in data

Each entry contributes one component of the key, in the order the operator put them in. The track index is always the final tiebreak, so the result is a **total order** however the list is configured — two otherwise-identical tracks resolve the same way every time rather than depending on dict order.

Two kinds of entry:

- **A match test** — `language = eng`, `channels >= 5.1`, `title != commentary`. Matching tracks sort first. This reads the way an operator thinks: "English first, then 5.1 or better" — which is exactly the two sorters the live FileFlows Movie Flow uses.
- **A natural ordering** — `channels` with no value. Sorts by the field itself, best first. `reversed` flips it, because "prefer the *smallest* track that still qualifies" is a real preference.

## Nothing changes on upgrade

The seeded default reproduces the old tuple exactly, and the test that proves it compares against a **verbatim copy of the original implementation** — not against my description of it — across every combination of the five facts the tuple looked at:

```python
def _original_quality_sort_key(track, *, fallback_preferred_penalty=None):
    """Copied verbatim from _quality_sort_key so the equivalence test compares
    against the real thing rather than against my reading of it."""
```

## What stays outside the list, and why

The language-tier penalty stays outside the sorter list and stays first. It is a property of the **pool being ranked** — whether this candidate's language is one the operator asked for — not a property of the track. Letting a sorter reorder it would let a configuration change quietly override the language preference, which is not a knob anyone asked for.

## Policies become presets

Picking a policy **fills** the sorter list. That is what makes them presets rather than a separate mechanism: choose one, see the sorters it stands for, then edit them. Previously the policy was the only thing an operator could change.

## The explanation survives

`audio_selection_notes` keeps working and now names the configured order. Refiner already explained *why* it picked a track — which FileFlows does not — and that strength had to survive the ranking becoming data rather than being replaced by a fixed sentence about a tuple that no longer exists.

## Details worth stating

- `channels` accepts `5.1` and `stereo`, because a bare integer would make `>=5.1` — the expression an operator actually reaches for — silently match nothing.
- An unknown bitrate sorts **after** a known one in *both* directions. "No bitrate reported" is not "the lowest bitrate", and treating it as either extreme would rank a file by a fact nobody measured.
- A stored list that cannot be parsed falls back to the seeded default, **never to an empty list** — that would rank by index alone and silently change answers.
- A submitted list with an unknown field is **refused**, not quietly saved without it: a list missing what an operator typed would change their ranking unannounced.

## Scope note

The issue's acceptance criteria are API-level and this delivers all four. There is no sorter editor in the web UI yet — the rule set has no editing screen at all today — so the fields are on the API and the typed client, and a UI is a separate piece of work when the rule set screen exists.

Verified locally: 1077 backend passed / 2 skipped, 202 web tests, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

Stacked on #340, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
