### PR TITLE
feat(refiner): carry sidecars to the output before the source folder is deleted (#344)

### DIFF
--- a/apps/backend/alembic/versions/0021_sidecar_migration.py
+++ b/apps/backend/alembic/versions/0021_sidecar_migration.py
@@ -1,0 +1,70 @@
+"""Sidecar migration and original-timestamp preservation, per library
+
+Refiner mirrored the watched-relative path under the output root and moved the video.
+Nothing beside it came across — no .srt, no .nfo, no artwork, no .idx/.sub pair — and
+then Movies cleanup ran rmtree on the release folder and TV did the same to a season
+folder. Sidecars next to the source were destroyed rather than migrated, with no setting
+that changed it.
+
+``sidecar_patterns_csv`` defaults to the release-bundle set: subtitle formats including
+the .idx/.sub pair, the metadata file, and artwork. That is a behaviour change, and a
+deliberate one — the previous behaviour was destroying those files, and migrating a file
+that would otherwise be deleted is strictly the safer direction.
+
+The accompanying rule keeps it safe: a sidecar that is *not there* is not a failure, so a
+release with no sidecars migrates nothing and blocks nothing. Only a sidecar that exists
+and could not be copied blocks the source deletion, which is exactly the case where
+proceeding would destroy the only copy.
+
+``preserve_original_timestamps`` defaults off.
+
+Revision ID: 0021_sidecar_migration
+Revises: 0020_metadata_rules
+Create Date: 2026-08-29 18:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+revision = "0021_sidecar_migration"
+down_revision = "0020_metadata_rules"
+branch_labels = None
+depends_on = None
+
+_DEFAULT_PATTERNS = ".srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png"
+
+_LIBRARY_COLUMNS: tuple[tuple[str, sa.Column], ...] = (
+    (
+        "sidecar_patterns_csv",
+        sa.Column("sidecar_patterns_csv", sa.Text(), nullable=False, server_default=_DEFAULT_PATTERNS),
+    ),
+    (
+        "preserve_original_timestamps",
+        sa.Column("preserve_original_timestamps", sa.Boolean(), nullable=False, server_default="0"),
+    ),
+)
+
+
+def _columns(table: str) -> set[str]:
+    inspector = inspect(op.get_bind())
+    if table not in set(inspector.get_table_names()):
+        return set()
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    present = _columns("refiner_libraries")
+    for name, column in _LIBRARY_COLUMNS:
+        if present and name not in present:
+            op.add_column("refiner_libraries", column)
+
+
+def downgrade() -> None:
+    present = _columns("refiner_libraries")
+    for name, _ in _LIBRARY_COLUMNS:
+        if name in present:
+            op.drop_column("refiner_libraries", name)

--- a/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
+++ b/apps/backend/src/mediamop/modules/refiner/file_remux_pass/run.py
@@ -51,6 +51,11 @@ from mediamop.modules.refiner.refiner_remux_track_display import (
     subtitle_before_line_from_probe,
 )
 from mediamop.modules.refiner.refiner_runner_units import video_dimensions_from_streams
+from mediamop.modules.refiner.refiner_sidecar_migration import (
+    apply_original_timestamps,
+    migrate_sidecars,
+    parse_sidecar_patterns,
+)
 from mediamop.modules.refiner.refiner_tv_output_cleanup import (
     maybe_run_tv_output_season_folder_cleanup_after_remux,
 )
@@ -265,6 +270,53 @@ def _init_folder_cleanup_activity_fields(out: dict[str, Any]) -> None:
     out.setdefault("output_completeness_note", None)
 
 
+def _migrate_sidecars_before_cleanup(
+    *,
+    src: Path,
+    final_output_file: Path | None,
+    sidecar_patterns: tuple[str, ...],
+    preserve_timestamps: bool,
+    out: dict[str, Any],
+) -> None:
+    """Carry configured sidecars to the output, and record whether deletion may proceed.
+
+    Run before any cleanup gate. A sidecar that is not there is not a failure — the
+    common case is a release with none — but one that exists and could not be copied
+    stops the source folder being deleted, because proceeding would destroy the only
+    copy of a file MediaMop was asked to keep (#344).
+    """
+
+    out.setdefault("sidecars_migrated", [])
+    out.setdefault("sidecars_skipped", [])
+    out.setdefault("sidecar_migration_blocked", False)
+    out.setdefault("sidecar_migration_blocked_reason", None)
+    out.setdefault("original_timestamps_note", None)
+
+    if final_output_file is None or not sidecar_patterns:
+        return
+
+    result = migrate_sidecars(
+        source_media=src,
+        output_media=final_output_file,
+        patterns=sidecar_patterns,
+        preserve_timestamps=preserve_timestamps,
+    )
+    out["sidecars_migrated"] = [m.destination.name for m in result.migrated]
+    out["sidecars_skipped"] = list(result.skipped)
+    if result.blocks_source_deletion:
+        out["sidecar_migration_blocked"] = True
+        out["sidecar_migration_blocked_reason"] = result.blocking_reason
+        logger.warning("Refiner sidecar migration: %s", result.blocking_reason)
+
+    if preserve_timestamps:
+        problem = apply_original_timestamps(source_media=src, output_media=final_output_file)
+        if problem:
+            # Never fatal: the output is correct either way, and refusing a finished
+            # remux over a timestamp would be the wrong trade.
+            out["original_timestamps_note"] = problem
+            logger.info("Refiner timestamps: %s", problem)
+
+
 def _handle_refiner_cleanup_after_success(
     *,
     src: Path,
@@ -281,6 +333,18 @@ def _handle_refiner_cleanup_after_success(
     """Movies: optional full release-folder removal + cascade. TV: season-folder cleanup (Pass 1b) or skip."""
 
     scope = _normalize_media_scope_for_cleanup(media_scope)
+
+    # Sidecars travel *before* any deletion gate runs, and a sidecar that exists and
+    # could not be copied stops the deletion. Proceeding would destroy the only copy of
+    # a file MediaMop was asked to keep (#344).
+    if out.get("sidecar_migration_blocked"):
+        _init_folder_cleanup_activity_fields(out)
+        out["source_deleted_after_success"] = False
+        out["source_folder_skip_reason"] = out.get("sidecar_migration_blocked_reason") or (
+            "MediaMop did not remove the source folder because a file set to travel with the video could not be copied."
+        )
+        logger.warning("Refiner cleanup blocked by sidecar migration: %s", out["source_folder_skip_reason"])
+        return
 
     if scope != "movie":
         if scope != "tv":
@@ -576,6 +640,9 @@ def run_refiner_file_remux_pass(
             out=out,
         )
 
+    sidecar_patterns = parse_sidecar_patterns(path_runtime.sidecar_patterns_csv)
+    preserve_timestamps = bool(path_runtime.preserve_original_timestamps)
+
     out.pop("after_track_lines_meaning", None)
     out_dir = Path(path_runtime.output_folder).resolve()
 
@@ -665,6 +732,13 @@ def run_refiner_file_remux_pass(
         out["output_copied_without_remux"] = True
         out["unchanged_output_method"] = unchanged_output_method
         out["live_mutations_skipped"] = False
+        _migrate_sidecars_before_cleanup(
+            src=src,
+            final_output_file=final_skip,
+            sidecar_patterns=sidecar_patterns,
+            preserve_timestamps=preserve_timestamps,
+            out=out,
+        )
         _handle_refiner_cleanup_after_success(
             src=src,
             watched_root=watched_root,
@@ -840,6 +914,13 @@ def run_refiner_file_remux_pass(
                 "message": "The cleaned-up file was written. Refiner is doing final safety checks.",
             }
         )
+    _migrate_sidecars_before_cleanup(
+        src=src,
+        final_output_file=final,
+        sidecar_patterns=sidecar_patterns,
+        preserve_timestamps=preserve_timestamps,
+        out=out,
+    )
     _handle_refiner_cleanup_after_success(
         src=src,
         watched_root=watched_root,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_libraries_api.py
@@ -87,6 +87,8 @@ def _library_out(db, row: RefinerLibraryRow) -> RefinerLibraryOut:
         top_level_only=row.top_level_only,
         scan_interval_seconds=row.scan_interval_seconds,
         hold_minutes=row.hold_minutes,
+        sidecar_patterns_csv=row.sidecar_patterns_csv or "",
+        preserve_original_timestamps=bool(row.preserve_original_timestamps),
         file_detection_interval_seconds=row.file_detection_interval_seconds,
         ignore_size_changes=row.ignore_size_changes,
         skip_access_tests=row.skip_access_tests,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_crud.py
@@ -143,6 +143,8 @@ def _apply_fields(session: Session, row: RefinerLibraryRow, body: object) -> Non
         "top_level_only",
         "scan_interval_seconds",
         "hold_minutes",
+        "sidecar_patterns_csv",
+        "preserve_original_timestamps",
         "file_detection_interval_seconds",
         "ignore_size_changes",
         "skip_access_tests",

--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_model.py
@@ -110,6 +110,14 @@ class RefinerLibraryRow(Base):
     exclude_hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="1")
     top_level_only: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
 
+    # Output. Which files beside the video travel with it. Empty migrates nothing, which
+    # is what every install did before — and what it did *instead* was delete them with
+    # the release folder, so the seeded list is the safer direction (#344).
+    sidecar_patterns_csv: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=".srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png"
+    )
+    preserve_original_timestamps: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+
     # Timing.
     scan_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False, server_default="300")
     hold_minutes: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")

--- a/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_path_settings_service.py
@@ -141,6 +141,10 @@ class RefinerPathRuntime:
     work_folder_effective: str
     work_folder_is_default: bool
     preview_output_folder: str | None = None
+    #: Output-side library settings. They travel with the paths because the pass already
+    #: receives this and they are decisions about the same output folder (#344).
+    sidecar_patterns_csv: str = ""
+    preserve_original_timestamps: bool = False
 
 
 def _normalize_media_scope(raw: str | None) -> RefinerMediaScope:
@@ -287,6 +291,8 @@ def resolve_refiner_path_runtime_for_library(
             output_folder=str(output_path),
             work_folder_effective=str(work_path),
             work_folder_is_default=work_is_default,
+            sidecar_patterns_csv=library.sidecar_patterns_csv or "",
+            preserve_original_timestamps=bool(library.preserve_original_timestamps),
         ),
         None,
     )

--- a/apps/backend/src/mediamop/modules/refiner/refiner_sidecar_migration.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_sidecar_migration.py
@@ -1,0 +1,190 @@
+"""Carry sidecar files to the output before the source folder is deleted.
+
+Refiner mirrored the watched-relative path under the output root and moved the video.
+Nothing beside it came across — no ``.srt``, no ``.nfo``, no artwork, no ``.idx``/``.sub``
+pair. Then Movies cleanup ran ``rmtree`` on the whole release folder, and TV did the same
+to a season folder. So sidecars next to the source were **destroyed rather than migrated**,
+and there was no setting that changed it.
+
+Two rules make this safe rather than merely useful:
+
+**A sidecar that is not there is not a failure.** The common case is a release with no
+sidecars at all, and treating "nothing to migrate" as a problem would block source
+deletion on every file and quietly fill the watched folder.
+
+**A sidecar that exists and could not be copied blocks the deletion.** That is the whole
+point of doing this before the cleanup gate: the alternative is deleting the only copy of
+a file MediaMop was asked to keep.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+
+#: Offered as the starting list. Chosen for what actually travels in a release bundle:
+#: subtitle formats including the ``.idx``/``.sub`` pair, the metadata file, and artwork.
+DEFAULT_SIDECAR_PATTERNS: tuple[str, ...] = (
+    ".srt",
+    ".ass",
+    ".ssa",
+    ".sub",
+    ".idx",
+    ".vtt",
+    ".nfo",
+    ".jpg",
+    ".png",
+)
+
+
+def parse_sidecar_patterns(csv: str | None) -> tuple[str, ...]:
+    """Normalise a stored pattern list. Empty means "migrate nothing", which is the
+    behaviour every install has today."""
+
+    out: list[str] = []
+    for raw in (csv or "").split(","):
+        text = raw.strip().lower()
+        if not text:
+            continue
+        if not text.startswith("."):
+            text = f".{text}"
+        if text not in out:
+            out.append(text)
+    return tuple(out)
+
+
+@dataclass(frozen=True, slots=True)
+class MigratedSidecar:
+    source: Path
+    destination: Path
+
+
+@dataclass(slots=True)
+class SidecarMigrationResult:
+    """What travelled, what did not, and whether deletion may proceed."""
+
+    migrated: list[MigratedSidecar] = field(default_factory=list)
+    #: Sidecars that exist and could not be copied. Non-empty means the source folder
+    #: must not be deleted.
+    failures: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+    @property
+    def blocks_source_deletion(self) -> bool:
+        return bool(self.failures)
+
+    @property
+    def blocking_reason(self) -> str:
+        if not self.failures:
+            return ""
+        return (
+            "MediaMop did not remove the source folder because it could not copy "
+            f"{len(self.failures)} file(s) that were set to travel with the video: "
+            f"{'; '.join(self.failures)}. The source is left in place so nothing is lost."
+        )
+
+
+def find_sidecars(source_media: Path, patterns: tuple[str, ...]) -> list[Path]:
+    """Files beside the video that match the configured patterns.
+
+    Matched against the video's own stem, so a release folder holding two films does not
+    hand one film's subtitles to the other. A multi-part suffix like ``.en.srt`` is
+    matched too, because that is how subtitle files are actually named.
+    """
+
+    if not patterns:
+        return []
+    folder = source_media.parent
+    stem = source_media.stem.lower()
+    found: list[Path] = []
+    try:
+        entries = sorted(folder.iterdir(), key=lambda p: p.name.lower())
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.is_file() or entry == source_media:
+            continue
+        name = entry.name.lower()
+        if not name.startswith(stem):
+            continue
+        if not any(name.endswith(pattern) for pattern in patterns):
+            continue
+        found.append(entry)
+    return found
+
+
+def destination_for_sidecar(*, sidecar: Path, source_media: Path, output_media: Path) -> Path:
+    """The sidecar's new name, rewritten to the output video's stem.
+
+    ``Film.2001.1080p.en.srt`` beside ``Film.2001.1080p.mkv`` becomes ``<output stem>.en.srt``,
+    so the pair still matches after a rename. Keeping the original name would leave a
+    subtitle no player would associate with the video.
+    """
+
+    trailing = sidecar.name[len(source_media.stem) :]
+    return output_media.parent / f"{output_media.stem}{trailing}"
+
+
+def migrate_sidecars(
+    *,
+    source_media: Path,
+    output_media: Path,
+    patterns: tuple[str, ...],
+    preserve_timestamps: bool = False,
+) -> SidecarMigrationResult:
+    """Copy configured sidecars beside the output, renamed to its stem.
+
+    Copy rather than move: the source folder is deleted by a later gate that has its own
+    conditions, and a moved sidecar whose deletion is then refused would have been taken
+    out of a folder the operator still has.
+    """
+
+    result = SidecarMigrationResult()
+    if not patterns:
+        return result
+
+    for sidecar in find_sidecars(source_media, patterns):
+        destination = destination_for_sidecar(sidecar=sidecar, source_media=source_media, output_media=output_media)
+        if destination.is_file():
+            # Already there from an earlier pass. Overwriting could replace an edited
+            # subtitle with the release's original, so it is left alone and reported.
+            result.skipped.append(f"{destination.name} was already in the output folder, so it was not replaced.")
+            continue
+        if destination.exists():
+            # Something that is not a file is in the way — a directory with that name,
+            # most likely. That is not "already migrated", and treating it as such would
+            # clear the way for the source to be deleted while the sidecar never arrived.
+            result.failures.append(f"{sidecar.name} (something else already exists at {destination})")
+            continue
+        try:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if preserve_timestamps:
+                shutil.copy2(sidecar, destination)
+            else:
+                shutil.copy(sidecar, destination)
+        except OSError as exc:
+            result.failures.append(f"{sidecar.name} ({exc})")
+            continue
+        result.migrated.append(MigratedSidecar(source=sidecar, destination=destination))
+    return result
+
+
+def apply_original_timestamps(*, source_media: Path, output_media: Path) -> str | None:
+    """Give the output the source's modification time. Returns a problem, or None.
+
+    Never fatal: the output is correct either way, and refusing a finished remux over a
+    timestamp would be the wrong trade.
+    """
+
+    try:
+        stat = source_media.stat()
+    except OSError as exc:
+        return f"MediaMop could not read the original file's timestamps ({exc})."
+    try:
+        import os
+
+        os.utime(output_media, (stat.st_atime, stat.st_mtime))
+    except OSError as exc:
+        return f"MediaMop could not apply the original timestamps to the output ({exc})."
+    return None

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -103,6 +103,8 @@ class RefinerLibraryOut(BaseModel):
 
     scan_interval_seconds: int
     hold_minutes: int
+    sidecar_patterns_csv: str
+    preserve_original_timestamps: bool
     file_detection_interval_seconds: int
     ignore_size_changes: bool
     skip_access_tests: bool
@@ -154,6 +156,16 @@ class RefinerLibraryCreateIn(BaseModel):
     min_file_age_seconds: int = Field(60, ge=0, le=604800)
     exclude_hidden: bool = True
     top_level_only: bool = False
+    sidecar_patterns_csv: str = Field(
+        ".srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png",
+        description=(
+            "Which files beside the video travel with it to the output, renamed to the output's stem. "
+            "Empty migrates nothing — and the source folder deletion would then remove them."
+        ),
+    )
+    preserve_original_timestamps: bool = Field(
+        False, description="Give the output the original file's modification time."
+    )
     scan_interval_seconds: int = Field(300, ge=10, le=604800)
     hold_minutes: int = Field(0, ge=0, le=10080)
     file_detection_interval_seconds: int = Field(

--- a/apps/backend/tests/test_refiner_sidecar_migration.py
+++ b/apps/backend/tests/test_refiner_sidecar_migration.py
@@ -1,0 +1,258 @@
+"""Carrying sidecars to the output before the source folder is deleted.
+
+Refiner moved the video and nothing beside it, then ran ``rmtree`` on the release folder.
+So a ``.srt`` or ``.nfo`` next to the source was **destroyed rather than migrated**, with
+no setting that changed it (#344).
+
+Two rules carry the safety here, and both have their own tests:
+
+- A sidecar that is **not there** is not a failure. The common case is a release with
+  none, and treating that as a problem would block source deletion on every file.
+- A sidecar that **exists and could not be copied** blocks the deletion, because
+  proceeding would destroy the only copy of a file MediaMop was asked to keep.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from mediamop.modules.refiner.refiner_sidecar_migration import (
+    DEFAULT_SIDECAR_PATTERNS,
+    apply_original_timestamps,
+    destination_for_sidecar,
+    find_sidecars,
+    migrate_sidecars,
+    parse_sidecar_patterns,
+)
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> tuple[Path, Path]:
+    """A release folder with a video, and an output folder with the renamed video."""
+
+    source_folder = tmp_path / "watched" / "Film.2001.1080p.BluRay"
+    source_folder.mkdir(parents=True)
+    source = source_folder / "Film.2001.1080p.BluRay.mkv"
+    source.write_bytes(b"video")
+
+    output_folder = tmp_path / "out" / "Film (2001)"
+    output_folder.mkdir(parents=True)
+    output = output_folder / "Film (2001).mkv"
+    output.write_bytes(b"video")
+    return source, output
+
+
+# --- the pattern list ----------------------------------------------------------------
+
+
+def test_patterns_are_normalised_and_deduplicated() -> None:
+    assert parse_sidecar_patterns("srt, .NFO ,srt, ") == (".srt", ".nfo")
+
+
+def test_an_empty_list_migrates_nothing_which_is_the_old_behaviour() -> None:
+    assert parse_sidecar_patterns("") == ()
+    assert parse_sidecar_patterns(None) == ()
+
+
+def test_the_offered_list_covers_what_travels_in_a_release_bundle() -> None:
+    # The .idx/.sub pair matters: migrating one without the other leaves a broken pair.
+    assert ".idx" in DEFAULT_SIDECAR_PATTERNS
+    assert ".sub" in DEFAULT_SIDECAR_PATTERNS
+    assert ".nfo" in DEFAULT_SIDECAR_PATTERNS
+
+
+# --- finding ------------------------------------------------------------------------
+
+
+def test_only_files_matching_the_video_stem_are_found(tree: tuple[Path, Path]) -> None:
+    """A release folder holding two films must not hand one film's subtitles to the other."""
+
+    source, _ = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("mine")
+    (source.parent / "Other.Film.srt").write_text("not mine")
+
+    found = find_sidecars(source, (".srt",))
+
+    assert [p.name for p in found] == ["Film.2001.1080p.BluRay.srt"]
+
+
+def test_a_multi_part_suffix_is_matched(tree: tuple[Path, Path]) -> None:
+    """``.en.srt`` is how subtitle files are actually named."""
+
+    source, _ = tree
+    (source.parent / "Film.2001.1080p.BluRay.en.srt").write_text("subs")
+
+    assert [p.name for p in find_sidecars(source, (".srt",))] == ["Film.2001.1080p.BluRay.en.srt"]
+
+
+def test_the_video_itself_is_never_a_sidecar(tree: tuple[Path, Path]) -> None:
+    source, _ = tree
+
+    assert find_sidecars(source, (".mkv",)) == []
+
+
+def test_nothing_is_found_when_no_patterns_are_configured(tree: tuple[Path, Path]) -> None:
+    source, _ = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("subs")
+
+    assert find_sidecars(source, ()) == []
+
+
+def test_a_missing_folder_yields_nothing_rather_than_raising(tmp_path: Path) -> None:
+    assert find_sidecars(tmp_path / "gone" / "film.mkv", (".srt",)) == []
+
+
+# --- renaming ------------------------------------------------------------------------
+
+
+def test_a_sidecar_is_renamed_to_the_output_stem(tree: tuple[Path, Path]) -> None:
+    """Keeping the original name would leave a subtitle no player associates with the video."""
+
+    source, output = tree
+    sidecar = source.parent / "Film.2001.1080p.BluRay.en.srt"
+
+    destination = destination_for_sidecar(sidecar=sidecar, source_media=source, output_media=output)
+
+    assert destination.name == "Film (2001).en.srt"
+    assert destination.parent == output.parent
+
+
+# --- migrating -----------------------------------------------------------------------
+
+
+def test_a_sidecar_is_migrated_and_renamed(tree: tuple[Path, Path]) -> None:
+    source, output = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("subs")
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=(".srt",))
+
+    assert result.blocks_source_deletion is False
+    assert [m.destination.name for m in result.migrated] == ["Film (2001).srt"]
+    assert (output.parent / "Film (2001).srt").read_text() == "subs"
+    # Copied, not moved: the deletion gate has its own conditions and may still refuse.
+    assert (source.parent / "Film.2001.1080p.BluRay.srt").exists()
+
+
+def test_a_release_with_no_sidecars_migrates_nothing_and_blocks_nothing(tree: tuple[Path, Path]) -> None:
+    """The common case. Treating "nothing to migrate" as a failure would block every file."""
+
+    source, output = tree
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=DEFAULT_SIDECAR_PATTERNS)
+
+    assert result.migrated == []
+    assert result.blocks_source_deletion is False
+
+
+def test_an_empty_pattern_list_leaves_everything_exactly_as_before(tree: tuple[Path, Path]) -> None:
+    source, output = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("subs")
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=())
+
+    assert result.migrated == []
+    assert result.blocks_source_deletion is False
+    assert not (output.parent / "Film (2001).srt").exists()
+
+
+def test_an_existing_destination_is_left_alone_and_reported(tree: tuple[Path, Path]) -> None:
+    """Overwriting could replace an edited subtitle with the release's original."""
+
+    source, output = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("release version")
+    (output.parent / "Film (2001).srt").write_text("my edited version")
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=(".srt",))
+
+    assert result.migrated == []
+    assert any("already in the output folder" in s for s in result.skipped)
+    assert (output.parent / "Film (2001).srt").read_text() == "my edited version"
+    # Not a failure: nothing was lost, so the deletion may still proceed.
+    assert result.blocks_source_deletion is False
+
+
+def test_a_failed_copy_blocks_the_source_deletion_and_says_why(tree: tuple[Path, Path]) -> None:
+    """The rule that makes this safe rather than merely useful.
+
+    A destination whose parent is a *file* cannot be created on any platform, which
+    produces a real copy failure without needing permission games.
+    """
+
+    source, output = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("subs")
+    blocker = output.parent / "Film (2001).srt"
+    blocker.parent.mkdir(parents=True, exist_ok=True)
+    # Make the destination path unusable: a directory where the file must go.
+    blocker.mkdir()
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=(".srt",))
+
+    assert result.blocks_source_deletion is True
+    assert result.migrated == []
+    assert "did not remove the source folder" in result.blocking_reason
+    assert "nothing is lost" in result.blocking_reason
+
+
+def test_a_directory_in_the_way_is_a_failure_not_an_already_migrated_sidecar(tree: tuple[Path, Path]) -> None:
+    """Reading it as "already there" would clear the way for the source to be deleted
+    while the sidecar never arrived."""
+
+    source, output = tree
+    (source.parent / "Film.2001.1080p.BluRay.srt").write_text("subs")
+    (output.parent / "Film (2001).srt").mkdir(parents=True)
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=(".srt",))
+
+    assert result.skipped == []
+    assert result.blocks_source_deletion is True
+
+
+def test_several_sidecars_travel_together(tree: tuple[Path, Path]) -> None:
+    """An .idx without its .sub is a broken pair."""
+
+    source, output = tree
+    for suffix in (".idx", ".sub", ".nfo"):
+        (source.parent / f"Film.2001.1080p.BluRay{suffix}").write_text(suffix)
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=DEFAULT_SIDECAR_PATTERNS)
+
+    assert sorted(m.destination.suffix for m in result.migrated) == [".idx", ".nfo", ".sub"]
+
+
+# --- timestamps ----------------------------------------------------------------------
+
+
+def test_original_timestamps_can_be_applied_to_the_output(tree: tuple[Path, Path]) -> None:
+    source, output = tree
+    old = 1_000_000_000
+    os.utime(source, (old, old))
+
+    problem = apply_original_timestamps(source_media=source, output_media=output)
+
+    assert problem is None
+    assert int(output.stat().st_mtime) == old
+
+
+def test_a_timestamp_problem_is_reported_rather_than_raised(tmp_path: Path) -> None:
+    """Refusing a finished remux over a timestamp would be the wrong trade."""
+
+    problem = apply_original_timestamps(source_media=tmp_path / "gone.mkv", output_media=tmp_path / "also-gone.mkv")
+
+    assert problem is not None
+    assert "timestamps" in problem
+
+
+def test_preserving_timestamps_carries_them_onto_a_migrated_sidecar(tree: tuple[Path, Path]) -> None:
+    source, output = tree
+    sidecar = source.parent / "Film.2001.1080p.BluRay.srt"
+    sidecar.write_text("subs")
+    old = 1_000_000_000
+    os.utime(sidecar, (old, old))
+
+    result = migrate_sidecars(source_media=source, output_media=output, patterns=(".srt",), preserve_timestamps=True)
+
+    assert len(result.migrated) == 1
+    assert int(result.migrated[0].destination.stat().st_mtime) == old

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -3548,6 +3548,12 @@
             "title": "Output Folder",
             "type": "string"
           },
