### PR TITLE
chore: Dependabot was not watching the frontend or the tray

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,20 @@ updates:
         patterns:
           - "*"
 
+  # apps/web is the shipped frontend. It was missing while docs-site was covered, so the
+  # marketing site got dependency PRs and the product did not. CI's `npm audit
+  # --audit-level=high` runs here too, but that only fails a build after the fact and
+  # ignores moderate severities — it does not open a PR to fix anything.
+  - package-ecosystem: npm
+    directory: /apps/web
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      web:
+        patterns:
+          - "*"
+
   - package-ecosystem: npm
     directory: /docs-site
     schedule:
@@ -28,5 +42,28 @@ updates:
     open-pull-requests-limit: 5
     groups:
       docs-site:
+        patterns:
+          - "*"
+
+  # The tray ships in the Windows installer and had no ecosystem entry at all, so Velopack
+  # and the test project's xunit packages were unmonitored. One directory each: Dependabot
+  # resolves NuGet per project file, and there is no .sln to cover both.
+  - package-ecosystem: nuget
+    directory: /apps/tray/MediaMop.Tray
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      tray:
+        patterns:
+          - "*"
+
+  - package-ecosystem: nuget
+    directory: /apps/tray/MediaMop.Tray.Tests
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      tray-tests:
         patterns:
           - "*"


### PR DESCRIPTION
Found while checking open PRs and Dependabot state after the v2.5.1 release.

## The gap

`.github/dependabot.yml` covered pip, github-actions, and npm in **`docs-site`** — but not `apps/web`. So the marketing site got dependency PRs and **the shipped product did not**.

The tray had no entry at all, in any ecosystem.

| Ecosystem | Directory | Before |
|---|---|---|
| pip | `/apps/backend` | covered |
| github-actions | `/` | covered |
| npm | `/docs-site` | covered |
| **npm** | **`/apps/web`** | **missing — the actual frontend** |
| **nuget** | **`/apps/tray/MediaMop.Tray`** | **missing — ships in the installer** |
| **nuget** | **`/apps/tray/MediaMop.Tray.Tests`** | **missing** |

## Why CI wasn't already covering it

CI runs `npm audit --audit-level=high` in `apps/web`, which is real but reactive: it fails a build *after* a vulnerability is public, ignores moderate severities, and never opens a PR to fix anything. Nothing at all watched the tray's `Velopack` or xunit packages.

## Notes

- Two NuGet entries rather than one, because Dependabot resolves NuGet per project file and there is no `.sln` covering both.
- Grouped and weekly, matching the existing entries, so each ecosystem opens one PR rather than one per package.

## Verification

YAML parses; six update entries resolve to the ecosystems and directories above. Full pre-push gate clean.

Current state otherwise: 0 open Dependabot alerts (60 total, all closed), 0 code scanning alerts, 0 secret scanning alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)