### PR TITLE
feat(refiner): metadata, cover-art and attachment removal (#342)

### DIFF
--- a/apps/backend/alembic/versions/0020_metadata_rules.py
+++ b/apps/backend/alembic/versions/0020_metadata_rules.py
@@ -1,0 +1,64 @@
+"""Metadata, cover-art and attachment removal on the rule set
+
+Refiner had no metadata handling at all: it planned video, audio and subtitle streams and
+copied everything else through untouched, so embedded cover art, stale titles, attached
+fonts and container tags all survived a pass.
+
+The cover-art case is the one with teeth. An embedded poster **is** an mjpeg video stream,
+and the plan kept every video stream it found — so the poster came through and was counted
+as video, leaving anything that reasons about "the video stream" to cope with two.
+
+Every option defaults **off**. A pass that started stripping titles and tags because an
+upgrade landed would be changing files nobody asked it to change.
+
+Revision ID: 0020_metadata_rules
+Revises: 0019_track_sorters
+Create Date: 2026-08-29 17:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0020_metadata_rules"
+down_revision = "0019_track_sorters"
+branch_labels = None
+depends_on = None
+
+_RULE_SET_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    ("remove_images", sa.Column("remove_images", sa.Boolean(), nullable=False, server_default="0")),
+    ("remove_attachments", sa.Column("remove_attachments", sa.Boolean(), nullable=False, server_default="0")),
+    ("remove_title", sa.Column("remove_title", sa.Boolean(), nullable=False, server_default="0")),
+    (
+        "remove_language_tags",
+        sa.Column("remove_language_tags", sa.Boolean(), nullable=False, server_default="0"),
+    ),
+    (
+        "remove_other_metadata",
+        sa.Column("remove_other_metadata", sa.Boolean(), nullable=False, server_default="0"),
+    ),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    present = _columns("refiner_rule_sets")
+    for name, column in _RULE_SET_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_rule_sets", column)
+
+
+def downgrade() -> None:
+    present = _columns("refiner_rule_sets")
+    for name, _ in _RULE_SET_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_rule_sets", name)

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -36,6 +36,7 @@ from mediamop.modules.refiner.refiner_remux_mux import (
 )
 from mediamop.modules.refiner.refiner_remux_rules import (
     RefinerRulesConfig,
+    attachment_streams,
     default_refiner_remux_rules_config,
     is_refiner_media_candidate,
     is_remux_required,
@@ -45,6 +46,7 @@ from mediamop.modules.refiner.refiner_remux_rules import (
 from mediamop.modules.refiner.refiner_remux_track_display import (
     audio_after_line_from_plan,
     audio_before_line_from_probe,
+    metadata_removed_line_from_plan,
     subtitle_after_line_from_plan,
     subtitle_before_line_from_probe,
 )
@@ -494,7 +496,7 @@ def run_refiner_file_remux_pass(
         )
     duration_seconds = _probe_duration_seconds(probe)
     config = rules_config if rules_config is not None else default_refiner_remux_rules_config()
-    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=config)
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=config, attachments=attachment_streams(probe))
     if plan is None:
         return _fail_before(
             relative_media_path=relative_media_path,
@@ -505,6 +507,7 @@ def run_refiner_file_remux_pass(
     remux_needed = is_remux_required(plan, audio, subs)
     before_a = audio_before_line_from_probe(audio)
     after_a = audio_after_line_from_plan(plan)
+    metadata_removed = metadata_removed_line_from_plan(plan)
     before_s = subtitle_before_line_from_probe(subs)
     after_s = subtitle_after_line_from_plan(plan, remove_all=config.subtitle_mode == "remove_all")
 
@@ -535,6 +538,9 @@ def run_refiner_file_remux_pass(
         "subs_after": after_s,
         "removed_audio": list(plan.removed_audio),
         "removed_subtitles": list(plan.removed_subtitles),
+        "removed_images": list(plan.removed_images),
+        "removed_attachments": list(plan.removed_attachments),
+        "metadata_removed": metadata_removed,
         "after_track_lines_meaning": "Planned output layout for this live pass.",
         "remux_required": remux_needed,
         "ffmpeg_argv": [str(x) for x in argv],

--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -128,6 +128,11 @@ def _rule_set_out(db, row: RefinerRuleSetRow) -> RefinerRuleSetOut:
         audio_preference_mode=row.audio_preference_mode,
         audio_sorters_json=row.audio_sorters_json or "",
         subtitle_sorters_json=row.subtitle_sorters_json or "",
+        remove_images=bool(row.remove_images),
+        remove_attachments=bool(row.remove_attachments),
+        remove_title=bool(row.remove_title),
+        remove_language_tags=bool(row.remove_language_tags),
+        remove_other_metadata=bool(row.remove_other_metadata),
         used_by_library_count=rule_set_usage_count(db, row),
         updated_at=row.updated_at,
     )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
@@ -276,6 +276,11 @@ def _apply_rule_set_fields(row: RefinerRuleSetRow, body: object) -> None:
         "preserve_forced_subs",
         "preserve_default_subs",
         "audio_preference_mode",
+        "remove_images",
+        "remove_attachments",
+        "remove_title",
+        "remove_language_tags",
+        "remove_other_metadata",
     ):
         setattr(row, field, getattr(body, field))
     _apply_sorter_fields(row, body)

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
@@ -61,6 +61,15 @@ class RefinerRuleSetRow(Base):
     audio_sorters_json: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
     subtitle_sorters_json: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
 
+    # Metadata and attachment stripping, all off by default. An embedded poster is an
+    # mjpeg video stream, so removing images is a stream decision as well as a metadata
+    # one (#342).
+    remove_images: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    remove_attachments: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    remove_title: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    remove_language_tags: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    remove_other_metadata: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_service.py
@@ -24,6 +24,7 @@ from mediamop.modules.refiner.refiner_library_model import (
     RefinerLibraryRow,
     RefinerRuleSetRow,
 )
+from mediamop.modules.refiner.refiner_metadata_rules import MetadataRules
 from mediamop.modules.refiner.refiner_remux_rules import RefinerRulesConfig, normalize_audio_preference_mode
 
 
@@ -125,6 +126,13 @@ def rules_config_for(session: Session, library: RefinerLibraryRow) -> RefinerRul
         preserve_default_subs=bool(rule_set.preserve_default_subs),
         audio_preference_mode=normalize_audio_preference_mode(rule_set.audio_preference_mode),
         audio_sorters_json=rule_set.audio_sorters_json or "",
+        metadata=MetadataRules(
+            remove_images=bool(rule_set.remove_images),
+            remove_attachments=bool(rule_set.remove_attachments),
+            remove_title=bool(rule_set.remove_title),
+            remove_language_tags=bool(rule_set.remove_language_tags),
+            remove_other_metadata=bool(rule_set.remove_other_metadata),
+        ),
     )
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_metadata_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_metadata_rules.py
@@ -1,0 +1,165 @@
+"""Embedded images, attachments and container metadata.
+
+Refiner had no metadata handling at all. It planned video, audio and subtitle streams and
+copied everything else through untouched, so embedded cover art, stale titles, attached
+fonts and container tags all survived a pass.
+
+The cover-art case is the one with teeth. **An embedded poster is an mjpeg video stream**,
+and the plan kept every video stream it found:
+
+    video_indices = [int(s["index"]) for s in video]
+
+So the poster was carried into the output and counted as video. Any logic that reasons
+about "the video stream" then has to cope with there being two of them, which is a bug
+waiting for the first person who writes it.
+
+Everything here defaults **off**. A pass that started stripping titles and tags because
+an upgrade landed would be changing files nobody asked it to change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: Codecs that appear as a video stream but are a still image. ffprobe reports an
+#: embedded poster exactly like a video track, so the codec is the only reliable signal.
+_IMAGE_CODECS: frozenset[str] = frozenset({"mjpeg", "png", "bmp", "gif", "webp", "jpeg", "tiff"})
+
+#: ffprobe's own marker for a stream that is a thumbnail rather than the picture.
+_ATTACHED_PIC = "attached_pic"
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataRules:
+    """What to strip. All off by default, so an upgrade changes nothing."""
+
+    remove_images: bool = False
+    remove_attachments: bool = False
+    remove_title: bool = False
+    remove_language_tags: bool = False
+    remove_other_metadata: bool = False
+
+    @property
+    def any_enabled(self) -> bool:
+        return (
+            self.remove_images
+            or self.remove_attachments
+            or self.remove_title
+            or self.remove_language_tags
+            or self.remove_other_metadata
+        )
+
+
+def is_image_stream(stream: dict[str, Any]) -> bool:
+    """True for an embedded poster or thumbnail carried as a video stream.
+
+    Two signals, either of which is enough. ``attached_pic`` is the explicit one and is
+    what a well-formed file sets; the codec check catches files where it is absent, which
+    is common in output from older tools.
+    """
+
+    if not isinstance(stream, dict):
+        return False
+    disposition = stream.get("disposition")
+    if isinstance(disposition, dict) and int(disposition.get(_ATTACHED_PIC) or 0):
+        return True
+    codec = str(stream.get("codec_name") or "").strip().lower()
+    if codec not in _IMAGE_CODECS:
+        return False
+    # A codec alone is not proof: some genuine video is mjpeg. A single frame, or a
+    # stream with no frame rate, is a still.
+    frames = stream.get("nb_frames")
+    try:
+        if frames is not None and int(frames) <= 1:
+            return True
+    except (TypeError, ValueError):
+        pass
+    rate = str(stream.get("avg_frame_rate") or "").strip()
+    return rate in {"", "0/0", "0/1"}
+
+
+def is_attachment_stream(stream: dict[str, Any]) -> bool:
+    """True for an attached font or similar."""
+
+    return isinstance(stream, dict) and str(stream.get("codec_type") or "").strip().lower() == "attachment"
+
+
+def split_video_and_images(video_streams: list[dict[str, Any]]) -> tuple[list[dict], list[dict]]:
+    """``(real video, embedded images)``.
+
+    Always separated, whether or not removal is switched on, so the plan knows which
+    stream is the picture even when the poster is being kept.
+    """
+
+    real: list[dict] = []
+    images: list[dict] = []
+    for stream in video_streams:
+        (images if is_image_stream(stream) else real).append(stream)
+    # A file of nothing but images is not a file with no video: keeping the first stream
+    # rather than planning an output with no picture at all is the safe reading of an
+    # ambiguous probe.
+    if not real and images:
+        return [images[0]], images[1:]
+    return real, images
+
+
+def describe_image_stream(stream: dict[str, Any]) -> str:
+    codec = str(stream.get("codec_name") or "unknown").strip()
+    width = stream.get("width")
+    height = stream.get("height")
+    size = f"{width}x{height}" if width and height else "unknown size"
+    return f"embedded image ({codec}, {size})"
+
+
+def describe_attachment_stream(stream: dict[str, Any]) -> str:
+    tags = stream.get("tags")
+    name = ""
+    if isinstance(tags, dict):
+        name = str(tags.get("filename") or tags.get("title") or "").strip()
+    return f"attachment ({name})" if name else "attachment"
+
+
+def metadata_argv_flags(rules: MetadataRules) -> list[str]:
+    """The ffmpeg flags for container-level stripping.
+
+    Order matters and is deliberate: ``-map_metadata -1`` clears everything, so a
+    narrower option has to come *after* it or be replaced by it. When only the title is
+    being removed, the title is cleared on its own and the rest of the metadata survives,
+    which is what "remove the title" means.
+    """
+
+    flags: list[str] = []
+    if rules.remove_other_metadata:
+        flags.extend(["-map_metadata", "-1"])
+    elif rules.remove_title:
+        flags.extend(["-metadata", "title="])
+    if rules.remove_other_metadata and rules.remove_title:
+        # Already cleared by -map_metadata, but stated explicitly so a container that
+        # regenerates a title from the filename does not quietly reintroduce one.
+        flags.extend(["-metadata", "title="])
+    if rules.remove_language_tags:
+        flags.extend(["-metadata:s", "language="])
+    return flags
+
+
+def metadata_removal_notes(
+    rules: MetadataRules,
+    *,
+    removed_images: list[dict[str, Any]],
+    removed_attachments: list[dict[str, Any]],
+) -> list[str]:
+    """What was stripped, for the before/after display and the activity detail."""
+
+    notes: list[str] = []
+    for stream in removed_images:
+        notes.append(f"Removed {describe_image_stream(stream)}.")
+    for stream in removed_attachments:
+        notes.append(f"Removed {describe_attachment_stream(stream)}.")
+    if rules.remove_title:
+        notes.append("Removed the container title.")
+    if rules.remove_language_tags:
+        notes.append("Removed stream language tags.")
+    if rules.remove_other_metadata:
+        notes.append("Removed the remaining container metadata.")
+    return notes

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_mux.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from mediamop.modules.refiner.refiner_metadata_rules import metadata_argv_flags
 from mediamop.modules.refiner.refiner_remux_rules import RemuxPlan
 
 logger = logging.getLogger(__name__)
@@ -221,6 +222,9 @@ def build_ffmpeg_argv(*, ffmpeg_bin: str, src: Path, dst: Path, plan: RemuxPlan)
     for t in plan.subtitles:
         args.extend(["-map", f"0:{t.input_index}"])
     args.extend(["-c", "copy"])
+    # Container-level stripping. After the maps, because the maps decide which streams
+    # exist and these decide what those streams carry.
+    args.extend(metadata_argv_flags(plan.metadata))
     for i, t in enumerate(plan.audio):
         args.extend([f"-disposition:a:{i:d}", "default" if t.default else "0"])
     for i, t in enumerate(plan.subtitles):

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_rules.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from mediamop.modules.refiner.refiner_metadata_rules import (
+    MetadataRules,
+    describe_attachment_stream,
+    describe_image_stream,
+    is_attachment_stream,
+    metadata_removal_notes,
+    split_video_and_images,
+)
 from mediamop.modules.refiner.refiner_track_sorters import (
     DEFAULT_AUDIO_SORTERS,
     TrackSorter,
@@ -192,6 +200,8 @@ class RefinerRulesConfig:
     #: The ordered sorter list, as stored JSON. Empty means the seeded default, which
     #: reproduces the ranking this used to hardcode (#341).
     audio_sorters_json: str = ""
+    #: Metadata and attachment stripping. All off by default (#342).
+    metadata: MetadataRules = field(default_factory=MetadataRules)
 
 
 def _ordered_preference_langs(config: RefinerRulesConfig) -> list[str]:
@@ -227,9 +237,23 @@ class RemuxPlan:
     removed_subtitles: list[str] = field(default_factory=list)
     default_audio_output_index: int = 0
     audio_selection_notes: list[str] = field(default_factory=list)
+    #: Embedded posters and attachments this plan drops, and the sentences describing
+    #: them. Separated from video because an embedded poster *is* a video stream and
+    #: anything reasoning about "the video stream" must not find two.
+    removed_images: list[str] = field(default_factory=list)
+    removed_attachments: list[str] = field(default_factory=list)
+    metadata_notes: list[str] = field(default_factory=list)
+    metadata: MetadataRules = field(default_factory=MetadataRules)
 
 
 def is_remux_required(plan: RemuxPlan, audio_probe: list[dict[str, Any]], sub_probe: list[dict[str, Any]]) -> bool:
+    # A file whose only change is metadata stripping still needs a pass. Without this it
+    # would be reported as "nothing to do" and copied through with its poster and title
+    # intact, which is the setting appearing not to work (#342).
+    if plan.removed_images or plan.removed_attachments:
+        return True
+    if plan.metadata.remove_title or plan.metadata.remove_language_tags or plan.metadata.remove_other_metadata:
+        return True
     if [t.input_index for t in plan.audio] != [int(s["index"]) for s in audio_probe]:
         return True
     if [t.input_index for t in plan.subtitles] != [int(s["index"]) for s in sub_probe]:
@@ -244,6 +268,15 @@ def is_remux_required(plan: RemuxPlan, audio_probe: list[dict[str, Any]], sub_pr
     ]
     new_sub = [(t.input_index, int(t.forced), int(t.default)) for t in plan.subtitles]
     return old_sub != new_sub
+
+
+def attachment_streams(probe: dict[str, Any]) -> list[dict]:
+    """Attached fonts and similar. Not returned by ``split_streams``, which predates them."""
+
+    streams = probe.get("streams")
+    if not isinstance(streams, list):
+        return []
+    return [s for s in streams if isinstance(s, dict) and is_attachment_stream(s)]
 
 
 def split_streams(probe: dict[str, Any]) -> tuple[list[dict], list[dict], list[dict]]:
@@ -443,12 +476,20 @@ def plan_remux(
     audio: list[dict[str, Any]],
     subtitles: list[dict[str, Any]],
     config: RefinerRulesConfig,
+    attachments: list[dict[str, Any]] | None = None,
 ) -> RemuxPlan | None:
     """
     Single winning audio track + retention policy: all other audio streams removed from output.
     Returns None if no audio would remain.
     """
-    video_indices = [int(s["index"]) for s in video]
+    rules = config.metadata
+    # Always split, whether or not removal is on, so the plan knows which stream is the
+    # picture even when the poster is being kept.
+    real_video, image_streams = split_video_and_images(video)
+    dropped_images = image_streams if rules.remove_images else []
+    kept_video = real_video if rules.remove_images else video
+    video_indices = [int(s["index"]) for s in kept_video]
+    dropped_attachments = [s for s in attachments or [] if is_attachment_stream(s)] if rules.remove_attachments else []
 
     removed_audio: list[str] = []
     notes: list[str] = []
@@ -575,6 +616,12 @@ def plan_remux(
         removed_subtitles=removed_sub_labels,
         default_audio_output_index=0,
         audio_selection_notes=notes,
+        removed_images=[describe_image_stream(s) for s in dropped_images],
+        removed_attachments=[describe_attachment_stream(s) for s in dropped_attachments],
+        metadata_notes=metadata_removal_notes(
+            rules, removed_images=dropped_images, removed_attachments=dropped_attachments
+        ),
+        metadata=rules,
     )
 
 

--- a/apps/backend/src/mediamop/modules/refiner/refiner_remux_track_display.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_remux_track_display.py
@@ -98,3 +98,14 @@ def subtitle_after_line_from_plan(plan: RemuxPlan, *, remove_all: bool) -> str:
     if not langs:
         return "None"
     return " · ".join(langs)
+
+
+def metadata_removed_line_from_plan(plan: RemuxPlan) -> str:
+    """What the pass stripped beyond audio and subtitles.
+
+    The before/after display already showed audio and subtitle changes; an embedded
+    poster disappearing with no line about it would look like the file lost something
+    unexplained (#342).
+    """
+
+    return join_track_lines(list(plan.metadata_notes))

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -27,6 +27,11 @@ class RefinerRuleSetOut(BaseModel):
     audio_preference_mode: str
     audio_sorters_json: str
     subtitle_sorters_json: str
+    remove_images: bool
+    remove_attachments: bool
+    remove_title: bool
+    remove_language_tags: bool
+    remove_other_metadata: bool
     used_by_library_count: int = Field(
         default=0, description="How many libraries reference this rule set. Deleting one still in use is refused."
     )
@@ -57,6 +62,17 @@ class RefinerRuleSetIn(BaseModel):
         ),
     )
     subtitle_sorters_json: str = Field("", description="The same, for subtitle tracks.")