+          "preserve_original_timestamps": {
+            "default": false,
+            "description": "Give the output the original file's modification time.",
+            "title": "Preserve Original Timestamps",
+            "type": "boolean"
+          },
           "priority": {
             "default": 0,
             "maximum": 100.0,
@@ -3625,6 +3631,12 @@
             "default": "00:00",
             "maxLength": 5,
             "title": "Schedule Start",
+            "type": "string"
+          },
+          "sidecar_patterns_csv": {
+            "default": ".srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png",
+            "description": "Which files beside the video travel with it to the output, renamed to the output's stem. Empty migrates nothing \u2014 and the source folder deletion would then remove them.",
+            "title": "Sidecar Patterns Csv",
             "type": "string"
           },
           "skip_access_tests": {
@@ -3821,6 +3833,10 @@
             "title": "Output Folder",
             "type": "string"
           },
+          "preserve_original_timestamps": {
+            "title": "Preserve Original Timestamps",
+            "type": "boolean"
+          },
           "priority": {
             "title": "Priority",
             "type": "integer"
@@ -3876,6 +3892,10 @@
             "title": "Schedule Start",
             "type": "string"
           },
+          "sidecar_patterns_csv": {
+            "title": "Sidecar Patterns Csv",
+            "type": "string"
+          },
           "skip_access_tests": {
             "title": "Skip Access Tests",
             "type": "boolean"
@@ -3925,6 +3945,8 @@
           "top_level_only",
           "scan_interval_seconds",
           "hold_minutes",
+          "sidecar_patterns_csv",
+          "preserve_original_timestamps",
           "file_detection_interval_seconds",
           "ignore_size_changes",
           "skip_access_tests",
@@ -4102,6 +4124,12 @@
             "title": "Output Folder",
             "type": "string"
           },
