### PR TITLE
test(tray): cover the update-settings read that decides whether to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
         with:
           dotnet-version: "9.0.x"
 
+      - name: MediaMop tray unit tests
+        run: dotnet test apps/tray/MediaMop.Tray.Tests --nologo --verbosity quiet
+
       - name: Install Velopack CLI
         run: dotnet tool install -g vpk
 

--- a/apps/tray/MediaMop.Tray.Tests/.gitignore
+++ b/apps/tray/MediaMop.Tray.Tests/.gitignore
@@ -1,0 +1,5 @@
+# Build output. The sibling MediaMop.Tray project has its bin/ and obj/ committed, which
+# is a pre-existing wart rather than a pattern to copy: it makes every local build show up
+# as a diff and puts binaries in review.
+bin/
+obj/

--- a/apps/tray/MediaMop.Tray.Tests/MediaMop.Tray.Tests.csproj
+++ b/apps/tray/MediaMop.Tray.Tests/MediaMop.Tray.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- The project under test is a WinForms exe; referencing it needs the same switches. -->
+    <UseWindowsForms>true</UseWindowsForms>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>MediaMop.Tray.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MediaMop.Tray\MediaMop.Tray.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/apps/tray/MediaMop.Tray.Tests/UpdateSettingsTests.cs
+++ b/apps/tray/MediaMop.Tray.Tests/UpdateSettingsTests.cs
@@ -1,0 +1,115 @@
+using System.Text.Json;
+
+using Xunit;
+
+namespace MediaMop.Tray.Tests;
+
+/// <summary>
+/// The tray is the component that actually installs an update, so what it reads out of
+/// update-settings.json decides whether software lands on a machine unattended. These
+/// tests exist because that read had no coverage at all while it silently escalated a
+/// damaged file to Auto.
+/// </summary>
+public sealed class UpdateSettingsTests : IDisposable
+{
+    private readonly string _home;
+    private readonly string? _previousHome;
+
+    public UpdateSettingsTests()
+    {
+        _home = Path.Combine(Path.GetTempPath(), "mediamop-tray-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(_home);
+        // Load logs through Program.RuntimeHome() on the failure path; point that at the
+        // temp folder so a test can never append to a real install's tray-host.log.
+        _previousHome = Environment.GetEnvironmentVariable("MEDIAMOP_HOME");
+        Environment.SetEnvironmentVariable("MEDIAMOP_HOME", _home);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("MEDIAMOP_HOME", _previousHome);
+        try { Directory.Delete(_home, recursive: true); } catch { }
+    }
+
+    private string SettingsPath => Path.Combine(_home, "update-settings.json");
+
+    [Fact]
+    public void No_file_is_the_shipped_default()
+    {
+        var got = UpdateSettings.Load(_home);
+
+        Assert.Equal(UpdateMode.Auto, got.Mode);
+        Assert.True(got.CheckOnStartup);
+        Assert.Equal(60, got.CheckIntervalMinutes);
+    }
+
+    [Fact]
+    public void A_saved_choice_round_trips()
+    {
+        new UpdateSettings
+        {
+            Mode = UpdateMode.DownloadOnly,
+            CheckOnStartup = false,
+            CheckIntervalMinutes = 240,
+        }.Save(_home);
+
+        var got = UpdateSettings.Load(_home);
+
+        Assert.Equal(UpdateMode.DownloadOnly, got.Mode);
+        Assert.False(got.CheckOnStartup);
+        Assert.Equal(240, got.CheckIntervalMinutes);
+    }
+
+    [Fact]
+    public void A_truncated_file_falls_back_to_notify_only_not_to_auto()
+    {
+        // The operator chose something. Auto is the only mode that installs with nobody
+        // watching, so it is the one guess that can act against that choice.
+        new UpdateSettings { Mode = UpdateMode.NotifyOnly }.Save(_home);
+        File.WriteAllText(SettingsPath, "{\"mode\": \"Notify");
+
+        Assert.Equal(UpdateMode.NotifyOnly, UpdateSettings.Load(_home).Mode);
+    }
+
+    [Fact]
+    public void An_unknown_mode_is_rejected_rather_than_defaulting_to_auto()
+    {
+        File.WriteAllText(SettingsPath, "{\"mode\": \"InstallEverythingNow\"}");
+
+        Assert.Equal(UpdateMode.NotifyOnly, UpdateSettings.Load(_home).Mode);
+    }
+
+    [Fact]
+    public void An_empty_file_falls_back_to_notify_only()
+    {
+        // Deserialize returns null for a bare "null" document rather than throwing, which
+        // is the case the old `?? new UpdateSettings()` quietly turned into Auto.
+        File.WriteAllText(SettingsPath, "null");
+
+        Assert.Equal(UpdateMode.NotifyOnly, UpdateSettings.Load(_home).Mode);
+    }
+
+    [Fact]
+    public void The_failure_path_says_why_in_the_tray_log()
+    {
+        File.WriteAllText(SettingsPath, "{ not json");
+
+        UpdateSettings.Load(_home);
+
+        var log = File.ReadAllText(Path.Combine(_home, "tray-host.log"));
+        Assert.Contains("update-settings.json could not be read", log);
+        Assert.Contains("NotifyOnly", log);
+    }
+
+    [Fact]
+    public void The_file_is_replaced_whole_and_leaves_no_scratch_file()
+    {
+        new UpdateSettings { Mode = UpdateMode.DownloadOnly, CheckIntervalMinutes = 10080 }.Save(_home);
+        new UpdateSettings { Mode = UpdateMode.Auto, CheckIntervalMinutes = 1 }.Save(_home);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(SettingsPath));
+        Assert.Equal("Auto", doc.RootElement.GetProperty("mode").GetString());
+        Assert.Equal(1, doc.RootElement.GetProperty("checkIntervalMinutes").GetInt32());
+        Assert.Empty(Directory.GetFiles(_home, "*.tmp"));
+    }
+}