+    remove_images: bool = Field(
+        False,
+        description=(
+            "Strip embedded cover art. An embedded poster is carried as a video stream, so this removes a "
+            "stream as well as an image."
+        ),
+    )
+    remove_attachments: bool = Field(False, description="Strip attached fonts and similar.")
+    remove_title: bool = Field(False, description="Strip the container title, leaving other metadata alone.")
+    remove_language_tags: bool = Field(False, description="Strip per-stream language tags.")
+    remove_other_metadata: bool = Field(False, description="Strip the remaining container metadata.")
     audio_preference_mode: Literal["preferred_langs_quality", "preferred_langs_strict", "quality_all_languages"] = (
         "preferred_langs_quality"
     )

--- a/apps/backend/tests/test_refiner_metadata_rules.py
+++ b/apps/backend/tests/test_refiner_metadata_rules.py
@@ -1,0 +1,328 @@
+"""Embedded images, attachments and container metadata.
+
+Refiner had no metadata handling: it planned video, audio and subtitle streams and copied
+everything else through untouched. The case with teeth is cover art — **an embedded poster
+is an mjpeg video stream**, and the plan kept every video stream it found, so the poster
+came through and was counted as video (#342).
+
+Every option defaults off, and there is a test asserting that a default configuration
+changes nothing, because an upgrade that started stripping titles would be changing files
+nobody asked it to change.
+"""
+
+from __future__ import annotations
+
+from mediamop.modules.refiner.refiner_metadata_rules import (
+    MetadataRules,
+    is_attachment_stream,
+    is_image_stream,
+    metadata_argv_flags,
+    metadata_removal_notes,
+    split_video_and_images,
+)
+from mediamop.modules.refiner.refiner_remux_mux import build_ffmpeg_argv
+from mediamop.modules.refiner.refiner_remux_rules import (
+    attachment_streams,
+    default_refiner_remux_rules_config,
+    is_remux_required,
+    plan_remux,
+    split_streams,
+)
+
+
+def _video(index: int = 0) -> dict:
+    return {
+        "index": index,
+        "codec_type": "video",
+        "codec_name": "h264",
+        "width": 1920,
+        "height": 1080,
+        "avg_frame_rate": "24000/1001",
+        "nb_frames": "150000",
+    }
+
+
+def _cover_art(index: int = 1, *, attached_pic: bool = True) -> dict:
+    """An embedded poster, exactly as ffprobe reports one."""
+
+    stream = {
+        "index": index,
+        "codec_type": "video",
+        "codec_name": "mjpeg",
+        "width": 600,
+        "height": 900,
+        "avg_frame_rate": "0/0",
+        "nb_frames": "1",
+    }
+    if attached_pic:
+        stream["disposition"] = {"attached_pic": 1, "default": 0}
+    return stream
+
+
+def _audio(index: int = 2) -> dict:
+    return {
+        "index": index,
+        "codec_type": "audio",
+        "codec_name": "eac3",
+        "channels": 6,
+        "bit_rate": "640000",
+        "tags": {"language": "eng"},
+        "disposition": {"default": 1},
+    }
+
+
+def _attachment(index: int = 3, name: str = "Arial.ttf") -> dict:
+    return {
+        "index": index,
+        "codec_type": "attachment",
+        "codec_name": "ttf",
+        "tags": {"filename": name},
+    }
+
+
+def _probe(*streams: dict) -> dict:
+    return {"streams": list(streams)}
+
+
+def _config(**over) -> object:
+    from dataclasses import replace
+
+    base = default_refiner_remux_rules_config()
+    return replace(base, metadata=MetadataRules(**over)) if over else base
+
+
+# --- recognising a poster ------------------------------------------------------------
+
+
+def test_an_attached_pic_is_recognised_as_an_image() -> None:
+    assert is_image_stream(_cover_art()) is True
+
+
+def test_a_single_frame_mjpeg_with_no_disposition_is_still_recognised() -> None:
+    """Common in output from older tools, which omit the attached_pic flag."""
+
+    assert is_image_stream(_cover_art(attached_pic=False)) is True
+
+
+def test_real_video_is_not_mistaken_for_a_poster() -> None:
+    assert is_image_stream(_video()) is False
+
+
+def test_genuine_mjpeg_video_is_not_mistaken_for_a_poster() -> None:
+    """A codec alone is not proof: some real video is mjpeg."""
+
+    stream = {
+        "index": 0,
+        "codec_type": "video",
+        "codec_name": "mjpeg",
+        "avg_frame_rate": "25/1",
+        "nb_frames": "50000",
+    }
+
+    assert is_image_stream(stream) is False
+
+
+def test_an_attachment_is_recognised() -> None:
+    assert is_attachment_stream(_attachment()) is True
+    assert is_attachment_stream(_audio()) is False
+
+
+def test_video_and_images_are_always_separated_even_when_kept() -> None:
+    """So the plan knows which stream is the picture even when the poster stays."""
+
+    real, images = split_video_and_images([_video(0), _cover_art(1)])
+
+    assert [s["index"] for s in real] == [0]
+    assert [s["index"] for s in images] == [1]
+
+
+def test_a_file_of_nothing_but_images_keeps_one_rather_than_planning_no_picture() -> None:
+    """An ambiguous probe must not produce an output with no video at all."""
+
+    real, images = split_video_and_images([_cover_art(0), _cover_art(1)])
+
+    assert len(real) == 1
+    assert len(images) == 1
+
+
+# --- the default changes nothing -----------------------------------------------------
+
+
+def test_by_default_a_poster_is_carried_through_exactly_as_before() -> None:
+    """An upgrade must not start changing files nobody asked it to change."""
+
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config())
+
+    assert plan is not None
+    assert plan.video_indices == [0, 1]
+    assert plan.removed_images == []
+    assert plan.metadata_notes == []
+
+
+def test_by_default_no_metadata_flags_reach_ffmpeg() -> None:
+    assert metadata_argv_flags(MetadataRules()) == []
+
+
+def test_by_default_a_file_needing_nothing_else_is_not_remuxed() -> None:
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config())
+
+    assert plan is not None
+    assert is_remux_required(plan, audio, subs) is False
+
+
+# --- removing --------------------------------------------------------------------
+
+
+def test_removing_images_drops_the_poster_from_the_planned_streams() -> None:
+    """The whole point: the poster stops being carried and stops counting as video."""
+
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_images=True))
+
+    assert plan is not None
+    assert plan.video_indices == [0]
+    assert len(plan.removed_images) == 1
+    assert "mjpeg" in plan.removed_images[0]
+    assert "600x900" in plan.removed_images[0]
+
+
+def test_removing_attachments_drops_an_attached_font() -> None:
+    probe = _probe(_video(0), _audio(1), _attachment(2, "Arial.ttf"))
+    video, audio, subs = split_streams(probe)
+
+    plan = plan_remux(
+        video=video,
+        audio=audio,
+        subtitles=subs,
+        config=_config(remove_attachments=True),
+        attachments=attachment_streams(probe),
+    )
+
+    assert plan is not None
+    assert len(plan.removed_attachments) == 1
+    assert "Arial.ttf" in plan.removed_attachments[0]
+
+
+def test_attachments_are_found_in_a_probe() -> None:
+    probe = _probe(_video(0), _audio(1), _attachment(2), _attachment(3, "Comic.ttf"))
+
+    assert [s["index"] for s in attachment_streams(probe)] == [2, 3]
+
+
+def test_removing_the_title_leaves_other_metadata_alone() -> None:
+    """ "Remove the title" means the title, not everything."""
+
+    flags = metadata_argv_flags(MetadataRules(remove_title=True))
+
+    assert flags == ["-metadata", "title="]
+    assert "-map_metadata" not in flags
+
+
+def test_removing_all_metadata_clears_everything_and_restates_the_title() -> None:
+    """Stated explicitly so a container regenerating a title from the filename cannot
+    quietly reintroduce one."""
+
+    flags = metadata_argv_flags(MetadataRules(remove_other_metadata=True, remove_title=True))
+
+    assert flags[:2] == ["-map_metadata", "-1"]
+    assert flags[-2:] == ["-metadata", "title="]
+
+
+def test_removing_language_tags_is_its_own_flag() -> None:
+    assert metadata_argv_flags(MetadataRules(remove_language_tags=True)) == ["-metadata:s", "language="]
+
+
+# --- the pass is required --------------------------------------------------------
+
+
+def test_a_file_whose_only_change_is_a_stripped_poster_is_remuxed() -> None:
+    """Otherwise it would be reported as "nothing to do" and copied through with the
+    poster intact, which is the setting appearing not to work."""
+
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_images=True))
+
+    assert plan is not None
+    assert is_remux_required(plan, audio, subs) is True
+
+
+def test_a_file_whose_only_change_is_a_stripped_title_is_remuxed() -> None:
+    video, audio, subs = split_streams(_probe(_video(0), _audio(1)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_title=True))
+
+    assert plan is not None
+    assert is_remux_required(plan, audio, subs) is True
+
+
+def test_a_file_whose_only_change_is_stripped_metadata_is_remuxed() -> None:
+    video, audio, subs = split_streams(_probe(_video(0), _audio(1)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_other_metadata=True))
+
+    assert plan is not None
+    assert is_remux_required(plan, audio, subs) is True
+
+
+# --- ffmpeg argv ------------------------------------------------------------------
+
+
+def test_the_argv_maps_only_the_real_video_when_images_are_removed() -> None:
+    from pathlib import Path
+
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_images=True))
+    assert plan is not None
+
+    argv = build_ffmpeg_argv(ffmpeg_bin="ffmpeg", src=Path("in.mkv"), dst=Path("out.mkv"), plan=plan)
+
+    mapped = [argv[i + 1] for i, token in enumerate(argv) if token == "-map"]
+    assert "0:0" in mapped
+    assert "0:1" not in mapped
+
+
+def test_the_argv_carries_the_metadata_flags_after_the_codec_copy() -> None:
+    from pathlib import Path
+
+    video, audio, subs = split_streams(_probe(_video(0), _audio(1)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_other_metadata=True))
+    assert plan is not None
+
+    argv = build_ffmpeg_argv(ffmpeg_bin="ffmpeg", src=Path("in.mkv"), dst=Path("out.mkv"), plan=plan)
+
+    assert "-map_metadata" in argv
+    assert argv.index("-map_metadata") > argv.index("copy")
+
+
+# --- what the operator is told ----------------------------------------------------
+
+
+def test_the_notes_say_what_was_removed() -> None:
+    notes = metadata_removal_notes(
+        MetadataRules(remove_images=True, remove_title=True),
+        removed_images=[_cover_art()],
+        removed_attachments=[],
+    )
+
+    assert any("embedded image" in n for n in notes)
+    assert any("container title" in n for n in notes)
+
+
+def test_the_display_line_is_empty_when_nothing_was_removed() -> None:
+    from mediamop.modules.refiner.refiner_remux_track_display import metadata_removed_line_from_plan
+
+    video, audio, subs = split_streams(_probe(_video(0), _audio(1)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config())
+    assert plan is not None
+
+    assert metadata_removed_line_from_plan(plan) in ("", "—", "-")
+
+
+def test_the_display_line_names_a_removed_poster() -> None:
+    from mediamop.modules.refiner.refiner_remux_track_display import metadata_removed_line_from_plan
+
+    video, audio, subs = split_streams(_probe(_video(0), _cover_art(1), _audio(2)))
+    plan = plan_remux(video=video, audio=audio, subtitles=subs, config=_config(remove_images=True))
+    assert plan is not None
+
+    assert "embedded image" in metadata_removed_line_from_plan(plan)

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -5282,9 +5282,39 @@
             "title": "Primary Audio Lang",
             "type": "string"
           },