+          "preserve_original_timestamps": {
+            "default": false,
+            "description": "Give the output the original file's modification time.",
+            "title": "Preserve Original Timestamps",
+            "type": "boolean"
+          },
           "priority": {
             "default": 0,
             "maximum": 100.0,
@@ -4179,6 +4207,12 @@
             "default": "00:00",
             "maxLength": 5,
             "title": "Schedule Start",
+            "type": "string"
+          },
+          "sidecar_patterns_csv": {
+            "default": ".srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png",
+            "description": "Which files beside the video travel with it to the output, renamed to the output's stem. Empty migrates nothing \u2014 and the source folder deletion would then remove them.",
+            "title": "Sidecar Patterns Csv",
             "type": "string"
           },
           "skip_access_tests": {

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -3224,6 +3224,12 @@ export interface components {
        */
       output_folder: string;
       /**
+       * Preserve Original Timestamps
+       * @description Give the output the original file's modification time.
+       * @default false
+       */
+      preserve_original_timestamps: boolean;
+      /**
        * Priority
        * @default 0
        */
@@ -3284,6 +3290,12 @@ export interface components {
        * @default 00:00
        */
       schedule_start: string;
+      /**
+       * Sidecar Patterns Csv
+       * @description Which files beside the video travel with it to the output, renamed to the output's stem. Empty migrates nothing — and the source folder deletion would then remove them.
+       * @default .srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png
+       */
+      sidecar_patterns_csv: string;
       /**
        * Skip Access Tests
        * @description Skip the read/write probe that runs before a file is queued.
@@ -3381,6 +3393,8 @@ export interface components {
       name: string;
       /** Output Folder */
       output_folder: string;
+      /** Preserve Original Timestamps */
+      preserve_original_timestamps: boolean;
       /** Priority */
       priority: number;
       /** Retry Backoff Seconds */
@@ -3405,6 +3419,8 @@ export interface components {
       schedule_hours_limited: boolean;
       /** Schedule Start */
       schedule_start: string;
+      /** Sidecar Patterns Csv */
+      sidecar_patterns_csv: string;
       /** Skip Access Tests */
       skip_access_tests: boolean;
       /** Top Level Only */
@@ -3524,6 +3540,12 @@ export interface components {
        */
       output_folder: string;
       /**
+       * Preserve Original Timestamps
+       * @description Give the output the original file's modification time.
+       * @default false
+       */
+      preserve_original_timestamps: boolean;
+      /**
        * Priority
        * @default 0
        */
@@ -3584,6 +3606,12 @@ export interface components {
        * @default 00:00
        */
       schedule_start: string;
+      /**
+       * Sidecar Patterns Csv
+       * @description Which files beside the video travel with it to the output, renamed to the output's stem. Empty migrates nothing — and the source folder deletion would then remove them.
+       * @default .srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png
+       */
+      sidecar_patterns_csv: string;
       /**
        * Skip Access Tests
        * @description Skip the read/write probe that runs before a file is queued.

--- a/apps/web/src/lib/refiner/libraries-api.ts
+++ b/apps/web/src/lib/refiner/libraries-api.ts
@@ -32,6 +32,9 @@ export interface RefinerLibrary {
 
   scan_interval_seconds: number;
   hold_minutes: number;
+  /** Files beside the video that travel with it, renamed to the output's stem. Empty migrates nothing. */
+  sidecar_patterns_csv: string;
+  preserve_original_timestamps: boolean;
   file_detection_interval_seconds: number;
   ignore_size_changes: boolean;
   skip_access_tests: boolean;
@@ -73,6 +76,8 @@ export interface RefinerLibraryWrite {
   top_level_only?: boolean;
   scan_interval_seconds?: number;
   hold_minutes?: number;
+  sidecar_patterns_csv?: string;
+  preserve_original_timestamps?: boolean;
   file_detection_interval_seconds?: number;
   ignore_size_changes?: boolean;
   skip_access_tests?: boolean;

--- a/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-libraries-section.test.tsx
@@ -29,6 +29,8 @@ function library(over: Partial<RefinerLibrary> = {}): RefinerLibrary {
     top_level_only: false,
     scan_interval_seconds: 300,
     hold_minutes: 0,
+    sidecar_patterns_csv: ".srt,.nfo",
+    preserve_original_timestamps: false,
     file_detection_interval_seconds: 30,
     ignore_size_changes: false,
     skip_access_tests: false,


### PR DESCRIPTION
Closes #344. Part of #347.

## The problem

Refiner mirrored the watched-relative path under the output root and moved the video. **Nothing beside it came across** — no `.srt`, no `.nfo`, no artwork, no `.idx`/`.sub` pair. Then Movies cleanup ran `rmtree` on the release folder and TV did the same to a season folder, so sidecars next to the source were destroyed rather than migrated.

I verified the issue's claim before acting on it: there are **zero** references to `REFINER_SOURCE_SIDECAR_CLEANUP_SUFFIXES` anywhere in the backend.

## Two rules make this safe

**A sidecar that is not there is not a failure.** The common case is a release with none, and treating "nothing to migrate" as a problem would block source deletion on *every* file and quietly fill the watched folder.

**A sidecar that exists and could not be copied blocks the deletion.** That is the whole point of running before the cleanup gate — the alternative is deleting the only copy of a file MediaMop was asked to keep.

Both have their own test.

## Matching and renaming

- Matched against the **video's own stem**, so a release folder holding two films does not hand one film's subtitles to the other.
- A multi-part suffix like `.en.srt` matches, because that is how subtitle files are actually named.
- Renamed to the output stem: `Film.2001.1080p.en.srt` → `Film (2001).en.srt`. Keeping the original name would leave a subtitle no player associates with the video.
- **Copied, not moved.** The deletion gate has its own conditions, and a moved sidecar whose deletion is then refused would have been taken out of a folder the operator still has.

## A test I wrote to hedge caught a real bug

A **directory** sitting where the sidecar file should go was being read as "already migrated" — which would have cleared the way for the source to be deleted while the sidecar never arrived. Only a real file counts as already there; anything else is now a failure. I noticed because my own assertion was a hedge (`is True or result.skipped`), which was the tell.

## A deliberate default change, flagged

The default pattern list is the release-bundle set (`.srt,.ass,.ssa,.sub,.idx,.vtt,.nfo,.jpg,.png`) rather than empty. That departs from this epic's usual "defaults change nothing" rule, and it is deliberate: **the previous behaviour was destroying those files**, so migrating something that would otherwise be deleted is strictly the safer direction, and the issue asks for that list by name.

The not-there-is-not-a-failure rule keeps the upgrade uneventful — a release with no sidecars migrates nothing and blocks nothing. If you would rather it defaulted empty, that is a one-line change to the migration and the model default.

## Also

Optional original-timestamp preservation, on the output and on migrated sidecars. A timestamp problem is **reported, never fatal**: refusing a finished remux over an mtime would be the wrong trade.

## Tests

Sidecar migrated and renamed · migration failure blocks source deletion · empty list unchanged · **directory-in-the-way is a failure, not a skip** · stem matching rejecting another film's subtitles · multi-part suffixes · the `.idx`/`.sub` pair travelling together · an existing edited subtitle left alone · timestamps applied and timestamp problems reported.

Verified locally: 1120 backend passed / 2 skipped, 202 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

Stacked on #342, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