--- a/apps/tray/MediaMop.Tray/MediaMop.Tray.csproj
+++ b/apps/tray/MediaMop.Tray/MediaMop.Tray.csproj
@@ -23,4 +23,10 @@
     <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- UpdateSettings is internal and stays that way: it is not API, it is this app's
+         own on-disk state. The tests reach it through here rather than by widening it. -->
+    <InternalsVisibleTo Include="MediaMop.Tray.Tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Follow-up to [#385](https://github.com/jampat000/MediaMop/pull/385). The tray decides whether software lands on a machine unattended, and none of that logic had a test — the only thing standing between the bug #385 fixed and the next one was `dotnet build` succeeding.

## What this adds

`apps/tray/MediaMop.Tray.Tests`, a new xunit project, wired into **windows-package-smoke** — the job that already has the .NET SDK — so it runs on every PR rather than only at package time.

Seven tests over `UpdateSettings`. **Four fail against the pre-#385 reader**, which is the point of writing them:

| Test | Pre-#385 |
|---|---|
| no file is the shipped default (`Auto`) | passes |
| a saved choice round-trips | passes |
| a truncated file falls back to `NotifyOnly`, not `Auto` | **fails** |
| an unknown mode string is rejected rather than defaulting to `Auto` | **fails** |
| a bare `null` document falls back too | **fails** |
| the failure path says why in `tray-host.log` | **fails** |
| the file is replaced whole, leaving no scratch file | passes |

The `null` case is the one the old `?? new UpdateSettings()` quietly turned into `Auto` — `System.Text.Json` returns null there rather than throwing, so it never reached the `catch`.

## Notes

- `UpdateSettings` **stays internal** — it is this app's own on-disk state, not API — so the tests reach it through `InternalsVisibleTo` rather than by widening it.
- `MEDIAMOP_HOME` is redirected per test, so the logging assertion cannot append to a real install's `tray-host.log`.
- The new project ignores its own `bin/`/`obj/`. The sibling `MediaMop.Tray` commits both, which is a pre-existing wart — being dealt with separately, where the rule will be consolidated into the root `.gitignore` to match how the rest of the repo does it.
- `packaging/windows/build-velopack.ps1` targets `MediaMop.Tray` by explicit path and there is no `.sln`, so a sibling project cannot be picked up by packaging.

## Verification

- `dotnet test apps/tray/MediaMop.Tray.Tests` — 7 passed
- Same suite against the pre-#385 `Program.cs` — 4 failed, 3 passed
- Full pre-push gate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)