### PR TITLE
feat(refiner): narrow the Deluno manifest parser to the confirmed contract (#364)

### DIFF
--- a/apps/backend/src/mediamop/modules/refiner/refiner_library_discovery.py
+++ b/apps/backend/src/mediamop/modules/refiner/refiner_library_discovery.py
@@ -53,6 +53,12 @@ class DiscoverableLibrary:
     root_path: str | None
     already_imported: bool
     local_path_problem: str | None
+    #: Where the manager expects processed output, when it processes before importing.
+    #: Shown before the import so the operator sees what will be filled in, rather than
+    #: discovering it afterwards.
+    output_path: str | None = None
+    processes_before_import: bool = False
+    output_path_problem: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -157,6 +163,11 @@ def discoverable_libraries(
                 root_path=descriptor.root_path,
                 already_imported=(connection_row.id, descriptor.key) in imported,
                 local_path_problem=local_path_problem(descriptor.root_path),
+                output_path=descriptor.output_path,
+                processes_before_import=descriptor.processes_before_import,
+                output_path_problem=(
+                    local_path_problem(descriptor.output_path) if descriptor.processes_before_import else None
+                ),
             )
         )
     return out
@@ -211,11 +222,22 @@ def import_libraries(
         # MediaMop cannot see: a library pointed at a folder that is not there would
         # fail every scan, and the operator is told why on the way in.
         usable_root = descriptor.root_path if local_path_problem(descriptor.root_path) is None else ""
+        # A manager that processes before importing tells MediaMop where it expects the
+        # finished file. Without this a discovered library arrived with no output folder
+        # and could not run a pass at all, which made discovery a half-import (#364).
+        # Held to the same textual local-path check as the watched folder, for the same
+        # reason: the manager's path is not necessarily one MediaMop can see.
+        usable_output = (
+            descriptor.output_path
+            if descriptor.processes_before_import and local_path_problem(descriptor.output_path) is None
+            else ""
+        )
         row = RefinerLibraryRow(
             name=_unique_name(session, descriptor.name or f"{connection_row.name} library {key}"),
             media_scope=descriptor.media_scope or "movie",
             display_order=order,
             watched_folder=usable_root or "",
+            output_folder=usable_output or "",
             discovered_from_connection_id=connection_row.id,
             discovered_library_key=key,
         )

--- a/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
+++ b/apps/backend/src/mediamop/modules/refiner/schemas_refiner_libraries.py
@@ -314,6 +314,20 @@ class DiscoverableLibraryOut(BaseModel):
         default=None,
         description="Why that path cannot be used on this machine, shown beside the manager's value.",
     )
+    processes_before_import: bool = Field(
+        default=False,
+        description=(
+            "Whether the manager processes this library before importing it. When it does, it also "
+            "publishes where it expects the finished file."
+        ),
+    )
+    output_path: str | None = Field(
+        default=None,
+        description="Where the manager expects processed output. Only set when it processes before importing.",
+    )
+    output_path_problem: str | None = Field(
+        default=None, description="Why that output path cannot be used on this machine."
+    )
 
 
 class RefinerLibraryImportIn(BaseModel):

--- a/apps/backend/src/mediamop/platform/media_managers/manager_dialects.py
+++ b/apps/backend/src/mediamop/platform/media_managers/manager_dialects.py
@@ -355,31 +355,48 @@ class ExternalIntegrationManagerPort:
 
 
 def _manifest_library_key(library: Mapping[str, Any]) -> str | None:
-    """The manager's own id for a library, kept only as an integration reference."""
+    """The manager's own id for a library, kept only as an integration reference.
 
-    number = _first_number(library, "id", "libraryId", "library_id")
+    Confirmed against a populated manifest (Deluno#331): ``id`` is the library's own
+    identifier, a hex string, stable across restarts. The numeric branch stays because
+    the arr products' root-folder ids are integers and share this helper.
+    """
+
+    number = _first_number(library, "id")
     if number is not None:
         return str(number)
-    return _first_text(library, "id", "libraryId", "library_id", "key", "uuid", "guid")
+    return _first_text(library, "id")
 
 
 def _manifest_library_descriptor(library: Mapping[str, Any]) -> ManagerLibraryDescriptor:
-    """One manifest entry, read tolerantly.
+    """One manifest entry, read against the confirmed contract.
 
