### PR TITLE
fix(dashboard): the module cards still laid out for three modules

### DIFF
--- a/apps/web/src/pages/dashboard/dashboard-page.test.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.test.tsx
@@ -137,6 +137,22 @@ describe("DashboardPage", () => {
     expect(screen.getByText("Removal rate")).toBeInTheDocument();
   });
 
+  it("gives the module cards a column each, so they fill the row", () => {
+    // The grid said three columns while only Refiner and Pruner were left, so the cards
+    // sat in two thirds of the row with an empty column beside them. Nothing tied the
+    // column count to the number of modules, so removing Subber could not have caught it.
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    );
+
+    const grid = screen.getByTestId("dashboard-module-cards");
+    const columns = /xl:grid-cols-(\d+)/.exec(grid.className)?.[1];
+
+    expect(Number(columns)).toBe(grid.children.length);
+  });
+
   it("keeps Refiner scan maintenance noise out of the dashboard", () => {
     useRefinerOverviewStatsQuery.mockReturnValue({
       data: {

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -594,7 +594,11 @@ export function DashboardPage() {
       </section>
 
       <section
-        className="mt-5 grid gap-4 xl:grid-cols-3"
+        // Two modules, so two columns. This was three when Subber was one of them (#331)
+        // and was left behind when it went, so Refiner and Pruner sat in two thirds of the
+        // row with an empty column beside them. Two also lines the cards up with the
+        // Needs attention / Recent activity pair below, which is already xl:grid-cols-2.
+        className="mt-5 grid gap-4 xl:grid-cols-2"
         data-testid="dashboard-module-cards"
       >
         {moduleCards.map((card) => (


### PR DESCRIPTION
## The bug

Subber's removal ([#331](https://github.com/jampat000/MediaMop/issues/331)) left Refiner and Pruner in a grid that still said `xl:grid-cols-3`:

```
moduleCards = [refinerCardForDashboard, prunerCard]   // two
className="mt-5 grid gap-4 xl:grid-cols-3"            // three
```

So at `xl` and above the two cards filled two thirds of the row with an empty column beside them, instead of stretching across it.

## The fix

`xl:grid-cols-2`. That also lines the module cards up with the **Needs attention / Recent activity** pair directly below, which was already `xl:grid-cols-2` — so the dashboard now has one consistent two-column rhythm rather than a 3-then-2 step.

Narrow widths are unchanged: the grid was already single-column below `xl`.

## Why it shipped

Nothing tied the column count to the number of modules, so removing one could not have caught it — the layout silently kept a slot for a module that no longer existed.

A test now asserts the two match:

```tsx
const columns = /xl:grid-cols-(\d+)/.exec(grid.className)?.[1];
expect(Number(columns)).toBe(grid.children.length);
```

Verified it catches the real thing: with `xl:grid-cols-3` restored it fails, and passes with the fix.

## Verification

210 web tests, eslint clean, `tsc --noEmit` clean, full pre-push gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)