### PR TITLE
docs: release the Refiner library model as v2.5.0

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.4.3"
+version = "2.5.0"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -7540,7 +7540,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.4.3"
+    "version": "2.5.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.4.3",
+      "version": "2.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.4.3",
+  "version": "2.5.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -1,0 +1,49 @@
+# MediaMop v2.5.0
+
+Date: 2026-08-29
+
+This release replaces Refiner's fixed "Movies" and "TV" settings with libraries you can add, name and configure yourself — each with its own folders, rules, schedule and media manager.
+
+## What Changed
+
+- **Refiner -> Libraries** is new. Add as many libraries as you like. Each one has its own watched, work and output folders, its own audio and subtitle rules, its own schedule, and its own media manager. Your existing Movies and TV settings become the first two libraries automatically.
+- **Refiner -> Files** is new. Every file Refiner knows about, with the state it is in and why — waiting to settle, queued, processing, done, skipped or failed.
+- **Refiner -> Schedules** is new. Restrict each library to the hours you choose, down to the quarter hour. A closed window now stops work being *started* — previously it only stopped work being queued, so a large remux begun just before closing time ran on for hours. Anything already running is allowed to finish.
+- **A pause control now sits in the toolbar**, reachable from any screen. It can expire on its own, and it keeps noticing new files while paused — the useful pause is "stop working on files", not "stop seeing them".
+- **Libraries can be discovered from a connected media manager.** If a manager can list its libraries, MediaMop reads the names, folders and media types and offers them, so you do not retype what the manager already knows.
+- **Audio track selection is now an ordered list of rules you can edit**, replacing the fixed ranking. A rule can look at language, channel count, codec or bitrate, and you choose the order they apply in.
+- **Original-language audio.** Connect a metadata provider and a library can keep whatever language the title was actually made in, rather than a language you had to name in advance.
+- **Hardware acceleration controls.** Choose how MediaMop decodes, disable a specific vendor, and say how strict to be if ffmpeg cannot honour the request.
+- **Metadata, cover art and attachments can be removed** as part of a cleaning pass.
+- **An explicit output collision policy.** Say what should happen when the output file already exists, instead of relying on what the code happened to do.
+- **Subtitle and artwork sidecars are carried to the output** before the source folder is deleted, so nothing is lost with the folder.
+- **A weighted work budget replaces the flat file count.** A large file counts for more than a small one, so a runner limit means something closer to actual load.
+- **Failed files can be retried or requeued** from the Files screen, one at a time or in bulk. Previously a failure recorded a reason and stopped there — no retry, no requeue, no way back — even though MediaMop deletes the source folder after a success.
+- **You can ask why a file is being held** and get a direct answer, rather than inferring it from what has not happened yet.
+- **A durable record of every processed file**, with its own retention setting, so history survives a restart and does not grow forever.
+
+## Fixes And Stability
+
+- **Files are now watched, not polled.** A new file is picked up as it lands, with the periodic scan kept as a backstop rather than the only mechanism.
+- **A file is judged ready by its size settling and by whether it can actually be opened**, replacing a guess based on modification time. A slow copy is no longer picked up half-written.
+- **More video containers are accepted**: `.mpe`, `.mpeg`, `.mpg`, `.mov`, `.flv`, `.wmv` and `.avchd`, on top of the five already handled. Each was verified by actually running it through a cleaning pass. A file with an extension MediaMop will not take is now reported with a reason, instead of being dropped silently — previously this was the only decision that told you nothing at all.
+- **The Docker upgrade command shown in Settings -> Upgrade could not work**, and has not since v2.3.6. It named an image tag that is never published (releases publish `v2.5.0`, not `2.5.0`), and `docker compose up` would not have used it even if it existed, because the documented compose file follows `:latest`. It now shows `docker compose pull && docker compose up -d`.
+- **A damaged update-settings file could turn on automatic updates.** An unreadable file was treated as "use the defaults", and the default is Auto. It now falls back to notify-only, so a corrupt file cannot install an update you did not choose. The file is also written atomically now, so it should not become damaged in the first place.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- **Your existing Refiner settings are carried across automatically.** The Movies and TV paths and rules you had become two libraries with the same values. Nothing needs to be re-entered.
+- **The old Refiner settings tables have been removed** now that libraries hold everything. This happens during the upgrade and needs no action.
+- **Configuration backups taken before this release can still be restored.** They are translated onto the seeded libraries. Backups taken from this release cannot be restored on an older version.
+- **Docker users:** the upgrade command shown in **Settings -> Upgrade** has been wrong since v2.3.6 — it named an image tag that is never published. If an upgrade appeared to do nothing, that is why. Use `docker compose pull && docker compose up -d`, which is what this release now shows.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:v2.5.0`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.4.3...v2.5.0


### PR DESCRIPTION
`main` carries the whole ADR-0014 epic — 24 merged PRs since v2.4.3 — and has no release to ship it in.

## What this PR does

- Bumps to **2.5.0** in `apps/backend/pyproject.toml` and `apps/web/package.json`, syncing `apps/web/package-lock.json` and the OpenAPI `info.version` to match, the same set the v2.4.3 bump touched.
- Adds `docs/release-notes/v2.5.0.md`, written for operators and **checked against the commits** rather than summarised from their subjects. Three claims were corrected in the process: a bullet that actually described a v2.4.0 fix, an audio-sorter capability list that did not match the fields a sorter can read, and the release range of the Docker bug below.

## Two items worth reading before tagging

Both describe behaviour operators have already been living with, so they are called out in the notes rather than buried:

- **The Docker upgrade command in Settings → Upgrade has been wrong since v2.3.6.** It showed `docker pull ghcr.io/jampat000/mediamop:2.4.3`, but releases publish `v2.4.3` — that tag does not exist — and the compose file in `docs/docker.md` follows `:latest`, so `compose up -d` would not have used it regardless. Anyone who followed it saw an upgrade that appeared to do nothing. Fixed in [#382](https://github.com/jampat000/MediaMop/pull/382); the Upgrade Notes say so explicitly.
- **A file MediaMop would not accept used to be dropped silently** — the only admission decision that reported nothing at all. Seven more containers are admitted now and a refusal states its reason.

## Release checklist (`docs/release-governance.md`)

- [x] Working tree clean, `main` up to date
- [x] Required check names still exposed by `ci.yml`: `mediamop`, `docker-smoke`, `windows-package-smoke`
- [x] No open issues tagged `priority: critical` or `priority: high` — the backlog is empty
- [x] `docs/release-notes/v2.5.0.md` created from the template (`release.yml` hard-fails without it)
- [ ] Tag pushed — deliberately left for a human, since `v*` publishes a public GitHub Release, a GHCR image and a Windows installer

After merge:

```bash
git fetch origin && git checkout main && git pull origin main && git tag -a v2.5.0 -m "MediaMop v2.5.0" && git push origin v2.5.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)