-    The documented manifest sample shows ``"libraries": []`` from an unconfigured
-    instance, so the populated entry shape is unconfirmed (Deluno#331). Every plausible
-    spelling of name, media type and root is accepted rather than guessing one and
-    failing on the others; a missing root surfaces as a mismatch the operator can fix,
-    which is the same outcome as a root MediaMop cannot see.
+    The shape was unconfirmed when #351 shipped, because the documented sample was
+    captured on an unconfigured instance and showed ``"libraries": []``. It is confirmed
+    now (Deluno#331), so this reads the documented keys rather than guessing among
+    plausible spellings — a parser that accepts shapes the manager never sends is a
+    parser nobody can reason about, and it hides the day the contract really changes.
+
+    ``processorOutputPath`` is populated **only** for a library whose ``importWorkflow``
+    is ``refine-before-import``; a ``standard`` library sends an empty string. So the
+    workflow is what MediaMop branches on, not whether the path happens to be there.
     """
 
     key = _manifest_library_key(library) or ""
-    name = _first_text(library, "name", "title", "label", "displayName", "display_name") or key
-    scope = _scope_from_media_type(
-        library.get("mediaType") or library.get("media_type") or library.get("scope") or library.get("type")
+    name = _first_text(library, "name") or key
+    scope = _scope_from_media_type(library.get("mediaType"))
+    root = _first_text(library, "rootPath")
+    workflow = (_text(library.get("importWorkflow")) or "").strip().lower()
+    processes_before_import = workflow == "refine-before-import"
+    output = _first_text(library, "processorOutputPath") if processes_before_import else None
+    return ManagerLibraryDescriptor(
+        key=key,
+        name=name,
+        media_scope=scope,
+        root_path=root,
+        output_path=output,
+        processes_before_import=processes_before_import,
     )
-    root = _first_text(library, "path", "rootFolder", "root_folder", "root", "rootPath", "root_path")
-    return ManagerLibraryDescriptor(key=key, name=name, media_scope=scope, root_path=root)
 
 
 def _manifest_libraries(payload: Any) -> list[dict[str, Any]]:

--- a/apps/backend/src/mediamop/platform/media_managers/manager_port.py
+++ b/apps/backend/src/mediamop/platform/media_managers/manager_port.py
@@ -154,6 +154,12 @@ class ManagerLibraryDescriptor:
     name: str
     media_scope: MediaScope | None
     root_path: str | None = None
+    #: Where the manager expects processed output, when it has somewhere to put it.
+    #: Deluno populates this only for a library configured ``refine-before-import``;
+    #: a ``standard`` library sends an empty value, so ``processes_before_import`` is
+    #: the field to branch on rather than the presence of a path (Deluno#331).
+    output_path: str | None = None
+    processes_before_import: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/apps/backend/tests/test_refiner_library_discovery.py
+++ b/apps/backend/tests/test_refiner_library_discovery.py
@@ -304,3 +304,175 @@ def test_a_connection_with_no_saved_key_cannot_be_asked(session: Session, tmp_pa
     with pytest.raises(RefinerDiscoveryError) as exc:
         discoverable_libraries(session, MediaMopSettings.load(), row)
     assert "address and API key" in str(exc.value)
+
+
+# --- the confirmed Deluno contract ----------------------------------------------------
+#
+# #351 shipped against an *unconfirmed* manifest: the documented sample was captured on an
+# unconfigured instance and showed `"libraries": []`, so the populated entry shape was
+# invisible. Deluno#331 answered it from a live rig. These are the two entries exactly as
+# that answer reported them, so the parser is tested against a real body rather than a
+# hand-written guess (#364).
+
+DELUNO_MANIFEST_LIBRARIES: list[dict] = [
+    {
+        "id": "01a03d99f2f47c6587a496701b52f58f",
+        "name": "Movies",
+        "mediaType": "movies",
+        "rootPath": r"C:\Deluno\Library\Movies",
+        "importWorkflow": "refine-before-import",
+        "processorOutputPath": r"C:\Deluno\Refined\Movies",
+    },
+    {
+        "id": "01a03d9c14537c67b22f8215ea5fc45f",
+        "name": "TV",
+        "mediaType": "tv",
+        "rootPath": r"C:\Deluno\Library\TV",
+        "importWorkflow": "standard",
+        "processorOutputPath": "",
+    },
+]
+
+
+def test_the_real_deluno_manifest_entries_parse() -> None:
+    from mediamop.platform.media_managers.manager_dialects import _manifest_library_descriptor
+
+    movies, tv = (_manifest_library_descriptor(entry) for entry in DELUNO_MANIFEST_LIBRARIES)
+
+    assert movies.key == "01a03d99f2f47c6587a496701b52f58f"
+    assert movies.name == "Movies"
+    # "movies" plural is what Deluno actually sends; Refiner's scope is singular.
+    assert movies.media_scope == "movie"
+    assert movies.root_path == r"C:\Deluno\Library\Movies"
+    assert tv.media_scope == "tv"
+    assert tv.root_path == r"C:\Deluno\Library\TV"
+
+
+def test_a_refine_before_import_library_carries_its_processed_output_root() -> None:
+    from mediamop.platform.media_managers.manager_dialects import _manifest_library_descriptor
+
+    movies = _manifest_library_descriptor(DELUNO_MANIFEST_LIBRARIES[0])
+
+    assert movies.processes_before_import is True
+    assert movies.output_path == r"C:\Deluno\Refined\Movies"
+
+
+def test_a_standard_library_reports_no_processed_output_root() -> None:
+    """The workflow is what to branch on, not whether the path happens to be there.
+
+    Deluno sends an empty string for a `standard` library, so treating a present-but-empty
+    value as a configured path would seed an output folder of "".
+    """
+
+    from mediamop.platform.media_managers.manager_dialects import _manifest_library_descriptor
+
+    tv = _manifest_library_descriptor(DELUNO_MANIFEST_LIBRARIES[1])
+
+    assert tv.processes_before_import is False
+    assert tv.output_path is None
+
+
+def test_an_entry_with_no_id_is_skipped_rather_than_imported_anonymously() -> None:
+    from mediamop.platform.media_managers.manager_dialects import _manifest_library_key
+
+    assert _manifest_library_key({"name": "Nameless", "rootPath": "/srv"}) is None
+    assert _manifest_library_key(DELUNO_MANIFEST_LIBRARIES[0]) == "01a03d99f2f47c6587a496701b52f58f"
+
+
+def test_importing_a_refine_before_import_library_seeds_its_output_folder(
+    session: Session, connection: MediaManagerConnectionRow, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without this a discovered library arrived with no output folder and could not run.
+
+    Discovery was a half-import: it filled in the watched folder and left the operator to
+    type the one the manager had already told MediaMop about.
+    """
+
+    watched = tmp_path / "library"
+    watched.mkdir()
+    output = tmp_path / "refined"
+    output.mkdir()
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(
+            key="01a03d99f2f47c6587a496701b52f58f",
+            name="Movies",
+            media_scope="movie",
+            root_path=str(watched),
+            output_path=str(output),
+            processes_before_import=True,
+        ),
+    )
+
+    created = import_libraries(session, _settings(), connection, keys=["01a03d99f2f47c6587a496701b52f58f"])[0]
+
+    assert created.watched_folder == str(watched)
+    assert created.output_folder == str(output)
+
+
+def test_a_standard_library_is_imported_with_no_output_folder(
+    session: Session, connection: MediaManagerConnectionRow, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It is not a refine-before-import library, so the manager has nowhere to expect
+    output and MediaMop must not invent one."""
+
+    watched = tmp_path / "library"
+    watched.mkdir()
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(key="8", name="TV", media_scope="tv", root_path=str(watched)),
+    )
+
+    created = import_libraries(session, _settings(), connection, keys=["8"])[0]
+
+    assert created.output_folder == ""
+
+
+def test_an_output_root_this_machine_cannot_see_is_left_empty_rather_than_saved(
+    session: Session, connection: MediaManagerConnectionRow, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same rule as the watched folder: the manager's path is not necessarily one
+    MediaMop can see, and a library pointed at a folder that is not there would fail."""
+
+    watched = tmp_path / "library"
+    watched.mkdir()
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(
+            key="7",
+            name="Movies",
+            media_scope="movie",
+            root_path=str(watched),
+            output_path="relative/not/absolute",
+            processes_before_import=True,
+        ),
+    )
+
+    created = import_libraries(session, _settings(), connection, keys=["7"])[0]
+
+    assert created.watched_folder == str(watched)
+    assert created.output_folder == ""
+
+
+def test_the_listing_shows_the_output_root_before_the_import(
+    session: Session, connection: MediaManagerConnectionRow, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """So the operator sees what will be filled in, rather than discovering it after."""
+
+    _reports(
+        monkeypatch,
+        ManagerLibraryDescriptor(
+            key="7",
+            name="Movies",
+            media_scope="movie",
+            root_path=str(tmp_path),
+            output_path=str(tmp_path),
+            processes_before_import=True,
+        ),
+    )
+
+    found = discoverable_libraries(session, _settings(), connection)[0]
+
+    assert found.processes_before_import is True
+    assert found.output_path == str(tmp_path)
+    assert found.output_path_problem is None

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -441,6 +441,36 @@
             "title": "Name",
             "type": "string"
           },
+          "output_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Where the manager expects processed output. Only set when it processes before importing.",
+            "title": "Output Path"
+          },
+          "output_path_problem": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Why that output path cannot be used on this machine.",
+            "title": "Output Path Problem"
+          },
+          "processes_before_import": {
+            "default": false,
+            "description": "Whether the manager processes this library before importing it. When it does, it also publishes where it expects the finished file.",
+            "title": "Processes Before Import",
+            "type": "boolean"
+          },
           "root_path": {
             "anyOf": [
               {

--- a/apps/web/src/lib/api/generated/openapi-types.ts
+++ b/apps/web/src/lib/api/generated/openapi-types.ts
@@ -1961,6 +1961,22 @@ export interface components {
       /** Name */
       name: string;
       /**
+       * Output Path
+       * @description Where the manager expects processed output. Only set when it processes before importing.
+       */
+      output_path?: string | null;
+      /**
+       * Output Path Problem
+       * @description Why that output path cannot be used on this machine.
+       */
+      output_path_problem?: string | null;
+      /**
+       * Processes Before Import
+       * @description Whether the manager processes this library before importing it. When it does, it also publishes where it expects the finished file.
+       * @default false
+       */
+      processes_before_import: boolean;
+      /**
        * Root Path
        * @description Where the manager sees this library, on the manager's host.
        */


### PR DESCRIPTION
Closes #364.

## The contract is confirmed

[jampat000/Deluno#331](https://github.com/jampat000/Deluno/issues/331) was answered from a live rig and closed. The populated entry is:

```
id=01a03d99f2f47c6587a496701b52f58f
  mediaType=movies
  rootPath=C:\Deluno\Library\Movies
  importWorkflow=refine-before-import
  processorOutputPath=C:\Deluno\Refined\Movies
```

## Narrowed

#351 shipped tolerant because the documented sample came from an unconfigured instance and showed `"libraries": []` — so it accepted every plausible spelling of id, name, media type and root rather than guessing one and failing on the others. That was **tolerant, not correct**: it had never been run against a populated manifest.

It reads the documented keys now. A parser that accepts shapes the manager never sends is a parser nobody can reason about, and it hides the day the contract really changes. The numeric `id` branch stays, because the arr products' root-folder ids are integers and share the helper.

## A real gap the answer closed

`processorOutputPath` was being **ignored**. A discovered library arrived with no output folder and **could not run a pass at all** — discovery filled in the watched folder and left the operator to type the one the manager had already told MediaMop about. It seeds both now.

`importWorkflow` is what MediaMop branches on, **not** whether the path happens to be there: Deluno sends an empty string for a `standard` library, so treating present-but-empty as configured would seed an output folder of `""`.

The output root is held to the same textual local-path check as the watched folder, for the same reason — the manager's path is not necessarily one MediaMop can see, and a library pointed at a folder that is not there would fail every pass. The listing reports it before the import too, so the operator sees what will be filled in rather than discovering it afterwards.

## Tests

Both entries **exactly as Deluno#331 reported them** — a real captured body, not a hand-written guess. Including that `movies` plural is what Deluno actually sends where Refiner's scope is singular, that a `standard` library yields no output root, that an entry with no id is skipped, and that an output root this machine cannot see is left empty rather than saved.

Verified locally: 1201 backend passed / 2 skipped, 209 web tests, ruff, mypy, `alembic check`, dead-code guard, web lint/build, OpenAPI regeneration stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
