### PR TITLE
docs: release the dashboard fix as v2.5.1

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.5.0"
+version = "2.5.1"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -7540,7 +7540,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.5.0"
+    "version": "2.5.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.5.1.md
+++ b/docs/release-notes/v2.5.1.md
@@ -1,0 +1,29 @@
+# MediaMop v2.5.1
+
+Date: 2026-08-29
+
+A small follow-up to v2.5.0 that squares up the dashboard and corrects the Docker image tag printed in the release notes.
+
+## What Changed
+
+- **The Refiner and Pruner cards on the Dashboard now fill the width of the page.** The layout still kept a third slot for Subber, which was removed before v2.5.0, so on a wide screen the two cards sat in two thirds of the row with an empty space beside them. They now line up with the status cards above and the panels below.
+
+## Fixes And Stability
+
+- **The Docker image tag shown in the release notes was wrong, and has been for every release.** The published image is `ghcr.io/jampat000/mediamop:2.5.1` — without a leading `v`. The notes said `v2.5.1`, which does not exist and returns `manifest unknown`. The v2.5.0 notes have been corrected in place, and the template no longer produces the wrong tag. The images themselves were always published correctly; only the instructions were wrong.
+
+## Upgrade Notes
+
+- If you are upgrading from an older Windows install that predates the updater service, run `MediaMopSetup.exe` once as administrator.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- Nothing in this release changes your data or settings. Upgrading from v2.5.0 needs no action.
+- **Docker users:** pull `ghcr.io/jampat000/mediamop:2.5.1` or `:latest`, not `v2.5.1`. If you follow the compose setup in the docs, `docker compose pull && docker compose up -d` is still the command to use.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:2.5.1`
+- `ghcr.io/jampat000/mediamop:latest`
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.5.0...v2.5.1


### PR DESCRIPTION
v2.5.0 shipped hours ago and the dashboard fix is user-visible, so it gets a release rather than waiting for whatever comes next.

## What this PR does

Bumps to **2.5.1** across the four version sources — `apps/backend/pyproject.toml`, `apps/web/package.json`, `apps/web/package-lock.json` and the OpenAPI `info.version` — and adds `docs/release-notes/v2.5.1.md`.

## What ships in it

- **[#391](https://github.com/jampat000/MediaMop/pull/391) — the Dashboard module cards fill the width.** The layout still kept a third slot for Subber, removed before v2.5.0, so on a wide screen Refiner and Pruner sat in two thirds of the row with dead space beside them. Verified by screenshot at 1280px, not just by the unit test — the cards now run flush with the status cards above.
- **[#390](https://github.com/jampat000/MediaMop/pull/390) — the Docker image tag in the notes is correct for the first time.** The published image has never carried a `v`; every release note said it did, so `docker pull ...:v2.5.0` returned `manifest unknown`. v2.5.0's notes and published Release body are already corrected in place, and the template no longer produces the wrong tag.

## Release checklist (`docs/release-governance.md`)

- [x] Working tree clean, `main` up to date
- [x] Required check names still exposed by `ci.yml`
- [x] No open issues tagged `priority: critical` or `priority: high` — none open at all
- [x] `docs/release-notes/v2.5.1.md` created (`release.yml` hard-fails without it)
- [x] Notes name the tag that actually exists: `ghcr.io/jampat000/mediamop:2.5.1`

## Verification

1208 backend tests, full pre-push gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)