### PR TITLE
Keep Windows tray alive when browser launch fails

### DIFF
--- a/apps/tray/MediaMop.Tray.Tests/BrowserLaunchTests.cs
+++ b/apps/tray/MediaMop.Tray.Tests/BrowserLaunchTests.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Diagnostics;
+
+using Xunit;
+
+namespace MediaMop.Tray.Tests;
+
+public sealed class BrowserLaunchTests : IDisposable
+{
+    private readonly string _home;
+    private readonly string? _previousHome;
+
+    public BrowserLaunchTests()
+    {
+        _home = Path.Combine(Path.GetTempPath(), "mediamop-tray-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(_home);
+        _previousHome = Environment.GetEnvironmentVariable("MEDIAMOP_HOME");
+        Environment.SetEnvironmentVariable("MEDIAMOP_HOME", _home);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("MEDIAMOP_HOME", _previousHome);
+        try { Directory.Delete(_home, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Browser_shell_failure_is_non_fatal_and_logged()
+    {
+        var result = Program.OpenBrowser(
+            8788,
+            _ => throw new Win32Exception(unchecked((int)0x80004021), "Shell execution unavailable"));
+
+        Assert.False(result);
+        var log = File.ReadAllText(Path.Combine(_home, "tray-host.log"));
+        Assert.Contains("Could not open MediaMop in the browser", log);
+        Assert.Contains("Shell execution unavailable", log);
+    }
+
+    [Fact]
+    public void Browser_launch_uses_the_local_server_and_shell_execution()
+    {
+        ProcessStartInfo? observed = null;
+
+        var result = Program.OpenBrowser(8788, info => observed = info);
+
+        Assert.True(result);
+        Assert.NotNull(observed);
+        Assert.Equal("http://127.0.0.1:8788/", observed.FileName);
+        Assert.True(observed.UseShellExecute);
+    }
+}

--- a/apps/tray/MediaMop.Tray/Program.cs
+++ b/apps/tray/MediaMop.Tray/Program.cs
@@ -175,13 +175,29 @@ static class Program
         return Path.Combine(programData, "MediaMop");
     }
 
-    internal static void OpenBrowser(int port)
+    internal static bool OpenBrowser(
+        int port,
+        Action<ProcessStartInfo>? startProcess = null)
     {
-        Process.Start(new ProcessStartInfo
+        var startInfo = new ProcessStartInfo
         {
             FileName = $"http://127.0.0.1:{port}/",
             UseShellExecute = true,
-        });
+        };
+
+        try
+        {
+            (startProcess ?? (info => Process.Start(info)))(startInfo);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Opening a browser is a convenience action. Session 0, disconnected RDP
+            // sessions, and hardened shell policies can reject shell execution; none of
+            // those conditions should stop the tray watchdog or its server process.
+            AppendFallbackLog($"Could not open MediaMop in the browser: {ex.Message}");
+            return false;
+        }
     }
 
     internal static void AppendFallbackLog(string message)

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -2208,9 +2208,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
-      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2258,9 +2258,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2278,11 +2278,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2362,9 +2362,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001786",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001786.tgz",
-      "integrity": "sha512-4oxTZEvqmLLrERwxO76yfKM7acZo310U+v4kqexI2TL1DkkUEMT8UijrxxcnVdxR3qkVf5awGRX+4Z6aPHVKrA==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -2887,9 +2887,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.331",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+      "version": "1.5.419",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
+      "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
       "dev": true,
       "license": "ISC"
     },
@@ -5219,11 +5219,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5771,9 +5774,9 @@
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.4.tgz",
+      "integrity": "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7074,9 +7077,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Incident\n\nOn app-server, MediaMop's backend started successfully on port 8788, but the tray host exited with Win32Exception 0x80004021 when Windows rejected shell execution for the startup browser URL. The orphaned backend later exited with no tray watchdog left to restart it.\n\n## Fix\n\n- Treat automatic and tray-requested browser opening as best-effort.\n- Log browser shell failures without terminating the tray host.\n- Add regression coverage for the exact Win32 shell failure and the expected localhost URL.\n\n## Verification\n\n- Tray tests: 10 passed.\n- dotnet format: clean.\n- Production restored on app-server:8788 with MediaMop 2.6.1 in no-browser mode; health, readiness, and database checks pass.\n- Removed the stale SYSTEM startup entry pointing to the nonexistent Program Files install; retained the Administrator startup entry with --no-browser.