### PR TITLE
fix(suite): the tray and the backend must not share a scratch filename

### DIFF
--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Literal
 
@@ -202,9 +203,23 @@ def put_update_settings(
     # Written whole and then renamed. `write_text` truncates first, so a crash mid-write
     # leaves the half-file that the read path above has to guess its way around; the point
     # of that fallback is to be unreachable in practice.
-    tmp = path.with_suffix(f"{path.suffix}.tmp")
-    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    os.replace(tmp, path)
+    #
+    # The scratch name is unique per write, not `update-settings.json.tmp`. The tray writes
+    # this same file when its menu changes the mode, and a shared scratch name lets one
+    # writer rename the other's file into place: the web UI saves NotifyOnly, is told it
+    # saved, and the file holds Auto. That is the silent change of an operator's choice
+    # this whole path exists to prevent. mkstemp keeps it in the same directory so the
+    # rename stays atomic.
+    tmp_name: str | None = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+        with os.fdopen(fd, "w", encoding="utf-8") as target:
+            target.write(json.dumps(payload, indent=2))
+        os.replace(tmp_name, path)
+        tmp_name = None
+    finally:
+        if tmp_name is not None and os.path.exists(tmp_name):
+            os.unlink(tmp_name)
     return UpdateSettingsOut(
         mode=mode,
         check_on_startup=check_on_startup,

--- a/apps/backend/tests/test_suite_update_service.py
+++ b/apps/backend/tests/test_suite_update_service.py
@@ -176,3 +176,22 @@ def test_the_settings_file_is_replaced_whole(tmp_path: object) -> None:
         "checkIntervalMinutes": 1,
     }
     assert not list(path.parent.glob("*.tmp"))
+
+
+def test_a_scratch_file_from_the_tray_is_not_renamed_into_place(tmp_path: object) -> None:
+    """The tray writes this same file. A shared scratch name lets one writer claim the other's.
+
+    Both implementations used ``update-settings.json.tmp``, so an interleaved save could
+    rename the tray's half-written file into place and tell the web UI it had saved — the
+    operator's choice silently replaced by someone else's, which is the exact failure the
+    atomic write was added to prevent.
+    """
+
+    settings = _settings_for(tmp_path)
+    foreign = tmp_path / "update-settings.json.tmp"  # type: ignore[operator]
+    foreign.write_text('{"mode": "Auto"}', encoding="utf-8")
+
+    update_service.put_update_settings(settings, "NotifyOnly", True, 60)
+
+    assert update_service.get_update_settings(settings).mode == "NotifyOnly"
+    assert foreign.exists(), "the other writer's scratch file was consumed"

--- a/apps/tray/MediaMop.Tray.Tests/UpdateSettingsTests.cs
+++ b/apps/tray/MediaMop.Tray.Tests/UpdateSettingsTests.cs
@@ -102,6 +102,22 @@ public sealed class UpdateSettingsTests : IDisposable
     }
 
     [Fact]
+    public void A_stale_scratch_file_from_another_writer_is_not_touched()
+    {
+        // The backend writes this same file. Both used to pick the same scratch name, so one
+        // could rename the other's half-written file into place and report success. The name
+        // is unique per write now, which is why this pre-existing file survives untouched.
+        // Planted at exactly the name the old code used, so this fails against it.
+        var foreign = SettingsPath + ".tmp";
+        File.WriteAllText(foreign, "{\"mode\": \"Auto\"}");
+
+        new UpdateSettings { Mode = UpdateMode.NotifyOnly }.Save(_home);
+
+        Assert.Equal(UpdateMode.NotifyOnly, UpdateSettings.Load(_home).Mode);
+        Assert.True(File.Exists(foreign));
+    }
+
+    [Fact]
     public void The_file_is_replaced_whole_and_leaves_no_scratch_file()
     {
         new UpdateSettings { Mode = UpdateMode.DownloadOnly, CheckIntervalMinutes = 10080 }.Save(_home);

--- a/apps/tray/MediaMop.Tray/Program.cs
+++ b/apps/tray/MediaMop.Tray/Program.cs
@@ -255,9 +255,23 @@ sealed class UpdateSettings
         // Written whole and then renamed. WriteAllText truncates first, so a crash mid-write
         // leaves exactly the half-file Load has to guess its way around; the point of that
         // fallback is to stay unreachable in practice.
-        var tmp = path + ".tmp";
-        File.WriteAllText(tmp, JsonSerializer.Serialize(this, JsonOptions));
-        File.Move(tmp, path, overwrite: true);
+        //
+        // The scratch name is unique per write, not "update-settings.json.tmp". The backend
+        // writes this same file when the Settings page saves, and a shared scratch name lets
+        // one writer rename the other's file into place — an operator told their choice was
+        // saved while the file holds a different one. Same directory, so the rename stays
+        // atomic; leading dot so a half-written file is not mistaken for real settings.
+        var tmp = Path.Combine(runtimeHome, $".update-settings.{Guid.NewGuid():n}.tmp");
+        try
+        {
+            File.WriteAllText(tmp, JsonSerializer.Serialize(this, JsonOptions));
+            File.Move(tmp, path, overwrite: true);
+        }
+        catch
+        {
+            if (File.Exists(tmp)) File.Delete(tmp);
+            throw;
+        }
     }
 }
 


### PR DESCRIPTION
A defect in my own fix from [#382](https://github.com/jampat000/MediaMop/pull/382) / [#385](https://github.com/jampat000/MediaMop/pull/385), found reviewing the two implementations side by side.

## The bug

Both the backend and the tray write `update-settings.json`, and after those PRs both wrote it atomically — through the **same** scratch path:

| | scratch file |
|---|---|
| backend (`put_update_settings`) | `update-settings.json.tmp` |
| tray (`UpdateSettings.Save`) | `update-settings.json.tmp` |

Interleave two saves and one writer renames the other's file into place:

1. Backend writes scratch with `NotifyOnly`
2. Tray writes the same scratch with `Auto`, overwriting it
3. Backend renames → the file now says **`Auto`** — and the API returns success
4. Tray's rename fails, its scratch already gone

The operator saved NotifyOnly, was told it saved, and the file holds Auto. **That is an operator's choice silently replaced by someone else's, in the dangerous direction** — precisely the failure the atomic write was added to prevent, not one it should introduce.

Not hypothetical in principle: the tray writes when its menu changes the mode, the backend when the Settings page saves. Unlikely to collide, but the consequence is a wrong value reported as saved.

## The fix

Each write uses a name unique to itself, in the same directory so the rename stays atomic:

- **Backend** — `tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)`, matching `prune_log_file` in `logs_service.py`, with the scratch file removed in a `finally` if the rename never happens.
- **Tray** — a GUID-suffixed name, deleted on failure before rethrowing.

## Tests

One per implementation, each planting a file at **exactly the shared name the old code used**, then asserting the save neither consumed it nor took its contents. Both fail against the previous code — verified by reverting each implementation in turn:

- backend: `1 failed, 10 passed`
- tray: `1 failed, 7 passed`

## Verification

1208 backend tests, 8 tray tests, mypy clean, full pre-push gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)