### PR TITLE
Release MediaMop 2.6.2

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mediamop-backend"
-version = "2.6.1"
+version = "2.6.2"
 description = "MediaMop backend spine (FastAPI, SQLite, Alembic)"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/apps/web/openapi/mediamop-openapi.json
+++ b/apps/web/openapi/mediamop-openapi.json
@@ -8086,7 +8086,7 @@
   },
   "info": {
     "title": "MediaMop API",
-    "version": "2.6.1"
+    "version": "2.6.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mediamop-web",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mediamop-web",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@fontsource/outfit": "^5.2.8",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mediamop-web",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "engines": {

--- a/docs/release-notes/v2.6.2.md
+++ b/docs/release-notes/v2.6.2.md
@@ -1,0 +1,33 @@
+# MediaMop v2.6.2
+
+Date: 2026-09-02
+
+This hotfix keeps the Windows tray application and MediaMop server running when Windows cannot open the dashboard in a browser automatically.
+
+## What Changed
+
+- Opening the dashboard at startup is now treated as a convenience instead of a requirement.
+- If Windows rejects the browser launch, MediaMop records a clear log message and continues running normally.
+- Automated coverage now reproduces the Windows shell failure that caused the tray application to exit.
+
+## Fixes And Stability
+
+- The Windows tray icon no longer disappears because the default browser could not be opened.
+- The bundled server remains supervised by the tray application and available on port 8788 after a browser-launch failure.
+- Frontend dependency metadata was refreshed and passes the release security audit with no known vulnerabilities.
+
+## Upgrade Notes
+
+- Windows users should install `MediaMop-win-Setup.exe`; existing users, settings, libraries, and processing history are preserved.
+- After that one-time bootstrap, future upgrades can be started from **Settings -> Upgrade**.
+- No configuration or database migration is required for this hotfix.
+
+## Docker
+
+- `ghcr.io/jampat000/mediamop:2.6.2`
+- `ghcr.io/jampat000/mediamop:latest`
+- Docker receives the matching release tag; the tray-specific fix affects Windows installations only.
+
+## Full Changelog
+
+https://github.com/jampat000/MediaMop/compare/v2.6.1...v2.6.2


### PR DESCRIPTION
## Summary

- bump backend and web release versions to 2.6.2
- add operator-facing 2.6.2 release notes
- publish the merged Windows tray browser-launch survivability hotfix in a permanent installer
- keep the Docker version and `latest` release tags aligned

## Local validation

- backend: 1,254 passed, 2 skipped
- frontend: 227 passed; production build, design tokens, and bundle budget passed
- npm audit: 0 vulnerabilities
- Windows tray: 10 passed, including simulated browser shell failure
- agent documentation map: passed