### PR TITLE
docs: the published image tag has no `v`, and I said otherwise

### DIFF
--- a/apps/backend/src/mediamop/platform/suite_settings/update_service.py
+++ b/apps/backend/src/mediamop/platform/suite_settings/update_service.py
@@ -100,12 +100,13 @@ def _build_release_status(
     docker_tag = release.version if release.version else None
     docker_update_command = None
     if install_type == "docker" and docker_tag:
-        # `docker compose pull` and not `docker pull <image>:<tag>`. Two reasons, either of
-        # which is fatal on its own: images publish as `v2.5.0` while `release.version` has
-        # had its `v` stripped, so the explicit tag does not exist; and the compose file
-        # documented in docs/docker.md pins `:latest`, so `compose up -d` would keep running
-        # the old image even after a successful pull. `compose pull` resolves whatever the
-        # operator's own compose file names, which is the only thing `compose up` will use.
+        # `docker compose pull`, not `docker pull <image>:<tag>`. The versioned tag does
+        # exist — release.yml pushes `${plain}` and `latest`, where plain is the tag with
+        # its `v` stripped — but naming it achieves nothing: `compose up -d` starts whatever
+        # the operator's compose file references, and the one documented in docs/docker.md
+        # follows `:latest`. The pull succeeded and the upgrade silently did not happen.
+        # `compose pull` resolves the same reference `compose up` will use, which is the
+        # only way to be sure the two agree.
         docker_update_command = "docker compose pull && docker compose up -d"
 
     return SuiteUpdateStatusOut(

--- a/apps/backend/tests/test_suite_update_service.py
+++ b/apps/backend/tests/test_suite_update_service.py
@@ -90,8 +90,8 @@ def test_build_suite_update_status_docker_includes_update_command(monkeypatch: p
 
     assert status.status == "update_available"
     assert status.install_type == "docker"
-    # Not `docker pull <image>:<tag>`: that tag does not exist (images publish as `v2.0.8`)
-    # and the documented compose file pins `:latest`, so `compose up -d` would ignore it.
+    # Not `docker pull <image>:<tag>`: the compose file documented in docs/docker.md follows
+    # `:latest`, so `compose up -d` starts the old image no matter which tag was pulled.
     assert status.docker_update_command == "docker compose pull && docker compose up -d"
     assert status.in_app_upgrade_supported is False
     assert status.in_app_upgrade_summary is None

--- a/docs/release-notes/TEMPLATE.md
+++ b/docs/release-notes/TEMPLATE.md
@@ -24,7 +24,7 @@ This release focuses on <plain-language summary in one sentence>.
 
 ## Docker
 
-- `ghcr.io/jampat000/mediamop:vX.Y.Z`
+- `ghcr.io/jampat000/mediamop:X.Y.Z`  <!-- no `v`: release.yml strips it for the image tag -->
 - `ghcr.io/jampat000/mediamop:latest`
 
 ## Full Changelog

--- a/docs/release-notes/v2.5.0.md
+++ b/docs/release-notes/v2.5.0.md
@@ -27,7 +27,7 @@ This release replaces Refiner's fixed "Movies" and "TV" settings with libraries 
 - **Files are now watched, not polled.** A new file is picked up as it lands, with the periodic scan kept as a backstop rather than the only mechanism.
 - **A file is judged ready by its size settling and by whether it can actually be opened**, replacing a guess based on modification time. A slow copy is no longer picked up half-written.
 - **More video containers are accepted**: `.mpe`, `.mpeg`, `.mpg`, `.mov`, `.flv`, `.wmv` and `.avchd`, on top of the five already handled. Each was verified by actually running it through a cleaning pass. A file with an extension MediaMop will not take is now reported with a reason, instead of being dropped silently — previously this was the only decision that told you nothing at all.
-- **The Docker upgrade command shown in Settings -> Upgrade could not work**, and has not since v2.3.6. It named an image tag that is never published (releases publish `v2.5.0`, not `2.5.0`), and `docker compose up` would not have used it even if it existed, because the documented compose file follows `:latest`. It now shows `docker compose pull && docker compose up -d`.
+- **The Docker upgrade command shown in Settings -> Upgrade could not work**, and has not since v2.3.6. It named a specific version tag, but `docker compose up -d` starts whatever your compose file references — and the documented one follows `:latest` — so the pull succeeded and the upgrade silently did not happen. It now shows `docker compose pull && docker compose up -d`, which resolves the same reference `compose up` will use.
 - **A damaged update-settings file could turn on automatic updates.** An unreadable file was treated as "use the defaults", and the default is Auto. It now falls back to notify-only, so a corrupt file cannot install an update you did not choose. The file is also written atomically now, so it should not become damaged in the first place.
 
 ## Upgrade Notes
@@ -37,11 +37,11 @@ This release replaces Refiner's fixed "Movies" and "TV" settings with libraries 
 - **Your existing Refiner settings are carried across automatically.** The Movies and TV paths and rules you had become two libraries with the same values. Nothing needs to be re-entered.
 - **The old Refiner settings tables have been removed** now that libraries hold everything. This happens during the upgrade and needs no action.
 - **Configuration backups taken before this release can still be restored.** They are translated onto the seeded libraries. Backups taken from this release cannot be restored on an older version.
-- **Docker users:** the upgrade command shown in **Settings -> Upgrade** has been wrong since v2.3.6 — it named an image tag that is never published. If an upgrade appeared to do nothing, that is why. Use `docker compose pull && docker compose up -d`, which is what this release now shows.
+- **Docker users:** the upgrade command shown in **Settings -> Upgrade** has been wrong since v2.3.6. If an upgrade appeared to run and change nothing, that is why. Use `docker compose pull && docker compose up -d`, which is what this release now shows.
 
 ## Docker
 
-- `ghcr.io/jampat000/mediamop:v2.5.0`
+- `ghcr.io/jampat000/mediamop:2.5.0`
 - `ghcr.io/jampat000/mediamop:latest`
 
 ## Full Changelog

--- a/docs/release.md
+++ b/docs/release.md
@@ -48,7 +48,7 @@ The `Release` workflow:
 - builds the Velopack Windows package on `windows-latest`
 - publishes `mediamop-web-dist.zip`
 - builds and pushes Docker tags:
-  - `ghcr.io/<owner>/<repo>:vX.Y.Z`
+  - `ghcr.io/<owner>/<repo>:X.Y.Z` (the git tag is `vX.Y.Z`; the image tag drops the `v`)
   - `ghcr.io/<owner>/<repo>:latest`
 - verifies the published Docker manifest resolves
 - runs the published Docker image and waits for `/health`


### PR DESCRIPTION
Found while running the post-release checklist on [v2.5.0](https://github.com/jampat000/MediaMop/releases/tag/v2.5.0) — by reading the release run rather than the docs.

## What is actually published

`release.yml` computes `plain=${GITHUB_REF_NAME#v}` and pushes:

- `ghcr.io/jampat000/mediamop:2.5.0`
- `ghcr.io/jampat000/mediamop:latest`

**There has never been a `v`-prefixed image tag.** The v2.4.3 run pushed `2.4.3` too. The git tag is `vX.Y.Z`; the image tag drops the `v`.

## Two things were wrong because of it

**1. The release notes told operators to pull a tag that does not exist.** Every release-notes file and `TEMPLATE.md` say `ghcr.io/jampat000/mediamop:vX.Y.Z`, which returns `manifest unknown`. `docs/release.md` describes the workflow the same way.

Fixed for v2.5.0, in the template so the next release does not repeat it, and in `docs/release.md`. **Older release notes are deliberately left alone** — their published GitHub Release bodies cannot be changed to match, and a repo copy that disagrees with the published one is worse than one that is consistently wrong.

**2. I gave a wrong reason for the [#382](https://github.com/jampat000/MediaMop/pull/382) fix.** I wrote that the Settings → Upgrade command named a tag that is never published. That was incorrect — the tag exists and the pull would have succeeded.

The command still could not work, for the other reason I gave, which stands on its own and is unaffected: `docker compose up -d` starts whatever the operator's compose file references, and the one documented in `docs/docker.md` follows `:latest`. So the pull succeeded and the upgrade silently did not happen — arguably worse than an error, because nothing looked wrong.

**The fix in #382 is unchanged and still correct.** Only the stated reason was wrong, in the code comment, the test comment and the release note. All three now say why accurately.

## Also updated

The published v2.5.0 GitHub Release body, so it matches the corrected notes file — governance item 3 requires those to agree.

## Verification

Full pre-push gate clean; `test_suite_update_service.py` 11 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)