+          "remove_attachments": {
+            "default": false,
+            "description": "Strip attached fonts and similar.",
+            "title": "Remove Attachments",
+            "type": "boolean"
+          },
           "remove_commentary": {
             "default": false,
             "title": "Remove Commentary",
+            "type": "boolean"
+          },
+          "remove_images": {
+            "default": false,
+            "description": "Strip embedded cover art. An embedded poster is carried as a video stream, so this removes a stream as well as an image.",
+            "title": "Remove Images",
+            "type": "boolean"
+          },
+          "remove_language_tags": {
+            "default": false,
+            "description": "Strip per-stream language tags.",
+            "title": "Remove Language Tags",
+            "type": "boolean"
+          },
+          "remove_other_metadata": {
+            "default": false,
+            "description": "Strip the remaining container metadata.",
+            "title": "Remove Other Metadata",
+            "type": "boolean"
+          },
+          "remove_title": {
+            "default": false,
+            "description": "Strip the container title, leaving other metadata alone.",
+            "title": "Remove Title",
             "type": "boolean"
           },
           "secondary_audio_lang": {
@@ -5363,8 +5393,28 @@
             "title": "Primary Audio Lang",
             "type": "string"
           },
+          "remove_attachments": {
+            "title": "Remove Attachments",
+            "type": "boolean"
+          },
           "remove_commentary": {
             "title": "Remove Commentary",
+            "type": "boolean"
+          },
+          "remove_images": {
+            "title": "Remove Images",
+            "type": "boolean"
+          },
+          "remove_language_tags": {
+            "title": "Remove Language Tags",
+            "type": "boolean"
+          },
+          "remove_other_metadata": {
+            "title": "Remove Other Metadata",
+            "type": "boolean"
+          },
+          "remove_title": {
+            "title": "Remove Title",
             "type": "boolean"
           },
           "secondary_audio_lang": {
@@ -5420,7 +5470,12 @@
           "preserve_default_subs",
           "audio_preference_mode",
           "audio_sorters_json",
-          "subtitle_sorters_json"
+          "subtitle_sorters_json",
+          "remove_images",
+          "remove_attachments",
+          "remove_title",
+          "remove_language_tags",
+          "remove_other_metadata"
         ],
         "title": "RefinerRuleSetOut",
         "type": "object"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -4027,10 +4027,40 @@ export interface components {
        */
       primary_audio_lang: string;
       /**
+       * Remove Attachments
+       * @description Strip attached fonts and similar.
+       * @default false
+       */
+      remove_attachments: boolean;
+      /**
        * Remove Commentary
        * @default false
        */
       remove_commentary: boolean;
+      /**
+       * Remove Images
+       * @description Strip embedded cover art. An embedded poster is carried as a video stream, so this removes a stream as well as an image.
+       * @default false
+       */
+      remove_images: boolean;
+      /**
+       * Remove Language Tags
+       * @description Strip per-stream language tags.
+       * @default false
+       */
+      remove_language_tags: boolean;
+      /**
+       * Remove Other Metadata
+       * @description Strip the remaining container metadata.
+       * @default false
+       */
+      remove_other_metadata: boolean;
+      /**
+       * Remove Title
+       * @description Strip the container title, leaving other metadata alone.
+       * @default false
+       */
+      remove_title: boolean;
       /**
        * Secondary Audio Lang
        * @default
@@ -4077,8 +4107,18 @@ export interface components {
       preserve_forced_subs: boolean;
       /** Primary Audio Lang */
       primary_audio_lang: string;
+      /** Remove Attachments */
+      remove_attachments: boolean;
       /** Remove Commentary */
       remove_commentary: boolean;
+      /** Remove Images */
+      remove_images: boolean;
+      /** Remove Language Tags */
+      remove_language_tags: boolean;
+      /** Remove Other Metadata */
+      remove_other_metadata: boolean;
+      /** Remove Title */
+      remove_title: boolean;
       /** Secondary Audio Lang */
       secondary_audio_lang: string;
       /** Subtitle Langs Csv */

--- a/apps/web/src/lib/refiner/libraries-api.ts
+++ b/apps/web/src/lib/refiner/libraries-api.ts
@@ -105,6 +105,12 @@ export interface RefinerRuleSet {
   /** Ordered track sorters as JSON. Empty means the default order Refiner has always applied. */
   audio_sorters_json: string;
   subtitle_sorters_json: string;
+  /** An embedded poster is carried as a video stream, so this removes a stream as well as an image. */
+  remove_images: boolean;
+  remove_attachments: boolean;
+  remove_title: boolean;
+  remove_language_tags: boolean;
+  remove_other_metadata: boolean;
   /** Libraries pointing at this rule set. Deleting one still in use is refused. */
   used_by_library_count: number;
   updated_at: string | null;


### PR DESCRIPTION
Closes #342. Part of #347.

## The gap

Refiner had **no metadata handling at all**. It planned video, audio and subtitle streams and copied everything else through untouched — embedded cover art, stale titles, attached fonts and container tags all survived a pass.

## The case with teeth

**An embedded poster is an mjpeg video stream**, and the plan kept every video stream it found:

```python
video_indices = [int(s["index"]) for s in video]
```

So the poster was carried into the output *and counted as video*, leaving anything that reasons about "the video stream" to cope with there being two of them.

Video and images are now **always separated**, whether or not removal is switched on, so the plan knows which stream is the picture even when the poster is being kept.

## Recognising a poster

Two signals, either sufficient:

- `attached_pic` — the explicit one a well-formed file sets.
- A single frame with no frame rate — catches files where it is absent, which is common in output from older tools.

A codec alone is **not** enough, because some genuine video is mjpeg. There is a test for exactly that.

A file of nothing but images keeps one rather than planning an output with no picture at all — an ambiguous probe should not produce a video-less file.

## `is_remux_required` accounts for it

Without this, a file whose only change was a stripped poster would be reported as "nothing to do" and copied through with the poster intact — the setting appearing not to work.

## Flag order is deliberate

`-map_metadata -1` clears everything, so:

- removing only the title clears the title alone and leaves the rest — which is what "remove the title" means;
- removing everything **states the title again afterwards**, so a container that regenerates one from the filename cannot quietly reintroduce it.

## Defaults are asserted, not assumed

Three tests prove a default configuration carries the poster through exactly as before, emits no ffmpeg flags, and reports no remux needed. An upgrade that started stripping titles would be changing files nobody asked it to change.

## What the operator sees

Removals appear in the activity detail (`removed_images`, `removed_attachments`, `metadata_removed`) and get their own before/after line, the way audio and subtitles already do. A poster disappearing with no line about it would look like the file lost something unexplained.

## Tests

Real ffprobe-shaped fixtures: an embedded mjpeg poster **with and without** `attached_pic`, genuine mjpeg video that must not be mistaken for one, attached fonts, argv mapping, flag ordering, and the three defaults-change-nothing assertions.

Verified locally: 1101 backend passed / 2 skipped, 202 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

Stacked on #341, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
