### PR TITLE
feat(refiner): close the API surface gate and its drift (#346)

### DIFF
--- a/apps/backend/src/mediamop/modules/refiner/refiner_hardware_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_hardware_api.py
@@ -29,7 +29,21 @@ router = APIRouter(tags=["refiner"])
 def get_refiner_hardware(_user: UserPublicDep, settings: SettingsDep) -> RefinerHardwareOut:
     """What ffmpeg on this machine reports it can do."""
 
-    _, ffmpeg_bin = resolve_ffprobe_ffmpeg(mediamop_home=settings.mediamop_home)
+    try:
+        _, ffmpeg_bin = resolve_ffprobe_ffmpeg(mediamop_home=settings.mediamop_home)
+    except RuntimeError as exc:
+        # A source install without ffmpeg on PATH is a supported state — Refiner reports
+        # it elsewhere and refuses passes with a clear reason. Reporting "no acceleration"
+        # here is the honest answer; letting the endpoint 500 would make a missing
+        # optional tool look like a broken application.
+        return RefinerHardwareOut(
+            detected=False,
+            available_methods=[],
+            vendors=[],
+            selectable_vendors=sorted(VENDOR_METHODS),
+            strictness_levels=list(STRICTNESS_LEVELS),
+            detail=f"MediaMop could not find ffmpeg, so it cannot report acceleration methods. {exc}",
+        )
     report = detect_acceleration(ffmpeg_bin)
     return RefinerHardwareOut(
         detected=report.detected,

--- a/apps/backend/src/mediamop/modules/refiner/refiner_maintenance_api.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_maintenance_api.py
@@ -1,0 +1,152 @@
+"""Refiner HTTP: the maintenance job families — ``/api/v1/refiner/maintenance``.
+
+Until #339 these families were switched on by an undocumented environment variable, and
+even then there was **no way to run one from outside the process, by any means**. An
+operator who wanted to reclaim stale work files had to wait for a timer they could not see.
+
+Triggering by hand deliberately ignores the schedule toggle. The toggle says whether
+MediaMop runs the family on its own; someone asking for it now has already decided.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from sqlalchemy import select
+from starlette import status as http_status
+
+from mediamop.api.deps import DbSessionDep, SettingsDep
+from mediamop.core.config import MediaMopSettings
+from mediamop.modules.refiner.jobs_model import RefinerJob, RefinerJobStatus
+from mediamop.modules.refiner.refiner_failure_cleanup_enqueue import enqueue_refiner_failure_cleanup_sweep_job
+from mediamop.modules.refiner.refiner_failure_cleanup_job_kinds import (
+    REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND,
+    REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND,
+)
+from mediamop.modules.refiner.refiner_operator_settings_service import ensure_refiner_operator_settings_row
+from mediamop.modules.refiner.refiner_work_temp_stale_sweep_enqueue import (
+    enqueue_refiner_work_temp_stale_sweep_job,
+)
+from mediamop.modules.refiner.refiner_work_temp_stale_sweep_job_kinds import (
+    REFINER_WORK_TEMP_STALE_SWEEP_JOB_KIND,
+)
+from mediamop.modules.refiner.schemas_refiner_maintenance import (
+    MaintenanceFamilyStateOut,
+    MaintenanceStateOut,
+    MaintenanceTriggerIn,
+    MaintenanceTriggerOut,
+)
+from mediamop.platform.auth.authorization import RequireOperatorDep
+from mediamop.platform.auth.csrf import (
+    current_raw_session_token,
+    require_session_secret,
+    validate_browser_post_origin,
+    verify_csrf_token,
+)
+from mediamop.platform.auth.deps_auth import UserPublicDep
+
+router = APIRouter(tags=["refiner"])
+
+_FAMILY_JOB_KINDS: dict[str, tuple[str, ...]] = {
+    "work_temp_stale_sweep": (REFINER_WORK_TEMP_STALE_SWEEP_JOB_KIND,),
+    "failure_cleanup": (
+        REFINER_MOVIE_FAILURE_CLEANUP_SWEEP_JOB_KIND,
+        REFINER_TV_FAILURE_CLEANUP_SWEEP_JOB_KIND,
+    ),
+}
+
+_FAMILY_DESCRIPTIONS: dict[str, str] = {
+    "work_temp_stale_sweep": ("Reclaims MediaMop's own stale working files. Safe, and switched on by default."),
+    "failure_cleanup": (
+        "Removes the source release folder after a file has failed terminally. This deletes the original, "
+        "so it stays switched off until you choose it."
+    ),
+}
+
+
+def _verify_csrf(request: Request, settings: MediaMopSettings, token: str) -> None:
+    validate_browser_post_origin(request, settings)
+    secret = require_session_secret(settings)
+    if not verify_csrf_token(secret, token, raw_session_token=current_raw_session_token(request, settings)):
+        raise HTTPException(status_code=http_status.HTTP_400_BAD_REQUEST, detail="Invalid or expired CSRF token.")
+
+
+def _state_for(db: DbSessionDep, family: str, *, enabled: bool) -> MaintenanceFamilyStateOut:
+    kinds = _FAMILY_JOB_KINDS[family]
+    rows = list(db.scalars(select(RefinerJob).where(RefinerJob.job_kind.in_(kinds)).order_by(RefinerJob.id.desc())))
+    pending = sum(1 for r in rows if r.status == RefinerJobStatus.PENDING.value)
+    running = sum(1 for r in rows if r.status == RefinerJobStatus.LEASED.value)
+
+    completed = next((r for r in rows if r.status == RefinerJobStatus.COMPLETED.value), None)
+    failed = next((r for r in rows if r.status == RefinerJobStatus.FAILED.value), None)
+    return MaintenanceFamilyStateOut(
+        family=family,  # type: ignore[arg-type]
+        enabled=enabled,
+        description=_FAMILY_DESCRIPTIONS[family],
+        pending=pending,
+        running=running,
+        last_completed_at=completed.updated_at if completed is not None else None,
+        last_failed_at=failed.updated_at if failed is not None else None,
+        last_error=failed.last_error if failed is not None else None,
+    )
+
+
+@router.get("/refiner/maintenance", response_model=MaintenanceStateOut)
+def get_refiner_maintenance(_user: UserPublicDep, db: DbSessionDep) -> MaintenanceStateOut:
+    """What each maintenance family is doing, and whether its schedule is on."""
+
+    operator = ensure_refiner_operator_settings_row(db)
+    families = [
+        _state_for(db, "work_temp_stale_sweep", enabled=bool(operator.work_temp_stale_sweep_enabled)),
+        _state_for(db, "failure_cleanup", enabled=bool(operator.failure_cleanup_enabled)),
+    ]
+    db.commit()
+    return MaintenanceStateOut(families=families)
+
+
+@router.post("/refiner/maintenance/run", response_model=MaintenanceTriggerOut)
+def post_refiner_maintenance_run(
+    request: Request,
+    _operator: RequireOperatorDep,
+    db: DbSessionDep,
+    settings: SettingsDep,
+    body: MaintenanceTriggerIn,
+) -> MaintenanceTriggerOut:
+    """Run one maintenance family now.
+
+    Ignores the schedule toggle on purpose: the toggle decides whether MediaMop runs this
+    on its own, and somebody asking for it now has already decided.
+    """
+
+    _verify_csrf(request, settings, body.csrf_token)
+
+    if body.family == "work_temp_stale_sweep":
+        enqueue_refiner_work_temp_stale_sweep_job(db, media_scope=body.media_scope)
+        db.commit()
+        return MaintenanceTriggerOut(
+            queued=True,
+            detail=(
+                f"Queued a work file sweep for {'TV' if body.media_scope == 'tv' else 'Movies'}. "
+                "It runs as soon as a worker is free."
+            ),
+        )
+
+    job, inserted = enqueue_refiner_failure_cleanup_sweep_job(db, media_scope=body.media_scope)
+    db.commit()
+    if not inserted:
+        # Already waiting or running. Saying so beats silently returning success for a
+        # button press that did nothing.
+        return MaintenanceTriggerOut(
+            queued=False,
+            job_id=int(job.id),
+            detail="A failure cleanup for this scope is already waiting or running, so nothing new was queued.",
+        )
+    return MaintenanceTriggerOut(
+        queued=True,
+        job_id=int(job.id),
+        detail=(
+            f"Queued failure cleanup for {'TV' if body.media_scope == 'tv' else 'Movies'}. "
+            "It runs as soon as a worker is free."
+        ),
+    )

--- a/apps/backend/src/mediamop/modules/refiner/router.py
+++ b/apps/backend/src/mediamop/modules/refiner/router.py
@@ -13,6 +13,7 @@ from mediamop.modules.refiner.refiner_hardware_api import router as refiner_hard
 from mediamop.modules.refiner.refiner_hold_diagnostic_api import router as refiner_hold_diagnostic_router
 from mediamop.modules.refiner.refiner_jobs_inspection_api import router as refiner_jobs_inspection_router
 from mediamop.modules.refiner.refiner_libraries_api import router as refiner_libraries_router
+from mediamop.modules.refiner.refiner_maintenance_api import router as refiner_maintenance_router
 from mediamop.modules.refiner.refiner_metadata_provider_api import router as refiner_metadata_provider_router
 from mediamop.modules.refiner.refiner_operator_settings_api import router as refiner_operator_settings_router
 from mediamop.modules.refiner.refiner_overview_stats_api import router as refiner_overview_stats_router
@@ -35,5 +36,6 @@ router.include_router(refiner_overview_stats_router)
 router.include_router(refiner_hold_diagnostic_router)
 router.include_router(refiner_hardware_router)
 router.include_router(refiner_metadata_provider_router)
+router.include_router(refiner_maintenance_router)
 router.include_router(refiner_file_remux_pass_router)
 router.include_router(refiner_watched_folder_remux_scan_dispatch_router)

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_maintenance.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_maintenance.py
@@ -1,0 +1,49 @@
+"""Request and response shapes for the maintenance job families.
+
+These families do real work on real paths and, until #339, could only be switched on by an
+undocumented environment variable and could not be triggered from outside the process at
+all. This is the surface that makes them operable (#346).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+MaintenanceFamily = Literal["work_temp_stale_sweep", "failure_cleanup"]
+MaintenanceScope = Literal["movie", "tv"]
+
+
+class MaintenanceFamilyStateOut(BaseModel):
+    """What one family is doing, and whether it is switched on."""
+
+    family: MaintenanceFamily
+    enabled: bool = Field(description="Whether the schedule runs this family. Triggering by hand ignores this.")
+    description: str = Field(description="What this family does, in a sentence.")
+    pending: int = Field(description="Queued and not yet started.")
+    running: int = Field(description="Leased by a worker right now.")
+    last_completed_at: datetime | None = None
+    last_failed_at: datetime | None = None
+    last_error: str | None = Field(
+        default=None, description="The most recent failure reason, when the last run failed."
+    )
+
+
+class MaintenanceStateOut(BaseModel):
+    families: list[MaintenanceFamilyStateOut]
+
+
+class MaintenanceTriggerIn(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    csrf_token: str = Field(..., min_length=1)
+    family: MaintenanceFamily
+    media_scope: MaintenanceScope = "movie"
+
+
+class MaintenanceTriggerOut(BaseModel):
+    queued: bool = Field(description="False when a run of this family was already waiting or in progress.")
+    detail: str = Field(description="What happened, written for the person reading it.")
+    job_id: int | None = None

--- a/apps/backend/tests/test_refiner_api_surface.py
+++ b/apps/backend/tests/test_refiner_api_surface.py
@@ -1,0 +1,229 @@
+"""The standing gate: every capability in the epic reaches the v1 API.
+
+This is not a test of any one feature. It is the guard that makes #346 a *standing*
+requirement rather than a box ticked once — the Refiner API drifted from the UI in both
+directions before, which is exactly how the gap went unnoticed:
+
+- endpoints with no consumer, reachable and untested from the client side;
+- client helpers with no screen;
+- capabilities with neither, which is what the five dormant job families were.
+
+A capability that is deliberately API-only is fine. A capability that is *accidentally*
+missing is what this catches. Adding a surface to the epic means adding it here, and a
+route being renamed without this being updated fails the build.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from tests.integration_helpers import auth_get, auth_post, csrf
+
+#: Every surface the epic promises, as (method, path). Paths are the route templates
+#: FastAPI registers, so a rename is a failure rather than a silent gap.
+REQUIRED_SURFACES: tuple[tuple[str, str], ...] = (
+    # Libraries — full CRUD, reorder, discovery.
+    ("GET", "/api/v1/refiner/libraries"),
+    ("POST", "/api/v1/refiner/libraries"),
+    ("GET", "/api/v1/refiner/libraries/{library_id}"),
+    ("PUT", "/api/v1/refiner/libraries/{library_id}"),
+    ("DELETE", "/api/v1/refiner/libraries/{library_id}"),
+    ("POST", "/api/v1/refiner/libraries/reorder"),
+    # Rule sets — CRUD, carrying sorters, metadata options and original-language options.
+    ("GET", "/api/v1/refiner/rule-sets"),
+    ("POST", "/api/v1/refiner/rule-sets"),
+    ("PUT", "/api/v1/refiner/rule-sets/{rule_set_id}"),
+    ("DELETE", "/api/v1/refiner/rule-sets/{rule_set_id}"),
+    # Files — list, log, remove, requeue, move to top, bulk requeue, why-held.
+    ("GET", "/api/v1/refiner/files"),
+    ("DELETE", "/api/v1/refiner/files/{file_id}"),
+    ("GET", "/api/v1/refiner/files/{file_id}/log"),
+    ("GET", "/api/v1/refiner/files/{file_id}/log/download"),
+    ("GET", "/api/v1/refiner/files/{file_id}/why-held"),
+    ("POST", "/api/v1/refiner/files/{file_id}/requeue"),
+    ("POST", "/api/v1/refiner/files/{file_id}/move-to-top"),
+    ("POST", "/api/v1/refiner/files/requeue"),
+    # Runtime control.
+    ("GET", "/api/v1/suite/pause"),
+    ("PUT", "/api/v1/suite/pause"),
+    # Capacity and schedules live on the operator settings and the library respectively,
+    # both covered above and by the settings surface.
+    ("GET", "/api/v1/refiner/operator-settings"),
+    ("PUT", "/api/v1/refiner/operator-settings"),
+    # Maintenance — trigger and read every promoted family.
+    ("GET", "/api/v1/refiner/maintenance"),
+    ("POST", "/api/v1/refiner/maintenance/run"),
+    # Hardware.
+    ("GET", "/api/v1/refiner/hardware"),
+    # Metadata provider.
+    ("GET", "/api/v1/refiner/metadata-provider"),
+    ("PUT", "/api/v1/refiner/metadata-provider"),
+    ("POST", "/api/v1/refiner/metadata-provider/test"),
+)
+
+#: Prefixes retired during the epic. A route reappearing under one of these means a lane
+#: was resurrected without the decision being revisited.
+RETIRED_SURFACES: tuple[str, ...] = (
+    "/api/v1/refiner/jobs/candidate-gate/enqueue",
+    "/api/v1/refiner/jobs/supplied-payload-evaluation/enqueue",
+)
+
+
+def _documented(client: TestClient) -> dict:
+    """The generated schema, which is what a generated client actually sees.
+
+    Deliberately the schema rather than a walk of the ASGI route table: a route that is
+    registered but undocumented is a route no generated client can call, so the schema is
+    the stricter and more useful source of truth.
+    """
+
+    return client.get("/openapi.json").json().get("paths", {})
+
+
+def test_every_capability_in_the_epic_reaches_the_v1_api(client_with_admin: TestClient) -> None:
+    """The gate. A missing surface here is a capability that exists only in the UI."""
+
+    documented = _documented(client_with_admin)
+    missing = [
+        (method, path)
+        for method, path in REQUIRED_SURFACES
+        if path not in documented or method.lower() not in documented[path]
+    ]
+
+    assert not missing, f"Capabilities missing from the v1 API and its OpenAPI schema: {missing}"
+
+
+def test_retired_lanes_have_not_come_back(client_with_admin: TestClient) -> None:
+    """Both were reachable, undocumented and called by nothing. They are not endpoints
+    any more, and a route reappearing means a decision was reversed by accident."""
+
+    documented = _documented(client_with_admin)
+    resurrected = [path for path in RETIRED_SURFACES if path in documented]
+
+    assert not resurrected, f"Retired endpoints are reachable again: {resurrected}"
+
+
+# --- auth and CSRF on the new endpoints ----------------------------------------------
+
+
+def _signed_in(client: TestClient) -> TestClient:
+    token = csrf(client)
+    response = auth_post(
+        client,
+        "/api/v1/auth/login",
+        json={"username": "alice", "password": "test-password-strong", "csrf_token": token},
+    )
+    assert response.status_code == 200, response.text
+    return client
+
+
+def test_maintenance_state_needs_a_session(client_with_admin: TestClient) -> None:
+    assert auth_get(client_with_admin, "/api/v1/refiner/maintenance").status_code == 401
+
+
+def test_maintenance_state_lists_every_promoted_family(client_with_admin: TestClient) -> None:
+    body = auth_get(_signed_in(client_with_admin), "/api/v1/refiner/maintenance").json()
+
+    families = {row["family"] for row in body["families"]}
+    assert families == {"work_temp_stale_sweep", "failure_cleanup"}
+    # The description is the operator-facing part: failure cleanup deletes originals and
+    # has to say so where the switch is.
+    cleanup = next(row for row in body["families"] if row["family"] == "failure_cleanup")
+    assert "deletes the original" in cleanup["description"]
+
+
+def test_triggering_maintenance_without_a_csrf_token_is_refused(client_with_admin: TestClient) -> None:
+    client = _signed_in(client_with_admin)
+
+    response = auth_post(
+        client, "/api/v1/refiner/maintenance/run", json={"family": "work_temp_stale_sweep", "media_scope": "movie"}
+    )
+
+    assert response.status_code == 422
+
+
+def test_triggering_maintenance_queues_a_run(client_with_admin: TestClient) -> None:
+    client = _signed_in(client_with_admin)
+
+    response = auth_post(
+        client,
+        "/api/v1/refiner/maintenance/run",
+        json={
+            "csrf_token": csrf(client),
+            "family": "work_temp_stale_sweep",
+            "media_scope": "movie",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["queued"] is True
+
+
+def test_an_unknown_family_is_refused(client_with_admin: TestClient) -> None:
+    client = _signed_in(client_with_admin)
+
+    response = auth_post(
+        client,
+        "/api/v1/refiner/maintenance/run",
+        json={"csrf_token": csrf(client), "family": "something_invented", "media_scope": "movie"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_the_hardware_report_needs_a_session_and_then_answers(client_with_admin: TestClient) -> None:
+    assert auth_get(client_with_admin, "/api/v1/refiner/hardware").status_code == 401
+
+    body = auth_get(_signed_in(client_with_admin), "/api/v1/refiner/hardware").json()
+
+    assert "available_methods" in body
+    assert "selectable_vendors" in body
+    assert body["detail"]
+
+
+def test_the_metadata_provider_never_returns_the_key(client_with_admin: TestClient) -> None:
+    """The key is write-only. A screen can say one is configured without being able to leak it."""
+
+    client = _signed_in(client_with_admin)
+    auth_get(client, "/api/v1/refiner/metadata-provider")
+
+    from tests.integration_helpers import auth_put
+
+    saved = auth_put(
+        client,
+        "/api/v1/refiner/metadata-provider",
+        json={
+            "csrf_token": csrf(client),
+            "provider": "tmdb",
+            "base_url": "https://metadata.example.workers.dev",
+            "api_key": "a-secret-key",
+        },
+    )
+
+    assert saved.status_code == 200, saved.text
+    body = saved.json()
+    assert body["key_configured"] is True
+    assert "a-secret-key" not in saved.text
+    assert body["base_url"] == "https://metadata.example.workers.dev"
+
+
+def test_the_metadata_provider_key_survives_a_save_that_omits_it(client_with_admin: TestClient) -> None:
+    """Saving the address must not require re-typing a secret the screen cannot show back."""
+
+    from tests.integration_helpers import auth_put
+
+    client = _signed_in(client_with_admin)
+    auth_put(
+        client,
+        "/api/v1/refiner/metadata-provider",
+        json={"csrf_token": csrf(client), "provider": "tmdb", "base_url": "https://one.example.com", "api_key": "k"},
+    )
+
+    body = auth_put(
+        client,
+        "/api/v1/refiner/metadata-provider",
+        json={"csrf_token": csrf(client), "provider": "tmdb", "base_url": "https://two.example.com"},
+    ).json()
+
+    assert body["key_configured"] is True
+    assert body["base_url"] == "https://two.example.com"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -625,6 +625,164 @@
         "title": "LogoutIn",
         "type": "object"
       },
+      "MaintenanceFamilyStateOut": {
+        "description": "What one family is doing, and whether it is switched on.",
+        "properties": {
+          "description": {
+            "description": "What this family does, in a sentence.",
+            "title": "Description",
+            "type": "string"
+          },
+          "enabled": {
+            "description": "Whether the schedule runs this family. Triggering by hand ignores this.",
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "family": {
+            "enum": [
+              "work_temp_stale_sweep",
+              "failure_cleanup"
+            ],
+            "title": "Family",
+            "type": "string"
+          },
+          "last_completed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Completed At"
+          },
+          "last_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The most recent failure reason, when the last run failed.",
+            "title": "Last Error"
+          },
+          "last_failed_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Failed At"
+          },
+          "pending": {
+            "description": "Queued and not yet started.",
+            "title": "Pending",
+            "type": "integer"
+          },
+          "running": {
+            "description": "Leased by a worker right now.",
+            "title": "Running",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "family",
+          "enabled",
+          "description",
+          "pending",
+          "running"
+        ],
+        "title": "MaintenanceFamilyStateOut",
+        "type": "object"
+      },
+      "MaintenanceStateOut": {
+        "properties": {
+          "families": {
+            "items": {
+              "$ref": "#/components/schemas/MaintenanceFamilyStateOut"
+            },
+            "title": "Families",
+            "type": "array"
+          }
+        },
+        "required": [
+          "families"
+        ],
+        "title": "MaintenanceStateOut",
+        "type": "object"
+      },
+      "MaintenanceTriggerIn": {
+        "additionalProperties": false,
+        "properties": {
+          "csrf_token": {
+            "minLength": 1,
+            "title": "Csrf Token",
+            "type": "string"
+          },
+          "family": {
+            "enum": [
+              "work_temp_stale_sweep",
+              "failure_cleanup"
+            ],
+            "title": "Family",
+            "type": "string"
+          },
+          "media_scope": {
+            "default": "movie",
+            "enum": [
+              "movie",
+              "tv"
+            ],
+            "title": "Media Scope",
+            "type": "string"
+          }
+        },
+        "required": [
+          "csrf_token",
+          "family"
+        ],
+        "title": "MaintenanceTriggerIn",
+        "type": "object"
+      },
+      "MaintenanceTriggerOut": {
+        "properties": {
+          "detail": {
+            "description": "What happened, written for the person reading it.",
+            "title": "Detail",
+            "type": "string"
+          },
+          "job_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Id"
+          },
+          "queued": {
+            "description": "False when a run of this family was already waiting or in progress.",
+            "title": "Queued",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "queued",
+          "detail"
+        ],
+        "title": "MaintenanceTriggerOut",
+        "type": "object"
+      },
       "MeOut": {
         "properties": {
           "user": {
@@ -10364,6 +10522,72 @@
           }
         },
         "summary": "Post Refiner Library Unlink",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/maintenance": {
+      "get": {
+        "description": "What each maintenance family is doing, and whether its schedule is on.",
+        "operationId": "get_refiner_maintenance_api_v1_refiner_maintenance_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceStateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Refiner Maintenance",
+        "tags": [
+          "refiner",
+          "refiner"
+        ]
+      }
+    },
+    "/api/v1/refiner/maintenance/run": {
+      "post": {
+        "description": "Run one maintenance family now.\n\nIgnores the schedule toggle on purpose: the toggle decides whether MediaMop runs this\non its own, and somebody asking for it now has already decided.",
+        "operationId": "post_refiner_maintenance_run_api_v1_refiner_maintenance_run_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MaintenanceTriggerIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MaintenanceTriggerOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Refiner Maintenance Run",
         "tags": [
           "refiner",
           "refiner"

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -1042,6 +1042,49 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/refiner/maintenance": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Refiner Maintenance
+     * @description What each maintenance family is doing, and whether its schedule is on.
+     */
+    get: operations["get_refiner_maintenance_api_v1_refiner_maintenance_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/refiner/maintenance/run": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Post Refiner Maintenance Run
+     * @description Run one maintenance family now.
+     *
+     *     Ignores the schedule toggle on purpose: the toggle decides whether MediaMop runs this
+     *     on its own, and somebody asking for it now has already decided.
+     */
+    post: operations["post_refiner_maintenance_run_api_v1_refiner_maintenance_run_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/refiner/metadata-provider": {
     parameters: {
       query?: never;
@@ -1996,6 +2039,82 @@ export interface components {
     LogoutIn: {
       /** Csrf Token */
       csrf_token?: string | null;
+    };
+    /**
+     * MaintenanceFamilyStateOut
+     * @description What one family is doing, and whether it is switched on.
+     */
+    MaintenanceFamilyStateOut: {
+      /**
+       * Description
+       * @description What this family does, in a sentence.
+       */
+      description: string;
+      /**
+       * Enabled
+       * @description Whether the schedule runs this family. Triggering by hand ignores this.
+       */
+      enabled: boolean;
+      /**
+       * Family
+       * @enum {string}
+       */
+      family: "work_temp_stale_sweep" | "failure_cleanup";
+      /** Last Completed At */
+      last_completed_at?: string | null;
+      /**
+       * Last Error
+       * @description The most recent failure reason, when the last run failed.
+       */
+      last_error?: string | null;
+      /** Last Failed At */
+      last_failed_at?: string | null;
+      /**
+       * Pending
+       * @description Queued and not yet started.
+       */
+      pending: number;
+      /**
+       * Running
+       * @description Leased by a worker right now.
+       */
+      running: number;
+    };
+    /** MaintenanceStateOut */
+    MaintenanceStateOut: {
+      /** Families */
+      families: components["schemas"]["MaintenanceFamilyStateOut"][];
+    };
+    /** MaintenanceTriggerIn */
+    MaintenanceTriggerIn: {
+      /** Csrf Token */
+      csrf_token: string;
+      /**
+       * Family
+       * @enum {string}
+       */
+      family: "work_temp_stale_sweep" | "failure_cleanup";
+      /**
+       * Media Scope
+       * @default movie
+       * @enum {string}
+       */
+      media_scope: "movie" | "tv";
+    };
+    /** MaintenanceTriggerOut */
+    MaintenanceTriggerOut: {
+      /**
+       * Detail
+       * @description What happened, written for the person reading it.
+       */
+      detail: string;
+      /** Job Id */
+      job_id?: number | null;
+      /**
+       * Queued
+       * @description False when a run of this family was already waiting or in progress.
+       */
+      queued: boolean;
     };
     /** MeOut */
     MeOut: {
@@ -7096,6 +7215,59 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["RefinerLibraryOut"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_refiner_maintenance_api_v1_refiner_maintenance_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MaintenanceStateOut"];
+        };
+      };
+    };
+  };
+  post_refiner_maintenance_run_api_v1_refiner_maintenance_run_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["MaintenanceTriggerIn"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MaintenanceTriggerOut"];
         };
       };
       /** @description Validation Error */

--- a/apps/web/src/lib/refiner/files-queries.ts
+++ b/apps/web/src/lib/refiner/files-queries.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { postRefinerFileRemuxPassEnqueue } from "./file-remux-pass-api";
 import {
   fetchRefinerFiles,
   forgetRefinerFile,
@@ -72,4 +73,19 @@ export function useRefinerFileLog() {
   // A mutation rather than a query: a processing record is read when someone opens it,
   // not for every row on every render.
   return useMutation({ mutationFn: (id: number) => fetchRefinerFileLog(id) });
+}
+
+export function useProcessRefinerFileNow() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      relative_media_path,
+      media_scope,
+    }: {
+      relative_media_path: string;
+      media_scope: "movie" | "tv";
+    }) => postRefinerFileRemuxPassEnqueue({ relative_media_path, media_scope }),
+    onSuccess: () =>
+      void qc.invalidateQueries({ queryKey: ["refiner", "files"] }),
+  });
 }

--- a/apps/web/src/lib/refiner/maintenance-api.ts
+++ b/apps/web/src/lib/refiner/maintenance-api.ts
@@ -1,0 +1,50 @@
+import { fetchCsrfToken } from "../api/auth-api";
+import { apiFetch, readJson, requireOk } from "../api/client";
+
+export type MaintenanceFamily = "work_temp_stale_sweep" | "failure_cleanup";
+
+export interface MaintenanceFamilyState {
+  family: MaintenanceFamily;
+  /** Whether the schedule runs this. Triggering by hand ignores it. */
+  enabled: boolean;
+  description: string;
+  pending: number;
+  running: number;
+  last_completed_at: string | null;
+  last_failed_at: string | null;
+  last_error: string | null;
+}
+
+export interface MaintenanceState {
+  families: MaintenanceFamilyState[];
+}
+
+export interface MaintenanceTriggerResult {
+  queued: boolean;
+  detail: string;
+  job_id: number | null;
+}
+
+export const refinerMaintenancePath = () => "/api/v1/refiner/maintenance";
+
+export async function fetchRefinerMaintenance(): Promise<MaintenanceState> {
+  const path = refinerMaintenancePath();
+  const response = await apiFetch(path);
+  await requireOk(path, response, "Could not read the maintenance state");
+  return readJson<MaintenanceState>(response);
+}
+
+export async function runRefinerMaintenance(
+  family: MaintenanceFamily,
+  media_scope: "movie" | "tv",
+): Promise<MaintenanceTriggerResult> {
+  const csrf_token = await fetchCsrfToken();
+  const path = `${refinerMaintenancePath()}/run`;
+  const response = await apiFetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ csrf_token, family, media_scope }),
+  });
+  await requireOk(path, response, "Could not start that maintenance job");
+  return readJson<MaintenanceTriggerResult>(response);
+}

--- a/apps/web/src/lib/refiner/maintenance-queries.ts
+++ b/apps/web/src/lib/refiner/maintenance-queries.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  fetchRefinerMaintenance,
+  runRefinerMaintenance,
+  type MaintenanceFamily,
+  type MaintenanceState,
+} from "./maintenance-api";
+import { fetchRefinerRuntimeSettings } from "./runtime-settings-api";
+import type { RefinerRuntimeSettingsOut } from "./types";
+
+export const refinerMaintenanceKey = () => ["refiner", "maintenance"];
+
+export function useRefinerMaintenanceQuery() {
+  return useQuery<MaintenanceState>({
+    queryKey: refinerMaintenanceKey(),
+    queryFn: fetchRefinerMaintenance,
+    // A queued sweep starts within seconds, so the panel has to notice without a reload.
+    refetchInterval: 15_000,
+  });
+}
+
+export function useRunRefinerMaintenance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      family,
+      mediaScope,
+    }: {
+      family: MaintenanceFamily;
+      mediaScope: "movie" | "tv";
+    }) => runRefinerMaintenance(family, mediaScope),
+    onSuccess: () =>
+      void qc.invalidateQueries({ queryKey: refinerMaintenanceKey() }),
+  });
+}
+
+export const refinerRuntimeSettingsKey = () => ["refiner", "runtime-settings"];
+
+export function useRefinerRuntimeSettingsQuery() {
+  return useQuery<RefinerRuntimeSettingsOut>({
+    queryKey: refinerRuntimeSettingsKey(),
+    queryFn: fetchRefinerRuntimeSettings,
+  });
+}

--- a/apps/web/src/pages/refiner/refiner-files-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-files-section.tsx
@@ -12,6 +12,7 @@ import {
 import {
   useForgetRefinerFile,
   useMoveRefinerFileToTop,
+  useProcessRefinerFileNow,
   useRefinerFileLog,
   useRefinerWhyHeld,
   useRequeueRefinerFile,
@@ -94,6 +95,7 @@ export function RefinerFilesSection() {
   const requeueMany = useRequeueRefinerFiles();
   const whyHeld = useRefinerWhyHeld();
   const fileLog = useRefinerFileLog();
+  const processNow = useProcessRefinerFileNow();
   const [openLog, setOpenLog] = useState<RefinerFileLog | null>(null);
   const editable = canEdit(me.data?.role);
 
@@ -142,6 +144,22 @@ export function RefinerFilesSection() {
       );
     } catch {
       setNotice("MediaMop could not ask why that file is held.");
+    }
+  };
+
+  const processFileNow = async (file: RefinerFile) => {
+    setNotice(null);
+    const library = libraries.data?.find((l) => l.id === file.library_id);
+    try {
+      await processNow.mutateAsync({
+        relative_media_path: file.relative_path,
+        media_scope: library?.media_scope === "tv" ? "tv" : "movie",
+      });
+      setNotice(
+        "Queued this file for processing. It starts as soon as there is capacity.",
+      );
+    } catch {
+      setNotice("That file could not be queued for processing.");
     }
   };
 
@@ -436,6 +454,18 @@ export function RefinerFilesSection() {
                         title="Asks every media manager covering this library what it is doing with this file, right now."
                       >
                         Why is this held?
+                      </button>
+                    ) : null}
+                    {file.status === "unprocessed" ||
+                    file.status === "processing_failed" ? (
+                      <button
+                        type="button"
+                        className={mmActionButtonClass({ variant: "tertiary" })}
+                        onClick={() => void processFileNow(file)}
+                        data-testid={`refiner-file-process-now-${file.id}`}
+                        title="Queues a remux pass for this file straight away."
+                      >
+                        Process now
                       </button>
                     ) : null}
                     <button

--- a/apps/web/src/pages/refiner/refiner-maintenance-section.test.tsx
+++ b/apps/web/src/pages/refiner/refiner-maintenance-section.test.tsx
@@ -1,0 +1,195 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, expect, it, vi } from "vitest";
+
+import * as authQueries from "../../lib/auth/queries";
+import type { MaintenanceState } from "../../lib/refiner/maintenance-api";
+import * as maintenanceQueries from "../../lib/refiner/maintenance-queries";
+import { RefinerMaintenanceSection } from "./refiner-maintenance-section";
+
+const mutate = vi.fn();
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function state(over: Partial<MaintenanceState> = {}): MaintenanceState {
+  return {
+    families: [
+      {
+        family: "work_temp_stale_sweep",
+        enabled: true,
+        description: "Reclaims MediaMop's own stale working files.",
+        pending: 0,
+        running: 0,
+        last_completed_at: null,
+        last_failed_at: null,
+        last_error: null,
+      },
+      {
+        family: "failure_cleanup",
+        enabled: false,
+        description:
+          "Removes the source release folder after a file has failed terminally. This deletes the original.",
+        pending: 0,
+        running: 0,
+        last_completed_at: null,
+        last_failed_at: null,
+        last_error: null,
+      },
+    ],
+    ...over,
+  };
+}
+
+function setup(data: MaintenanceState, role = "operator") {
+  vi.spyOn(authQueries, "useMeQuery").mockReturnValue({
+    data: { role },
+  } as ReturnType<typeof authQueries.useMeQuery>);
+  vi.spyOn(maintenanceQueries, "useRefinerMaintenanceQuery").mockReturnValue({
+    data,
+  } as ReturnType<typeof maintenanceQueries.useRefinerMaintenanceQuery>);
+  vi.spyOn(
+    maintenanceQueries,
+    "useRefinerRuntimeSettingsQuery",
+  ).mockReturnValue({ data: undefined } as ReturnType<
+    typeof maintenanceQueries.useRefinerRuntimeSettingsQuery
+  >);
+  vi.spyOn(maintenanceQueries, "useRunRefinerMaintenance").mockReturnValue({
+    mutateAsync: mutate,
+    isPending: false,
+  } as unknown as ReturnType<
+    typeof maintenanceQueries.useRunRefinerMaintenance
+  >);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mutate.mockReset();
+});
+
+it("lists every promoted family and whether it is scheduled", async () => {
+  setup(state());
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+
+  expect(
+    await screen.findByTestId("refiner-maintenance-work_temp_stale_sweep"),
+  ).toHaveTextContent("scheduled");
+  expect(
+    screen.getByTestId("refiner-maintenance-failure_cleanup"),
+  ).toHaveTextContent("not scheduled");
+});
+
+it("carries the warning where the switch is", async () => {
+  setup(state());
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+
+  // Failure cleanup deletes originals, and the operator sees that beside the button.
+  expect(
+    await screen.findByTestId("refiner-maintenance-failure_cleanup"),
+  ).toHaveTextContent(/deletes the original/i);
+});
+
+it("runs a family for one scope", async () => {
+  setup(state());
+  mutate.mockResolvedValue({
+    queued: true,
+    detail: "Queued a work file sweep.",
+  });
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+  fireEvent.click(
+    await screen.findByTestId(
+      "refiner-maintenance-run-work_temp_stale_sweep-tv",
+    ),
+  );
+
+  expect(mutate).toHaveBeenCalledWith({
+    family: "work_temp_stale_sweep",
+    mediaScope: "tv",
+  });
+});
+
+it("shows the server's own words when nothing was queued", async () => {
+  setup(state());
+  mutate.mockResolvedValue({
+    queued: false,
+    detail: "A failure cleanup for this scope is already waiting or running.",
+  });
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+  fireEvent.click(
+    await screen.findByTestId("refiner-maintenance-run-failure_cleanup-movie"),
+  );
+
+  expect(
+    await screen.findByTestId("refiner-maintenance-notice"),
+  ).toHaveTextContent(/already waiting or running/);
+});
+
+it("reports a running family rather than showing it as idle", async () => {
+  setup(
+    state({
+      families: [
+        {
+          family: "work_temp_stale_sweep",
+          enabled: true,
+          description: "Reclaims stale working files.",
+          pending: 0,
+          running: 1,
+          last_completed_at: null,
+          last_failed_at: null,
+          last_error: null,
+        },
+      ],
+    }),
+  );
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+
+  expect(
+    await screen.findByTestId("refiner-maintenance-work_temp_stale_sweep"),
+  ).toHaveTextContent(/Running now/);
+});
+
+it("surfaces the reason a run failed", async () => {
+  setup(
+    state({
+      families: [
+        {
+          family: "failure_cleanup",
+          enabled: true,
+          description: "Removes the source release folder.",
+          pending: 0,
+          running: 0,
+          last_completed_at: null,
+          last_failed_at: "2026-08-26T14:00:00Z",
+          last_error: "The work folder was missing.",
+        },
+      ],
+    }),
+  );
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+
+  expect(
+    await screen.findByTestId("refiner-maintenance-failure_cleanup"),
+  ).toHaveTextContent("The work folder was missing.");
+});
+
+it("does not offer a viewer the run buttons", async () => {
+  setup(state(), "viewer");
+
+  render(<RefinerMaintenanceSection />, { wrapper });
+
+  await screen.findByTestId("refiner-maintenance-work_temp_stale_sweep");
+  expect(
+    screen.queryByTestId("refiner-maintenance-run-work_temp_stale_sweep-movie"),
+  ).not.toBeInTheDocument();
+});

--- a/apps/web/src/pages/refiner/refiner-maintenance-section.tsx
+++ b/apps/web/src/pages/refiner/refiner-maintenance-section.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+
+import { useMeQuery } from "../../lib/auth/queries";
+import type {
+  MaintenanceFamily,
+  MaintenanceFamilyState,
+} from "../../lib/refiner/maintenance-api";
+import {
+  useRefinerMaintenanceQuery,
+  useRefinerRuntimeSettingsQuery,
+  useRunRefinerMaintenance,
+} from "../../lib/refiner/maintenance-queries";
+import { mmActionButtonClass } from "../../lib/ui/mm-control-roles";
+
+function canEdit(role: string | undefined): boolean {
+  return role === "admin" || role === "operator";
+}
+
+const FAMILY_LABELS: Record<MaintenanceFamily, string> = {
+  work_temp_stale_sweep: "Work file sweep",
+  failure_cleanup: "Failure cleanup",
+};
+
+function stateLine(family: MaintenanceFamilyState): string {
+  if (family.running > 0) return `Running now (${family.running}).`;
+  if (family.pending > 0)
+    return `Queued (${family.pending}), waiting for a worker.`;
+  if (family.last_failed_at)
+    return `Last run failed: ${family.last_error ?? "no reason recorded"}.`;
+  if (family.last_completed_at)
+    return `Last finished ${new Date(family.last_completed_at).toLocaleString()}.`;
+  return "Has not run yet.";
+}
+
+/**
+ * Maintenance families, and what the running instance is actually configured with.
+ *
+ * Until #339 these families could only be switched on by an undocumented environment
+ * variable, and there was no way to run one from outside the process at all — an operator
+ * who wanted to reclaim stale work files had to wait for a timer they could not see.
+ */
+export function RefinerMaintenanceSection() {
+  const me = useMeQuery();
+  const maintenance = useRefinerMaintenanceQuery();
+  const runtime = useRefinerRuntimeSettingsQuery();
+  const run = useRunRefinerMaintenance();
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const editable = canEdit(me.data?.role);
+
+  const trigger = async (
+    family: MaintenanceFamily,
+    mediaScope: "movie" | "tv",
+  ) => {
+    setNotice(null);
+    try {
+      // The server says whether anything was actually queued — a run already waiting
+      // reports that rather than a success for a button press that did nothing.
+      const result = await run.mutateAsync({ family, mediaScope });
+      setNotice(result.detail);
+    } catch {
+      setNotice("That maintenance job could not be started.");
+    }
+  };
+
+  return (
+    <div className="space-y-4" data-testid="refiner-maintenance-section">
+      <p className="text-sm text-[var(--mm-text2)]">
+        Housekeeping MediaMop runs on a schedule. You can also start one now —
+        starting it by hand ignores the schedule switch.
+      </p>
+
+      {notice ? (
+        <p
+          className="rounded border border-[var(--mm-border)] px-3 py-2 text-sm"
+          role="status"
+          data-testid="refiner-maintenance-notice"
+        >
+          {notice}
+        </p>
+      ) : null}
+
+      <ul className="space-y-2">
+        {(maintenance.data?.families ?? []).map((family) => (
+          <li
+            key={family.family}
+            className="rounded border border-[var(--mm-border)] p-3"
+            data-testid={`refiner-maintenance-${family.family}`}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="font-medium text-[var(--mm-text1)]">
+                  {FAMILY_LABELS[family.family]}{" "}
+                  <span className="text-xs font-normal text-[var(--mm-text3)]">
+                    {family.enabled ? "scheduled" : "not scheduled"}
+                  </span>
+                </p>
+                {/* The description carries the warning where the switch is: failure
+                    cleanup deletes originals. */}
+                <p className="text-sm text-[var(--mm-text2)]">
+                  {family.description}
+                </p>
+                <p className="mt-1 text-xs text-[var(--mm-text3)]">
+                  {stateLine(family)}
+                </p>
+              </div>
+              {editable ? (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "tertiary" })}
+                    disabled={run.isPending}
+                    onClick={() => void trigger(family.family, "movie")}
+                    data-testid={`refiner-maintenance-run-${family.family}-movie`}
+                  >
+                    Run for Movies
+                  </button>
+                  <button
+                    type="button"
+                    className={mmActionButtonClass({ variant: "tertiary" })}
+                    disabled={run.isPending}
+                    onClick={() => void trigger(family.family, "tv")}
+                    data-testid={`refiner-maintenance-run-${family.family}-tv`}
+                  >
+                    Run for TV
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {runtime.data ? (
+        <div
+          className="rounded border border-[var(--mm-border)] p-3"
+          data-testid="refiner-runtime-settings"
+        >
+          <p className="font-medium text-[var(--mm-text1)]">
+            What this instance is running with
+          </p>
+          {/* Read-only. These come from the environment and a restart, so showing them
+              as editable would promise something the screen cannot deliver. */}
+          <ul className="mt-1 space-y-1 text-sm text-[var(--mm-text2)]">
+            <li>{runtime.data.worker_mode_summary}</li>
+            <li>{runtime.data.sqlite_throughput_note}</li>
+            <li>
+              File types accepted:{" "}
+              {runtime.data.refiner_media_extensions.join(", ")}
+            </li>
+          </ul>
+          <p className="mt-1 text-xs text-[var(--mm-text3)]">
+            {runtime.data.configuration_note}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/pages/refiner/refiner-page.tsx
+++ b/apps/web/src/pages/refiner/refiner-page.tsx
@@ -9,6 +9,7 @@ import {
   type RefinerOverviewOpenTab,
 } from "./refiner-overview-tab";
 import { RefinerLibrariesSection } from "./refiner-libraries-section";
+import { RefinerMaintenanceSection } from "./refiner-maintenance-section";
 import { RefinerSchedulesSection } from "./refiner-schedules-section";
 import { RefinerRemuxSection } from "./refiner-remux-section";
 import {
@@ -22,6 +23,7 @@ type RefinerPageTabId =
   | "audio-subtitles"
   | "files"
   | "jobs"
+  | "maintenance"
   | "schedules";
 
 const REFINER_TAB_BLURBS: Record<RefinerPageTabId, string> = {
@@ -36,6 +38,8 @@ const REFINER_TAB_BLURBS: Record<RefinerPageTabId, string> = {
   files:
     "Every file Refiner has looked at, and why it is or is not being processed.",
   jobs: "View queued, running, and recent Refiner jobs for troubleshooting and progress.",
+  maintenance:
+    "Housekeeping MediaMop runs on a schedule, and what this instance is configured with. Start one now if you need to.",
 };
 
 export function RefinerPage() {
@@ -48,6 +52,7 @@ export function RefinerPage() {
     { id: "schedules", label: "Schedules" },
     { id: "files", label: "Files" },
     { id: "jobs", label: "Jobs" },
+    { id: "maintenance", label: "Maintenance" },
   ];
 
   const openFromOverview = (target: RefinerOverviewOpenTab) => {
@@ -129,6 +134,7 @@ export function RefinerPage() {
           {tab === "schedules" ? <RefinerSchedulesSection /> : null}
           {tab === "files" ? <RefinerFilesSection /> : null}
           {tab === "jobs" ? <RefinerJobsInspectionSection /> : null}
+          {tab === "maintenance" ? <RefinerMaintenanceSection /> : null}
         </div>
       </div>
     </div>

--- a/scripts/dead-code-allowlist.json
+++ b/scripts/dead-code-allowlist.json
@@ -1,9 +1,6 @@
 {
   "_comment": "Dead code kept on purpose. Every entry states why. Anything not listed fails the build; anything listed that is no longer dead also fails, so this file cannot rot quietly. See scripts/check-dead-code.mjs.",
-  "webExports": {
-    "src/lib/refiner/file-remux-pass-api.ts:11 - postRefinerFileRemuxPassEnqueue": "Thin wrapper over a live v1 endpoint. Its hook was removed in #328; #334/#346 are expected to wire it to a screen.",
-    "src/lib/refiner/runtime-settings-api.ts:7 - fetchRefinerRuntimeSettings": "Thin wrapper over a live v1 endpoint. Its hook was removed in #328; #334/#346 are expected to wire it to a screen."
-  },
+  "webExports": {},
   "backendModules": {
     "apps/backend/src/mediamop/api/main.py": "ASGI entrypoint. Referenced by string as mediamop.api.main:app from docker/entrypoint.sh, scripts/dev-backend.ps1 and the E2E conftest, never by import.",
     "apps/backend/src/mediamop/core/exceptions.py": "Declared scaffolding for domain error types. Kept as the agreed home for them rather than re-litigated here.",


### PR DESCRIPTION
Closes #346. Part of #347.

The cross-cutting gate: no capability in the epic is done until it is on the v1 API and in the generated OpenAPI schema. Most of the surface arrived with the features themselves — this closes the three gaps the issue named, and adds the guard that keeps them closed.

## Capabilities with neither an endpoint nor a consumer

The maintenance families had **no API surface whatsoever**. There was no way to run a work-temp sweep or a failure cleanup from outside the process, by any means — an operator who wanted to reclaim stale work files had to wait for a timer they could not see.

- `GET /api/v1/refiner/maintenance` — what each family is doing, and whether its schedule is on.
- `POST /api/v1/refiner/maintenance/run` — run one now, **deliberately ignoring the schedule toggle**: that toggle decides whether MediaMop runs it on its own, and somebody asking for it now has already decided.

A run already waiting reports that rather than returning success for a button press that did nothing.

## Client helpers with no screen

Both entries in the dead-code allowlist named *this issue* as the one expected to wire them. Both are now wired to real consumers:

- `postRefinerFileRemuxPassEnqueue` → a **Process now** row action on the Files screen.
- `fetchRefinerRuntimeSettings` → what the running instance is actually configured with, beside the maintenance controls.

**The web allowlist is empty for the first time** — 0 unreferenced exports, 0 allowlisted.

## Endpoints with no consumer

Both were removed in #339. The guard now asserts they have not come back.

## The guard is the point

It makes #346 a **standing** requirement rather than a box ticked once, because the API drifted from the UI in both directions before and that is exactly how the gap went unnoticed.

It asserts against the **generated OpenAPI schema**, not a walk of the route table: a route that is registered but undocumented is a route no generated client can call, so the schema is the stricter and more useful source of truth. My first version walked the routes and reported *everything* as missing while the schema check passed on the same list — which is how I found that out.

Adding a surface to the epic now means adding it to `REQUIRED_SURFACES`, and renaming a route without updating it fails the build.

## A real bug the guard caught

`GET /api/v1/refiner/hardware` **raised a 500 when ffmpeg is absent** — resolving the binary raises even though detection never does. A source install without ffmpeg is a supported state that Refiner reports elsewhere and refuses passes over with a clear reason, so the endpoint now answers "no acceleration" with the reason. A missing optional tool should not look like a broken application.

## Tests

The surface gate itself · retired lanes staying retired · maintenance state and its family descriptions · triggering with and without CSRF · unknown family refused · auth on every new endpoint · **the provider key never appearing in a response** · the key surviving a save that omits it · hardware answering without a session refused · plus 7 web tests for the maintenance screen.

Verified locally: 1193 backend passed / 2 skipped, 209 web tests, 7 E2E, ruff, mypy, bandit, `alembic upgrade head` + `alembic check`, **dead-code guard with an empty web allowlist**, web lint/build, OpenAPI regeneration stable.

Stacked on #343, which has since merged; this branch is rebased onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
